### PR TITLE
fix: missing icons for Inline Chat 

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Insert at Cusor now inserts the complete code snippets at cursor position. [pull/282](https://github.com/sourcegraph/cody/pull/282)
 - Minimizing the change of Cody replying users with response related to the language-uage prompt. [pull/279](https://github.com/sourcegraph/cody/pull/279)
+- Inline Chat: Add missing icons for Inline Chat and Inline Fixups decorations. [pull/319](https://github.com/sourcegraph/cody/pull/319)
 
 ### Changed
 

--- a/vscode/src/services/InlineAssist.ts
+++ b/vscode/src/services/InlineAssist.ts
@@ -29,7 +29,7 @@ export function getSingleLineRange(line: number): vscode.Range {
  */
 export function getIconPath(speaker: string, extPath: string): vscode.Uri {
     const extensionPath = vscode.Uri.file(extPath)
-    const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist')
+    const webviewPath = vscode.Uri.joinPath(extensionPath, 'dist/webviews')
     return vscode.Uri.joinPath(webviewPath, speaker === 'cody' ? 'cody.png' : 'sourcegraph.png')
 }
 

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -261,10 +261,15 @@ export class InlineController {
         this.selectionRange = initRange
         this.thread = null
     }
-
+    /**
+     * Display error message when Cody is unable to complete a request
+     */
     public async error(): Promise<void> {
-        this.reply('Request failed. Please close this and try again.', 'error')
-        if (this.currentTaskId) {
+        const fixupInProgress = this.currentTaskId.length > 0
+        const requestType = fixupInProgress ? 'fix/touch request' : 'request'
+        const msg = 'Please provide Cody with more details and try again.'
+        this.reply(`Cody was unable to complete your ${requestType}. ${msg}`, 'error')
+        if (fixupInProgress) {
             await this.stopFixMode(true)
         }
     }


### PR DESCRIPTION
PR includes the following changes:

- Fixed missing icons for inline chat. Issue was that we have moved the output directory from `dist` to `dist/webview`, so we were not able to get the correct icon path
- Update error message for Inline Touch


## Test plan

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->

Inline Chat Before:
![Screenshot 2023-07-19 at 8 20 39 AM](https://github.com/sourcegraph/cody/assets/68532117/dda01ca1-254b-4fc7-90a8-e74d0a5277e5)

Inline Chat After:
![image](https://github.com/sourcegraph/cody/assets/68532117/7af97b99-85bb-4867-a6cf-8495f8da8ec4)
![image](https://github.com/sourcegraph/cody/assets/68532117/bd4c68a1-6a01-48ce-8e0c-267d91ed2aad)
