### PR TITLE
declutter and clean up vscode package.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -292,11 +292,6 @@
         "title": "Find Code Smells"
       },
       {
-        "command": "cody.test.token",
-        "category": "Cody",
-        "title": "Set Access Token"
-      },
-      {
         "command": "cody.settings.user",
         "category": "Cody",
         "title": "User Settings",
@@ -345,31 +340,6 @@
         "icon": "$(list-unordered)"
       },
       {
-        "command": "cody.walkthrough.showLogin",
-        "category": "Cody Walkthrough",
-        "title": "Show Login"
-      },
-      {
-        "command": "cody.walkthrough.showChat",
-        "category": "Cody Walkthrough",
-        "title": "Show Chat"
-      },
-      {
-        "command": "cody.walkthrough.showFixup",
-        "category": "Cody Walkthrough",
-        "title": "Show Fixup"
-      },
-      {
-        "command": "cody.walkthrough.showExplain",
-        "category": "Cody Walkthrough",
-        "title": "Show Explain"
-      },
-      {
-        "command": "cody.walkthrough.enableInlineChat",
-        "category": "Cody Walkthrough",
-        "title": "Show Inline Chat"
-      },
-      {
         "command": "cody.comment.add",
         "title": "Ask Cody",
         "category": "Cody Inline Chat",
@@ -402,7 +372,7 @@
       },
       {
         "command": "cody.inline.new",
-        "title": "Start a new Thread (Ctrl+Shift+C)",
+        "title": "Start New Thread",
         "category": "Cody Inline Chat",
         "when": "cody.activated && config.cody.inlineChat.enabled",
         "enablement": "editorFocus"
@@ -492,6 +462,7 @@
       {
         "command": "cody.inline.new",
         "key": "ctrl+shift+c",
+        "mac": "cmd+shift+c",
         "when": "cody.activated && editorFocus && config.cody.inlineChat.enabled"
       }
     ],
@@ -542,10 +513,6 @@
         {
           "command": "cody.recipe.find-code-smells",
           "when": "cody.activated && editorHasSelection"
-        },
-        {
-          "command": "cody.test.token",
-          "when": "false"
         },
         {
           "command": "cody.focus",
@@ -599,26 +566,6 @@
         {
           "command": "cody.guardrails.debug",
           "when": "config.cody.experimental.guardrails && editorHasSelection"
-        },
-        {
-          "command": "cody.walkthrough.showLogin",
-          "when": "false"
-        },
-        {
-          "command": "cody.walkthrough.showChat",
-          "when": "false"
-        },
-        {
-          "command": "cody.walkthrough.showFixup",
-          "when": "false"
-        },
-        {
-          "command": "cody.walkthrough.showExplain",
-          "when": "false"
-        },
-        {
-          "command": "cody.walkthrough.enableInlineChat",
-          "when": "false"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
- Do not register walkthrough commands (`cody.walkthrough.*`). These are only used in the walkthrough and do not need to be registered to work there.
- Do not register `cody.test.token`. This is only used for tests. It was mistakenly showing in the command palette and was a no-op there.
- Do not mention the Linux/Windows keybinding for `cody.inline.new` in the title because it differs for macOS. Also give it a macOS keybinding that does not use Ctrl.

## Test plan

Run the extension and confirm the walkthrough buttons work (in the VS Code walkthrough menu > Cody AI and then expanding the sections) and that there are no command registration errors.