### PR TITLE
fix: remove fixup ending tag

### DIFF
--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -62,7 +62,7 @@ export function getFileExtension(fileName: string): string {
 // ex. Remove  `tags:` that Cody sometimes include in the returned content
 // It also removes all spaces before a new line to keep the indentations
 export function contentSanitizer(text: string): string {
-    let output = text + '\n'
+    let output = text.replace(/<\/selection>\s*$/, '')
     const tagsIndex = text.indexOf('tags:')
     if (tagsIndex !== -1) {
         // NOTE: 6 is the length of `tags:` + 1 space

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -62,7 +62,7 @@ export function getFileExtension(fileName: string): string {
 // ex. Remove  `tags:` that Cody sometimes include in the returned content
 // It also removes all spaces before a new line to keep the indentations
 export function contentSanitizer(text: string): string {
-    let output = text.replace(/<\/selection>\s*$/, '')
+    let output = text.trimEnd().replace(/<\/selection>$/, '')
     const tagsIndex = text.indexOf('tags:')
     if (tagsIndex !== -1) {
         // NOTE: 6 is the length of `tags:` + 1 space

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,7 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Inline Chat: Remove the additional `</selection>` tag from Inline Fixups. [pull/182](https://github.com/sourcegraph/cody/pull/182)
+- Inline Chat: Since last version, running Inline Fixups would add an additional `</selection>` tag to the end of the code edited by Cody, which has now been removed. [pull/182](https://github.com/sourcegraph/cody/pull/182)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Inline Chat: Remove the additional `</selection>` tag from Inline Fixups. [pull/182](https://github.com/sourcegraph/cody/pull/182)
+
 ### Changed
 
 ## [0.4.3]

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -370,16 +370,28 @@ export class InlineController {
         }
         // Stop tracking for file changes to perfotm replacement
         this.isInProgress = false
-        const chatSelection = this.getSelectionRange()
-        const documentUri = vscode.Uri.joinPath(this.workspacePath, fileName)
-        const range = new vscode.Selection(chatSelection.start, new vscode.Position(chatSelection.end.line + 1, 0))
-        const newRange = await editDocByUri(documentUri, { start: range.start.line, end: range.end.line }, replacement)
+        try {
+            const chatSelection = this.getSelectionRange()
+            const documentUri = vscode.Uri.joinPath(this.workspacePath, fileName)
+            const range = new vscode.Selection(chatSelection.start, new vscode.Position(chatSelection.end.line + 1, 0))
+            const newRange = await editDocByUri(
+                documentUri,
+                { start: range.start.line, end: range.end.line },
+                replacement
+            )
 
-        const lens = this.codeLenses.get(this.currentTaskId)
-        lens?.storeContext(this.currentTaskId, documentUri, original, replacement)
+            const lens = this.codeLenses.get(this.currentTaskId)
+            lens?.storeContext(this.currentTaskId, documentUri, original, replacement)
 
-        await this.stopFixMode(false, newRange)
-        logEvent('CodyVSCodeExtension:inline-assist:replaced')
+            await this.stopFixMode(false, newRange)
+            logEvent('CodyVSCodeExtension:inline-assist:replaced')
+        } catch (error) {
+            await this.stopFixMode(true)
+            console.error(error)
+            await vscode.window.showErrorMessage(
+                'Fixup failed. Please make sure you are in a single repository workspace and try again.'
+            )
+        }
     }
     /**
      * Return latest selection


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/114

This is a quick temporary fix for the issue where fixup replacement contains `</selection>` tag at the end:
![image](https://github.com/sourcegraph/cody/assets/68532117/0a22fffd-7968-4d3b-8dc4-0c26824af69b)

This fix is served as a temporary fix as Dom's PR https://github.com/sourcegraph/cody/pull/70 to improve the multiplexer should fix this issue properly. 
Adding this line of code however, could use as a fallback in the future and should not break anything before and after Dom's PR:
![image](https://github.com/sourcegraph/cody/assets/68532117/ac93f843-1c36-4ad1-920e-ce1dd26c0d48)

Also added error handling to surface error messages during the inline fixup step.

## Notes

Looks like the issue was a regression from https://github.com/sourcegraph/sourcegraph/pull/54665 as this issue does not exist when switching to the previous version (0.4.2). As the response is now being streamed to Inline Chat, caused the result to be sent to the multiplexer before the turn is marked as completed.

## Test Plan

1. Start Cody from this branch
2. Perform a Inline Fixup
3. Check if the fixup result includes the `</selection>` at the end