### PR TITLE
cody: change history icon

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -337,7 +337,7 @@
         "category": "Cody",
         "title": "Chat History",
         "group": "Cody",
-        "icon": "$(list-unordered)"
+        "icon": "$(history)"
       },
       {
         "command": "cody.comment.add",


### PR DESCRIPTION
Suggestion to change chat history icon from `listed-unordered` to a more familiar history clock for users. 

![CleanShot 2023-07-19 at 15 44 06@2x](https://github.com/sourcegraph/cody/assets/51868853/ffbf5030-2692-4ce5-92f5-f478c18d5df4)


## Test plan
n/a just an icon change

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->
