### PR TITLE
Add scip-typescript indexing job

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -1,0 +1,50 @@
+name: scip-typescript
+on:
+  push:
+    paths:
+      - '**.ts'
+      - '**.tsx'
+      - '**.js'
+
+jobs:
+  scip-typescript:
+    if: github.repository == 'sourcegraph/cody'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        id: pnpm-install
+        with:
+          version: 8.6.6
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx @sourcegraph/scip-typescript index --pnpm-workspaces --no-global-caches
+      - run: yarn global add @sourcegraph/src
+      - name: Upload SCIP to Cloud
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.com/
+      - name: Upload SCIP to S2
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        env:
+          SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
+      - name: Upload lsif to Dogfood
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://k8s.sgdev.org/
+      - name: Upload lsif to Demo
+        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        env:
+          SRC_ENDPOINT: https://demo.sourcegraph.com/

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -6,8 +6,6 @@ import { AgentEditor } from './editor'
 import { MessageHandler } from './jsonrpc'
 import { ConnectionConfiguration, TextDocument } from './protocol'
 
-// TODO: Comment to trigger CI, remove before merging this PR
-
 export class Agent extends MessageHandler {
     private client?: Promise<Client>
     public workspaceRootPath: string | null = null

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -6,6 +6,8 @@ import { AgentEditor } from './editor'
 import { MessageHandler } from './jsonrpc'
 import { ConnectionConfiguration, TextDocument } from './protocol'
 
+// TODO: Comment to trigger CI, remove before merging this PR
+
 export class Agent extends MessageHandler {
     private client?: Promise<Client>
     public workspaceRootPath: string | null = null


### PR DESCRIPTION
The sourcegraph.com auto-indexing queue has a lot of jobs so it takes a long time for the index to catch up with the latest commit. Having the indexing job in the repo makes sure we always have precise intel for the latest commits.