### PR TITLE
allow manual triggering of completions

### DIFF
--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -206,12 +206,6 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
-        // In this case, VS Code won't be showing suggestions anyway and we are more likely to want
-        // suggested method names from the language server instead.
-        if (context.triggerKind === vscode.InlineCompletionTriggerKind.Invoke || sameLinePrefix.endsWith('.')) {
-            return []
-        }
-
         const sharedProviderOptions = {
             prefix,
             suffix,

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -252,7 +252,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             )
         }
 
-        if (!this.disableTimeouts) {
+        if (!this.disableTimeouts && context.triggerKind !== vscode.InlineCompletionTriggerKind.Invoke) {
             await new Promise<void>(resolve => setTimeout(resolve, timeout))
         }
 


### PR DESCRIPTION
This line was mistakenly added, based on a misunderstanding. The `context.triggerKind` refers to how *inline completions* were triggered, not the *suggest widget* (the dropdown menu). It caused the `Trigger Inline Suggestion` VS Code action to not do anything in Cody. Now, that action works.

As for the other case (`sameLinePrefix.endsWith('.')`), we are already suppressing Cody completions when `context.selectedCompletionInfo` is present (which is when there is a selected item in the suggest widget), which already covers that case more robustly.

## Test plan

Run the VS Code `Trigger Inline Suggestion` action and confirm it works.