### PR TITLE
custom prompts: add intro and new context type

### DIFF
--- a/.vscode/cody.json
+++ b/.vscode/cody.json
@@ -1,0 +1,36 @@
+{
+  "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph to use.",
+  "recipes": {
+    "Spell Checker": {
+      "prompt": "Spell check the selected code and let me know if I have any typos or non-standard usage.",
+      "context": {
+        "codebase": false
+      }
+    },
+    "Refactor Code": {
+      "prompt": "Suggest ways to refactor the selected code to improve readability and maintainability",
+      "context": {
+        "currentDir": true
+      }
+    },
+    "Compare Files in Opened Tabs": {
+      "prompt": "Compare the code from the shared files and explain how they are related",
+      "context": {
+        "openTabs": true,
+        "excludeSelection": true
+      }
+    },
+    "GH Search: Deploy Repoes not owned by Sourcegraph": {
+      "prompt": "What are the names of repositories that are used for deploying Sourcegraph, but is not directly owned by Sourcegraph?",
+      "command": "gh",
+      "args": ["search", "repos", "sourcegraph", "deploy"],
+      "note": "You must have gh command installed and authenticated to use this recipe"
+    },
+    "Last Git Commit Info": {
+      "prompt": "Who made the last commit to this repository and what did they change?",
+      "command": "git",
+      "args": ["log", "-1"],
+      "note": "You must have git command installed and authenticated to use this recipe"
+    }
+  }
+}

