### PR TITLE
update: eventlogger

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -14,6 +14,7 @@ export interface Configuration {
     inlineChat: boolean
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
+    experimentalCustomRecipes: boolean
     autocompleteAdvancedProvider: 'anthropic' | 'unstable-codegen' | 'unstable-huggingface'
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedAccessToken: string | null
@@ -43,4 +44,14 @@ export interface Configuration {
 export interface ConfigurationWithAccessToken extends Configuration {
     /** The access token, which is stored in the secret storage (not configuration). */
     accessToken: string | null
+}
+
+export interface EventLoggerConfigurationDetails {
+    contextSelection: ConfigurationUseContext
+    chatPredictions: boolean
+    inline: boolean
+    nonStop: boolean
+    suggestions: boolean
+    guardrails: boolean
+    customRecipes: boolean
 }

--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -5,7 +5,7 @@ export class EventLogger {
     private extensionDetails = { ide: 'VSCode', ideExtensionType: 'Cody' }
     public configurationDetails: EventLoggerConfigurationDetails
     constructor(
-        private gqlAPIClient: SourcegraphGraphQLAPIClient,
+        public gqlAPIClient: SourcegraphGraphQLAPIClient,
         private config: ConfigurationWithAccessToken
     ) {
         this.configurationDetails = this.onConfigurationChange(config)
@@ -23,6 +23,7 @@ export class EventLogger {
             customRecipes: newConfig.experimentalCustomRecipes,
         }
         this.configurationDetails = configDetails
+        this.gqlAPIClient = new SourcegraphGraphQLAPIClient(newConfig)
         return configDetails
     }
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Insert at Cusor now inserts the complete code snippets at cursor position. [pull/282](https://github.com/sourcegraph/cody/pull/282)
 - Minimizing the change of Cody replying users with response related to the language-uage prompt. [pull/279](https://github.com/sourcegraph/cody/pull/279)
+- Inline Chat: Add missing icons for Inline Chat and Inline Fixups decorations. [pull/318](https://github.com/sourcegraph/cody/pull/318)
 
 ### Changed
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -28,7 +28,6 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 import { View } from '../../webviews/NavBar'
 import { getFullConfig } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
-import { logEvent } from '../event-logger'
 import { FilenameContextFetcher } from '../local-context/filename-context-fetcher'
 import { LocalKeywordContextFetcher } from '../local-context/local-keyword-context-fetcher'
 import { debug } from '../log'
@@ -36,6 +35,7 @@ import { getRerankWithLog } from '../logged-rerank'
 import { FixupTask } from '../non-stop/FixupTask'
 import { IdleRecipeRunner } from '../non-stop/roles'
 import { AuthProvider } from '../services/AuthProvider'
+import { logEvent } from '../services/EventLogger'
 import { LocalStorage } from '../services/LocalStorageProvider'
 import { SecretStorage } from '../services/SecretStorageProvider'
 import { TestSupport } from '../test-support'
@@ -904,7 +904,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         // Display error message as assistant response for users with indexed codebase but getting search errors
         if (this.codebaseContext.checkEmbeddingsConnection() && searchErrors) {
             this.transcript.addErrorAsAssistantResponse(searchErrors)
-            debug('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
+            debug('ChatViewProvider:onLogEmbeddingsErrors', 'searchErrors', { verbose: searchErrors })
         }
     }
 
@@ -952,6 +952,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 logEvent(`CodyVSCodeExtension:Auth:${value}`, endpointUri, endpointUri)
                 break
             case 'click':
+                logEvent(`CodyVSCodeExtension:${value}:clicked`, endpointUri, endpointUri)
+                break
+            case 'insert':
                 logEvent(`CodyVSCodeExtension:${value}:clicked`, endpointUri, endpointUri)
                 break
         }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,7 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
-import { logEvent } from '../event-logger'
+import { logEvent } from '../services/EventLogger'
 
 interface CompletionEvent {
     params: {

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -21,6 +21,7 @@ describe('getConfiguration', () => {
             experimentalGuardrails: false,
             inlineChat: true,
             experimentalNonStop: false,
+            experimentalCustomRecipes: false,
             customHeaders: {},
             debugEnable: false,
             debugVerbose: false,
@@ -58,6 +59,8 @@ describe('getConfiguration', () => {
                     case 'cody.inlineChat.enabled':
                         return true
                     case 'cody.experimental.nonStop':
+                        return true
+                    case 'cody.experimental.customRecipes':
                         return true
                     case 'cody.debug.enable':
                         return true

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -109,6 +109,7 @@ describe('getConfiguration', () => {
             experimentalGuardrails: true,
             inlineChat: true,
             experimentalNonStop: true,
+            experimentalCustomRecipes: true,
             debugEnable: true,
             debugVerbose: true,
             debugFilter: /.*/,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -8,7 +8,7 @@ import type {
 
 import { DOTCOM_URL } from './chat/protocol'
 import { CONFIG_KEY, ConfigKeys } from './configuration-keys'
-import { logEvent } from './event-logger'
+import { logEvent } from './services/EventLogger'
 import { LocalStorage } from './services/LocalStorageProvider'
 import { getAccessToken, SecretStorage } from './services/SecretStorageProvider'
 
@@ -66,6 +66,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         inlineChat: config.get(CONFIG_KEY.inlineChatEnabled, true),
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
         experimentalNonStop: config.get('cody.experimental.nonStop' as any, isTesting),
+        experimentalCustomRecipes: config.get('cody.experimental.customRecipes' as any, isTesting),
         autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -10,8 +10,8 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult, KeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
 
-import { logEvent } from '../event-logger'
 import { debug } from '../log'
+import { logEvent } from '../services/EventLogger'
 
 /**
  * Exclude files without extensions and hidden files (starts with '.')

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -129,7 +129,7 @@ const register = async (
     )
 
     // Re-initialize external services on configuration change
-    const onConfigChangeServices = async (): Promise<void> => {
+    const updateServices = async (): Promise<void> => {
         const newConfig = await getFullConfig(secretStorage, localStorage)
         chatProvider.onConfigurationChange(newConfig)
         externalServicesOnDidConfigurationChange(newConfig)
@@ -138,10 +138,8 @@ const register = async (
     disposables.push(
         // Update external services when configurationChangeEvent is triggered by the webview
         // This is triggered during the user authentication step
-        chatProvider.configurationChangeEvent.event(() => onConfigChangeServices),
-        vscode.workspace.onDidChangeConfiguration(
-            event => event.affectsConfiguration('cody') && onConfigChangeServices()
-        )
+        chatProvider.configurationChangeEvent.event(() => updateServices()),
+        vscode.workspace.onDidChangeConfiguration(event => event.affectsConfiguration('cody') && updateServices())
     )
 
     const executeRecipe = async (recipe: RecipeID, openChatView = true): Promise<void> => {

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -16,10 +16,10 @@ import {
     unauthenticatedStatus,
 } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
-import { logEvent } from '../event-logger'
 import { debug } from '../log'
 
 import { AuthMenu, LoginStepInputBox, TokenInputBox } from './AuthMenus'
+import { logEvent } from './EventLogger'
 import { LocalAppDetector } from './LocalAppDetector'
 import { LocalStorage } from './LocalStorageProvider'
 import { SecretStorage } from './SecretStorageProvider'

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -17,17 +17,13 @@ export async function updateEventLogger(
 ): Promise<void> {
     const status = await localStorage.setAnonymousUserID()
     anonymousUserID = localStorage.getAnonymousUserID() || ''
-    if (!eventLoggerGQLClient) {
-        eventLoggerGQLClient = new SourcegraphGraphQLAPIClient(config)
+    if (!eventLogger || !eventLoggerGQLClient) {
         eventLogger = new EventLogger(eventLoggerGQLClient, config)
-        if (status === 'installed') {
-            logEvent('CodyInstalled')
-        } else {
-            logEvent('CodyVSCodeExtension:CodySavedLogin:executed')
-        }
-    } else {
-        eventLoggerGQLClient.onConfigurationChange(config)
+        eventLoggerGQLClient = eventLogger.gqlAPIClient
+        logEvent(status === 'installed' ? 'CodyInstalled' : 'CodyVSCodeExtension:CodySavedLogin:executed')
+        return
     }
+    eventLoggerGQLClient.onConfigurationChange(config)
 }
 
 /**

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -2,24 +2,24 @@ import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/confi
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { EventLogger } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
 
-import { version as packageVersion } from '../package.json'
+import { version as packageVersion } from '../../package.json'
+import { debug } from '../log'
 
-import { debug } from './log'
-import { LocalStorage } from './services/LocalStorageProvider'
+import { LocalStorage } from './LocalStorageProvider'
 
 let eventLoggerGQLClient: SourcegraphGraphQLAPIClient
 export let eventLogger: EventLogger | null = null
 let anonymousUserID: string
 
 export async function updateEventLogger(
-    config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>,
+    config: ConfigurationWithAccessToken,
     localStorage: LocalStorage
 ): Promise<void> {
     const status = await localStorage.setAnonymousUserID()
     anonymousUserID = localStorage.getAnonymousUserID() || ''
     if (!eventLoggerGQLClient) {
         eventLoggerGQLClient = new SourcegraphGraphQLAPIClient(config)
-        eventLogger = EventLogger.create(eventLoggerGQLClient)
+        eventLogger = new EventLogger(eventLoggerGQLClient, config)
         if (status === 'installed') {
             logEvent('CodyInstalled')
         } else {

--- a/vscode/src/services/InlineAssist.ts
+++ b/vscode/src/services/InlineAssist.ts
@@ -29,7 +29,7 @@ export function getSingleLineRange(line: number): vscode.Range {
  */
 export function getIconPath(speaker: string, extPath: string): vscode.Uri {
     const extensionPath = vscode.Uri.file(extPath)
-    const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist')
+    const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist/webviews')
     return vscode.Uri.joinPath(webviewPath, speaker === 'cody' ? 'cody.png' : 'sourcegraph.png')
 }
 

--- a/vscode/src/services/InlineAssist.ts
+++ b/vscode/src/services/InlineAssist.ts
@@ -29,7 +29,7 @@ export function getSingleLineRange(line: number): vscode.Range {
  */
 export function getIconPath(speaker: string, extPath: string): vscode.Uri {
     const extensionPath = vscode.Uri.file(extPath)
-    const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist/webviews')
+    const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist')
     return vscode.Uri.joinPath(webviewPath, speaker === 'cody' ? 'cody.png' : 'sourcegraph.png')
 }
 

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -263,8 +263,11 @@ export class InlineController {
     }
 
     public async error(): Promise<void> {
-        this.reply('Request failed. Please close this and try again.', 'error')
-        if (this.currentTaskId) {
+        const fixupInProgress = this.currentTaskId.length > 0
+        const requestType = fixupInProgress ? 'fix/touch request' : 'request'
+        const msg = 'Please provide Cody with more details and try again.'
+        this.reply(`Cody was unable to complete your ${requestType}. ${msg}`, 'error')
+        if (fixupInProgress) {
             await this.stopFixMode(true)
         }
     }

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -4,10 +4,10 @@ import * as vscode from 'vscode'
 import { ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
 import { SURROUNDING_LINES } from '@sourcegraph/cody-shared/src/prompt/constants'
 
-import { logEvent } from '../event-logger'
 import { CodyTaskState } from '../non-stop/utils'
 
 import { CodeLensProvider } from './CodeLensProvider'
+import { logEvent } from './EventLogger'
 import { editDocByUri, getIconPath, updateRangeOnDocChange } from './InlineAssist'
 
 const initPost = new vscode.Position(0, 0)

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -263,11 +263,8 @@ export class InlineController {
     }
 
     public async error(): Promise<void> {
-        const fixupInProgress = this.currentTaskId.length > 0
-        const requestType = fixupInProgress ? 'fix/touch request' : 'request'
-        const msg = 'Please provide Cody with more details and try again.'
-        this.reply(`Cody was unable to complete your ${requestType}. ${msg}`, 'error')
-        if (fixupInProgress) {
+        this.reply('Request failed. Please close this and try again.', 'error')
+        if (this.currentTaskId) {
             await this.stopFixMode(true)
         }
     }


### PR DESCRIPTION
PR includes the following changes:

- Fixed missing icons for inline chat. Issue was that we have moved the output directory from `dist` to `dist/webview`, so we were not able to get the correct icon path (moved to https://github.com/sourcegraph/cody/pull/320)
- refactor EventLogger to use shared configs to simplify update steps during onConfigChange
- Move event-logger to services directory


## Test plan

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->

Inline Chat Before:
![Screenshot 2023-07-19 at 8 20 39 AM](https://github.com/sourcegraph/cody/assets/68532117/dda01ca1-254b-4fc7-90a8-e74d0a5277e5)

Inline Chat After:
![image](https://github.com/sourcegraph/cody/assets/68532117/7af97b99-85bb-4867-a6cf-8495f8da8ec4)
![image](https://github.com/sourcegraph/cody/assets/68532117/bd4c68a1-6a01-48ce-8e0c-267d91ed2aad)
