### PR TITLE
preserve leading whitespace in completions

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -77,7 +77,8 @@ async function complete(
     code: string,
     responses?: CompletionResponse[],
     languageId: string = 'typescript',
-    context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined }
+    context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },
+    triggerMoreEagerly = true
 ): Promise<{
     requests: CompletionParameters[]
     completions: vscode.InlineCompletionItem[]
@@ -108,7 +109,7 @@ async function complete(
         history: new History(),
         codebaseContext: null as any,
         disableTimeouts: true,
-        triggerMoreEagerly: false,
+        triggerMoreEagerly,
     })
 
     if (!code.includes(CURSOR_MARKER)) {
@@ -217,8 +218,19 @@ describe('Cody completions', () => {
         expect(requests[0]!.stopSequences).toEqual(['\n\nHuman:', '</CODE5711>', '\n\n'])
     })
 
-    it('does not make a request when in the middle of a word', async () => {
-        const { requests } = await complete(`foo${CURSOR_MARKER}`)
+    it('makes a request when in the middle of a word when triggerMoreEagerly is true', async () => {
+        const { requests } = await complete(
+            `foo${CURSOR_MARKER}`,
+            [createCompletionResponse('()')],
+            undefined,
+            undefined,
+            true
+        )
+        expect(requests).toHaveLength(1)
+    })
+
+    it('does not make a request when in the middle of a word when triggerMoreEagerly is false', async () => {
+        const { requests } = await complete(`foo${CURSOR_MARKER}`, undefined, undefined, undefined, false)
         expect(requests).toHaveLength(0)
     })
 
@@ -305,19 +317,24 @@ describe('Cody completions', () => {
         expect(requests).toHaveLength(0)
     })
 
-    it('trims completions that start with whitespace', async () => {
-        const { completions } = await complete(`function bubbleSort(${CURSOR_MARKER})`, [
-            createCompletionResponse('\t\t\tarray) {'),
-            createCompletionResponse('items) {'),
+    it('preserves leading whitespace when prefix has no trailing whitespace', async () => {
+        const { completions } = await complete(`const isLocalHost = window.location.host${CURSOR_MARKER}`, [
+            createCompletionResponse(" === 'localhost'"),
         ])
+        expect(completions[0]).toMatchInlineSnapshot(`
+          InlineCompletionItem {
+            "insertText": " === 'localhost'",
+          }
+        `)
+    })
+
+    it('collapses leading whitespace when prefix has trailing whitespace', async () => {
+        const { completions } = await complete(`const x = ${CURSOR_MARKER}`, [createCompletionResponse('\t7')])
 
         expect(completions).toMatchInlineSnapshot(`
             [
               InlineCompletionItem {
-                "insertText": "array) {",
-              },
-              InlineCompletionItem {
-                "insertText": "items) {",
+                "insertText": "7",
               },
             ]
         `)
@@ -476,7 +493,7 @@ describe('Cody completions', () => {
             expect(completions).toMatchInlineSnapshot(`
                             [
                               InlineCompletionItem {
-                                "insertText": "{
+                                "insertText": " {
                                 console.log('Hello');
                             }",
                               },

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -14,7 +14,7 @@ import {
     indentation,
     OPENING_CODE_TAG,
     PrefixComponents,
-    trimStartUntilNewline,
+    trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
 import { batchCompletions, lastNLines, messagesToText } from '../utils'
 
@@ -118,10 +118,10 @@ export class AnthropicProvider extends Provider {
         const trimmedPrefixContainNewline = this.prefix.slice(this.prefix.trimEnd().length).includes('\n')
         if (trimmedPrefixContainNewline) {
             // The prefix already contains a `\n` that Claude was not aware of, so we remove any
-            // leading `\n` that claude might add.
-            completion = completion.trimStart()
+            // leading `\n` followed by whitespace that Claude might add.
+            completion = completion.replace(/^\s*\n\s*/, '')
         } else {
-            completion = trimStartUntilNewline(completion)
+            completion = trimLeadingWhitespaceUntilNewline(completion)
         }
 
         // Remove bad symbols from the start of the completion string.

--- a/vscode/src/completions/shared-post-process.ts
+++ b/vscode/src/completions/shared-post-process.ts
@@ -1,6 +1,6 @@
 import { Completion } from '.'
 import { truncateMultilineCompletion } from './multiline'
-import { trimUntilSuffix } from './text-processing'
+import { collapseDuplicativeWhitespace, trimUntilSuffix } from './text-processing'
 
 /**
  * This function implements post-processing logic that is applied regardless of
@@ -25,6 +25,7 @@ export function sharedPostProcess({
         content = truncateMultilineCompletion(content, prefix, suffix, languageId)
     }
     content = trimUntilSuffix(content, prefix, suffix)
+    content = collapseDuplicativeWhitespace(prefix, content)
 
     return {
         ...completion,

--- a/vscode/src/completions/text-processing.test.ts
+++ b/vscode/src/completions/text-processing.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
-import { CLOSING_CODE_TAG, extractFromCodeBlock, OPENING_CODE_TAG } from './text-processing'
+import {
+    CLOSING_CODE_TAG,
+    collapseDuplicativeWhitespace,
+    extractFromCodeBlock,
+    OPENING_CODE_TAG,
+    trimLeadingWhitespaceUntilNewline,
+} from './text-processing'
 
 describe('extractFromCodeBlock', () => {
     it('extracts value from code completion XML tags', () => {
@@ -25,5 +31,25 @@ describe('extractFromCodeBlock', () => {
         expect(extractFromCodeBlock(`${OPENING_CODE_TAG}hello world${CLOSING_CODE_TAG}`)).toBe('')
         expect(extractFromCodeBlock(`hello world${OPENING_CODE_TAG}`)).toBe('')
         expect(extractFromCodeBlock(OPENING_CODE_TAG)).toBe('')
+    })
+})
+
+describe('trimLeadingWhitespaceUntilNewline', () => {
+    test('trims spaces', () => expect(trimLeadingWhitespaceUntilNewline('  \n  a')).toBe('\n  a'))
+    test('preserves carriage returns', () => expect(trimLeadingWhitespaceUntilNewline('\t\r\n  a')).toBe('\r\n  a'))
+})
+
+describe('collapseDuplicativeWhitespace', () => {
+    test('trims space', () => expect(collapseDuplicativeWhitespace('x = ', ' 7')).toBe('7'))
+    test('trims identical duplicative whitespace chars', () =>
+        expect(collapseDuplicativeWhitespace('x =\t ', '\t 7')).toBe('7'))
+    test('trims non-identical duplicative whitespace chars', () =>
+        expect(collapseDuplicativeWhitespace('x =\t ', '  7')).toBe('7'))
+    test('trims more whitespace chars from completion than in prefix', () => {
+        expect(collapseDuplicativeWhitespace('x = ', '  7')).toBe('7')
+        expect(collapseDuplicativeWhitespace('x = ', '\t 7')).toBe('7')
+    })
+    test('does not trim newlines', () => {
+        expect(collapseDuplicativeWhitespace('x = ', '\n7')).toBe('\n7')
     })
 })

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -189,12 +189,11 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
     return insertionLines.slice(0, insertionEnd).join('\n')
 }
 
-export function trimStartUntilNewline(str: string): string {
-    const index = str.indexOf('\n')
-    if (index === -1) {
-        return str.trimStart()
-    }
-    return str.slice(0, index).trimStart() + str.slice(index)
+/**
+ * Trims whitespace before the first newline (if it exists).
+ */
+export function trimLeadingWhitespaceUntilNewline(str: string): string {
+    return str.replace(/^\s+?(\r?\n)/, '$1')
 }
 
 const NON_WHITESPACE_REGEX = /\S|$/
@@ -203,4 +202,19 @@ function getFirstNCharsPreservingLeadingSpaces(value: string, charsNumber: numbe
 
     // Return the leading whitespaces and first N characters
     return value.slice(0, startIndex + charsNumber)
+}
+
+/**
+ * Collapses whitespace that appears at the end of prefix and the start of completion.
+ *
+ * For example, if prefix is `const isLocalhost = window.location.host ` and completion is ` ===
+ * 'localhost'`, it trims the leading space in the completion to avoid a duplicate space.
+ *
+ * Language-specific customizations are needed here to get greater accuracy.
+ */
+export function collapseDuplicativeWhitespace(prefix: string, completion: string): string {
+    if (prefix.endsWith(' ') || prefix.endsWith('\t')) {
+        completion = completion.replace(/^[\t ]+/, '')
+    }
+    return completion
 }


### PR DESCRIPTION
Given `const isLocalhost = window.location.host{CURSOR}` and a completion ` === 'localhost'`, the leading whitespace before the `===` should be preserved. This comes up most frequently when using the new experimental `cody.autocomplete.experimental.triggerMoreEagerly` setting introduced in https://github.com/sourcegraph/cody/pull/260, which triggers autocomplete even before the user types space.

![image](https://github.com/sourcegraph/cody/assets/1976/9f533f22-1529-46e6-886c-11503ede3efd)
![image](https://github.com/sourcegraph/cody/assets/1976/619aff84-c579-4353-bbca-55798f682813)



## Test plan

Added test case