### PR TITLE
add logging to `publicProperties` in new logged events

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -500,7 +500,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         if (enabledPlugins.length === 0) {
             return {}
         }
-        logEvent('CodyVSCodeExtension:getPluginsContext:enabledPlugins', { names: enabledPluginNames })
+        logEvent('CodyVSCodeExtension:getPluginsContext:enabledPlugins', { names: enabledPluginNames }, { names: enabledPluginNames })
 
         this.transcript.addAssistantResponse('', 'Identifying applicable plugins...\n')
         this.sendTranscript()
@@ -520,7 +520,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 enabledPlugins,
                 previousMessages
             )
-            logEvent('CodyVSCodeExtension:getPluginsContext:descriptorsFound', { count: descriptors.length })
+            logEvent('CodyVSCodeExtension:getPluginsContext:descriptorsFound', { count: descriptors.length }, { count: descriptors.length })
             if (descriptors.length !== 0) {
                 this.transcript.addAssistantResponse(
                     '',
@@ -531,6 +531,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 this.sendTranscript()
 
                 logEvent('CodyVSCodeExtension:getPluginsContext:runPluginFunctionsCalled', {
+                    count: descriptors.length,
+                }, {
                     count: descriptors.length,
                 })
                 return await plugins.runPluginFunctions(descriptors, this.config.pluginsConfig)

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -500,7 +500,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         if (enabledPlugins.length === 0) {
             return {}
         }
-        logEvent('CodyVSCodeExtension:getPluginsContext:enabledPlugins', { names: enabledPluginNames }, { names: enabledPluginNames })
+        logEvent(
+            'CodyVSCodeExtension:getPluginsContext:enabledPlugins',
+            { names: enabledPluginNames },
+            { names: enabledPluginNames }
+        )
 
         this.transcript.addAssistantResponse('', 'Identifying applicable plugins...\n')
         this.sendTranscript()
@@ -520,7 +524,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 enabledPlugins,
                 previousMessages
             )
-            logEvent('CodyVSCodeExtension:getPluginsContext:descriptorsFound', { count: descriptors.length }, { count: descriptors.length })
+            logEvent(
+                'CodyVSCodeExtension:getPluginsContext:descriptorsFound',
+                { count: descriptors.length },
+                { count: descriptors.length }
+            )
             if (descriptors.length !== 0) {
                 this.transcript.addAssistantResponse(
                     '',
@@ -530,11 +538,15 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 )
                 this.sendTranscript()
 
-                logEvent('CodyVSCodeExtension:getPluginsContext:runPluginFunctionsCalled', {
-                    count: descriptors.length,
-                }, {
-                    count: descriptors.length,
-                })
+                logEvent(
+                    'CodyVSCodeExtension:getPluginsContext:runPluginFunctionsCalled',
+                    {
+                        count: descriptors.length,
+                    },
+                    {
+                        count: descriptors.length,
+                    }
+                )
                 return await plugins.runPluginFunctions(descriptors, this.config.pluginsConfig)
             }
         } catch (error) {


### PR DESCRIPTION
In the new logged plugin events, specific data was passed to the `eventProperties` field but not `publicProperties`. This will log to both now