### PR TITLE
update VS Code readme and marketplace listing to match top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,14 @@ _&mdash; or &mdash;_
 
 Cody is a code AI tool that autocompletes, writes, fixes, and refactors code (and answers code questions), with:
 
-- **Codebase context**: Cody fetches relevant code context from across your entire codebase to write better code that uses more of your codebase's APIs, impls, and idioms, with less hallucination.
-- **Smooth editor UX:** Popular extensions for [VS Code](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and [JetBrains](https://plugins.jetbrains.com/plugin/9682-cody-ai-by-sourcegraph) (and WIP support for Neovim and Emacs).
+- **Codebase context:** Cody fetches relevant code context from across your entire codebase to write better code that uses more of your codebase's APIs, impls, and idioms, with less hallucination.
+- **Editor features:** Popular extensions for [VS Code](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and [JetBrains](https://plugins.jetbrains.com/plugin/9682-cody-ai-by-sourcegraph) (and WIP support for Neovim and Emacs).
+  - **Autocomplete:** with better suggestions based on your entire codebase, not just a few recently opened files
+  - **Inline chat:** refactor code based on natural language input, ask questions about code snippets, etc.
+  - **Recipes:** explain code, generate unit test, generate docstring, and many more (contribute your own!)
+  - **Codebase-wide chat:** ask questions about your entire codebase
 - **Swappable LLMs:** Support for Anthropic Claude and OpenAI GPT-4/3.5, highly experimental support for self-hosted LLMs, and more soon.
-
-Cody's main features are:
-
-- Autocomplete
-- Inline chat: refactor code based on natural language input, ask questions about code snippets, etc.
-- Recipes: explain code, generate unit test, generate docstring, and many more (contribute your own!)
-- Codebase-wide chat: ask questions about your entire codebase
+  - **Free LLM usage included** (currently Anthropic Claude/OpenAI GPT-4) for individual devs on both personal and work code, subject to reasonable per-user rate limits ([more info](#usage)).
 
 See [cody.dev](https://cody.dev) for more info.
 
@@ -68,7 +66,8 @@ Cody is often magical and sometimes frustratingly wrong. Cody's goal is to be po
 
 - Use the <kbd>👍</kbd>/<kbd>👎</kbd> buttons in the chat sidebar to give feedback.
 - [File an issue](https://github.com/sourcegraph/cody/issues) (or submit a PR!) when you see problems.
-- [Join our Discord.](https://discord.gg/s2qDtYGnAE)
+- [Discussions](https://github.com/sourcegraph/cody/discussions)
+- [Discord](https://discord.gg/s2qDtYGnAE)
 
 ## Usage
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,65 +1,42 @@
-# Cody AI by Sourcegraph
+# Cody: code AI with codebase context
 
-Cody for VS Code is an AI code assistant that can write code and answer questions across your entire codebase. It combines the power of large language models with Sourcegraph’s Code Graph API, generating deep knowledge of all of your code (and not just your open files). Large monorepos, multiple languages, and complex codebases are no problem for Cody.
+> "An AI pair programmer that actually knows about your entire codebase's APIs, impls, and idioms"
 
-For example, you can ask Cody:
+Cody for VS Code is a free, open-source code AI tool that autocompletes, writes, fixes, and refactors code (and answers code questions), with:
 
-- Where is the CI config for the web integration tests?
-- Write a new GraphQL resolver for the AuditLog
-- Why is the UserConnectionResolver giving an error "unknown user", and how do I fix it?
-- Add helpful debug log statements
-- Make this work _(seriously, it often works—try it!)_
+- **Codebase context:** Cody fetches relevant code context from across your entire codebase to write better code that uses more of your codebase's APIs, impls, and idioms, with less hallucination.
+- **Editor features**
+  - **Autocomplete:** with better suggestions based on your entire codebase, not just a few recently opened files
+  - **Inline chat:** refactor code based on natural language input, ask questions about code snippets, etc.
+  - **Recipes:** explain code, generate unit test, generate docstring, and many more (contribute your own!)
+  - **Codebase-wide chat:** ask questions about your entire codebase
+- **Free LLM usage included** (currently Anthropic Claude/OpenAI GPT-4) for individual devs on both personal and work code, subject to reasonable per-user rate limits.
 
-  **Cody AI is in beta, and we’d love your [feedback](https://github.com/sourcegraph/cody/discussions/new?category=product-feedback&labels=vscode)**!
+See [cody.dev](https://cody.dev) for more info.
 
-## Features
+## Demos
 
-<!-- NOTE: These should stay roughly in sync with doc/cody/index.md, although that page needs to be not specific to VS Code. -->
+**Autocomplete:**
 
-### 🤖 Ask Cody about anything in your codebase
+> ![Example of using code autocomplete](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-completions-may2023-optim.gif)
 
-Cody understands your entire codebase — not just your open files. Ask questions, insert code, and use the built-in recipes such as "Summarize recent code changes" and "Improve variable names".
+**Inline chat:**
 
-![Example of chatting with Cody](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-chat-may2023-optim.gif)
+> <img src="https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody_inline_June23-sm.gif" width=600>
 
-### ✨ Tools for fixing and explaining code
+**Codebase-wide chat:**
 
-Cody can perform complex inline fixups, or answer questions inline. Interact with Cody within your code through Inline Assist, or use the "Fixup code from inline instructions" recipe for more involved fixups.
+> ![Example of chatting with Cody](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-chat-may2023-optim.gif)
 
-![Example of using a fixup](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-fixup-may2023-optim.gif)
-
-### 🔨 Let Cody write code for you
-
-Cody can provide real-time code autocompletions as you're typing. As you start coding, or after you type a comment, Cody will look at the context around your open files, your file history, and your entire codebase to predict what you're trying to implement and provide suggestions.
-
-![Example of using code autocomplete](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-completions-may2023-optim.gif)
-
-## 🍿 See it in action
-
-- https://twitter.com/beyang/status/1647744307045228544
-- https://twitter.com/sqs/status/1647673013343780864
-
-## 🍳 Built-in recipes
-
-Select the recipes tab or right-click on a selection of code and choose one of the `Ask Cody > ...` recipes, such as:
-
-- Explain code
-- Generate unit test
-- Generate docstring
-- Improve variable names
-- Translate to different language
-- Summarize recent code changes
-- Detect code smells
-- Generate release notes
-
-_We also welcome also pull request contributions for new, useful recipes!_
+[More demos](https://cody.dev)
 
 ## Feedback
 
 - [Issue tracker](https://github.com/sourcegraph/cody/issues)
-- [Discord chat](https://discord.gg/s2qDtYGnAE)
+- [Discussions](https://github.com/sourcegraph/cody/discussions)
+- [Discord](https://discord.gg/s2qDtYGnAE)
 - [Twitter (@sourcegraph)](https://twitter.com/sourcegraph)
 
 ## Development
 
-Cody is open source (Apache 2) in the [sourcegraph/cody repository](https://github.com/sourcegraph/cody). See [CONTRIBUTING.md](CONTRIBUTING.md).
+Cody for VS Code is developed in the open-source (Apache 2) [sourcegraph/cody repository](https://github.com/sourcegraph/cody).

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,12 +1,12 @@
 {
   "name": "cody-ai",
   "private": true,
-  "displayName": "Cody AI by Sourcegraph",
+  "displayName": "Cody",
   "version": "0.4.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",
-  "description": "AI code assistant that writes code and answers questions for you",
+  "description": "Code AI with codebase context",
   "scripts": {
     "dev": "pnpm run build:dev && CODY_FOCUS_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=\"$INIT_CWD/vscode\" --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 . --goto ./src/logged-rerank.ts:16:5",
     "generate:completions": "ts-node-transpile-only ./src/testutils/cli/run-code-completions-on-dataset.ts",
@@ -52,7 +52,18 @@
     "codegen",
     "autocomplete",
     "bot",
-    "model"
+    "model",
+    "typescript",
+    "javascript",
+    "python",
+    "golang",
+    "go",
+    "html",
+    "css",
+    "java",
+    "php",
+    "swift",
+    "kotlin"
   ],
   "repository": {
     "type": "git",
@@ -858,7 +869,7 @@
         "cody.debug.enable": {
           "order": 99,
           "type": "boolean",
-          "markdownDescription": "Turns on debug output (visible in the VS Code Output panel under \"Cody AI by Sourcegraph\")"
+          "markdownDescription": "Turns on debug output (visible in the VS Code Output panel under \"Cody by Sourcegraph\")"
         },
         "cody.debug.verbose": {
           "order": 99,

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -9,10 +9,10 @@ import {
 
 import { getConfiguration } from './configuration'
 
-const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Cody AI by Sourcegraph', 'json')
+const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Cody by Sourcegraph', 'json')
 
 /**
- * Logs text for debugging purposes to the "Cody AI by Sourcegraph" output channel.
+ * Logs text for debugging purposes to the "Cody by Sourcegraph" output channel.
  *
  * There are three config settings that alter the behavior of this function.
  * A window refresh may be needed if these settings are changed for the behavior


### PR DESCRIPTION
Also improve wording in a few places.

Removes the old inline chat example because we now prefer using the `+` button.

Removes longer descriptions of some features (which were about their value, not how to use them) in lieu of simple demo videos.