### PR TITLE
Cody: Update extension display name

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cody-ai",
   "private": true,
-  "displayName": "Cody",
+  "displayName": "Cody AI",
   "version": "0.4.3",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",


### PR DESCRIPTION
We get an error when publishing when using the display name "Cody".

[Failed build
](https://github.com/sourcegraph/cody/actions/runs/5518311241/jobs/10062085036)

`Error: This extension display name 'Cody' is taken. Please try a different one. For queries contact VSMarketplace@microsoft.com.`

Using "Cody AI" as it's similar to what we had before. We can still omit the "by Sourcegraph" as that information is already shown I think.

Other suggestions welcome!