### PR TITLE
cli: add commit command to generate a commit message

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,7 +32,13 @@ $ <strong>cody</strong>
 ...
 </code></pre>
 
-Use `--help` for a list of command-line options.
+Or have it write a commit message for your Git changes:
+
+```shell
+$ cody commit --dry-run
+```
+
+Use `--help` for more information.
 
 ## Development
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -13,6 +13,7 @@
     "start": "pnpm run --silent build && dist/cody",
     "lint": "pnpm run lint:js",
     "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
+    "test": "vitest",
     "build": "esbuild ./src/program.ts --bundle --outfile=dist/cody --platform=node --log-level=warning",
     "build-ts": "tsc --build --emitDeclarationOnly",
     "prepublishOnly": "pnpm run --silent build"

--- a/cli/src/client/completions.ts
+++ b/cli/src/client/completions.ts
@@ -1,10 +1,18 @@
+import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { ANSWER_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
-import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
+import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
 import {
     CompletionCallbacks,
     CompletionParameters,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+
+import { debugLog } from '../log'
+import { GlobalOptions } from '../program'
+
+import { Client, getClient } from '.'
+import { interactionFromMessage } from './interactions'
+import { getPreamble } from './preamble'
 
 const DEFAULT_CHAT_COMPLETION_PARAMETERS: Omit<CompletionParameters, 'messages'> = {
     temperature: 0.2,
@@ -13,10 +21,59 @@ const DEFAULT_CHAT_COMPLETION_PARAMETERS: Omit<CompletionParameters, 'messages'>
     topP: -1,
 }
 
-export function streamCompletions(
-    client: SourcegraphNodeCompletionsClient,
-    messages: Message[],
-    cb: CompletionCallbacks
-) {
+export function streamCompletions(client: SourcegraphCompletionsClient, messages: Message[], cb: CompletionCallbacks) {
     return client.stream({ messages, ...DEFAULT_CHAT_COMPLETION_PARAMETERS }, cb)
+}
+
+export async function getCompletion(
+    client: Pick<SourcegraphCompletionsClient, 'complete'>,
+    messages: Message[]
+): Promise<string> {
+    const response = await client.complete({ messages, ...DEFAULT_CHAT_COMPLETION_PARAMETERS })
+    return response.completion
+}
+
+export async function getCompletionWithContext(
+    clientOrGlobalOptions: Client | GlobalOptions,
+    humanMessage: string,
+    assistantMessage: string | undefined,
+    debug: boolean
+): Promise<string> {
+    const client = 'debug' in clientOrGlobalOptions ? await getClient(clientOrGlobalOptions) : clientOrGlobalOptions
+
+    const transcript = new Transcript()
+
+    const messages: { human: Message; assistant?: Message }[] = [
+        {
+            human: { speaker: 'human', text: humanMessage },
+            assistant: assistantMessage
+                ? {
+                      speaker: 'assistant',
+                      text: assistantMessage,
+                  }
+                : undefined,
+        },
+    ]
+    for (const [index, message] of messages.entries()) {
+        const interaction = await interactionFromMessage(
+            message.human,
+            client.intentDetector,
+            // Fetch codebase context only for the last message
+            index === messages.length - 1 ? client.codebaseContext : null
+        )
+
+        transcript.addInteraction(interaction)
+
+        if (message.assistant?.text) {
+            transcript.addAssistantResponse(message.assistant?.text)
+        }
+    }
+
+    const { prompt: finalPrompt, contextFiles } = await transcript.getPromptForLastInteraction(
+        getPreamble(client.codebaseContext.getCodebase())
+    )
+    debugLog(debug, 'Context files', contextFiles.map(({ fileName }) => fileName).join('\n'))
+    transcript.setUsedContextFilesForLastInteraction(contextFiles)
+
+    return getCompletion(client.completionsClient, finalPrompt)
 }

--- a/cli/src/client/index.ts
+++ b/cli/src/client/index.ts
@@ -1,5 +1,3 @@
-import { Command } from 'commander'
-
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/intent-detector/client'
@@ -18,9 +16,7 @@ export interface Client {
     completionsClient: SourcegraphCompletionsClient
 }
 
-export async function getClient(program: Command): Promise<Client> {
-    const { codebase, endpoint, context: contextType, debug } = program.optsWithGlobals<GlobalOptions>()
-
+export async function getClient({ codebase, endpoint, context: contextType, debug }: GlobalOptions): Promise<Client> {
     const accessToken: string | undefined = process.env.SRC_ACCESS_TOKEN
     if (accessToken === undefined || accessToken === '') {
         console.error(

--- a/cli/src/client/interactions.ts
+++ b/cli/src/client/interactions.ts
@@ -8,8 +8,8 @@ import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 
 async function getContextMessages(
     text: string,
-    intentDetector: IntentDetector,
-    codebaseContext: CodebaseContext
+    intentDetector: Pick<IntentDetector, 'isCodebaseContextRequired'>,
+    codebaseContext: Pick<CodebaseContext, 'getContextMessages'>
 ): Promise<ContextMessage[]> {
     const contextMessages: ContextMessage[] = []
 
@@ -29,8 +29,8 @@ async function getContextMessages(
 
 export async function interactionFromMessage(
     message: Message,
-    intentDetector: IntentDetector,
-    codebaseContext: CodebaseContext | null
+    intentDetector: Pick<IntentDetector, 'isCodebaseContextRequired'>,
+    codebaseContext: Pick<CodebaseContext, 'getContextMessages'> | null
 ): Promise<Interaction | null> {
     if (!message.text) {
         return Promise.resolve(null)

--- a/cli/src/commands/commit/command.test.ts
+++ b/cli/src/commands/commit/command.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { createGitHelpers } from '../../gitHelpers'
+import { withTemporaryGitRepository } from '../../gitHelpers/testHelpers'
+
+import { run } from './command'
+
+vi.mock('../../client/completions', () => ({
+    getCompletionWithContext: () => Promise.resolve('abc</commit-message>'),
+}))
+
+describe('commit', () => {
+    test('generates commit message', () =>
+        withTemporaryGitRepository({
+            stagedFiles: {
+                'a.js': 'function getUsername() { return process.env.USER }',
+            },
+            run: async (gitDir: string) => {
+                expect(
+                    await run(
+                        { otherCommits: false, dryRun: true, all: false },
+                        {
+                            cwd: gitDir,
+                            gitHelpers: createGitHelpers(),
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+                            client: {} as any,
+                        },
+                        { debug: false }
+                    )
+                ).toBe('abc')
+            },
+        }))
+})

--- a/cli/src/commands/commit/command.ts
+++ b/cli/src/commands/commit/command.ts
@@ -1,0 +1,121 @@
+import { spawn as _spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { cwd } from 'process'
+
+import { Command } from 'commander'
+
+import { Client, getClient } from '../../client'
+import { getCompletionWithContext } from '../../client/completions'
+import { createGitHelpers, GitHelpers } from '../../gitHelpers'
+import { debugLog } from '../../log'
+import { GlobalOptions } from '../../program'
+
+const spawn = promisify(_spawn)
+
+interface CommitOptions {
+    diffFile?: string
+    otherCommits: boolean
+    dryRun: boolean
+    all: boolean
+}
+
+export const commitCommand = new Command('commit')
+    .description('Write a Git commit message.')
+    .option('--diff-file <file>', 'Read the diff from a file (or /dev/stdin) instead of invoking `git diff`')
+    .option('--other-commits', 'Include your recent commit messages as examples', true)
+    .option('--dry-run', 'Show suggested message but do not invoke `git commit`', false)
+    .option('-a, --all', 'Same as `git commit -a` flag', false)
+    .action(async (options, program: Command) =>
+        console.log(
+            await run(
+                options,
+                {
+                    cwd: cwd(),
+                    gitHelpers: createGitHelpers(),
+                    client: await getClient(program.optsWithGlobals<GlobalOptions>()),
+                },
+                program.optsWithGlobals<GlobalOptions>()
+            )
+        )
+    )
+
+interface CommitEnvironment {
+    cwd: string
+    gitHelpers: GitHelpers
+    client: Client | GlobalOptions
+}
+
+export async function run(
+    options: CommitOptions,
+    { cwd, gitHelpers, client }: CommitEnvironment,
+    globalOptions: Pick<GlobalOptions, 'debug'>
+): Promise<string> {
+    const diff = options.diffFile
+        ? await fs.readFile(options.diffFile, 'utf8')
+        : await gitHelpers.getDiffToCommit({ cwd, stagedOnly: !options.all })
+    debugLog(globalOptions.debug, 'Diff', diff)
+
+    const otherCommitMessages = options.otherCommits ? await gitHelpers.getOtherCommitMessages({ cwd }) : []
+    debugLog(globalOptions.debug, 'Other commit messages', otherCommitMessages.join('\n--\n'))
+
+    const commitMessage = await generateCommitMessage(diff, otherCommitMessages, globalOptions.debug, client)
+
+    if (!options.dryRun) {
+        // Run `git commit` with the commit message.
+        const messageFile = path.join(await gitHelpers.gitDir({ cwd }), 'CODY_COMMIT_MSG')
+        await fs.writeFile(messageFile, commitMessage, 'utf8')
+        try {
+            await spawn(
+                'git',
+                ['commit', options.all ? '--all' : null, `--file=${messageFile}`, '--edit'].filter(
+                    (arg): arg is string => arg !== null
+                ),
+                {
+                    cwd,
+                    stdio: 'inherit',
+                }
+            )
+        } finally {
+            await fs.rm(messageFile, { force: true })
+        }
+    }
+
+    return commitMessage
+}
+
+async function generateCommitMessage(
+    diff: string,
+    otherCommitMessages: string[],
+    debug: boolean,
+    client: Client | GlobalOptions
+): Promise<string> {
+    // Strip ' (#123)' pull request references from the other commit messages because they can
+    // mislead the LLM.
+    for (const [i, msg] of otherCommitMessages.entries()) {
+        otherCommitMessages[i] = msg.replace(/^(.*)\s+\(#\d+\)(\n|$)/, '$1')
+    }
+
+    const humanMessage = [
+        'A commit message consists of a short subject line and a body with additional details about and reasons for the change. Commit messages are concise, technical, and specific to the change. They also mention any UI or user-facing changes.',
+        otherCommitMessages.length > 0
+            ? `Here are some examples of good commit messages for other diffs:\n\n${otherCommitMessages
+                  .map(m => `<commit-message>\n${m}\n</commit-message>`)
+                  .join('\n\n')}`
+            : null,
+        `Here is a diff:\n\n<diff>\n${diff}\n</diff>`,
+        'Write a commit message and body the diff.',
+    ]
+        .filter(s => s !== null)
+        .join('\n\n')
+
+    const completion = await getCompletionWithContext(
+        client,
+        humanMessage,
+        'Here is a suggested commit message for the diff:\n\n<commit-message>',
+        debug
+    )
+    const commitMessage = completion.slice(0, completion.indexOf('</commit-message>')).trim()
+    return commitMessage
+}

--- a/cli/src/commands/commit/compare.test.sh
+++ b/cli/src/commands/commit/compare.test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+# Usage: compare.test.sh <REVSPEC>
+REVSPEC="${1-HEAD}"
+COMMIT_SHA=$(git rev-parse --verify "$REVSPEC^{commit}")
+
+# Create temp file and delete when script exits.
+tmpfile=$(mktemp)
+trap "rm -f $tmpfile" EXIT
+
+git --no-pager show --no-color --unified=1 --format= $COMMIT_SHA > $tmpfile
+
+# get git commit message
+echo '# Actual commit message:'
+echo
+git --no-pager show --format=format:%B --no-patch $COMMIT_SHA
+echo '###############################################################'
+echo '# Cody-generated commit message:'
+pnpm run --silent start --debug commit --diff-file $tmpfile

--- a/cli/src/commands/commit/index.ts
+++ b/cli/src/commands/commit/index.ts
@@ -1,0 +1,1 @@
+export { commitCommand } from './command'

--- a/cli/src/gitHelpers/index.ts
+++ b/cli/src/gitHelpers/index.ts
@@ -1,0 +1,61 @@
+import { execFile as _execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFile = promisify(_execFile)
+
+export interface GitHelpers {
+    getDiffToCommit(options: { cwd: string; stagedOnly: boolean }): Promise<string>
+    getOtherCommitMessages(options: { cwd: string }): Promise<string[]>
+    gitDir(options: { cwd: string }): Promise<string>
+}
+
+export function createGitHelpers(): GitHelpers {
+    return {
+        async getDiffToCommit({ cwd, stagedOnly }) {
+            const { stdout } = await execFile(
+                'git',
+                [
+                    'diff',
+                    '--patch',
+                    '--unified=1',
+                    '--diff-algorithm=minimal',
+                    '--no-color',
+                    '-M',
+                    '-C',
+                    stagedOnly ? '--staged' : 'HEAD',
+                ],
+                { cwd }
+            )
+            return stdout
+        },
+        async getOtherCommitMessages({ cwd }) {
+            const { stdout: gitAuthorEmail } = await execFile('git', ['config', 'user.email'], {
+                cwd,
+            })
+
+            const { stdout } = await execFile(
+                'git',
+                [
+                    'log',
+                    '-z',
+                    '--format=%B',
+                    '--max-count=3',
+                    '--skip=5', // recent commits might be too similar and too suggestive toward the LLM
+                    `--author=${gitAuthorEmail.trim()}`,
+                    'refs/remotes/origin/HEAD',
+                ],
+                {
+                    cwd,
+                }
+            )
+            return stdout
+                .split('\0')
+                .map(message => message.trim())
+                .filter(message => message !== '')
+        },
+        async gitDir({ cwd }) {
+            const { stdout } = await execFile('git', ['rev-parse', '--git-dir'], { cwd })
+            return stdout.trim()
+        },
+    }
+}

--- a/cli/src/gitHelpers/testHelpers.ts
+++ b/cli/src/gitHelpers/testHelpers.ts
@@ -1,0 +1,58 @@
+import { execFile as _execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { promisify } from 'node:util'
+import path from 'path'
+
+const execFile = promisify(_execFile)
+
+const commitSignatureEnv: NodeJS.ProcessEnv = {
+    GIT_COMMITTER_NAME: 'a',
+    GIT_COMMITTER_EMAIL: 'a@a.com',
+    GIT_AUTHOR_NAME: 'a',
+    GIT_AUTHOR_EMAIL: 'a@a.com',
+}
+
+export async function withTemporaryGitRepository<T>({
+    committedFiles,
+    stagedFiles,
+    run,
+}: {
+    committedFiles?: { [name: string]: string }
+    stagedFiles: { [name: string]: string }
+    run: (gitDir: string) => T
+}): Promise<T> {
+    let tmpGitDir: string | undefined
+    try {
+        tmpGitDir = await mkdtemp(path.join(tmpdir(), 'cody-cli-test-'))
+
+        // Create Git repository.
+        await execFile('git', ['init'], { cwd: tmpGitDir })
+        if (committedFiles) {
+            for (const [name, contents] of Object.entries(committedFiles)) {
+                await writeAndGitAddFile(tmpGitDir, name, contents)
+            }
+        }
+        await execFile('git', ['commit', '--message', 'test', '--allow-empty'], {
+            cwd: tmpGitDir,
+            env: commitSignatureEnv,
+        })
+
+        if (stagedFiles) {
+            for (const [name, contents] of Object.entries(stagedFiles)) {
+                await writeAndGitAddFile(tmpGitDir, name, contents)
+            }
+        }
+
+        return run(tmpGitDir)
+    } finally {
+        if (tmpGitDir !== undefined) {
+            await rm(tmpGitDir, { recursive: true, force: true })
+        }
+    }
+}
+
+async function writeAndGitAddFile(gitDir: string, name: string, contents: string): Promise<void> {
+    await writeFile(path.join(gitDir, name), contents, 'utf8')
+    await execFile('git', ['add', '--', name], { cwd: gitDir })
+}

--- a/cli/src/log.ts
+++ b/cli/src/log.ts
@@ -1,0 +1,10 @@
+export function debugLog(debug: boolean, title: string, text: string): void {
+    if (debug) {
+        const sep = '###############################################'
+        console.error(sep)
+        console.error(`# ${title}`)
+        console.error(sep)
+        console.error(text)
+        console.error(sep)
+    }
+}

--- a/cli/src/program.ts
+++ b/cli/src/program.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander'
 
 import { ConfigurationUseContext } from '@sourcegraph/cody-shared/src/configuration'
 
+import { commitCommand } from './commands/commit'
 import { replCommand } from './commands/repl'
 
 export interface GlobalOptions {
@@ -16,11 +17,12 @@ const program = new Command()
     .name('cody')
     .version('0.0.1')
     .description('Cody CLI')
-    .option('-c, --codebase <value>', 'Codebase to use for context fetching', 'github.com/sourcegraph/sourcegraph')
+    .option('-c, --codebase <value>', 'Codebase to use for context fetching', 'github.com/sourcegraph/cody')
     .option('-e, --endpoint <value>', 'Sourcegraph instance to connect to', 'https://sourcegraph.com')
     .option('--context [embeddings,keyword,none,blended]', 'How Cody fetches context', 'blended')
     .option('--debug', 'Enable debug logging', false)
     .addCommand(replCommand)
+    .addCommand(commitCommand)
 
 // Make `repl` the default subcommand.
 const args = process.argv.slice(2)

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+    logLevel: 'warn',
+})

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -54,5 +54,5 @@ export abstract class SourcegraphCompletionsClient {
     }
 
     public abstract stream(params: CompletionParameters, cb: CompletionCallbacks): () => void
-    public abstract complete(params: CompletionParameters, abortSignal: AbortSignal): Promise<CompletionResponse>
+    public abstract complete(params: CompletionParameters, abortSignal?: AbortSignal): Promise<CompletionResponse>
 }

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -9,7 +9,7 @@ import { parseEvents } from './parse'
 import { CompletionCallbacks, CompletionParameters, CompletionResponse } from './types'
 
 export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClient {
-    public async complete(params: CompletionParameters, abortSignal: AbortSignal): Promise<CompletionResponse> {
+    public async complete(params: CompletionParameters, abortSignal?: AbortSignal): Promise<CompletionResponse> {
         const log = this.logger?.startCompletion(params)
 
         const headers = new Headers(this.config.customHeaders as HeadersInit)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,13 @@
     "noEmit": true
   },
   "files": [],
-  "include": [".eslintrc.js", ".prettierrc.js", "vitest.workspace.js", "lib/shared/vitest.config.ts"],
+  "include": [
+    ".eslintrc.js",
+    ".prettierrc.js",
+    "vitest.workspace.js",
+    "lib/shared/vitest.config.ts",
+    "cli/vitest.config.ts"
+  ],
   "exclude": ["dist", "node_modules"],
   "references": [
     { "path": "agent" },


### PR DESCRIPTION
The new (experimental) `cody commit` command passes the diffs (with added codebase context) from a Git repository to Cody to write a commit message. It optionally invokes `git commit` if `--dry-run` is not set.

(It wrote the 2 commit messages in this PR with only minor modifications.)

## Example

```
$ cd cli && pnpm run --silent build && dist/cody commit --dry-run
Add completions client and utilities

This commit adds utilities for interacting with the completions client to generate completions and responses. It includes:

- A `streamCompletions()` function to stream completions from the client.
- A `getCompletion()` function to get a single completion response. 
- A `getCompletionWithContext()` function to generate completions with context from the transcript and codebase.

This allows us to reuse completions logic in different parts of the codebase.
```

## Test plan

n/a; experimental feature