### PR TITLE
use explicit imports for describe/test/it/expect

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -2,6 +2,8 @@ import assert from 'assert'
 import { spawn } from 'child_process'
 import path from 'path'
 
+import { afterAll, describe, it } from 'vitest'
+
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 
 import { MessageHandler } from './jsonrpc'

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "rootDir": ".",
     "outDir": "dist",
-    "types": ["vitest/globals"],
   },
   "include": ["**/*", ".*", "package.json"],
   "exclude": ["dist"],

--- a/lib/shared/src/chat/bot-response-multiplexer.test.ts
+++ b/lib/shared/src/chat/bot-response-multiplexer.test.ts
@@ -1,5 +1,7 @@
 import assert from 'assert'
 
+import { describe, it } from 'vitest'
+
 import { BotResponseMultiplexer, BufferedBotResponseSubscriber } from './bot-response-multiplexer'
 
 function promise<T>(): [(value: T) => void, Promise<T>] {

--- a/lib/shared/src/chat/transcript/transcript.test.ts
+++ b/lib/shared/src/chat/transcript/transcript.test.ts
@@ -1,5 +1,7 @@
 import assert from 'assert'
 
+import { describe, it } from 'vitest'
+
 import { CodebaseContext } from '../../codebase-context'
 import { MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
 import { Message } from '../../sourcegraph-api'

--- a/lib/shared/src/common/markdown/markdown.test.ts
+++ b/lib/shared/src/common/markdown/markdown.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, test } from 'vitest'
+
 import { escapeMarkdown, registerHighlightContributions, renderMarkdown } from '.'
 
 // TODO(sqs): copied from sourcegraph/sourcegraph. should dedupe.

--- a/lib/shared/src/guardrails/index.test.ts
+++ b/lib/shared/src/guardrails/index.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { summariseAttribution } from '.'
 
 const genRepos = (count: number) => {

--- a/lib/shared/src/hallucinations-detector/index.test.ts
+++ b/lib/shared/src/hallucinations-detector/index.test.ts
@@ -1,5 +1,7 @@
 import assert from 'assert'
 
+import { describe, it } from 'vitest'
+
 import { findFilePaths, highlightTokens } from '.'
 
 const markdownText = `# Title

--- a/lib/shared/src/sourcegraph-api/utils.test.ts
+++ b/lib/shared/src/sourcegraph-api/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { toPartialUtf8String } from './utils'
 
 describe('toPartialUtf8String', () => {

--- a/lib/shared/tsconfig.json
+++ b/lib/shared/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": "src",
     "outDir": "dist",
     "lib": ["ESNext", "DOM.Iterable"],
-    "types": ["vitest/globals"],
   },
   "include": ["src"],
   "exclude": ["dist"],

--- a/vscode/src/chat/fastFileFinder.test.ts
+++ b/vscode/src/chat/fastFileFinder.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { filePathContains, makeTrimRegex } from './fastFileFinder'
 
 describe('makeTrimRegex', () => {

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect } from 'vitest'
+
 import { defaultAuthStatus, unauthenticatedStatus } from './protocol'
 import { convertGitCloneURLToCodebaseName, newAuthStatus } from './utils'
 

--- a/vscode/src/completions/bestJaccardMatch.test.ts
+++ b/vscode/src/completions/bestJaccardMatch.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { bestJaccardMatch, getWords } from './bestJaccardMatch'
 
 const targetSnippet = `

--- a/vscode/src/completions/cache.test.ts
+++ b/vscode/src/completions/cache.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { CompletionsCache } from './cache'
 
 describe('CompletionsCache', () => {

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 
 import {

--- a/vscode/src/completions/document.ts
+++ b/vscode/src/completions/document.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode'
  * defined by `maxPrefixLength` and `maxSuffixLength` respectively. If the length of the entire
  * document content in either direction is smaller than these parameters, the entire content will be used.
  *w
+ *
  * @param document - A `vscode.TextDocument` object, the document in which to find the context.
  * @param position - A `vscode.Position` object, the position in the document from which to find the context.
  * @param maxPrefixLength - A number representing the maximum length of the prefix to get from the document.

--- a/vscode/src/completions/text-processing.test.ts
+++ b/vscode/src/completions/text-processing.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { CLOSING_CODE_TAG, extractFromCodeBlock, OPENING_CODE_TAG } from './text-processing'
 
 describe('extractFromCodeBlock', () => {

--- a/vscode/src/completions/utils.test.ts
+++ b/vscode/src/completions/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { sliceUntilFirstNLinesOfSuffixMatch } from './utils'
 
 describe('sliceUntilFirstNLinesOfSuffixMatch', () => {

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
 import { DOTCOM_URL } from './chat/protocol'

--- a/vscode/src/local-context/filename-context-fetcher.ts
+++ b/vscode/src/local-context/filename-context-fetcher.ts
@@ -19,6 +19,7 @@ export class FilenameContextFetcher {
 
     /**
      * Returns pieces of context relevant for the given query. Uses a filename search approach
+     *
      * @param query user query
      * @param numResults the number of context results to return
      * @returns a list of context results, sorted in *reverse* order (that is,

--- a/vscode/src/non-stop/FixupFileObserver.ts
+++ b/vscode/src/non-stop/FixupFileObserver.ts
@@ -21,6 +21,7 @@ export class FixupFileObserver {
      * document is renamed or deleted the FixupFile will be updated to provide
      * the current file URI. This creates a FixupFile if one does not exist and
      * starts tracking it; see maybeForUri.
+     *
      * @param uri the URI of the document to monitor.
      * @returns a new FixupFile representing the document.
      */
@@ -37,6 +38,7 @@ export class FixupFileObserver {
      * Gets the FixupFile for a given URI, if one exists. This operation is
      * fast; vscode event sinks which are provided a URI can use this to quickly
      * check whether the file may have fixups.
+     *
      * @param uri the URI of the document of interest.
      * @returns a FixupFile representing the document, if one exists.
      */

--- a/vscode/src/non-stop/FixupScheduler.ts
+++ b/vscode/src/non-stop/FixupScheduler.ts
@@ -20,6 +20,7 @@ export class FixupScheduler implements FixupIdleTaskRunner {
 
     /**
      * Schedules a callback which will run when the event loop is idle.
+     *
      * @param callback the callback to run.
      */
     public scheduleIdle<T>(worker: () => T): Promise<T> {

--- a/vscode/src/non-stop/diff.test.ts
+++ b/vscode/src/non-stop/diff.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import { computeDiff, dumpUse, longestCommonSubsequence } from './diff'
 
 // Note, computeDiff does not treat its arguments symmetrically

--- a/vscode/src/non-stop/roles.ts
+++ b/vscode/src/non-stop/roles.ts
@@ -18,6 +18,7 @@ export interface FixupFileCollection {
      * If there is a FixupFile for the specified URI, return it, otherwise
      * undefined. VScode callbacks which have a document or URI can use this
      * to determine if there may be interest in the URI.
+     *
      * @param uri the URI of the document of interest.
      */
     maybeFileForUri(uri: vscode.Uri): FixupFile | undefined

--- a/vscode/src/non-stop/tracked-range.test.ts
+++ b/vscode/src/non-stop/tracked-range.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 
+import { describe, expect, it } from 'vitest'
 import { Position, Range } from 'vscode'
 
 import { updateRange, updateRangeMultipleChanges } from './tracked-range'

--- a/vscode/src/non-stop/utils.test.ts
+++ b/vscode/src/non-stop/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect } from 'vitest'
+
 import { getFileNameAfterLastDash } from './utils'
 
 // Test for getFileNameAfterLastDash

--- a/vscode/src/services/InlineAssist.test.ts
+++ b/vscode/src/services/InlineAssist.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
 import { editDocByUri, updateRangeOnDocChange } from './InlineAssist'

--- a/vscode/src/testutils/vscode.ts
+++ b/vscode/src/testutils/vscode.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest'
+
 import { vsCodeMocks } from './mocks'
 
 /**

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -6,7 +6,6 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM"],
-    "types": ["vitest/globals"],
   },
   "include": [
     "src",

--- a/vscode/webviews/UserHistory.tsx
+++ b/vscode/webviews/UserHistory.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-array-index-key */
-
 import { useCallback } from 'react'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'

--- a/web/src/sample.test.ts
+++ b/web/src/sample.test.ts
@@ -1,1 +1,3 @@
+import { expect, test } from 'vitest'
+
 test('should pass', () => expect(1).toBe(1))

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "dist",
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM"],
-    "types": ["vitest/globals"],
   },
   "include": ["src", "vite.config.ts", ".eslintrc.js"],
   "exclude": ["dist"],


### PR DESCRIPTION
Removes implicit globals for the test helpers, in favor of the (preferred) method of importing them explicitly from `vitest`.