### PR TITLE
better logging for trigger-more-eagerly autocomplete

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -930,7 +930,7 @@
         "cody.autocomplete.experimental.triggerMoreEagerly": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Trigger autocomplete when the cursor is at the end of a word (instead of waiting for a space or other non-word character)."
+          "markdownDescription": "Trigger autocomplete when the cursor is at the end of a word (instead of waiting for a space or other non-word character). Share feedback at https://github.com/sourcegraph/cody/discussions/274."
         },
         "cody.plugins.enabled": {
           "type": "boolean",

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -187,6 +187,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         if (cursorAtWord && !this.triggerMoreEagerly) {
             return []
         }
+        const triggeredMoreEagerly = this.triggerMoreEagerly && cursorAtWord
 
         // Don't show completions if a selected completion info is present (so something is selected
         // from the completions dropdown list based on the lang server) and the returned completion
@@ -287,6 +288,10 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             providerIdentifier: this.providerConfig.identifier,
             languageId,
             contextSummary,
+            triggeredMoreEagerly,
+            settings: {
+                'cody.autocomplete.experimental.triggerMoreEagerly': this.triggerMoreEagerly,
+            },
         })
         const stopLoading = this.statusBar.startLoading('Completions are being generated')
         this.stopLoading = stopLoading

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -14,6 +14,17 @@ interface CompletionEvent {
             duration: number
         }
         languageId: string
+
+        /**
+         * Whether the completion was triggered only because of the experimental settting
+         * `cody.autocomplete.experimental.triggerMoreEagerly`.
+         */
+        triggeredMoreEagerly: boolean
+
+        /** Relevant user settings. */
+        settings: {
+            'cody.autocomplete.experimental.triggerMoreEagerly': boolean
+        }
     }
     // The timestamp when the request started
     startedAt: number
@@ -57,7 +68,7 @@ export function start(params: CompletionEvent['params']): string {
     return id
 }
 
-// Suggested completions will not logged individually. Instead, we log them when
+// Suggested completions will not be logged individually. Instead, we log them when
 // we either hide them again (they are NOT accepted) or when they ARE accepted.
 // This way, we can calculate the duration they were actually visible.
 export function suggest(id: string): void {


### PR DESCRIPTION
Instruments our existing autocomplete logging to better track the new trigger-more-eagerly behavior introduced in #260:

1. Whether user has the `cody.autocomplete.experimental.triggerMoreEagerly` setting enabled.
1. Whether the completion was shown only because of that setting.

Discussion on this feature at https://github.com/sourcegraph/cody/discussions/274.

## Test plan

n/a; for experimental feature only