### PR TITLE
Cody: Reduce scroll threshold for auto scroll

### DIFF
--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -68,7 +68,7 @@ export const Transcript: React.FunctionComponent<
             // We allow some small threshold for "what is considered not scrolled up" so that
             // minimal scroll doesn't affect it (ie. if I'm not all the way scrolled down by like a
             // pixel or two, I probably still want it to scroll).
-            const SCROLL_THRESHOLD = 100
+            const SCROLL_THRESHOLD = 50
             const delta = Math.abs(
                 transcriptContainerRef.current.scrollHeight -
                     transcriptContainerRef.current.offsetHeight -


### PR DESCRIPTION
## Description

To give a typing feel, we reduced streaming intervals between character chunks in [this PR](https://github.com/sourcegraph/sourcegraph/pull/54665)

We should also adjust this scroll threshold, as it is now more likely that a new chunk will come in while a user scrolls, and move them back to the bottom of the threshold.