### PR TITLE
show inline completions even when suggest widget is visible (experimental)

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -20,6 +20,7 @@ export interface Configuration {
     autocompleteAdvancedCache: boolean
     autocompleteAdvancedEmbeddings: boolean
     autocompleteExperimentalTriggerMoreEagerly: boolean
+    autocompleteExperimentalCompleteSuggestWidgetSelection?: boolean
     pluginsEnabled?: boolean
     pluginsDebugEnabled?: boolean
     pluginsConfig?: {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -926,7 +926,7 @@
         "cody.autocomplete.experimental.completeSuggestWidgetSelection": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Autocomplete based on the currently selection in the suggest widget. Requires the VS Code user setting `editor.inlineSuggest.suppressSuggestions` set to true."
+          "markdownDescription": "Autocomplete based on the currently selection in the suggest widget. Requires the VS Code user setting `editor.inlineSuggest.suppressSuggestions` set to true and will change it to true in user settings if it is not true."
         },
         "cody.plugins.enabled": {
           "type": "boolean",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -923,6 +923,11 @@
           "default": false,
           "markdownDescription": "Trigger autocomplete when the cursor is at the end of a word (instead of waiting for a space or other non-word character). Share feedback at https://github.com/sourcegraph/cody/discussions/274."
         },
+        "cody.autocomplete.experimental.completeSuggestWidgetSelection": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Autocomplete based on the currently selection in the suggest widget. Requires the VS Code user setting `editor.inlineSuggest.suppressSuggestions` set to true."
+        },
         "cody.plugins.enabled": {
           "type": "boolean",
           "default": false,

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -30,6 +30,7 @@ interface CodyCompletionItemProviderConfig {
     isCompletionsCacheEnabled?: boolean
     isEmbeddingsContextEnabled?: boolean
     triggerMoreEagerly: boolean
+    completeSuggestWidgetSelection?: boolean
 }
 
 export class CodyCompletionItemProvider implements vscode.InlineCompletionItemProvider {
@@ -52,6 +53,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     private disableTimeouts: boolean
     private isEmbeddingsContextEnabled: boolean
     private triggerMoreEagerly: boolean
+    private completeSuggestWidgetSelection?: boolean
     public inlineCompletionsCache?: CompletionsCache
 
     constructor(config: CodyCompletionItemProviderConfig) {
@@ -67,6 +69,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             isEmbeddingsContextEnabled = true,
             isCompletionsCacheEnabled = true,
             triggerMoreEagerly,
+            completeSuggestWidgetSelection,
         } = config
 
         this.providerConfig = providerConfig
@@ -79,6 +82,22 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         this.disableTimeouts = disableTimeouts
         this.isEmbeddingsContextEnabled = isEmbeddingsContextEnabled
         this.triggerMoreEagerly = triggerMoreEagerly
+        this.completeSuggestWidgetSelection = completeSuggestWidgetSelection
+
+        if (this.completeSuggestWidgetSelection) {
+            // This must be set to true, or else the suggest widget showing will suppress inline
+            // completions. Note that the VS Code proposed API inlineCompletionsAdditions contains
+            // an InlineCompletionList#suppressSuggestions field that lets an inline completion
+            // provider override this on a per-completion basis. Because that API is proposed, we
+            // can't use it and must instead resort to writing to the user's VS Code settings.
+            //
+            // The cody.autocomplete.experimental.completeSuggestWidgetSelection setting is
+            // experimental and off by default. Before turning it on by default, we need to try to
+            // find a workaround that is not silently updating the user's VS Code settings.
+            void vscode.workspace
+                .getConfiguration()
+                .update('editor.inlineSuggest.suppressSuggestions', true, vscode.ConfigurationTarget.Global)
+        }
 
         this.promptChars =
             providerConfig.maximumContextCharacters - providerConfig.maximumContextCharacters * responsePercentage
@@ -194,11 +213,15 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         }
         const triggeredMoreEagerly = this.triggerMoreEagerly && cursorAtWord
 
-        // Don't show completions if a selected completion info is present (so something is selected
-        // from the completions dropdown list based on the lang server) and the returned completion
-        // range does not contain the same selection.
+        let triggeredForSuggestWidgetSelection: string | undefined
         if (context.selectedCompletionInfo) {
-            return []
+            if (this.completeSuggestWidgetSelection) {
+                triggeredForSuggestWidgetSelection = context.selectedCompletionInfo.text
+            } else {
+                // Don't show completions if the suggest widget (which shows language autocomplete)
+                // is showing.
+                return []
+            }
         }
 
         // If we have a suffix in the same line as the cursor and the suffix contains any word
@@ -288,8 +311,10 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             languageId,
             contextSummary,
             triggeredMoreEagerly,
+            triggeredForSuggestWidgetSelection: triggeredForSuggestWidgetSelection !== undefined,
             settings: {
-                'cody.autocomplete.experimental.triggerMoreEagerly': this.triggerMoreEagerly,
+                autocompleteExperimentalTriggerMoreEagerly: this.triggerMoreEagerly,
+                autocompleteExperimentalCompleteSuggestWidgetSelection: Boolean(this.completeSuggestWidgetSelection),
             },
         })
         const stopLoading = this.statusBar.startLoading('Completions are being generated')
