### PR TITLE
Hotkey cmd+K clears & restarts session

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -235,7 +235,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 }
             }
         },
-        [inputHistory, historyIndex, setFormInput, onChatSubmit, formInput, setMessageBeingEdited]
+        [inputHistory, historyIndex, setFormInput, onChatSubmit, onSubmit, formInput, setMessageBeingEdited]
     )
 
     const transcriptWithWelcome = useMemo<ChatMessage[]>(

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -218,6 +218,11 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 return
             }
 
+            // Clear & reset session on CMD+K
+            if (event.metaKey && event.key === 'k') {
+                onSubmit('/r', 'user')
+            }
+
             if (formInput === inputHistory[historyIndex] || !formInput) {
                 if (event.key === 'ArrowUp' && caretPosition === 0) {
                     const newIndex = historyIndex - 1 < 0 ? inputHistory.length - 1 : historyIndex - 1

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,9 +8,12 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Added support for the CMD+K hotkey to clear the code chat history. [pull/245](https://github.com/sourcegraph/cody/pull/245)
+
 ### Fixed
 
 - Inline Chat: Since last version, running Inline Fixups would add an additional `</selection>` tag to the end of the code edited by Cody, which has now been removed. [pull/182](https://github.com/sourcegraph/cody/pull/182)
+- Chat Command: Fixed an issue where /r(est) had a trailing space. [pull/245](https://github.com/sourcegraph/cody/pull/245)
 
 ### Changed
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -447,7 +447,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
 
     private async executeChatCommands(text: string): Promise<void> {
         switch (true) {
-            case /^\/r(est)?\s/i.test(text):
+            case /^\/r(est)?/i.test(text):
                 await this.clearAndRestartSession()
                 break
             case /^\/s(earch)?\s/i.test(text):


### PR DESCRIPTION
Closes #[229](https://github.com/sourcegraph/cody/issues/229) - Uses the common terminal hotkey [CMD-K](https://docs.warp.dev/features/keyboard-shortcuts#blocks) to clear & restart the Cody session like it does in terminal.

## Test
- Launch Cody from this branch
- Ensure there is chat history or start a new thread
- CMD+K and observe new session start