### PR TITLE
Cody: Update workspace server endpoint same as the user settings

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Inline Chat: Update keybind when condition to `editorFocus`. [pull/54437](https://github.com/sourcegraph/sourcegraph/pull/54437)
 - Inline Touch: Create a new `.test.` file when `test` or `tests` is included in the instruction. [pull/54437](https://github.com/sourcegraph/sourcegraph/pull/54437)
 - Prevents errors from being displayed for a cancelled requests. [pull/54429](https://github.com/sourcegraph/sourcegraph/pull/54429)
+- Fixed URI error message in workspace settings. [pull/40](https://github.com/sourcegraph/cody/pull/40)
 
 ### Changed
 

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -108,6 +108,11 @@ export async function updateConfiguration(configKey: string, configValue: string
     await codyConfiguration.update(configKey, configValue, vscode.ConfigurationTarget.Global)
 }
 
+// Update workspace configurations in VS Code for Cody
+export async function updateWorkSpaceConfiguration(configKey: string, configValue: string): Promise<void> {
+    await codyConfiguration.update(configKey, configValue, vscode.ConfigurationTarget.Workspace)
+}
+
 export const getFullConfig = async (
     secretStorage: SecretStorage,
     localStorage?: LocalStorage
@@ -115,6 +120,7 @@ export const getFullConfig = async (
     const config = getConfiguration(vscode.workspace.getConfiguration())
     // Migrate endpoints to local storage
     config.serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
+    await updateWorkSpaceConfiguration('serverEndpoint', config.serverEndpoint)
     const accessToken = (await getAccessToken(secretStorage)) || null
     return { ...config, accessToken }
 }


### PR DESCRIPTION
This PR closes [issue](https://github.com/sourcegraph/sourcegraph/issues/54467).
Instead of removing the format URI, which would remove the validation, I have added a function to update the workspace server endpoint settings same as that of the user settings. This way, it won't show any URI error.

## Test plan
All tests have passed.
Tested using different Sign In options such as Cody App, Sourcegraph.com.