--- a/.vscode/cody.json
+++ b/.vscode/cody.json
@@ -1,5 +1,5 @@
 {
-  "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph to use.",
+  "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph.",
   "recipes": {
     "Spell Checker": {
       "prompt": "Spell check the selected code and let me know if I have any typos or non-standard usage.",

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -62,7 +62,7 @@ export function getFileExtension(fileName: string): string {
 // ex. Remove  `tags:` that Cody sometimes include in the returned content
 // It also removes all spaces before a new line to keep the indentations
 export function contentSanitizer(text: string): string {
-    let output = text.trimEnd().replace(/<\/selection>$/, '')
+    let output = text.replace(/<\/selection>\s$/, '')
     const tagsIndex = text.indexOf('tags:')
     if (tagsIndex !== -1) {
         // NOTE: 6 is the length of `tags:` + 1 space

--- a/lib/shared/src/chat/recipes/my-prompt.ts
+++ b/lib/shared/src/chat/recipes/my-prompt.ts
@@ -33,14 +33,14 @@ export class MyPrompt implements Recipe {
 
         const truncatedText = truncateText(promptText, MAX_HUMAN_INPUT_TOKENS)
 
-        // Add com mand output to prompt text when available
+        // Add command output to prompt text when available
         const commandOutput = context.editor.controllers?.prompt.get()
         if (commandOutput) {
-            // promptT ext += `\n${commandOutput}\n`
+            // promptText += `\n${commandOutput}\n`
             promptText += 'Please refer to the command output or the code I am looking at to answer my quesiton.'
         }
 
-        // Add sel ection file name as display when available
+        // Add selection file name as display when available
         const displayText = selection?.fileName ? this.getHumanDisplayText(humanInput, selection?.fileName) : humanInput
 
         return Promise.resolve(
@@ -71,7 +71,7 @@ export class MyPrompt implements Recipe {
         const isCodebaseContextRequired = contextConfig
             ? (JSON.parse(contextConfig) as CodyPromptContext)
             : defaultCodyPromptContext
-        // Codebas e context is not included by default
+        // Codebase context is not included by default
         if (isCodebaseContextRequired.codebase) {
             const codebaseContextMessages = await codebaseContext.getContextMessages(text, {
                 numCodeResults: 12,
@@ -79,28 +79,28 @@ export class MyPrompt implements Recipe {
             })
             contextMessages.push(...codebaseContextMessages)
         }
-        // Create  context messages from open tabs
+        // Create context messages from open tabs
         if (isCodebaseContextRequired.openTabs) {
             const openTabsContext = await MyPrompt.getEditorOpenTabsContext()
             contextMessages.push(...openTabsContext)
         }
-        // Create  context messages from current directory
+        // Create context messages from current directory
         if (isCodebaseContextRequired.currentDir) {
             const currentDirContext = await MyPrompt.getCurrentDirContext()
             contextMessages.push(...currentDirContext)
         }
-        // Add sel ected text as context when available
+        // Add selected text as context when available
         if (selection?.selectedText && !isCodebaseContextRequired.excludeSelection) {
             contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
         }
-        // Create  context messages from terminal output if any
+        // Create context messages from terminal output if any
         if (commandOutput) {
             contextMessages.push(...MyPrompt.getTerminalOutputContext(commandOutput))
         }
         return contextMessages.slice(-12)
     }
 
-    // Get con text from current editor open tabs
+    // Get context from current editor open tabs
     public static async getEditorOpenTabsContext(): Promise<ContextMessage[]> {
         const contextMessages: ContextMessage[] = []
         // Get a list of the open tabs
@@ -141,7 +141,7 @@ export class MyPrompt implements Recipe {
         return InlineTouch.getEditorDirContext(currentDoc.fileName.replace(/\/[^/]+$/, ''))
     }
 
-    // Get dis play text for human
+    // Get display text for human
     private getHumanDisplayText(humanChatInput: string, fileName: string): string {
         return humanChatInput + InlineTouch.displayPrompt + fileName
     }

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,12 +9,14 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Added
 
 - Added support for the CMD+K hotkey to clear the code chat history. [pull/245](https://github.com/sourcegraph/cody/pull/245)
+- [Internal Only] `Custom Recipe` is available for S2 internal users for testing purpose. [pull/81](https://github.com/sourcegraph/cody/pull/81)
 
 ### Fixed
 
 - Fixed a bug that caused messages to disappear when signed-in users encounter an authentication error. [pull/201](https://github.com/sourcegraph/cody/pull/201)
 - Inline Chat: Since last version, running Inline Fixups would add an additional `</selection>` tag to the end of the code edited by Cody, which has now been removed. [pull/182](https://github.com/sourcegraph/cody/pull/182)
 - Chat Command: Fixed an issue where /r(est) had a trailing space. [pull/245](https://github.com/sourcegraph/cody/pull/245)
+- Inline Fixups: Fixed a regression where Cody's inline fixup suggestions were not properly replacing the user's selection. [pull/70](https://github.com/sourcegraph/cody/pull/70)
 
 ### Changed
 

--- a/vscode/resources/bin/cody.json
+++ b/vscode/resources/bin/cody.json
@@ -1,0 +1,36 @@
+{
+  "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph to use.",
+  "recipes": {
+    "Spell Checker": {
+      "prompt": "Spell check the selected code and let me know if I have any typos or non-standard usage.",
+      "context": {
+        "codebase": false
+      }
+    },
+    "Refactor Code": {
+      "prompt": "Suggest ways to refactor the selected code to improve readability and maintainability",
+      "context": {
+        "currentDir": true
+      }
+    },
+    "Compare Files in Opened Tabs": {
+      "prompt": "Compare the code from the shared files and explain how they are related",
+      "context": {
+        "openTabs": true,
+        "excludeSelection": true
+      }
+    },
+    "GH Search: Deploy Repoes not owned by Sourcegraph": {
+      "prompt": "What are the names of repositories that are used for deploying Sourcegraph, but is not directly owned by Sourcegraph?",
+      "command": "gh",
+      "args": ["search", "repos", "sourcegraph", "deploy"],
+      "note": "You must have gh command installed and authenticated to use this recipe"
+    },
+    "Last Git Commit Info": {
+      "prompt": "Who made the last commit to this repository and what did they change?",
+      "command": "git",
+      "args": ["log", "-1"],
+      "note": "You must have git command installed and authenticated to use this recipe"
+    }
+  }
+}

--- a/vscode/resources/bin/cody.json
+++ b/vscode/resources/bin/cody.json
@@ -1,5 +1,5 @@
 {
-  "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph to use.",
+  "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph.",
   "recipes": {
     "Spell Checker": {
       "prompt": "Spell check the selected code and let me know if I have any typos or non-standard usage.",

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -643,7 +643,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             return
         }
         // Create a new recipe
-        if (title === 'new') {
+        if (title === 'add') {
             await this.editor.controllers.prompt.add()
             await this.sendMyPrompts()
             return

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -647,6 +647,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             await this.editor.controllers.prompt.add()
             await this.sendMyPrompts()
             return
+        } // Create a new recipe
+        if (title === 'clear') {
+            await this.editor.controllers.prompt.clear()
+            await this.sendMyPrompts()
+            return
         }
         this.showTab('chat')
         // Get prompt details from controller by title then execute

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -647,10 +647,36 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             await this.editor.controllers.prompt.add()
             await this.sendMyPrompts()
             return
-        } // Create a new recipe
+        }
+        // Clear all recipes stored in user global storage
         if (title === 'clear') {
             await this.editor.controllers.prompt.clear()
             await this.sendMyPrompts()
+            return
+        }
+        if (title === 'new-workspace-example-file') {
+            if (!this.currentWorkspaceRoot) {
+                void vscode.window.showErrorMessage('Could not find workspace path.')
+                return
+            }
+            try {
+                // copy the cody.json file from the extension path and move it to the workspace root directory
+                // Find the fsPath of the cody.json example file from the this.rgPath
+                const extensionPath = this.rgPath.slice(0, Math.max(0, this.rgPath.lastIndexOf('/')))
+                const extensionUri = vscode.Uri.parse(extensionPath)
+                const codyJsonPath = vscode.Uri.joinPath(extensionUri, 'cody.json')
+                const bytes = await vscode.workspace.fs.readFile(codyJsonPath)
+                const decoded = new TextDecoder('utf-8').decode(bytes)
+                const workspaceUri = vscode.Uri.parse(this.currentWorkspaceRoot)
+                const workspaceCodyJsonPath = vscode.Uri.joinPath(workspaceUri, '.vscode/cody.json')
+                const workspaceEditor = new vscode.WorkspaceEdit()
+                workspaceEditor.createFile(workspaceCodyJsonPath, { ignoreIfExists: false })
+                workspaceEditor.insert(workspaceCodyJsonPath, new vscode.Position(0, 0), decoded)
+                await vscode.workspace.applyEdit(workspaceEditor)
+                await vscode.window.showTextDocument(workspaceCodyJsonPath)
+            } catch (error) {
+                void vscode.window.showErrorMessage(`Could not create a new cody.json file: ${error}`)
+            }
             return
         }
         this.showTab('chat')

--- a/vscode/src/my-cody/MyPromptController.ts
+++ b/vscode/src/my-cody/MyPromptController.ts
@@ -155,11 +155,14 @@ export class MyPromptController {
         // Get the prompt name and prompt description from the user using the input box with 2 steps
         const promptName = await vscode.window.showInputBox({
             title: 'Creating a new custom recipe...',
-            prompt: 'What is the name for the new recipe?',
+            prompt: 'Enter an unique name for the new recipe.',
             placeHolder: 'e,g. Vulnerability Scanner',
             validateInput: (input: string) => {
-                if (!input) {
-                    return 'Please enter a prompt name.'
+                if (!input || input === 'add' || input === 'clear') {
+                    return 'Please enter a valid name for the recipe.'
+                }
+                if (this.myPromptStore.has(input)) {
+                    return 'A recipe with the same name already exists. Please enter a different name.'
                 }
                 return
             },

--- a/vscode/src/my-cody/MyPromptController.ts
+++ b/vscode/src/my-cody/MyPromptController.ts
@@ -148,6 +148,11 @@ export class MyPromptController {
     }
 
     public async clear(): Promise<void> {
+        if (!this.builder.userPromptsSize) {
+            void vscode.window.showInformationMessage(
+                'No User Recipes to remove. If you want to remove Workspace Recipes, please remove the .vscode/cody.json file from your repository.'
+            )
+        }
         await this.context.globalState.update(MY_CODY_PROMPTS_KEY, null)
     }
 
@@ -210,6 +215,8 @@ class MyRecipesBuilder {
     public myPromptsMap = new Map<string, CodyPrompt>()
     public idSet = new Set<string>()
 
+    public userPromptsSize = 0
+
     public codebase: string | null = null
 
     constructor(private globalState: vscode.Memento, private workspaceRoot: string | null) {}
@@ -220,7 +227,8 @@ class MyRecipesBuilder {
         this.idSet = new Set<string>()
         // user prompts
         const storagePrompts = this.getPromptsFromExtensionStorage()
-        this.build(storagePrompts, 'user')
+        const storagePromptsMap = this.build(storagePrompts, 'user')
+        this.userPromptsSize = storagePromptsMap?.size || 0
         // workspace prompts
         const wsPrompts = await this.getPromptsFromWorkspace(this.workspaceRoot)
         this.build(wsPrompts, 'workspace')

--- a/vscode/src/services/DecorationProvider.ts
+++ b/vscode/src/services/DecorationProvider.ts
@@ -90,7 +90,7 @@ export class DecorationProvider {
      */
     public setState(status: CodyTaskState, newRange: vscode.Range): void {
         this.status = status
-        this.range = new vscode.Range(newRange.start.line, 0, Math.max(0, newRange.end.line - 1), 0)
+        this.range = new vscode.Range(newRange.start.line, 0, Math.max(0, newRange.end.line), 0)
         this.decorate()
         this._onDidChange.fire()
     }

--- a/vscode/webviews/Recipes.module.css
+++ b/vscode/webviews/Recipes.module.css
@@ -16,6 +16,13 @@
     justify-content: space-between;
     align-items: center;
 
-    font-size: 1rem;
+    font-size: 0.8rem;
     font-weight: bold;
+}
+
+.recipes-notes {
+    display: flex;
+    align-items: center;
+    margin: 0.1rem 0;
+    font-size: small;
 }

--- a/vscode/webviews/Recipes.tsx
+++ b/vscode/webviews/Recipes.tsx
@@ -41,27 +41,49 @@ export const Recipes: React.FunctionComponent<{
             <div className="non-transcript-container">
                 <div className={styles.recipes}>
                     {myPromptsEnabled && (
-                        <div className={styles.recipesHeader}>
-                            <span>My Prompts</span>
-                            <VSCodeButton type="button" appearance="icon" onClick={() => onMyPromptClick('new')}>
-                                <i className="codicon codicon-plus" title="Create a new recipe with custom prompt" />
-                            </VSCodeButton>
-                        </div>
-                    )}
-                    {myPromptsEnabled &&
-                        myPrompts?.map(promptID => (
+                        <>
+                            <div>
+                                <div className={styles.recipesHeader}>
+                                    <span>My Prompts</span>
+                                    <VSCodeButton
+                                        type="button"
+                                        appearance="icon"
+                                        onClick={() => onMyPromptClick('add')}
+                                    >
+                                        <i
+                                            className="codicon codicon-plus"
+                                            title="Create a new recipe with custom prompt"
+                                        />
+                                    </VSCodeButton>
+                                </div>
+                            </div>
+                            <div className={styles.recipesNotes}>
+                                Use the + button above to create your very own recipe. To create a Workspace recipe that
+                                is available to all users, add the cody.json file to the .vscode directory of your
+                                workspace.
+                            </div>
+                            {myPrompts?.map(promptID => (
+                                <VSCodeButton
+                                    key={promptID}
+                                    className={styles.recipeButton}
+                                    type="button"
+                                    onClick={() => onMyPromptClick(promptID)}
+                                >
+                                    {promptID}
+                                </VSCodeButton>
+                            ))}
                             <VSCodeButton
-                                key={promptID}
                                 className={styles.recipeButton}
                                 type="button"
-                                onClick={() => onMyPromptClick(promptID)}
+                                onClick={() => onMyPromptClick('clear')}
                             >
-                                {promptID}
+                                Remove all User Recipes
                             </VSCodeButton>
-                        ))}
-                    <div className={styles.recipesHeader}>
-                        <span>Featured</span>
-                    </div>
+                            <div className={styles.recipesHeader}>
+                                <span>Featured</span>
+                            </div>
+                        </>
+                    )}
                     {Object.entries(recipesList).map(([key, value]) => (
                         <VSCodeButton
                             key={key}

--- a/vscode/webviews/Recipes.tsx
+++ b/vscode/webviews/Recipes.tsx
@@ -56,11 +56,11 @@ export const Recipes: React.FunctionComponent<{
                                         />
                                     </VSCodeButton>
                                 </div>
-                            </div>
-                            <div className={styles.recipesNotes}>
-                                Use the + button above to create your very own recipe. To create a Workspace recipe that
-                                is available to all users, add the cody.json file to the .vscode directory of your
-                                workspace.
+                                <small className={styles.recipesNotes}>
+                                    Use the + button above to create your very own recipe. To create a Workspace recipe
+                                    that is available to all users, add the cody.json file to the .vscode directory of
+                                    your workspace.
+                                </small>
                             </div>
                             {myPrompts?.map(promptID => (
                                 <VSCodeButton

--- a/vscode/webviews/Recipes.tsx
+++ b/vscode/webviews/Recipes.tsx
@@ -58,10 +58,19 @@ export const Recipes: React.FunctionComponent<{
                                 </div>
                                 <small className={styles.recipesNotes}>
                                     Use the + button above to create your very own recipe. To create a Workspace recipe
-                                    that is available to all users, add the cody.json file to the .vscode directory of
-                                    your workspace.
+                                    that is available to all users, add a recipe item to the .vscode/cody.json file in
+                                    your repository.
                                 </small>
                             </div>
+                            {!myPrompts?.length && (
+                                <VSCodeButton
+                                    className={styles.recipeButton}
+                                    type="button"
+                                    onClick={() => onMyPromptClick('new-workspace-example-file')}
+                                >
+                                    Create a cody.json file with examples
+                                </VSCodeButton>
+                            )}
                             {myPrompts?.map(promptID => (
                                 <VSCodeButton
                                     key={promptID}
@@ -72,13 +81,15 @@ export const Recipes: React.FunctionComponent<{
                                     {promptID}
                                 </VSCodeButton>
                             ))}
-                            <VSCodeButton
-                                className={styles.recipeButton}
-                                type="button"
-                                onClick={() => onMyPromptClick('clear')}
-                            >
-                                Remove all User Recipes
-                            </VSCodeButton>
+                            {myPrompts?.length && (
+                                <VSCodeButton
+                                    className={styles.recipeButton}
+                                    type="button"
+                                    onClick={() => onMyPromptClick('clear')}
+                                >
+                                    Remove all User Recipes
+                                </VSCodeButton>
+                            )}
                             <div className={styles.recipesHeader}>
                                 <span>Featured</span>
                             </div>


### PR DESCRIPTION
This PR adds new context types to the custom prompts feature.

Users can specify what type of context to include when building their recipe:

```
export interface CodyPromptContext {
    codebase: boolean
    openTabs?: boolean
    currentDir?: boolean
    excludeSelection?: boolean
}
```
Add intro to My Prompts and button to create cody.json file in current workspace:
![image](https://github.com/sourcegraph/cody/assets/68532117/5f54f69a-675d-4d05-aa34-b2c715c97420)
