### PR TITLE
add deprecationMessage for serverEndpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .stylelintcache
 dist/
 *.tsbuildinfo
+.DS_Store

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 hoist=false
-

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -788,9 +788,10 @@
         "cody.serverEndpoint": {
           "order": 1,
           "type": "string",
-          "format": "uri",
           "description": "URL to the Sourcegraph instance.",
-          "examples": "https://example.sourcegraph.com"
+          "examples": "https://example.sourcegraph.com",
+          "markdownDeprecationMessage": "**Deprecated**: Please sign in via the UI instead. If you are already signed in, you can empty this field to remove this warning.",
+          "deprecationMessage": "Deprecated: Please sign in via the UI instead."
         },
         "cody.codebase": {
           "order": 2,


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/54467

We are now storing the server endpoint in local storage to support multiple endpoints login so we can deprecate the `cody.serverEndpoint` setting. 

We still read the config in the code if the user has previously configured the endpoint in their settings, which will then migrate the endpoint from their config file to local storage automatically. 