### PR TITLE
update: log app and auth events

### DIFF
--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -23,7 +23,12 @@ export type WebviewMessage =
     | { command: 'openFile'; filePath: string }
     | { command: 'edit'; text: string }
     | { command: 'insert'; text: string }
-    | { command: 'auth'; type: 'signin' | 'signout' | 'support' | 'app' | 'callback'; endpoint?: string }
+    | {
+          command: 'auth'
+          type: 'signin' | 'signout' | 'support' | 'app' | 'callback'
+          endpoint?: string
+          value?: string
+      }
     | { command: 'abort' }
     | { command: 'chat-button'; action: string }
     | { command: 'setEnabledPlugins'; plugins: string[] }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -86,8 +86,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             if (isInsert) {
                 vscodeAPI.postMessage({ command: 'insert', text })
             }
-            const event = isInsert ? 'insert' : 'click'
-            vscodeAPI.postMessage({ command: 'event', event, value: text })
+            const eventName = isInsert ? 'insert:' : 'copy:'
+            vscodeAPI.postMessage({ command: 'event', event: 'click', value: eventName + text })
         },
         [vscodeAPI]
     )

--- a/vscode/webviews/ConnectApp.tsx
+++ b/vscode/webviews/ConnectApp.tsx
@@ -43,6 +43,7 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
             command: 'auth',
             type: 'app',
             endpoint: url,
+            value: inDownloadMode ? 'download' : 'connect',
         })
 
     return (


### PR DESCRIPTION
Log app and auth event.

Add `app` to event names when logging in with app's URL

## Test plan

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->

Update to log events. Defer to data team to confirm 