### PR TITLE
[Cody completion]: Improve trailing completion based on suffix string

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -788,12 +788,15 @@ describe('Cody completions', () => {
 
             it('example with return', async () => {
                 const { completions } = await complete(
-                    `console.log('<< stop completion: ${CURSOR_MARKER}')
-                           return []`,
+                    `
+                    console.log('<< stop completion: ${CURSOR_MARKER}')
+                    return []
+                    `,
                     [
                         createCompletionResponse(`
                                     lastChange was delete')
-                                        return []`),
+                                        return []
+                        `),
                     ]
                 )
 
@@ -802,11 +805,14 @@ describe('Cody completions', () => {
 
             it('example with inline comment', async () => {
                 const { completions } = await complete(
-                    `// ${CURSOR_MARKER}
-                           const currentFilePath = path.normalize(document.fileName)`,
+                    `
+                    // ${CURSOR_MARKER}
+                    const currentFilePath = path.normalize(document.fileName)
+                    `,
                     [
                         createCompletionResponse(`Get the file path
-                                   const filePath = document.fileName`),
+                        const filePath = document.fileName
+                        `),
                     ]
                 )
 

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -770,20 +770,48 @@ describe('Cody completions', () => {
             `)
         })
 
-        it('stops when the next non-empty line of the suffix matches partially', async () => {
-            const { completions } = await complete(
-                `path: $GITHUB_WORKSPACE/vscode/.vscod-etest/${CURSOR_MARKER}
-    key: {{ runner.os }}-pnpm-store-{{ hashFiles('**/pnpm-lock.yaml') }}
-                `,
-                [
-                    createCompletionResponse(`
-                    pnpm-store
-                        key: {{ runner.os }}-pnpm-{{ steps.pnpm-cache.outputs.STORE_PATH }}
-                    }`),
-                ]
-            )
+        describe('stops when the next non-empty line of the suffix matches partially', () => {
+            it('simple example', async () => {
+                const { completions } = await complete(
+                    `path: $GITHUB_WORKSPACE/vscode/.vscod-etest/${CURSOR_MARKER}
+                           key: {{ runner.os }}-pnpm-store-{{ hashFiles('**/pnpm-lock.yaml') }}`,
+                    [
+                        createCompletionResponse(`
+                                    pnpm-store
+                                        key: {{ runner.os }}-pnpm-{{ steps.pnpm-cache.outputs.STORE_PATH }}
+                                    }`),
+                    ]
+                )
 
-            expect(completions[0].insertText).toBe('pnpm-store')
+                expect(completions[0].insertText).toBe('pnpm-store')
+            })
+
+            it('example with return', async () => {
+                const { completions } = await complete(
+                    `console.log('<< stop completion: ${CURSOR_MARKER}')
+                           return []`,
+                    [
+                        createCompletionResponse(`
+                                    lastChange was delete')
+                                        return []`),
+                    ]
+                )
+
+                expect(completions[0].insertText).toBe("lastChange was delete')")
+            })
+
+            it('example with inline comment', async () => {
+                const { completions } = await complete(
+                    `// ${CURSOR_MARKER}
+                           const currentFilePath = path.normalize(document.fileName)`,
+                    [
+                        createCompletionResponse(`Get the file path
+                                   const filePath = document.fileName`),
+                    ]
+                )
+
+                expect(completions[0].insertText).toBe('Get the file path')
+            })
         })
 
         it('ranks results by number of lines', async () => {

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -786,46 +786,43 @@ describe('Cody completions', () => {
             expect(completions.length).toBe(0)
         })
 
-        // We don't support smart completion cut base on multi line suffix yet
-        it.fails('multiline completion duplicate', async () => {
+        it('cuts off a matching line with the next line even if the completion is longer', async () => {
             const { completions } = await complete(
                 `
-                    function bubbleSort() {
-                      ${CURSOR_MARKER}
-                        do {
-                          swapped = false;
-                            for (let i = 0; i < array.length - 1; i++) {
-                                if (array[i] > array[i + 1]) {
-                                    let temp = array[i];
-                                    array[i] = array[i + 1];
-                                    array[i + 1] = temp;
-                                    swapped = true;
-                                }
-                            }
-                       } while (swapped);
+            function bubbleSort() {
+                ${CURSOR_MARKER}
+                do {
+                    swapped = false;
+                    for (let i = 0; i < array.length - 1; i++) {
+                        if (array[i] > array[i + 1]) {
+                            let temp = array[i];
+                            array[i] = array[i + 1];
+                            array[i + 1] = temp;
+                            swapped = true;
+                        }
                     }
-                `,
+                } while (swapped);
+            }
+            `,
                 [
                     createCompletionResponse(`
-                      let swapped;
-                        do {
-                          swapped = false;
-                            for (let i = 0; i < array.length - 1; i++) {
-                                if (array[i] > array[i + 1]) {
-                                    let temp = array[i];
-                                    array[i] = array[i + 1];
-                                    array[i + 1] = temp;
-                                    swapped = true;
-                                }
-                          }
-                     } while (swapped);
-                    `),
+                    let swapped;
+                    do {
+                        swapped = false;
+                        for (let i = 0; i < array.length - 1; i++) {
+                            if (array[i] > array[i + 1]) {
+                                let temp = array[i];
+                                array[i] = array[i + 1];
+                                array[i + 1] = temp;
+                                swapped = true;
+                            }
+                        }
+                    } while (swapped);
+                `),
                 ]
             )
 
-            expect(completions[0].insertText).toMatchInlineSnapshot(`
-                      "let swapped;"
-            `)
+            expect(completions[0].insertText).toBe('let swapped;')
         })
 
         describe('stops when the next non-empty line of the suffix matches partially', () => {

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -786,6 +786,48 @@ describe('Cody completions', () => {
             expect(completions.length).toBe(0)
         })
 
+        // We don't support smart completion cut base on multi line suffix yet
+        it.fails('multiline completion duplicate', async () => {
+            const { completions } = await complete(
+                `
+                    function bubbleSort() {
+                      ${CURSOR_MARKER}
+                        do {
+                          swapped = false;
+                            for (let i = 0; i < array.length - 1; i++) {
+                                if (array[i] > array[i + 1]) {
+                                    let temp = array[i];
+                                    array[i] = array[i + 1];
+                                    array[i + 1] = temp;
+                                    swapped = true;
+                                }
+                            }
+                       } while (swapped);
+                    }
+                `,
+                [
+                    createCompletionResponse(`
+                      let swapped;
+                        do {
+                          swapped = false;
+                            for (let i = 0; i < array.length - 1; i++) {
+                                if (array[i] > array[i + 1]) {
+                                    let temp = array[i];
+                                    array[i] = array[i + 1];
+                                    array[i + 1] = temp;
+                                    swapped = true;
+                                }
+                          }
+                     } while (swapped);
+                    `),
+                ]
+            )
+
+            expect(completions[0].insertText).toMatchInlineSnapshot(`
+                      "let swapped;"
+            `)
+        })
+
         describe('stops when the next non-empty line of the suffix matches partially', () => {
             it('simple example', async () => {
                 const { completions } = await complete(
@@ -914,7 +956,7 @@ describe('Cody completions', () => {
                 ]
             )
 
-            expect(completions[0].insertText).toBe("console.log('one')")
+            expect(completions.length).toBe(0)
         })
 
         it('normalizes Cody responses starting with an empty line and following the exact same indentation as the start line', async () => {

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -155,21 +155,11 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
         if (i === 0) {
             const lastNewlineOfPrefix = prefix.lastIndexOf('\n')
             line = prefix.slice(lastNewlineOfPrefix + 1) + line
-
-            // Skip any procession for the first (inline string insertion/completion)
-            continue
         }
 
-        if (line === firstNonEmptySuffixLine) {
+        if (isAlmostTheSameString(line, firstNonEmptySuffixLine)) {
             insertionEnd = i
             break
-        }
-
-        if (i === insertionLines.length - 1) {
-            if (isAlmostTheSameString(line.trim(), firstNonEmptySuffixLine.trim())) {
-                insertionEnd = i
-                break
-            }
         }
     }
 

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -157,7 +157,9 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
             line = prefix.slice(lastNewlineOfPrefix + 1) + line
         }
 
-        if (isAlmostTheSameString(line, firstNonEmptySuffixLine)) {
+        const isSameIndentation = indentation(line) === indentation(firstNonEmptySuffixLine)
+
+        if (isSameIndentation && isAlmostTheSameString(line, firstNonEmptySuffixLine)) {
             insertionEnd = i
             break
         }

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -177,9 +177,9 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
 }
 
 function getFirstNonEmptyLine(suffix: string): string {
-    const sameLineSuffix = suffix.slice(suffix.indexOf('\n'))
+    const nextLineSuffix = suffix.slice(suffix.indexOf('\n'))
 
-    for (const line of sameLineSuffix.split('\n')) {
+    for (const line of nextLineSuffix.split('\n')) {
         if (line.trim().length > 0) {
             return line
         }

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -160,9 +160,16 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
             continue
         }
 
-        if (isAlmostTheSameString(line.trim(), firstNonEmptySuffixLine.trim())) {
+        if (line === firstNonEmptySuffixLine) {
             insertionEnd = i
             break
+        }
+
+        if (i === insertionLines.length - 1) {
+            if (isAlmostTheSameString(line.trim(), firstNonEmptySuffixLine.trim())) {
+                insertionEnd = i
+                break
+            }
         }
     }
 

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -157,7 +157,7 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
             line = prefix.slice(lastNewlineOfPrefix + 1) + line
         }
 
-        const isSameIndentation = indentation(line) === indentation(firstNonEmptySuffixLine)
+        const isSameIndentation = indentation(line) <= indentation(firstNonEmptySuffixLine)
 
         if (isSameIndentation && isAlmostTheSameString(line, firstNonEmptySuffixLine)) {
             insertionEnd = i

--- a/vscode/src/completions/utils/string-comparator.test.ts
+++ b/vscode/src/completions/utils/string-comparator.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAlmostTheSameString, LevenshteinCompare } from './string-comparator'
+
+describe('isAlmostTheSameString', () => {
+    it.each([
+        [true, '', ''],
+        [true, 'return []', ' return []'],
+        [true, 'const abortController = new AbortController()', 'const networkAbortController = new AbortController()'],
+        [
+            true,
+            'const currentFilePath = path.normalize(document.fileName)',
+            'const filePath = path.normalize(document.fileName)',
+        ],
+        [
+            false,
+            "console.log('Hello world', getSumAandB(a, b))",
+            "console.error('Error log', getDBConnection(context))",
+        ],
+    ])('should return %b for strings %s and %s', (expected, stringA, stringB) => {
+        expect(isAlmostTheSameString(stringA, stringB)).toBe(expected)
+    })
+})
+
+describe('Levenshtein comparator', () => {
+    it.each([
+        ['', '', 0],
+        ['a', '', 1],
+        ['aa', '', 2],
+        ['', 'b', 1],
+        ['', 'bb', 2],
+        ['Mark', 'Zack', 2],
+        ['POLYNOMIAL', 'EXPONENTIAL', 6],
+    ])('should return a correct number of edit for %s and %s strings (edits = %i)', (a, b, expected) => {
+        const numbersOfEdit = LevenshteinCompare(a, b)
+
+        expect(numbersOfEdit).toBe(expected)
+    })
+})

--- a/vscode/src/completions/utils/string-comparator.ts
+++ b/vscode/src/completions/utils/string-comparator.ts
@@ -9,7 +9,7 @@
  *
  * For more details see https://en.wikipedia.org/wiki/Levenshtein_distance
  */
-export const isAlmostTheSameString = (stringA: string, stringB: string, percentage: number = 0.3): boolean => {
+export const isAlmostTheSameString = (stringA: string, stringB: string, percentage: number = 0.33): boolean => {
     const maxLength = Math.max(stringA.length, stringB.length)
     const editOperations = LevenshteinCompare(stringA, stringB)
 

--- a/vscode/src/completions/utils/string-comparator.ts
+++ b/vscode/src/completions/utils/string-comparator.ts
@@ -1,0 +1,91 @@
+/**
+ * Compares string by editing distance algorithm, returns true
+ * whenever string are almost the same, means that strings are
+ * the same if we can apply less than MAX_NUMBER_EDITS to the stringA
+ * to convert it to the stringB. There are three possible types of edit
+ * - Substitution
+ * - Insertion
+ * - Deletion
+ *
+ * For more details see https://en.wikipedia.org/wiki/Levenshtein_distance
+ */
+export const isAlmostTheSameString = (stringA: string, stringB: string, percentage: number = 0.3): boolean => {
+    const maxLength = Math.max(stringA.length, stringB.length)
+    const editOperations = LevenshteinCompare(stringA, stringB)
+
+    // Strings are the same
+    if (editOperations === 0) {
+        return true
+    }
+
+    const operationToLength = editOperations / maxLength
+
+    return percentage > operationToLength
+}
+
+/**
+ * Returns minimal number of edits (Substitution, Insertion, Deletion)
+ * to covert a to b. For simplicity, we take for a fact that all edits
+ * have the same weight/cost.
+ *
+ * Example:
+ * Let's have strings "EDITING" and "DISTANCE"
+ *
+ * 1 2 3 4 5 6 7 8 9
+ * E D I - T I N G -
+ * - D I S T A N C E
+ *
+ * Edit cost is 5 because
+ * - Delete symbol at index 1 (cost = 1)
+ * - Insert symbol S at index 4 (cost = 2)
+ * - Replace at index 6 (cost = 3)
+ * - Replace at index 8 (cost = 4)
+ * - Insert at index 9 (cost = 5)
+ */
+export function LevenshteinCompare(A: string, B: string): number {
+    // Invariants and common cases checks
+    if (A === B) {
+        return 0
+    }
+
+    if (A.length === 0) {
+        return B.length
+    }
+
+    if (B.length === 0) {
+        return A.length
+    }
+
+    // Edit matrix by (B length + 1) on (A length + 1)
+    const matrix: number[][] = []
+
+    // Populate matrix with initial values
+    // prefill first column with symbol indexes
+    for (let m = 0; m <= B.length; m++) {
+        matrix[m] = []
+
+        if (m === 0) {
+            matrix[0] = A.split('').map((_, index) => index)
+        } else {
+            matrix[m][0] = m
+        }
+    }
+
+    for (let n = 1; n <= B.length; ++n) {
+        for (let m = 1; m <= A.length; ++m) {
+            if (B[n - 1] === A[m - 1]) {
+                // Symbols are equal the minimal number of operations
+                // stays the same as it was on previous step
+                matrix[n][m] = matrix[n - 1][m - 1]
+            } else {
+                const deletion = matrix[n - 1][m]
+                const insertion = matrix[n][m - 1]
+                const substitution = matrix[n - 1][m - 1]
+
+                matrix[n][m] = Math.min(deletion, insertion, substitution) + 1
+            }
+        }
+    }
+
+    return matrix[B.length][A.length]
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/264

Prior to this PR, we cut off some trailing parts of completion based on the number of connected characters sequence in the begining of the suffix part (see this PR for more details https://github.com/sourcegraph/cody/pull/108). In this PR, we do simular same logic, but we try to compare strings a bit deeper based on a minimum number of edits operation over strings. If there is more than 30% of differences, we won't cut off the trailing completion. Otherwise, we cut off the completion string. This should handle cases like 

```
// Todo: cancel network request 
const abortController = new AbortController() // ← completion
const networkAbortController = new AbortController()
```

To be clear, even this comparing isn't ideal because there will be some corner cases when we will or won't cut off parts that same/different compared to the first suffix string. But it should cover more cases than the current logic. 

## Test plan
- Testing is the most tricky part here, but we need to find places where Cody generates completion similar to the suffix (next string after insertion happens). You can find a few examples of this behaviour in the issue thread https://github.com/sourcegraph/cody/issues/264 

