### PR TITLE
Set `CODY_RELEASE_TYPE` for vscode-release

### DIFF
--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -39,7 +39,7 @@ jobs:
           fi
       - run: vscode/scripts/download-rg.sh x86_64-unknown-linux
       - run: xvfb-run -a pnpm run test
-      - run: pnpm -C vscode run release
+      - run: CODY_RELEASE_TYPE=stable pnpm -C vscode run release
         if: github.repository == 'sourcegraph/cody'
         env:
           VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}


### PR DESCRIPTION
We didn't have this set so the release action failed: https://github.com/sourcegraph/cody/actions/runs/5517824827