### PR TITLE
make the @sourcegraph/cody-cli package publishable

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,62 @@
+name: cli-release
+
+on:
+  push:
+    tags:
+      - cli-v*
+
+jobs:
+  release:
+    if: github.repository == 'sourcegraph/cody'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # for publishing the release
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .tool-versions
+      - uses: pnpm/action-setup@v2
+        with:
+          run_install: true
+      - name: get release version
+        id: release_version
+        run: |
+          TAGGED_VERSION="${GITHUB_REF/refs\/tags\/cli-v/}"
+
+          if [[ ! "${TAGGED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "Invalid version tag '${TAGGED_VERSION}'"
+            exit 1
+          fi
+
+          echo "CLI_VERSION=${TAGGED_VERSION}" >> $GITHUB_ENV
+          WRITTEN_VERSION="$(cat cli/package.json | jq '.version' -r)"
+
+          if [[ "${TAGGED_VERSION}" != "${WRITTEN_VERSION}" ]]; then
+            echo "Release tag and version in cli/package.json do not match: '${TAGGED_VERSION}' vs. '${WRITTEN_VERSION}'"
+            exit 1
+          fi
+      - run: pnpm -C cli run test
+      - run: pnpm -C cli publish
+        if: github.repository == 'sourcegraph/cody'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Cody CLI ${{ env.CLI_VERSION }}
+          draft: false
+      - name: upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./cli/dist/cody
+          asset_name: cody-cli-${{ env.CLI_VERSION }}.js
+          asset_content_type: text/javascript

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,3 +27,13 @@ Use `--help` for a list of command-line options.
 ```shell
 pnpm run start
 ```
+
+### Release
+
+To publish a new release of the `@sourcegraph/cody-cli` package:
+
+1. Increment the `version` in [`package.json`](package.json).
+1. Commit the version increment.
+1. `git tag cli-v$(jq -r .version package.json)`
+1. `git push --tags`
+1. Wait for the [cli-release workflow](https://github.com/sourcegraph/cody/actions/workflows/cli-release.yml) to finish.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,16 +1,21 @@
 {
   "name": "@sourcegraph/cody-cli",
-  "private": true,
-  "displayName": "Sourcegraph Cody CLI",
   "version": "0.0.1",
   "license": "Apache-2.0",
-  "description": "Cody CLI",
+  "description": "Cody CLI (experimental)",
+  "homepage": "https://cody.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/cody",
+    "directory": "cli"
+  },
   "scripts": {
     "start": "pnpm run --silent build && dist/cody",
     "lint": "pnpm run lint:js",
     "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
     "build": "esbuild ./src/program.ts --bundle --outfile=dist/cody --platform=node --log-level=warning",
-    "build-ts": "tsc --build --emitDeclarationOnly"
+    "build-ts": "tsc --build --emitDeclarationOnly",
+    "prepublishOnly": "pnpm run --silent build"
   },
   "dependencies": {
     "@sourcegraph/cody-shared": "workspace:*",
@@ -21,6 +26,12 @@
     "@types/prompts": "^2.4.4"
   },
   "main": "dist/program.js",
+  "files": [
+    "dist",
+    "src",
+    "!**/*.test.*",
+    "!**/*.tsbuildinfo"
+  ],
   "bin": {
     "cody": "./dist/cody"
   }


### PR DESCRIPTION
Also set up a GitHub Action to publish this for the tag `cli-v*`.

## Test plan

n/a; CLI is experimental