### PR TITLE
improve single-line completion perf by only fetching 1 completion

### DIFF
--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -219,7 +219,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             completers.push(
                 this.providerConfig.create({
                     ...sharedProviderOptions,
-                    n: 3,
+                    n: 3, // 3 vs. 1 does not meaningfully affect perf
                     multilineMode,
                 })
             )
@@ -229,7 +229,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             completers.push(
                 this.providerConfig.create({
                     ...sharedProviderOptions,
-                    n: 3,
+                    n: 1, // 1 vs. 3 improves perf
                     multilineMode: null,
                 })
             )


### PR DESCRIPTION
Running 5 iterations each of completing a large file in single-line completion mode:

n=1: 1372ms, 1181ms, 1298ms
n=3: 1958ms, 1769ms

(There was no significant perf difference for n=1 vs. n=3 on multi-line mode.)

## Test plan

Run a single-line completion and ensure it works.