### PR TITLE
remove nonexistent .eslintrc.js entry from tsconfig.json files

### DIFF
--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "dist",
     "baseUrl": "./src",
   },
-  "include": ["src", ".eslintrc.js"],
+  "include": ["src"],
   "exclude": ["dist"],
   "references": [
     {

--- a/slack/tsconfig.json
+++ b/slack/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "dist",
     "baseUrl": "./src",
   },
-  "include": ["src", "package.json", ".eslintrc.js"],
+  "include": ["src", "package.json"],
   "exclude": ["dist"],
   "references": [
     {

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -16,7 +16,6 @@
     "vite.config.ts",
     "webpack.config.js",
     "package.json",
-    ".eslintrc.js",
     ".storybook/*.ts",
   ],
   "exclude": ["scripts", "dist", "test/integration"],

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,7 +6,7 @@
     "jsx": "react-jsx",
     "lib": ["ESNext", "DOM"],
   },
-  "include": ["src", "vite.config.ts", ".eslintrc.js"],
+  "include": ["src", "vite.config.ts"],
   "exclude": ["dist"],
   "references": [{ "path": "../lib/shared" }, { "path": "../lib/ui" }],
 }


### PR DESCRIPTION
These are now `.eslintrc.json` files and do not need TypeScript typechecking.

## Test plan

n/a; build only