### PR TITLE
custom recipes: add /open command and improve prompts

### DIFF
--- a/.vscode/cody.json
+++ b/.vscode/cody.json
@@ -38,6 +38,14 @@
         "currentDir": true
       },
       "note": "Works best if there are other test files in the current directory"
+    },
+    "Compare Files in Opened Tabs": {
+      "prompt": "Compare the code from opened tabs and explain their relationships.",
+      "context": {
+        "openTabs": true,
+        "excludeSelection": true
+      },
+      "description": "This recipe lets Cody analyze code from open tabs to provide insights on how they relate to each other."
     }
   }
 }

--- a/.vscode/cody.json
+++ b/.vscode/cody.json
@@ -2,15 +2,16 @@
   "description": "This file is used for building custom workspace recipes for Cody by Sourcegraph.",
   "recipes": {
     "Spell Checker": {
-      "prompt": "Correct all typos and non-standard usage for the selected code. Make sure the revised version is consistent with the surrounding code. Do not format the answer as a code block. If you are unsure about a word, please leave it as is."
+      "prompt": "Correct all typos and non-standard usage for the selected code."
     },
     "Refactor Code": {
       "prompt": "Please analyze the code and suggest constructive edits that follow best practices and improve code quality and readability. Focus your responses on being clear, thoughtful, coherent and easy for me to understand. Do not make changes that alter intended functionality without explaining why. Avoid responses that are overly complex or difficult to implement. Strive to provide helpful recommendations based on other shared code snippests."
     },
     "Generate README.md for Current Directory": {
-      "prompt": "Create a README.md for this directory.",
+      "prompt": "Write a detailed README.md introduction for this project. If possible, briefly explain what the directory is and its key features. Use Markdown formatting. Focus on clarity and being beginner-friendly. Surround the answer with a code block to indicate that it is code.",
       "context": {
-        "currentDir": true
+        "currentDir": true,
+        "excludeSelection": true
       }
     },
     "Commit Message for Current Changes": {
@@ -18,24 +19,25 @@
       "command": "git",
       "args": ["diff"],
       "context": {
-        "none": true
+        "excludeSelection": true
       },
       "note": "You must have git installed and authenticated to use this recipe"
     },
-    "Debug latest error from Cody app": {
+    "Debug last error from Cody app": {
       "prompt": "Tell me about the most recent error in log and how I can resolve it.",
       "command": "cat",
       "args": ["~/Library/Logs/com.sourcegraph.cody/Cody.log"],
       "context": {
-        "none": true
+        "excludeSelection": true
       },
       "note": "You must have Cody app installed to use this recipe"
     },
     "Generate Multiple Unit Tests": {
-      "prompt": "Generate at least 3 unit tests for the selected code. Provide me with full workable and only import libraries that are also used by other test files in the directory",
+      "prompt": "Generate at least 3 unit tests for the selected code. Provide me with full, workable unit tests. You may import common libraries like the language's built-in test framework. If there are existing test files in the directory, try to follow similar patterns and imports used in those files. If no test files exist yet, use common best practices for unit testing this language.",
       "context": {
         "currentDir": true
-      }
+      },
+      "note": "Works best if there are other test files in the current directory"
     }
   }
 }

