### PR TITLE
Cody: Fix inline loading state

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -426,6 +426,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         void this.saveTranscriptToChatHistory()
         this.sendChatHistory()
         void vscode.commands.executeCommand('setContext', 'cody.reply.pending', false)
+        this.editor.controllers.inline.setResponsePending(false)
         if (!ignoreEmbeddingsError) {
             this.logEmbeddingsSearchErrors()
         }

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -219,10 +219,12 @@ export class InlineController {
     public setResponsePending(isResponsePending: boolean): void {
         let iterations = 0
 
-        if (!isResponsePending && this.responsePendingInterval) {
-            clearInterval(this.responsePendingInterval)
-            this.responsePendingInterval = null
-            iterations = 0
+        if (!isResponsePending) {
+            if (this.responsePendingInterval) {
+                clearInterval(this.responsePendingInterval)
+                this.responsePendingInterval = null
+                iterations = 0
+            }
             return
         }
 


### PR DESCRIPTION
## Description

Noticed this doing some final regression testing for the 0.4.3 release. It is possible to end up with a loading state that isn't cleared if a user manually stops the response. Just need to copy where `cody.reply.pending` is set