### PR TITLE
autocomplete: cut-off completions on partial suffix match

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -8,7 +8,8 @@
   "icon": "resources/cody.png",
   "description": "Code AI with codebase context",
   "scripts": {
-    "dev": "pnpm run build:dev && CODY_FOCUS_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=\"$INIT_CWD/vscode\" --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 . --goto ./src/logged-rerank.ts:16:5",
+    "dev:instance": "CODY_FOCUS_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=\"$INIT_CWD/vscode\" --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 . --goto ./src/logged-rerank.ts:16:5",
+    "dev": "pnpm run build:dev && pnpm run dev:instance",
     "generate:completions": "ts-node-transpile-only ./src/testutils/cli/run-code-completions-on-dataset.ts",
     "build": "tsc --build && pnpm run esbuild --minify && vite build --mode production",
     "build:dev": "tsc --build && concurrently \"pnpm run esbuild --sourcemap\" \"vite build --mode development\"",

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -779,6 +779,26 @@ describe('Cody completions', () => {
             `)
         })
 
+        it('stops when the next non-empty line of the suffix matches partially', async () => {
+            const { completions } = await complete(
+                `path: $GITHUB_WORKSPACE/vscode/.vscod-etest/${CURSOR_MARKER}
+    key: {{ runner.os }}-pnpm-store-{{ hashFiles('**/pnpm-lock.yaml') }}
+                `,
+                [
+                    createCompletionResponse(`
+                    pnpm-store
+                        key: {{ runner.os }}-pnpm-{{ steps.pnpm-cache.outputs.STORE_PATH }}
+                    }`),
+                ]
+            )
+
+            expect(completions[0]).toMatchInlineSnapshot(`
+                InlineCompletionItem {
+                  "insertText": "pnpm-store",
+                }
+            `)
+        })
+
         it('ranks results by number of lines', async () => {
             const { completions } = await complete(
                 `

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -124,6 +124,13 @@ function trimSpace(s: string): TrimmedString {
     return { trimmed, leadSpace: s.slice(0, headEnd), rearSpace: s.slice(headEnd + trimmed.length) }
 }
 
+/**
+ * The magic number based on intution and experimentation.
+ * We do not want to match too small number of symbols to avoid false positives.
+ * We do not want to match the whole string because it leads to suffix duplication.
+ */
+const NUMBER_OF_CHARS_TO_MATCH_AND_CUT_SUFFIX = 15
+
 /*
  * Trims the insertion string until the first line that matches the suffix string.
  *
@@ -146,6 +153,11 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
 
     const insertionLines = insertion.split('\n')
     let insertionEnd = insertionLines.length
+    const firstNonEmptySuffixLinePart = getFirstNCharsPreservingLeadingSpaces(
+        firstNonEmptySuffixLine,
+        NUMBER_OF_CHARS_TO_MATCH_AND_CUT_SUFFIX
+    )
+
     for (let i = 0; i < insertionLines.length; i++) {
         let line = insertionLines[i]
 
@@ -155,12 +167,25 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
             line = prefix.slice(lastNewlineOfPrefix + 1) + line
         }
 
-        // Trim the end of the lines to avoid trailing whitespace causing issues
-        if (line.trimEnd() === firstNonEmptySuffixLine.trimEnd()) {
+        /**
+         * We cut the completion on the partial match of the suffix
+         *
+         * For example, if the suffix is:
+         * `  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}`
+         *
+         * And the completions is:
+         * `pnpm-store\n  key: ${{ runner.os }}-pnpm-${{ steps.pnpm-cache.outputs.STORE_PATH }}`
+         *
+         * We cut the completion on the `  key:` part to avoid duplicating the suffix.
+         * The resulting completion will be: `pnpm-store`.
+         */
+        const linePart = getFirstNCharsPreservingLeadingSpaces(line, NUMBER_OF_CHARS_TO_MATCH_AND_CUT_SUFFIX)
+        if (linePart.length && firstNonEmptySuffixLinePart.startsWith(linePart)) {
             insertionEnd = i
             break
         }
     }
+
     return insertionLines.slice(0, insertionEnd).join('\n')
 }
 
@@ -170,4 +195,12 @@ export function trimStartUntilNewline(str: string): string {
         return str.trimStart()
     }
     return str.slice(0, index).trimStart() + str.slice(index)
+}
+
+const NON_WHITESPACE_REGEX = /\S|$/
+function getFirstNCharsPreservingLeadingSpaces(value: string, charsNumber: number): string {
+    const startIndex = value.search(NON_WHITESPACE_REGEX)
+
+    // Return the leading whitespaces and first N characters
+    return value.slice(0, startIndex + charsNumber)
 }


### PR DESCRIPTION
## Context

Proposal based on feedback: [#1](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1688847762962619) and [#2](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1688885824688359).

We can cut off the completion on the partial suffix match (first N characters) to prevent suggesting code duplicating the completion suffix. We want to rely on a big-enough number of symbols to avoid false positives. We do not want to match the whole string because it leads to suffix duplication. Example:

![image](https://github.com/sourcegraph/cody/assets/3846380/5c92ece9-9c2e-49ac-b115-e879b6d1d25a)

We can use fancier algorithms like Levenstein distance instead, but it needs to be clarified if it will perform better in the wild. 

## Test plan

Added unit tests.