--- a/lib/shared/src/chat/recipes/my-prompt.ts
+++ b/lib/shared/src/chat/recipes/my-prompt.ts
@@ -161,9 +161,9 @@ export class MyPrompt implements Recipe {
             if (dirPath && doc.uri.fsPath.includes(dirPath)) {
                 continue
             }
-            const fileName = vscode.workspace.asRelativePath(doc.uri.fsPath)
             // remove workspace root path from fileName
             const fileContent = await vscode.workspace.openTextDocument(doc.uri)
+            const fileName = vscode.workspace.asRelativePath(doc.uri.fsPath)
             const truncatedContent = truncateText(fileContent.getText(), MAX_CURRENT_FILE_TOKENS)
             const docAsMessage = getContextMessageWithResponse(
                 populateCurrentEditorContextTemplate(truncatedContent, fileName),

--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -54,7 +54,7 @@ interface VsCodeFixupController {
 interface VsCodeMyPromptController {
     get(type?: string): string | null
     run(command: string): string | null
-    add(): Promise<void>
+    menu(): Promise<void>
 }
 
 export interface ActiveTextEditorViewControllers {

--- a/vscode/resources/samples/user-cody.json
+++ b/vscode/resources/samples/user-cody.json
@@ -1,38 +1,32 @@
 {
   "title": "Cody Custom Recipes - User",
-  "description": "This is an example file to showcase how to build custom recipes for Cody by Sourcegraph.",
+  "description": "This file showcases how to build custom recipes for Cody by Sourcegraph.",
   "recipes": {
     "Spell Checker": {
-      "prompt": "Correct all typos and non-standard usage for the selected code."
+      "prompt": "Review the selected code and correct any typos and non-standard usage. Ensure the corrected code remains unchanged in its functionality and readability."
+    },
+    "Generate Multiple Unit Tests": {
+      "prompt": "Create at least 3 full, workable unit tests for the selected code. You may import common libraries for testing. Follow patterns and imports used in existing test files if available, otherwise use best practices for unit testing in this language.",
+      "context": {
+        "currentDir": true
+      }
     },
     "Refactor Code": {
-      "prompt": "Please analyze the code and suggest constructive edits that follow best practices and improve code quality and readability. Focus your responses on being clear, thoughtful, coherent and easy for me to understand. Do not make changes that alter intended functionality without explaining why. Avoid responses that are overly complex or difficult to implement. Strive to provide helpful recommendations based on other shared code snippests."
+      "prompt": "Analyze the code and suggest constructive edits that improve code quality and readability. Focus on providing clear, thoughtful, and coherent recommendations. Avoid altering intended functionality without explanation. Make suggestions that are easy to implement and based on shared code snippets. Provide full revised code at the end."
     },
-    "GH Search: Deploy Repoes not owned by Sourcegraph": {
-      "prompt": "What are the names of repositories that are used for deploying Sourcegraph but is not directly owned by Sourcegraph?",
+    "GH Search: Deployed Repositories not owned by Sourcegraph": {
+      "prompt": "Find repositories used for deploying Sourcegraph but not directly owned by Sourcegraph.",
       "command": "gh",
       "args": ["search", "repos", "sourcegraph", "deploy"],
-      "note": "You must have gh command installed and authenticated to use this recipe"
+      "description": "Make sure you have the 'gh' command installed and authenticated. "
     },
     "Compare Files in Opened Tabs": {
-      "prompt": "Compare the code and explain how they are related",
+      "prompt": "Compare the code from opened tabs and explain their relationships.",
       "context": {
         "openTabs": true,
         "excludeSelection": true
-      }
-    },
-    "Generate Multiple Unit Tests": {
-      "prompt": "Generate at least 3 unit tests for the selected code. Provide me with full, workable unit tests. You may import common libraries like the language's built-in test framework. If there are existing test files in the directory, try to follow similar patterns and imports used in those files. If no test files exist yet, use common best practices for unit testing this language.",
-      "context": {
-        "currentDir": true
       },
-      "note": "Works best if there are other test files in the current directory"
-    },
-    "Remove User Recipes File": {
-      "prompt": "",
-      "command": "rm",
-      "args": ["~/.vscode/cody.json"],
-      "note": "This delete the cody.json file and reset the conversation with Cody"
+      "description": "This recipe lets Cody analyze code from open tabs to provide insights on how they relate to each other."
     }
   }
 }

--- a/vscode/resources/samples/user-cody.json
+++ b/vscode/resources/samples/user-cody.json
@@ -1,8 +1,9 @@
 {
+  "title": "Cody Custom Recipes - User",
   "description": "This is an example file to showcase how to build custom recipes for Cody by Sourcegraph.",
   "recipes": {
     "Spell Checker": {
-      "prompt": "Spell check the selected code and correct all typos and non-standard usage. Make sure the revised version is consistent with the surrounding code."
+      "prompt": "Correct all typos and non-standard usage for the selected code."
     },
     "Refactor Code": {
       "prompt": "Please analyze the code and suggest constructive edits that follow best practices and improve code quality and readability. Focus your responses on being clear, thoughtful, coherent and easy for me to understand. Do not make changes that alter intended functionality without explaining why. Avoid responses that are overly complex or difficult to implement. Strive to provide helpful recommendations based on other shared code snippests."
@@ -13,15 +14,22 @@
       "args": ["search", "repos", "sourcegraph", "deploy"],
       "note": "You must have gh command installed and authenticated to use this recipe"
     },
-    "Generate Unit Tests": {
-      "prompt": "Generate multiple unit tests with full workable code",
+    "Compare Files in Opened Tabs": {
+      "prompt": "Compare the code and explain how they are related",
+      "context": {
+        "openTabs": true,
+        "excludeSelection": true
+      }
+    },
+    "Generate Multiple Unit Tests": {
+      "prompt": "Generate at least 3 unit tests for the selected code. Provide me with full, workable unit tests. You may import common libraries like the language's built-in test framework. If there are existing test files in the directory, try to follow similar patterns and imports used in those files. If no test files exist yet, use common best practices for unit testing this language.",
       "context": {
         "currentDir": true
       },
       "note": "Works best if there are other test files in the current directory"
     },
     "Remove User Recipes File": {
-      "prompt": "/reset",
+      "prompt": "",
       "command": "rm",
       "args": ["~/.vscode/cody.json"],
       "note": "This delete the cody.json file and reset the conversation with Cody"

--- a/vscode/resources/samples/user-cody.json
+++ b/vscode/resources/samples/user-cody.json
@@ -14,12 +14,6 @@
     "Refactor Code": {
       "prompt": "Analyze the code and suggest constructive edits that improve code quality and readability. Focus on providing clear, thoughtful, and coherent recommendations. Avoid altering intended functionality without explanation. Make suggestions that are easy to implement and based on shared code snippets. Provide full revised code at the end."
     },
-    "GH Search: Deployed Repositories not owned by Sourcegraph": {
-      "prompt": "Find repositories used for deploying Sourcegraph but not directly owned by Sourcegraph.",
-      "command": "gh",
-      "args": ["search", "repos", "sourcegraph", "deploy"],
-      "description": "Make sure you have the 'gh' command installed and authenticated. "
-    },
     "Compare Files in Opened Tabs": {
       "prompt": "Compare the code from opened tabs and explain their relationships.",
       "context": {

--- a/vscode/resources/samples/workspace-cody.json
+++ b/vscode/resources/samples/workspace-cody.json
@@ -17,10 +17,6 @@
         "excludeSelection": true
       },
       "note": "You must have git installed and authenticated to use this recipe"
-    },
-    "Open User Recipes File": {
-      "prompt": "/open user",
-      "note": "Open the existing cody.json file for User recipes in your editor if any"
     }
   }
 }

--- a/vscode/resources/samples/workspace-cody.json
+++ b/vscode/resources/samples/workspace-cody.json
@@ -1,15 +1,9 @@
 {
+  "title": "Cody Custom Recipes - Workspace",
   "description": "This is an example file to showcase how to build custom recipes for Cody by Sourcegraph.",
   "recipes": {
-    "Compare Files in Opened Tabs": {
-      "prompt": "Compare the code and explain how they are related",
-      "context": {
-        "openTabs": true,
-        "excludeSelection": true
-      }
-    },
     "Generate README.md for Current Directory": {
-      "prompt": "Create a README.md for this directory.",
+      "prompt": "Write a detailed README.md introduction for this project. If possible, briefly explain what the directory is and its key features. Use Markdown formatting. Focus on clarity and being beginner-friendly. Surround the answer with a code block to indicate that it is code.",
       "context": {
         "currentDir": true,
         "excludeSelection": true
@@ -20,24 +14,13 @@
       "command": "git",
       "args": ["diff"],
       "context": {
-        "none": true
+        "excludeSelection": true
       },
       "note": "You must have git installed and authenticated to use this recipe"
     },
-    "Debug latest error from Cody app": {
-      "prompt": "Tell me about the most recent error in log and how I can resolve it.",
-      "command": "cat",
-      "args": ["~/Library/Logs/com.sourcegraph.cody/Cody.log"],
-      "context": {
-        "none": true
-      },
-      "note": "You must have Cody app installed to use this recipe"
-    },
-    "Remove Workspace Recipes File": {
-      "prompt": "/reset",
-      "command": "rm",
-      "args": [".vscode/cody.json"]
-    },
-    "note": "This delete the cody.json file from your workspace and reset the conversation with Cody"
+    "Open User Recipes File": {
+      "prompt": "/open user",
+      "note": "Open the existing cody.json file for User recipes in your editor if any"
+    }
   }
 }

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -453,19 +453,23 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         if (this.config.experimentalChatPredictions) {
             void this.runRecipeForSuggestion('next-questions', text)
         }
-        await this.executeChatCommands(text)
+        await this.executeChatCommands(text, 'chat-question')
     }
 
-    private async executeChatCommands(text: string): Promise<void> {
+    private async executeChatCommands(text: string, recipeID: RecipeID = 'chat-question'): Promise<void> {
         switch (true) {
-            case /^\/r(est)?/i.test(text):
+            case /^\/o(pen)?/i.test(text):
+                // open the user's ~/.vscode/cody.json file
+                await this.editor.controllers.prompt.open(text.split(' ')[1])
+                break
+            case /^\/r(eset)?/i.test(text):
                 await this.clearAndRestartSession()
                 break
             case /^\/s(earch)?\s/i.test(text):
                 await this.executeRecipe('context-search', text)
                 break
             default:
-                return this.executeRecipe('chat-question', text)
+                return this.executeRecipe(recipeID, text)
         }
     }
 
@@ -755,20 +759,18 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             }
             return
         }
-        this.showTab('chat')
-        // Get prompt details from controller by title then execute
+        // Get prompt details from controller by title then execute prompt's command
         const prompt = this.editor.controllers.prompt.find(title)
+        this.editor.controllers.prompt.getCommandOutput()
         if (!prompt) {
-            void vscode.window.showErrorMessage(`Could not find prompt for the "${title}" recipe.`)
+            // void vscode.window.showErrorMessage(`Could not find prompt for the "${title}" recipe.`)
             debug('executeMyPrompt:noPrompt', title)
             return
         }
-        if (/^\/r(est)?/i.test(prompt)) {
-            this.editor.controllers.prompt.getCommandOutput()
-            await this.clearAndRestartSession()
-            return
+        if (!prompt.startsWith('/')) {
+            this.showTab('chat')
         }
-        await this.executeRecipe('my-prompt', prompt, true)
+        await this.executeChatCommands(prompt, 'my-prompt')
     }
 
     /**

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -120,14 +120,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.disposables.push(this.configurationChangeEvent)
 
         this.currentWorkspaceRoot = ''
-
-        // listen for file change event for JSON files used for building Custom Recipes
-        const myWorkspacePromptsWatcher = this.editor.controllers?.prompt?.wsFileWatcher
-        const myUserPromptsWatcher = this.editor.controllers?.prompt?.userFileWatcher
-        myWorkspacePromptsWatcher?.onDidChange(() => this.sendMyPrompts())
-        myWorkspacePromptsWatcher?.onDidDelete(() => this.sendMyPrompts())
-        myUserPromptsWatcher?.onDidChange(() => this.sendMyPrompts())
-        myUserPromptsWatcher?.onDidDelete(() => this.sendMyPrompts())
+        this.customRecipesInit()
 
         // listen for vscode active editor change event
         this.disposables.push(
@@ -738,14 +731,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             return
         }
         // Create a new recipe
-        if (title === 'add') {
-            await this.editor.controllers.prompt.add()
-            await this.sendMyPrompts()
-            return
-        }
-        // Clear all recipes stored in user global storage
-        if (title === 'clear') {
-            await this.editor.controllers.prompt.clear()
+        if (title === 'menu') {
+            await this.editor.controllers.prompt.menu()
             await this.sendMyPrompts()
             return
         }
@@ -763,7 +750,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         const prompt = this.editor.controllers.prompt.find(title)
         this.editor.controllers.prompt.getCommandOutput()
         if (!prompt) {
-            // void vscode.window.showErrorMessage(`Could not find prompt for the "${title}" recipe.`)
             debug('executeMyPrompt:noPrompt', title)
             return
         }
@@ -771,6 +757,16 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             this.showTab('chat')
         }
         await this.executeChatCommands(prompt, 'my-prompt')
+    }
+
+    private customRecipesInit(): void {
+        // listen for file change event for JSON files used for building Custom Recipes
+        const myWorkspacePromptsWatcher = this.editor.controllers?.prompt?.wsFileWatcher
+        const myUserPromptsWatcher = this.editor.controllers?.prompt?.userFileWatcher
+        myWorkspacePromptsWatcher?.onDidChange(() => this.sendMyPrompts())
+        myWorkspacePromptsWatcher?.onDidDelete(() => this.sendMyPrompts())
+        myUserPromptsWatcher?.onDidChange(() => this.sendMyPrompts())
+        myUserPromptsWatcher?.onDidDelete(() => this.sendMyPrompts())
     }
 
     /**

--- a/vscode/src/my-cody/CustomRecipesBuilder.ts
+++ b/vscode/src/my-cody/CustomRecipesBuilder.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode'
+
+import { Preamble } from '@sourcegraph/cody-shared/src/chat/preamble'
+import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
+
+import { constructFileUri } from './helper'
+import { CodyPrompt, CodyPromptType, CustomRecipesFileName, MyPrompts, MyPromptsJSON } from './types'
+
+export class CustomRecipesBuilder {
+    public myPremade: Preamble | undefined = undefined
+    public myPromptsMap = new Map<string, CodyPrompt>()
+    public myStarter = ''
+    public idSet = new Set<string>()
+
+    public userPromptsJSON: MyPromptsJSON | null = null
+
+    public promptSize = promptSizeInit
+
+    public jsonFileUris: { user?: vscode.Uri; workspace?: vscode.Uri }
+
+    public codebase: string | null = null
+
+    constructor(
+        private workspaceRoot?: string,
+        private homeDir?: string
+    ) {
+        this.jsonFileUris = {
+            user: constructFileUri(CustomRecipesFileName, homeDir),
+            workspace: constructFileUri(CustomRecipesFileName, workspaceRoot),
+        }
+    }
+
+    public async get(): Promise<MyPrompts> {
+        // reset map and set
+        this.myPromptsMap = new Map<string, CodyPrompt>()
+        this.idSet = new Set<string>()
+        this.promptSize = { ...promptSizeInit }
+        // user prompts
+        if (this.homeDir) {
+            const userPrompts = await this.getPromptsFromFileSystem('user')
+            this.build(userPrompts, 'user')
+        }
+        // workspace prompts
+        if (this.workspaceRoot) {
+            const wsPrompts = await this.getPromptsFromFileSystem('workspace')
+            this.build(wsPrompts, 'workspace')
+        }
+        return { prompts: this.myPromptsMap, premade: this.myPremade, starter: this.myStarter }
+    }
+
+    public getIDs(): string[] {
+        return [...this.idSet]
+    }
+
+    public build(content: string | null, type: CodyPromptType): Map<string, CodyPrompt> | null {
+        if (!content) {
+            return null
+        }
+        const json = JSON.parse(content) as MyPromptsJSON
+        const prompts = json.recipes
+        for (const key in prompts) {
+            if (Object.prototype.hasOwnProperty.call(prompts, key)) {
+                const prompt = prompts[key]
+                prompt.type = type
+                this.myPromptsMap.set(key, prompt)
+                this.idSet.add(key)
+            }
+        }
+        this.myPremade = json.premade
+        if (json.starter && json?.starter !== this.myStarter) {
+            PromptMixin.addCustom(newPromptMixin(json.starter))
+            this.myStarter = json.starter
+        }
+        if (type === 'user') {
+            this.userPromptsJSON = json
+        }
+        this.promptSize[type] = this.myPromptsMap.size
+        return this.myPromptsMap
+    }
+
+    private async getPromptsFromFileSystem(type: CodyPromptType): Promise<string | null> {
+        const codyJsonFilePath = type === 'user' ? this.jsonFileUris.user : this.jsonFileUris.workspace
+        if (!codyJsonFilePath) {
+            return null
+        }
+        try {
+            const bytes = await vscode.workspace.fs.readFile(codyJsonFilePath)
+            const decoded = new TextDecoder('utf-8').decode(bytes) || null
+            return decoded
+        } catch {
+            return null
+        }
+    }
+}
+
+const promptSizeInit = {
+    user: 0,
+    workspace: 0,
+}

--- a/vscode/src/my-cody/CustomRecipesBuilder.ts
+++ b/vscode/src/my-cody/CustomRecipesBuilder.ts
@@ -6,6 +6,10 @@ import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt
 import { constructFileUri } from './helper'
 import { CodyPrompt, CodyPromptType, CustomRecipesFileName, MyPrompts, MyPromptsJSON } from './types'
 
+/**
+ * The CustomRecipesBuilder class is responsible for loading and building the custom prompts from the cody.json files.
+ * It has methods to get the prompts from the file system, parse the JSON, and build the prompts map.
+ */
 export class CustomRecipesBuilder {
     public myPremade: Preamble | undefined = undefined
     public myPromptsMap = new Map<string, CodyPrompt>()
@@ -30,6 +34,7 @@ export class CustomRecipesBuilder {
         }
     }
 
+    // Get the formatted context from the json config file
     public async get(): Promise<MyPrompts> {
         // reset map and set
         this.myPromptsMap = new Map<string, CodyPrompt>()
@@ -48,10 +53,12 @@ export class CustomRecipesBuilder {
         return { prompts: this.myPromptsMap, premade: this.myPremade, starter: this.myStarter }
     }
 
+    // This is use to remove duplicate prompts
     public getIDs(): string[] {
         return [...this.idSet]
     }
 
+    // Build the map of prompts from the json string
     public build(content: string | null, type: CodyPromptType): Map<string, CodyPrompt> | null {
         if (!content) {
             return null
@@ -78,6 +85,7 @@ export class CustomRecipesBuilder {
         return this.myPromptsMap
     }
 
+    // Get the context of the json file from the file system
     private async getPromptsFromFileSystem(type: CodyPromptType): Promise<string | null> {
         const codyJsonFilePath = type === 'user' ? this.jsonFileUris.user : this.jsonFileUris.workspace
         if (!codyJsonFilePath) {

--- a/vscode/src/my-cody/InputMenu.ts
+++ b/vscode/src/my-cody/InputMenu.ts
@@ -1,0 +1,230 @@
+import * as vscode from 'vscode'
+
+import { defaultCodyPromptContext } from '@sourcegraph/cody-shared/src/chat/recipes/my-prompt'
+
+import { prompt_creation_title } from './helper'
+import { CodyPrompt } from './types'
+
+export type answerType = 'add' | 'file' | 'delete' | 'recipes' | 'open' | 'cancel'
+export type recipeType = 'user' | 'workspace'
+
+export async function showCustomRecipeMenu(): Promise<answerType | void> {
+    const options = [
+        'Create New User Recipe',
+        'Generate Recipes Config File',
+        'Delete Recipes Config File',
+        'Open Recipes Config File',
+        'Cancel',
+    ]
+    const selectedOption = await vscode.window.showQuickPick(options)
+    if (!selectedOption) {
+        return
+    }
+    switch (selectedOption) {
+        case 'Create New User Recipe': {
+            return 'add'
+        }
+        case 'Open Recipes Config File': {
+            return 'open'
+        }
+        case 'Generate Recipes Config File': {
+            return 'file'
+        }
+        case 'Delete Recipes Config File': {
+            return 'delete'
+        }
+        default:
+            return
+    }
+}
+
+export async function recipePicker(promptList: string[] = []): Promise<string> {
+    const selectedRecipe = (await vscode.window.showQuickPick(promptList)) || ''
+    return selectedRecipe
+}
+
+// This allows users to create a new prompt via UI using the input box and quick pick without having to manually edit the cody.json file
+export async function createNewPrompt(promptName?: string): Promise<CodyPrompt | null> {
+    if (!promptName) {
+        return null
+    }
+    // Get the prompt description from the user using the input box
+    const minPromptLength = 3
+    const promptDescription = await vscode.window.showInputBox({
+        title: prompt_creation_title,
+        prompt: 'Enter a prompt for the recipe. A prompt is a set of instructions/questions for Cody to follow and answer.',
+        placeHolder: "e,g. 'Create five different test cases for the selected code''",
+        validateInput: (input: string) => {
+            if (!input || input.split(' ').length < minPromptLength) {
+                return `Prompt cannot be empty and should be as detailed as possible. Please enter a prompt with at least ${minPromptLength} words.`
+            }
+            return null
+        },
+    })
+    if (!promptDescription) {
+        void vscode.window.showErrorMessage('Invalid values.')
+        return null
+    }
+    const newPrompt: CodyPrompt = { prompt: promptDescription }
+    newPrompt.context = { ...defaultCodyPromptContext }
+    // Get the context types from the user using the quick pick
+    const promptContext = await vscode.window.showQuickPick(contextTypes, {
+        title: 'Select the context to include with the prompt for the new recipe',
+        placeHolder: 'TIPS: Providing limited but precise context helps Cody provide more relevant answers',
+        canPickMany: true,
+        ignoreFocusOut: false,
+        onDidSelectItem: (item: vscode.QuickPickItem) => {
+            item.picked = !item.picked
+        },
+    })
+    if (promptContext?.length) {
+        for (const context of promptContext) {
+            switch (context.id) {
+                case 'selection':
+                    newPrompt.context.excludeSelection = !context.picked
+                    break
+                case 'codebase':
+                    newPrompt.context.codebase = true
+                    break
+                case 'currentDir':
+                    newPrompt.context.currentDir = true
+                    break
+                case 'openTabs':
+                    newPrompt.context.openTabs = true
+                    break
+                case 'none':
+                    newPrompt.context.none = true
+                    break
+                case 'command': {
+                    const promptCommand = await showPromptCommandInput()
+                    if (promptCommand) {
+                        const commandParts = promptCommand.split(' ')
+                        if (commandParts.length) {
+                            newPrompt.command = commandParts.shift()
+                            newPrompt.args = commandParts
+                        }
+                        break
+                    }
+                }
+            }
+        }
+    }
+    return newPrompt
+}
+
+export const contextTypes = [
+    {
+        id: 'selection',
+        label: 'Selected Code',
+        detail: 'Code currently highlighted in the active editor.',
+        picked: true,
+    },
+    {
+        id: 'codebase',
+        label: 'Codebase',
+        detail: 'Code snippets retrieved from the available source for codebase context (embeddings or local keyword search).',
+        picked: false,
+    },
+    {
+        id: 'currentDir',
+        label: 'Current Directory',
+        description: 'If the prompt includes "test(s)", only test files will be included.',
+        detail: 'First 10 text files in the current directory',
+        picked: false,
+    },
+    {
+        id: 'openTabs',
+        label: 'Current Open Tabs',
+        detail: 'First 10 text files in current open tabs',
+        picked: false,
+    },
+    {
+        id: 'command',
+        label: 'Command Output',
+        detail: 'The output returned from a terminal command run from your local workspace. E.g. git describe --long',
+        picked: false,
+    },
+    {
+        id: 'none',
+        label: 'None',
+        detail: 'Exclude all types of context.',
+        picked: false,
+    },
+]
+
+export async function showPromptCommandInput(): Promise<string | void> {
+    // Get the command to run from the user using the input box
+    const promptCommand = await vscode.window.showInputBox({
+        title: prompt_creation_title,
+        prompt: '[Optional] Add a terminal command for the recipe to run from your current workspace. The output will be shared with Cody as context for the prompt. (The added command must work on your local machine.)',
+        placeHolder: 'e,g. node your-script.js, git describe --long, cat src/file-name.js etc.',
+    })
+    return promptCommand
+}
+
+export async function showPromptNameInput(myPromptStore: Map<string, CodyPrompt>): Promise<string | void> {
+    const promptName = await vscode.window.showInputBox({
+        title: prompt_creation_title,
+        prompt: 'Enter an unique name for the new recipe.',
+        placeHolder: 'e,g. Vulnerability Scanner',
+        validateInput: (input: string) => {
+            if (!input || input.split(' ').length < 2) {
+                return 'Please enter a valid name for the recipe. A recipe name should be at least two words.'
+            }
+            if (myPromptStore.has(input)) {
+                return 'A recipe with the same name already exists. Please enter a different name.'
+            }
+            return
+        },
+    })
+    return promptName
+}
+
+export async function showRemoveConfirmationInput(): Promise<string | void> {
+    const confirmRemove = await vscode.window.showWarningMessage(
+        'Are you sure you want to remove .vscode/cody.json from your home directory?',
+        { modal: true },
+        'Yes',
+        'No'
+    )
+    return confirmRemove
+}
+
+export async function showRecipeTypeQuickPick(
+    action: 'file' | 'delete' | 'open',
+    prompts: {
+        user: number
+        workspace: number
+    }
+): Promise<recipeType | null> {
+    const options: string[] = []
+    if (action === 'file') {
+        if (prompts.user === 0) {
+            options.push('user')
+        }
+        if (prompts.workspace === 0) {
+            options.push('workspace')
+        }
+    } else {
+        if (prompts.user > 0) {
+            options.push('user')
+        }
+        if (prompts.workspace > 0) {
+            options.push('workspace')
+        }
+    }
+    if (options.length === 0) {
+        const msg =
+            action === 'file'
+                ? 'File for both User and Workspace Recipes already exists...'
+                : 'No recipe files were found...'
+        options.push(msg)
+    }
+    const title = 'Select recipe type to continue...'
+    // Show quick pick menu
+    const recipeType = await vscode.window.showQuickPick(options, { title })
+    if (recipeType !== 'user' && recipeType !== 'workspace') {
+        return null
+    }
+    return recipeType
+}

--- a/vscode/src/my-cody/InputMenu.ts
+++ b/vscode/src/my-cody/InputMenu.ts
@@ -3,10 +3,9 @@ import * as vscode from 'vscode'
 import { defaultCodyPromptContext } from '@sourcegraph/cody-shared/src/chat/recipes/my-prompt'
 
 import { prompt_creation_title } from './helper'
-import { CodyPrompt } from './types'
+import { CodyPrompt, CodyPromptType } from './types'
 
 export type answerType = 'add' | 'file' | 'delete' | 'recipes' | 'open' | 'cancel'
-export type recipeType = 'user' | 'workspace'
 
 export async function showCustomRecipeMenu(): Promise<answerType | void> {
     const options = [
@@ -196,7 +195,7 @@ export async function showRecipeTypeQuickPick(
         user: number
         workspace: number
     }
-): Promise<recipeType | null> {
+): Promise<CodyPromptType | null> {
     const options: string[] = []
     if (action === 'file') {
         if (prompts.user === 0) {

--- a/vscode/src/my-cody/MyToolsProvider.ts
+++ b/vscode/src/my-cody/MyToolsProvider.ts
@@ -1,7 +1,9 @@
-import { spawnSync } from 'child_process'
+import { exec, spawnSync } from 'child_process'
 import os from 'os'
 
 import * as vscode from 'vscode'
+
+import { getFileNameFromPath, getFileToRemove, outputWrapper } from './helper'
 
 const rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath
 const currentFilePath = vscode.window.activeTextEditor?.document.uri.fsPath
@@ -11,19 +13,27 @@ const homePath = os.homedir()
 export class MyToolsProvider {
     private tools = new Map<string, string>()
     private username: string
+    private user: { name: string; homeDir: string; workspaceRoot?: string; currentFilePath?: string }
 
     constructor(public context: vscode.ExtensionContext) {
         this.username = this.runCommand('git', ['config', 'user.name'])
+        this.user = this.getUserInfo()
     }
 
     public getUserInfo(): { name: string; homeDir: string; workspaceRoot?: string; currentFilePath?: string } {
-        const user = {
+        if (this.user?.workspaceRoot) {
+            return this.user
+        }
+        return {
             name: this.username,
             homeDir: homePath,
             workspaceRoot: rootPath,
             currentFilePath,
         }
-        return user
+    }
+
+    public async openFile(uri?: vscode.Uri): Promise<void> {
+        return vscode.commands.executeCommand('vscode.open', uri)
     }
 
     public async openFolder(): Promise<void> {
@@ -32,23 +42,65 @@ export class MyToolsProvider {
 
     public runCommand(command: string, args: string[] = [], runFromWSRoot = true): string {
         const fullCommand = `${command} ${args.join(' ')}`
-        const output = spawnSync(command, args, { cwd: runFromWSRoot ? rootPath : currentFilePath, encoding: 'utf8' })
-        return outputWrapper.replace('{command}', fullCommand).replace('{output}', output.stdout.toString().trim())
+        try {
+            const output =
+                spawnSync(command, args, {
+                    cwd: runFromWSRoot ? rootPath : currentFilePath,
+                    encoding: 'utf8',
+                }) || ''
+            // stringify the output of the command first
+            const outputString = JSON.stringify(output.stdout.toString().trim())
+            if (!outputString) {
+                void vscode.window.showInformationMessage(
+                    `No output return from ${fullCommand}. Please make sure the command works in your terminal before trying again.`
+                )
+            }
+            return outputString ? outputWrapper.replace('{command}', fullCommand).replace('{output}', outputString) : ''
+        } catch (error) {
+            // handle error
+            void vscode.window.showInformationMessage(
+                `Failed to run ${fullCommand}. Please make sure the command works in your terminal before trying again.`
+            )
+            console.error(error)
+            return ''
+        }
+    }
+
+    public exeCommand(command: string): string | undefined {
+        try {
+            const { stdout, stderr } = exec(command, {
+                cwd: this.user.homeDir,
+                encoding: 'utf8',
+            })
+            // stringify the output of the command first
+            const outputString = JSON.stringify(stdout?.toString().trim())
+            if (!outputString || stderr) {
+                console.error(stderr)
+                throw new Error(`No output from ${command}.`)
+            }
+            return outputWrapper.replace('{command}', command).replace('{output}', outputString)
+        } catch {
+            // handle error
+            void vscode.window.showErrorMessage(
+                'Failed to run command. Please make sure the command works in your terminal before trying again.'
+            )
+            return
+        }
     }
 
     // A tool that allows the user to interact with the the file system
     public async runFileSystemCommand(command: string): Promise<void> {
         switch (command) {
             case 'add': {
-                const file = await vscode.window.showOpenDialog({
+                const selectedFile = await vscode.window.showOpenDialog({
                     canSelectFiles: true,
                     canSelectFolders: false,
                     canSelectMany: false,
                     openLabel: 'Select File',
                 })
-                if (file) {
-                    const fileName = file[0].path.split('/').pop()
-                    const filePath = file[0].path
+                if (selectedFile) {
+                    const fileName = getFileNameFromPath(selectedFile[0].path)
+                    const filePath = selectedFile[0].path
                     if (fileName && filePath) {
                         this.tools.set(fileName, filePath)
                     }
@@ -56,18 +108,14 @@ export class MyToolsProvider {
                 break
             }
             case 'remove': {
-                const fileToRemove = await vscode.window.showQuickPick(Array.from(this.tools.keys()))
+                const fileToRemove = await getFileToRemove(Array.from(this.tools.keys()))
                 if (fileToRemove) {
                     this.tools.delete(fileToRemove)
                 }
                 break
             }
+            default:
+                return
         }
     }
 }
-
-const outputWrapper = `
-Here is the output of \`{command}\` command:
-\`\`\`sh
-{output}
-\`\`\``

--- a/vscode/src/my-cody/helper.ts
+++ b/vscode/src/my-cody/helper.ts
@@ -1,12 +1,8 @@
 import * as vscode from 'vscode'
 
-import { defaultCodyPromptContext } from '@sourcegraph/cody-shared/src/chat/recipes/my-prompt'
-
-import { CodyPrompt } from './MyPromptController'
-
-export function makeFileUri(fileName: string, rootDirPath?: string): vscode.Uri | null {
+export function constructFileUri(fileName: string, rootDirPath?: string): vscode.Uri | undefined {
     if (!rootDirPath) {
-        return null
+        return undefined
     }
     const rootDirUri = vscode.Uri.parse(rootDirPath)
     const codyJsonFilePath = vscode.Uri.joinPath(rootDirUri, fileName)
@@ -16,7 +12,7 @@ export function makeFileUri(fileName: string, rootDirPath?: string): vscode.Uri 
 // Create a .vscode/cody.json file in the root directory of the workspace or user's home directory using the sample files
 export async function createJSONFile(extensionPath: string, rootDirPath: string, isUserType: boolean): Promise<void> {
     const sampleFileName = isUserType ? 'user-cody.json' : 'workspace-cody.json'
-    const codyJsonPath = makeFileUri('resources/samples/' + sampleFileName, extensionPath)
+    const codyJsonPath = constructFileUri('resources/samples/' + sampleFileName, extensionPath)
     if (!rootDirPath || !codyJsonPath) {
         void vscode.window.showErrorMessage('Failed to create cody.json file.')
         return
@@ -28,7 +24,7 @@ export async function createJSONFile(extensionPath: string, rootDirPath: string,
 
 // Add context from the sample files to the .vscode/cody.json file
 export async function saveJSONFile(context: string, rootDirPath: string, isSaveMode = false): Promise<void> {
-    const codyJsonFilePath = makeFileUri('.vscode/cody.json', rootDirPath)
+    const codyJsonFilePath = constructFileUri('.vscode/cody.json', rootDirPath)
     if (!codyJsonFilePath) {
         return
     }
@@ -57,118 +53,34 @@ export function createFileWatch(fsPath?: string): vscode.FileSystemWatcher | nul
     return watcher
 }
 
-export const prompt_creation_title = 'Creating a new custom recipe...'
-
-// This allows users to create a new prompt via UI using the input box and quick pick without having to manually edit the cody.json file
-export async function createNewPrompt(promptName?: string): Promise<CodyPrompt | null> {
-    if (!promptName) {
-        return null
+export async function deleteFile(uri?: vscode.Uri): Promise<void> {
+    if (!uri) {
+        return
     }
-    // Get the prompt description from the user using the input box
-    const minPromptLength = 3
-    const promptDescription = await vscode.window.showInputBox({
-        title: prompt_creation_title,
-        prompt: 'Enter a prompt for the recipe. A prompt is a set of instructions/questions for Cody to follow and answer.',
-        placeHolder: "e,g. 'Create five different test cases for the selected code''",
-        validateInput: (input: string) => {
-            if (!input || input.split(' ').length < minPromptLength) {
-                return `Prompt cannot be empty and should be as detailed as possible. Please enter a prompt with at least ${minPromptLength} words.`
-            }
-            return null
-        },
-    })
-    if (!promptDescription) {
-        void vscode.window.showErrorMessage('Invalid values.')
-        return null
-    }
-    const newPrompt: CodyPrompt = { prompt: promptDescription }
-    newPrompt.context = { ...defaultCodyPromptContext }
-    // Get the context types from the user using the quick pick
-    const promptContext = await vscode.window.showQuickPick(contextTypes, {
-        title: 'Select the context to include with the prompt for the new recipe',
-        placeHolder: 'TIPS: Providing limited but precise context helps Cody provide more relevant answers',
-        canPickMany: true,
-        ignoreFocusOut: false,
-        onDidSelectItem: (item: vscode.QuickPickItem) => {
-            item.picked = !item.picked
-        },
-    })
-    if (promptContext?.length) {
-        for (const context of promptContext) {
-            switch (context.id) {
-                case 'selection':
-                    newPrompt.context.excludeSelection = !context.picked
-                    break
-                case 'codebase':
-                    newPrompt.context.codebase = true
-                    break
-                case 'currentDir':
-                    newPrompt.context.currentDir = true
-                    break
-                case 'openTabs':
-                    newPrompt.context.openTabs = true
-                    break
-                case 'none':
-                    newPrompt.context.none = true
-                    break
-            }
-        }
-    }
-    // Get the command to run from the user using the input box
-    const promptCommand = await vscode.window.showInputBox({
-        title: prompt_creation_title,
-        prompt: '[Optional] Add a terminal command for the recipe to run from your current workspace. The output will be shared with Cody as context for the prompt. (The added command must work on your local machine.)',
-        placeHolder: 'e,g. node your-script.js, git describe --long, cat src/file-name.js etc.',
-    })
-    if (promptCommand) {
-        const commandParts = promptCommand.split(' ')
-        if (!commandParts.length) {
-            return null
-        }
-        newPrompt.command = commandParts.shift()
-        newPrompt.args = commandParts
-    }
-    return newPrompt
+    await vscode.workspace.fs.delete(uri)
 }
 
-const contextTypes = [
-    {
-        id: 'selection',
-        label: 'Selected Code',
-        detail: 'Code currently highlighted in the active editor.',
-        picked: true,
-    },
-    {
-        id: 'codebase',
-        label: 'Codebase',
-        detail: 'Code snippests from embeddings.',
-        picked: false,
-    },
-    {
-        id: 'currentDir',
-        label: 'Current Directory',
-        description: 'If the prompt includes "test(s)", only test files will be included.',
-        detail: 'First 10 text files in the current directory',
-        picked: false,
-    },
-    {
-        id: 'openTabs',
-        label: 'Current Open Tabs',
-        detail: 'First 10 text files in current open tabs',
-        picked: false,
-    },
-    {
-        id: 'none',
-        label: 'none',
-        detail: 'Exclude all types of context.',
-        picked: false,
-    },
-]
+export const prompt_creation_title = 'Creating a new custom recipe...'
 
 export async function doesPathExist(filePath?: string): Promise<boolean> {
     try {
         return (filePath && !!(await vscode.workspace.fs.stat(vscode.Uri.file(filePath)))) || false
-    } catch {
+    } catch (error) {
+        console.error('Failed to locate file', error)
         return false
     }
 }
+
+export function getFileNameFromPath(path: string): string | undefined {
+    return path.split('/').pop()
+}
+
+export async function getFileToRemove(keys: string[]): Promise<string | undefined> {
+    return vscode.window.showQuickPick(Array.from(keys))
+}
+
+export const outputWrapper = `
+Here is the output of \`{command}\` command:
+\`\`\`sh
+{output}
+\`\`\``

--- a/vscode/src/my-cody/types.ts
+++ b/vscode/src/my-cody/types.ts
@@ -1,0 +1,36 @@
+import { Preamble } from '@sourcegraph/cody-shared/src/chat/preamble'
+import { CodyPromptContext } from '@sourcegraph/cody-shared/src/chat/recipes/my-prompt'
+
+export interface MyPromptsJSON {
+    // A set of reusable prompts where instructions and context can be configured.
+    recipes: { [id: string]: CodyPrompt }
+    // Premade are a set of prompts that are added to the start of every new conversation.
+    // This is where we define the "persona" and "rules" to share with LLM
+    premade?: CodyPromptPremade
+    // Starter is added to the start of every human input sent to Cody.
+    starter?: string
+}
+
+export interface CodyPrompt {
+    prompt: string
+    command?: string
+    args?: string[]
+    context?: CodyPromptContext
+    type?: CodyPromptType
+}
+
+export interface CodyPromptPremade {
+    actions: string
+    rules: string
+    answer: string
+}
+
+export type CodyPromptType = 'workspace' | 'user'
+
+export interface MyPrompts {
+    prompts: Map<string, CodyPrompt>
+    premade?: Preamble
+    starter: string
+}
+
+export const CustomRecipesFileName = '.vscode/cody.json'

--- a/vscode/webviews/Recipes.tsx
+++ b/vscode/webviews/Recipes.tsx
@@ -52,7 +52,7 @@ export const Recipes: React.FunctionComponent<{
                                         <VSCodeButton
                                             type="button"
                                             appearance="icon"
-                                            onClick={() => onMyPromptClick('add')}
+                                            onClick={() => onMyPromptClick('menu')}
                                         >
                                             <i className="codicon codicon-tools" title="Update your custom recipes" />
                                         </VSCodeButton>

--- a/vscode/webviews/Recipes.tsx
+++ b/vscode/webviews/Recipes.tsx
@@ -48,16 +48,15 @@ export const Recipes: React.FunctionComponent<{
                                     className={styles.recipesHeader}
                                 >
                                     <span>Custom Recipes</span>
-                                    <VSCodeButton
-                                        type="button"
-                                        appearance="icon"
-                                        onClick={() => onMyPromptClick('add')}
-                                    >
-                                        <i
-                                            className="codicon codicon-plus"
-                                            title="Create a new User recipe accessible only to you across Workspaces"
-                                        />
-                                    </VSCodeButton>
+                                    {myPrompts?.length > 0 && (
+                                        <VSCodeButton
+                                            type="button"
+                                            appearance="icon"
+                                            onClick={() => onMyPromptClick('add')}
+                                        >
+                                            <i className="codicon codicon-tools" title="Update your custom recipes" />
+                                        </VSCodeButton>
+                                    )}
                                 </div>
                                 {myPrompts?.length === 0 && (
                                     <small className={styles.recipesNotes}>


### PR DESCRIPTION
1. add `/open` command  - the main purpose is to make it easier for users to build a recipe that involves opening a file
1. improve prompts used in custom recipes sample
1. fix JSON format issue
1. cleared up some helper functions

Example recipe that utilizes the /open command:

```json
{
  "title": "Cody Custom Recipes - Workspace",
  "description": "This is an example file to showcase how to build custom recipes for Cody by Sourcegraph.",
  "recipes": {
    "Open User Recipes File": {
      "prompt": "/open user",
      "note": "Open the existing cody.json file for User recipes in your editor if any"
    }
  }
}

```

## Test plan

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->

### To test the /open command

- Enter `/open package.json` in Cody's chatbox with a workspace opened. the package.json file should be opened for you
- Enter `/open user` to open the .vscode/cody.json located in your home directory

### To test the recipe samples

1. sign into Cody with your s2 account
2. copy the recipes from the sample files to the recipes field within your .vscode/cody.json file
3. save the file
4. run the recipe