@@ -352,17 +377,19 @@ function toInlineCompletionItems(
     document: vscode.TextDocument,
     position: vscode.Position,
     completions: Completion[]
-): vscode.InlineCompletionItem[] {
-    return completions.map(completion => {
-        const lines = completion.content.split(/\r\n|\r|\n/m).length
-        const currentLineText = document.lineAt(position)
-        const endOfLine = currentLineText.range.end
-        return new vscode.InlineCompletionItem(completion.content, new vscode.Range(position, endOfLine), {
-            title: 'Completion accepted',
-            command: 'cody.autocomplete.inline.accepted',
-            arguments: [{ codyLogId: logId, codyLines: lines }],
-        })
-    })
+): vscode.InlineCompletionList {
+    return {
+        items: completions.map(completion => {
+            const lines = completion.content.split(/\r\n|\r|\n/m).length
+            const currentLineText = document.lineAt(position)
+            const endOfLine = currentLineText.range.end
+            return new vscode.InlineCompletionItem(completion.content, new vscode.Range(position, endOfLine), {
+                title: 'Completion accepted',
+                command: 'cody.autocomplete.inline.accepted',
+                arguments: [{ codyLogId: logId, codyLines: lines }],
+            })
+        }),
+    }
 }
 
 function rankCompletions(completions: Completion[]): Completion[] {

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -380,7 +380,7 @@ function toInlineCompletionItems(
 ): vscode.InlineCompletionList {
     return {
         items: completions.map(completion => {
-            const lines = completion.content.split(/\r\n|\r|\n/m).length
+            const lines = completion.content.split(/\r\n|\r|\n/).length
             const currentLineText = document.lineAt(position)
             const endOfLine = currentLineText.range.end
             return new vscode.InlineCompletionItem(completion.content, new vscode.Range(position, endOfLine), {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,6 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
+import { ConfigKeys } from '../configuration-keys'
 import { logEvent } from '../event-logger'
 
 interface CompletionEvent {
@@ -21,10 +22,20 @@ interface CompletionEvent {
          */
         triggeredMoreEagerly: boolean
 
+        /**
+         * Whether the completion was triggered only because of the experimental setting
+         * `cody.autocomplete.experimental.completeSuggestWidgetSelection`.
+         */
+        triggeredForSuggestWidgetSelection: boolean
+
         /** Relevant user settings. */
-        settings: {
-            'cody.autocomplete.experimental.triggerMoreEagerly': boolean
-        }
+        settings: Record<
+            Extract<
+                ConfigKeys,
+                'autocompleteExperimentalTriggerMoreEagerly' | 'autocompleteExperimentalCompleteSuggestWidgetSelection'
+            >,
+            boolean
+        >
     }
     // The timestamp when the request started
     startedAt: number

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -31,6 +31,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedCache: true,
             autocompleteAdvancedEmbeddings: true,
             autocompleteExperimentalTriggerMoreEagerly: false,
+            autocompleteExperimentalCompleteSuggestWidgetSelection: false,
         })
     })
 
@@ -77,6 +78,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.experimental.triggerMoreEagerly':
                         return false
+                    case 'cody.autocomplete.experimental.completeSuggestWidgetSelection':
+                        return false
                     case 'cody.plugins.enabled':
                         return true
                     case 'cody.plugins.config':
@@ -115,6 +118,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedCache: false,
             autocompleteAdvancedEmbeddings: false,
             autocompleteExperimentalTriggerMoreEagerly: false,
+            autocompleteExperimentalCompleteSuggestWidgetSelection: false,
         })
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -78,6 +78,10 @@ export function getConfiguration(config: ConfigGetter): Configuration {
             CONFIG_KEY.autocompleteExperimentalTriggerMoreEagerly,
             false
         ),
+        autocompleteExperimentalCompleteSuggestWidgetSelection: config.get(
+            CONFIG_KEY.autocompleteExperimentalCompleteSuggestWidgetSelection,
+            false
+        ),
         pluginsEnabled: config.get<boolean>(CONFIG_KEY.pluginsEnabled, false),
         pluginsDebugEnabled: config.get<boolean>(CONFIG_KEY.pluginsDebugEnabled, true),
         pluginsConfig: config.get(CONFIG_KEY.pluginsConfig, {}),

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -378,6 +378,7 @@ function createCompletionsProvider(
         isCompletionsCacheEnabled: config.autocompleteAdvancedCache,
         isEmbeddingsContextEnabled: config.autocompleteAdvancedEmbeddings,
         triggerMoreEagerly: config.autocompleteExperimentalTriggerMoreEagerly,
+        completeSuggestWidgetSelection: config.autocompleteExperimentalCompleteSuggestWidgetSelection,
     })
 
     disposables.push(


### PR DESCRIPTION
Previously, when the suggest widget (which shows a list of function names, variable names, etc., from language symbols) was visible, Cody did not show an inline completion.

With the new experimental `cody.autocomplete.experimental.completeSuggestWidgetSelection` VS Code user setting, now Cody will show an inline completion when the first suggest widget item is selected. Its completion is based only on the characters you have typed, not the selected completion item (but the former is typically a prefix of the former). Taking the actual suggest widget completion item's `text` into account would be a UX improvement.

Related: https://github.com/sourcegraph/cody/issues/303

## Test plan

In a file, type a few characters that would trigger the suggest widget to show. Confirm that Cody *also* shows an inline completion (even while the suggest widget is still visible).


https://github.com/sourcegraph/cody/assets/1976/9df03c67-6285-458d-ab8e-10bad4c46d34

