### PR TITLE
experimental more eager autocomplete triggering

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -19,6 +19,7 @@ export interface Configuration {
     autocompleteAdvancedAccessToken: string | null
     autocompleteAdvancedCache: boolean
     autocompleteAdvancedEmbeddings: boolean
+    autocompleteExperimentalTriggerMoreEagerly: boolean
     pluginsEnabled?: boolean
     pluginsDebugEnabled?: boolean
     pluginsConfig?: {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- A new experimental user setting `cody.autocomplete.experimental.triggerMoreEagerly` causes autocomplete to trigger earlier, before you type a space or other non-word character.
+
 ### Fixed
 
 ### Changed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -929,6 +929,11 @@
           "default": true,
           "markdownDescription": "Enables the use of embeddings as code completions context."
         },
+        "cody.autocomplete.experimental.triggerMoreEagerly": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Trigger autocomplete when the cursor is at the end of a word (instead of waiting for a space or other non-word character)."
+        },
         "cody.plugins.enabled": {
           "type": "boolean",
           "default": false,

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -101,6 +101,7 @@ async function complete(
         history: null as any,
         codebaseContext: null as any,
         disableTimeouts: true,
+        triggerMoreEagerly: false,
     })
 
     if (!code.includes(CURSOR_MARKER)) {
@@ -145,7 +146,7 @@ async function complete(
 
     return {
         requests,
-        completions,
+        completions: 'items' in completions ? completions.items : completions,
     }
 }
 

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -30,6 +30,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteAdvancedCache: true,
             autocompleteAdvancedEmbeddings: true,
+            autocompleteExperimentalTriggerMoreEagerly: false,
         })
     })
 
@@ -74,6 +75,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.advanced.embeddings':
                         return false
+                    case 'cody.autocomplete.experimental.triggerMoreEagerly':
+                        return false
                     case 'cody.plugins.enabled':
                         return true
                     case 'cody.plugins.config':
@@ -111,6 +114,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteAdvancedCache: false,
             autocompleteAdvancedEmbeddings: false,
+            autocompleteExperimentalTriggerMoreEagerly: false,
         })
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -74,6 +74,10 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         autocompleteAdvancedAccessToken: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedAccessToken, null),
         autocompleteAdvancedCache: config.get(CONFIG_KEY.autocompleteAdvancedCache, true),
         autocompleteAdvancedEmbeddings: config.get(CONFIG_KEY.autocompleteAdvancedEmbeddings, true),
+        autocompleteExperimentalTriggerMoreEagerly: config.get(
+            CONFIG_KEY.autocompleteExperimentalTriggerMoreEagerly,
+            false
+        ),
         pluginsEnabled: config.get<boolean>(CONFIG_KEY.pluginsEnabled, false),
         pluginsDebugEnabled: config.get<boolean>(CONFIG_KEY.pluginsDebugEnabled, true),
         pluginsConfig: config.get(CONFIG_KEY.pluginsConfig, {}),

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -383,6 +383,7 @@ function createCompletionsProvider(
         codebaseContext,
         isCompletionsCacheEnabled: config.autocompleteAdvancedCache,
         isEmbeddingsContextEnabled: config.autocompleteAdvancedEmbeddings,
+        triggerMoreEagerly: config.autocompleteExperimentalTriggerMoreEagerly,
     })
 
     disposables.push(

--- a/vscode/src/testutils/cli/run-code-completions-on-dataset.ts
+++ b/vscode/src/testutils/cli/run-code-completions-on-dataset.ts
@@ -50,6 +50,7 @@ async function initCompletionsProvider(): Promise<CodyCompletionItemProvider> {
         history,
         codebaseContext: null as any,
         disableTimeouts: true,
+        triggerMoreEagerly: false,
     })
 
     return completionsProvider
@@ -95,7 +96,7 @@ async function generateCompletionsForDataset(codeSamples: string[]): Promise<voi
                 selectedCompletionInfo: undefined,
             })
 
-            const completions = completionItems.map(item =>
+            const completions = ('items' in completionItems ? completionItems.items : completionItems).map(item =>
                 typeof item.insertText === 'string' ? item.insertText : ''
             )
 


### PR DESCRIPTION
Previously, autocomplete only triggered *after* you typed a non-letter character:

- `if err` would NOT trigger autocomplete
- `if err<SPACE>` WOULD trigger autocomplete

Now, the new experimental `cody.autocomplete.experimental.triggerMoreEagerly` VS Code setting changes the behavior so that autocomplete is triggered in the first case.

See https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1689357531463279 for context.

## Known issues

This has performance and UX consequences, so it's experimental for now.

- The completions sometimes lack a leading space, which results in /sometimes/ (eg) incorrectly completing `<Link` to `<Linkhref="..."`.

## Test plan

Set `cody.autocomplete.experimental.triggerMoreEagerly` to true. Open a code file and type `if err` or `const message` (without a space afterwards). Confirm that a completion appears. Now toggle that setting off, and confirm that a completion does not appear.