### PR TITLE
improve Anthropic code completion prompt

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -201,7 +201,7 @@ describe('Cody completions', () => {
         expect(messages[messages.length - 1]).toMatchInlineSnapshot(`
             {
               "speaker": "assistant",
-              "text": "Okay, here is some code: <CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+              "text": "Here is the code: <CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
                     this.startLine =",
             }
         `)

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -61,11 +61,11 @@ export class AnthropicProvider extends Provider {
         const prefixMessages: Message[] = [
             {
                 speaker: 'human',
-                text: `You are Cody, a code completion AI developed by Sourcegraph. You write code in between tags like this:${OPENING_CODE_TAG}/* Code goes here */${CLOSING_CODE_TAG}`,
+                text: `You are a code completion AI that writes high-quality code like a senior engineer. You write code in between tags like this:${OPENING_CODE_TAG}/* Code goes here */${CLOSING_CODE_TAG}`,
             },
             {
                 speaker: 'assistant',
-                text: 'I am Cody, a code completion AI developed by Sourcegraph.',
+                text: 'I am a code completion AI that writes high-quality code like a senior engineer.',
             },
             {
                 speaker: 'human',
@@ -73,7 +73,7 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'assistant',
-                text: `Okay, here is some code: ${OPENING_CODE_TAG}${tail.trimmed}`,
+                text: `Here is the code: ${OPENING_CODE_TAG}${tail.trimmed}`,
             },
         ]
         return { messages: prefixMessages, prefix: { head, tail, overlap } }


### PR DESCRIPTION
This seemed to yield better results that did not result in trivial(ly incorrect) completions.

Also, it is not needed to say we are Cody since this is autocomplete not chat, so the identity of the bot is less likely to come up.

## Test plan

n/a