### PR TITLE
separately cache non-empty lines with differing trailing whitespace

### DIFF
--- a/vscode/src/completions/cache.test.ts
+++ b/vscode/src/completions/cache.test.ts
@@ -30,26 +30,42 @@ describe('CompletionsCache', () => {
         })
     })
 
-    it('returns the cached items when the prefix has less whitespace', () => {
+    it('trims trailing whitespace on empty line', () => {
         const cache = new CompletionsCache()
         cache.add('id1', [{ prefix: 'foo \n  ', content: 'bar' }])
 
-        expect(cache.get('foo \n  ')).toEqual({
+        expect(cache.get('foo \n  ', true)).toEqual({
             logId: 'id1',
             isExactPrefix: false,
             completions: [{ prefix: 'foo \n  ', content: 'bar' }],
         })
-        expect(cache.get('foo \n ')).toEqual({
+        expect(cache.get('foo \n ', true)).toEqual({
             logId: 'id1',
             isExactPrefix: false,
             completions: [{ prefix: 'foo \n ', content: 'bar' }],
         })
-        expect(cache.get('foo \n')).toEqual({
+        expect(cache.get('foo \n', true)).toEqual({
             logId: 'id1',
             isExactPrefix: false,
             completions: [{ prefix: 'foo \n', content: 'bar' }],
         })
-        expect(cache.get('foo ')).toEqual(undefined)
+        expect(cache.get('foo ', true)).toEqual(undefined)
+    })
+
+    it('does not trim trailing whitespace on non-empty line', () => {
+        const cache = new CompletionsCache()
+        cache.add('id1', [{ prefix: 'foo', content: 'bar' }])
+
+        expect(cache.get('foo', true)).toEqual({
+            logId: 'id1',
+            isExactPrefix: true,
+            completions: [{ prefix: 'foo', content: 'bar' }],
+        })
+        expect(cache.get('foo ', true)).toEqual(undefined)
+        expect(cache.get('foo  ', true)).toEqual(undefined)
+        expect(cache.get('foo \n', true)).toEqual(undefined)
+        expect(cache.get('foo\n', true)).toEqual(undefined)
+        expect(cache.get('foo\t', true)).toEqual(undefined)
     })
 
     it('has a lookup function for untrimmed prefixes', () => {

--- a/vscode/src/completions/text-processing.test.ts
+++ b/vscode/src/completions/text-processing.test.ts
@@ -5,6 +5,7 @@ import {
     collapseDuplicativeWhitespace,
     extractFromCodeBlock,
     OPENING_CODE_TAG,
+    trimEndOnLastLineIfWhitespaceOnly,
     trimLeadingWhitespaceUntilNewline,
 } from './text-processing'
 
@@ -52,4 +53,9 @@ describe('collapseDuplicativeWhitespace', () => {
     test('does not trim newlines', () => {
         expect(collapseDuplicativeWhitespace('x = ', '\n7')).toBe('\n7')
     })
+})
+
+describe('trimEndOnLastLineIfWhitespaceOnly', () => {
+    test('trims end', () => expect(trimEndOnLastLineIfWhitespaceOnly('a\n  ')).toBe('a\n'))
+    test('does not trim end', () => expect(trimEndOnLastLineIfWhitespaceOnly('a\nb  ')).toBe('a\nb  '))
 })

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -218,3 +218,10 @@ export function collapseDuplicativeWhitespace(prefix: string, completion: string
     }
     return completion
 }
+
+/**
+ * Trims trailing whitespace on the last line if the last line is whitespace-only.
+ */
+export function trimEndOnLastLineIfWhitespaceOnly(text: string): string {
+    return text.replace(/(\r?\n)\s+$/, '$1')
+}


### PR DESCRIPTION
For example, a cached completion for `a =` should not be returned for `a = ` (with a trailing
space). We still preserve the trailing-whitespace trimming behavior for entirely empty lines to
avoid rerunning completion when the user is just indenting on a new line.

Fixes the issue reported at https://github.com/sourcegraph/cody/pull/284#pullrequestreview-1534394856.

## Test plan

Follow the steps in the linked comment's video.