### PR TITLE
escape custom html tags to support regular expressions

### DIFF
--- a/lib/shared/src/common/markdown/markdown.test.ts
+++ b/lib/shared/src/common/markdown/markdown.test.ts
@@ -174,11 +174,22 @@ describe('extractHTMLTagName', () => {
     it('extracts the tag name of a closing token', () => {
         expect(extractHtmlTagName('</a someAttribute="1">')).toBe('a')
     })
+
+    it('correctly extracts custom html tags', () => {
+        expect(extractHtmlTagName('<my-custom-tag someAttribute="1">')).toBe('my-custom-tag')
+        expect(extractHtmlTagName('</my-custom-tag someAttribute="1">')).toBe('my-custom-tag')
+    })
 })
 
 describe('isValidHTMLTag', () => {
     it('treats svg tags as valid HTML', () => {
         expect(isValidHTMLTag('svg')).toBe(true)
+    })
+
+    it('is not case sensitive', () => {
+        expect(isValidHTMLTag('li')).toBe(true)
+        expect(isValidHTMLTag('LI')).toBe(true)
+        expect(isValidHTMLTag('Li')).toBe(true)
     })
 
     it('treats custom tags as invalid HTML', () => {

--- a/lib/shared/src/common/markdown/markdown.test.ts
+++ b/lib/shared/src/common/markdown/markdown.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, test } from 'vitest'
 
-import { escapeMarkdown, extractHtmlTagName, isValidHTMLTag, registerHighlightContributions, renderMarkdown } from '.'
+import {
+    escapeMarkdown,
+    extractHtmlTagName,
+    registerHighlightContributions,
+    renderMarkdown,
+    shouldEscapeTagWithElementName,
+} from '.'
 
 // TODO(sqs): copied from sourcegraph/sourcegraph. should dedupe.
 
@@ -181,18 +187,18 @@ describe('extractHTMLTagName', () => {
     })
 })
 
-describe('isValidHTMLTag', () => {
-    it('treats svg tags as valid HTML', () => {
-        expect(isValidHTMLTag('svg')).toBe(true)
+describe('shouldEscapeTagWithElementName', () => {
+    it('treats svg as valid', () => {
+        expect(shouldEscapeTagWithElementName('svg')).toBe(false)
     })
 
     it('is not case sensitive', () => {
-        expect(isValidHTMLTag('li')).toBe(true)
-        expect(isValidHTMLTag('LI')).toBe(true)
-        expect(isValidHTMLTag('Li')).toBe(true)
+        expect(shouldEscapeTagWithElementName('li')).toBe(false)
+        expect(shouldEscapeTagWithElementName('LI')).toBe(false)
+        expect(shouldEscapeTagWithElementName('Li')).toBe(false)
     })
 
-    it('treats custom tags as invalid HTML', () => {
-        expect(isValidHTMLTag('myTag')).toBe(false)
+    it('treats custom element names as invalid', () => {
+        expect(shouldEscapeTagWithElementName('myTag')).toBe(true)
     })
 })

--- a/lib/shared/src/common/markdown/markdown.test.ts
+++ b/lib/shared/src/common/markdown/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from 'vitest'
 
-import { escapeMarkdown, registerHighlightContributions, renderMarkdown } from '.'
+import { escapeMarkdown, extractHtmlTagName, isValidHTMLTag, registerHighlightContributions, renderMarkdown } from '.'
 
 // TODO(sqs): copied from sourcegraph/sourcegraph. should dedupe.
 
@@ -121,6 +121,10 @@ describe('renderMarkdown', () => {
         const input = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'
         expect(renderMarkdown(input)).toBe('<p><a download="">D</a>\n<a>D2</a></p>')
     })
+    it('renders paragraphs containing regular expressions correctly', () => {
+        const input = '/^(?<myLabel>[A-Za-z]+).(?<myOtherLabel>[A-Za-z]+)/'
+        expect(renderMarkdown(input)).toBe('<p>/^(?&lt;myLabel&gt;[A-Za-z]+).(?&lt;myOtherLabel&gt;[A-Za-z]+)/</p>')
+    })
 })
 
 describe('escapeMarkdown', () => {
@@ -159,5 +163,25 @@ const someTypeScriptCode \\= funcCall\\(\\)
 &lt;b&gt;inline html&lt;\\/b&gt;
 
 Escaped \\\\\\* markdown and escaped html code \\\\\\&gt\\\\\\;`)
+    })
+})
+
+describe('extractHTMLTagName', () => {
+    it('extracts the tag name of a opening token', () => {
+        expect(extractHtmlTagName('<a someAttribute="1">')).toBe('a')
+    })
+
+    it('extracts the tag name of a closing token', () => {
+        expect(extractHtmlTagName('</a someAttribute="1">')).toBe('a')
+    })
+})
+
+describe('isValidHTMLTag', () => {
+    it('treats svg tags as valid HTML', () => {
+        expect(isValidHTMLTag('svg')).toBe(true)
+    })
+
+    it('treats custom tags as invalid HTML', () => {
+        expect(isValidHTMLTag('myTag')).toBe(false)
     })
 })

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -14,10 +14,10 @@ const escapeHTML = (html: string): string => {
 }
 
 /**
- * All HTML tags in the list are treated as valid HTML that doesn't need to be escaped in markedjs.
- * Unsafe tags like script are valid in here as they should only be removed by DOMPurify
+ * All HTML element names in the list are treated as valid HTML that doesn't need to be escaped in markedjs.
+ * Unsafe elements like script are valid in here as they should only be removed by DOMPurify
  */
-const HTML_TAGS_NO_ESCAPE: Set<string> = new Set([
+const HTML_ELEMENT_NAMES_NO_ESCAPE: Set<string> = new Set([
     'a',
     'abbr',
     'acronym',
@@ -132,14 +132,15 @@ const HTML_TAGS_NO_ESCAPE: Set<string> = new Set([
 ])
 
 /**
- * Checks if a given HTML tag is a valid, non-custom HTML tag
+ * Determines whether the provided HTML element name should be escaped or not.
  *
- * @example isValidHTMLTag('a') and isValidHTMLTag('svg') will return true
- * @example isValidHTMLTag('myTag') will return false
- * @param tag A HTML tag (e.g. img, svg, my-custom-tag)
- * @returns If the given tag is a valid HTML tag
+ * @example shouldEscapeTagWithElementName('a') and shouldEscapeTagWithElementName('svg') will return false
+ * @example shouldEscapeTagWithElementName('myTag') will return true
+ * @param elementName A HTML element name (e.g. img, svg, my-custom-tag)
+ * @returns If the given element name should be escaped
  */
-export const isValidHTMLTag = (tag: string): boolean => HTML_TAGS_NO_ESCAPE.has(tag.toLowerCase())
+export const shouldEscapeTagWithElementName = (elementName: string): boolean =>
+    !HTML_ELEMENT_NAMES_NO_ESCAPE.has(elementName.toLowerCase())
 
 /**
  * Extracts the name of the HTML tag of a given HTML token
@@ -221,11 +222,11 @@ export const renderMarkdown = (
         }
 
         const tagName = extractHtmlTagName(token.text)
-        if (isValidHTMLTag(tagName)) {
+        if (!shouldEscapeTagWithElementName(tagName)) {
             return
         }
 
-        // all custom HTML tags should be escaped as they are probably part of a text block or a regex.
+        // all custom HTML element names should be escaped as they are probably part of a text block or a regex.
         // Otherwise they would be removed by the sanitizer
         token.text = token.text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
     }

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -239,8 +239,6 @@ export const renderMarkdown = (
         tokenizer,
     })
 
-    console.log(rendered)
-
     const dompurifyConfig: DOMPurifyConfig & { RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false } =
         typeof options.dompurifyConfig === 'object'
             ? options.dompurifyConfig

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -14,6 +14,124 @@ const escapeHTML = (html: string): string => {
 }
 
 /**
+ * All HTML tags in the list are treated as valid HTML that doesn't need to be escaped in markedjs.
+ * Unsafe tags like script are valid in here as they should only be removed by DOMPurify
+ */
+const HTML_TAGS_NO_ESCAPE: Set<string> = new Set([
+    'a',
+    'abbr',
+    'acronym',
+    'address',
+    'area',
+    'article',
+    'aside',
+    'audio',
+    'b',
+    'base',
+    'basefont',
+    'bdi',
+    'bdo',
+    'big',
+    'blockquote',
+    'body',
+    'br',
+    'button',
+    'canvas',
+    'caption',
+    'center',
+    'cite',
+    'code',
+    'col',
+    'colgroup',
+    'data',
+    'datalist',
+    'dd',
+    'del',
+    'details',
+    'dfn',
+    'dialog',
+    'div',
+    'dl',
+    'dt',
+    'em',
+    'embed',
+    'fieldset',
+    'figcaption',
+    'figure',
+    'footer',
+    'form',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'head',
+    'header',
+    'hr',
+    'html',
+    'i',
+    'iframe',
+    'img',
+    'input',
+    'ins',
+    'kbd',
+    'label',
+    'legend',
+    'li',
+    'link',
+    'main',
+    'map',
+    'mark',
+    'meta',
+    'meter',
+    'nav',
+    'noscript',
+    'object',
+    'ol',
+    'optgroup',
+    'option',
+    'output',
+    'p',
+    'param',
+    'picture',
+    'pre',
+    'progress',
+    'q',
+    'rp',
+    'rt',
+    'ruby',
+    's',
+    'samp',
+    'script',
+    'section',
+    'select',
+    'small',
+    'source',
+    'span',
+    'strong',
+    'style',
+    'sub',
+    'summary',
+    'sup',
+    'svg',
+    'table',
+    'tbody',
+    'td',
+    'template',
+    'textarea',
+    'tfoot',
+    'th',
+    'thead',
+    'time',
+    'title',
+    'tr',
+    'track',
+    'u',
+    'ul',
+])
+
+/**
  * Checks if a given HTML tag is a valid, non-custom HTML tag
  *
  * @example isValidHTMLTag('a') and isValidHTMLTag('svg') will return true
@@ -21,21 +139,7 @@ const escapeHTML = (html: string): string => {
  * @param tag A HTML tag (e.g. img, svg, my-custom-tag)
  * @returns If the given tag is a valid HTML tag
  */
-export const isValidHTMLTag = (tag: string): boolean => {
-    // svg is not a valid HTML tag for document.createElement but should still be treated as valid.
-    const overrides: { [key: string]: boolean } = { SVG: true }
-
-    tag = tag.toUpperCase()
-    try {
-        return (
-            overrides[tag] ||
-            // eslint-disable-next-line @typescript-eslint/no-base-to-string
-            document.createElement(tag).toString() !== '[object HTMLUnknownElement]'
-        )
-    } catch {
-        return false
-    }
-}
+export const isValidHTMLTag = (tag: string): boolean => HTML_TAGS_NO_ESCAPE.has(tag)
 
 /**
  * Extracts the name of the HTML tag of a given HTML token

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -139,7 +139,7 @@ const HTML_TAGS_NO_ESCAPE: Set<string> = new Set([
  * @param tag A HTML tag (e.g. img, svg, my-custom-tag)
  * @returns If the given tag is a valid HTML tag
  */
-export const isValidHTMLTag = (tag: string): boolean => HTML_TAGS_NO_ESCAPE.has(tag)
+export const isValidHTMLTag = (tag: string): boolean => HTML_TAGS_NO_ESCAPE.has(tag.toLowerCase())
 
 /**
  * Extracts the name of the HTML tag of a given HTML token
@@ -147,12 +147,9 @@ export const isValidHTMLTag = (tag: string): boolean => HTML_TAGS_NO_ESCAPE.has(
  * @param htmlToken The text of the HTML token (e.g. <img> or </img> or <img someAttribute>)
  * @returns The name of the HTML tag (e.g. img)
  */
-export const extractHtmlTagName = (htmlToken: string): string => {
-    // remove the leading < or </ if present
-    htmlToken = htmlToken.replace(/<\/?/, '')
-    // matches the first word consisting of alphanumeric characters, representing the html tag name
-    return htmlToken.match(/^[\dA-Za-z]*/)?.[0] ?? ''
-}
+export const extractHtmlTagName = (htmlToken: string): string =>
+    // matches the first word after the html opening tag, representing the html tag name
+    htmlToken.match(/(?<=(<|<\/))[A-Za-z-]+/g)?.[0] ?? ''
 
 /**
  * Attempts to syntax-highlight the given code.


### PR DESCRIPTION
fixes https://github.com/sourcegraph/cody/issues/41

I noticed that all online markdown editors I tried that also support inline HTML and are based on markedjs seem to have this problem.

The problem is that <myLabel> in the regular expression is detected as a HTML token in the markedjs tokenizer. As myLabel isn't listed in the ALLOWED_TAGS, DOMPurify will later on remove it. 

I tried several ideas but the only one that worked and doesn't introduce new security issues due to worse sanitizing is to escape all unknown HTML tags.

The regular expression is now displayed correctly and the highlighting will still work as you can see below:
![Screenshot from 2023-07-17 23-53-06](https://github.com/sourcegraph/cody/assets/56530704/967e68f8-54a6-44b1-860d-78bdcf5d5353)

### Test plan

tested locally and added unit tests