### PR TITLE
Cody: Limit completions to 2 lines in single line mode

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -234,6 +234,47 @@ describe('Cody completions', () => {
         `)
     })
 
+    it('completes up to two lines in single line mode', async () => {
+        const { completions } = await complete(
+            `
+        function test() {
+            console.log(1);
+            ${CURSOR_MARKER}
+        }
+        `,
+            [createCompletionResponse('console.log(2);\n    console.log(3);\n    console.log(4);')]
+        )
+
+        expect(completions).toMatchInlineSnapshot(`
+          [
+            InlineCompletionItem {
+              "insertText": "console.log(2);
+              console.log(3);",
+            },
+          ]
+        `)
+    })
+
+    it('only complete one line if the second line is indented in single line mode', async () => {
+        const { completions } = await complete(
+            `
+        function test() {
+            console.log(1);
+            ${CURSOR_MARKER}
+        }
+        `,
+            [createCompletionResponse('if (true) {\n        console.log(3);\n    }\n    console.log(4);')]
+        )
+
+        expect(completions).toMatchInlineSnapshot(`
+          [
+            InlineCompletionItem {
+              "insertText": "if (true) {",
+            },
+          ]
+        `)
+    })
+
     it('completes a single-line at the middle of a sentence', async () => {
         const { completions } = await complete(`function bubbleSort(${CURSOR_MARKER})`, [
             createCompletionResponse('array) {'),


### PR DESCRIPTION
This commit limits code completions to 2 lines when in single line mode, to avoid cluttering the editor with too many lines.

Added unit tests for:

- Completing up to 2 lines
- Completing 1 line if the second line is indented

This fixes a UX issue where inline completions look like a truncated multi-line completion, e.g.:

<img width="758" alt="Screenshot 2023-07-17 at 14 20 48" src="https://github.com/sourcegraph/cody/assets/458591/062048fc-c332-4aca-9feb-187eeed35242">


<!-- All pull requests REQUIRE a test plan:
https://docs.sourcegraph.com/dev/background-information/testing_principles -->