### PR TITLE
Fix input history down button

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -231,9 +231,11 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     setHistoryIndex(newIndex)
                     setFormInput(inputHistory[newIndex])
                 } else if (event.key === 'ArrowDown' && caretPosition === formInput.length) {
-                    const newIndex = historyIndex + 1 >= inputHistory.length ? 0 : historyIndex + 1
-                    setHistoryIndex(newIndex)
-                    setFormInput(inputHistory[newIndex])
+                    if (historyIndex + 1 < inputHistory.length) {
+                        const newIndex = historyIndex + 1
+                        setHistoryIndex(newIndex)
+                        setFormInput(inputHistory[newIndex])
+                    }
                 }
             }
         },

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Insert at Cusor now inserts the complete code snippets at cursor position. [pull/282](https://github.com/sourcegraph/cody/pull/282)
 - Minimizing the change of Cody replying users with response related to the language-uage prompt. [pull/279](https://github.com/sourcegraph/cody/pull/279)
 - Inline Chat: Add missing icons for Inline Chat and Inline Fixups decorations. [pull/320](https://github.com/sourcegraph/cody/pull/320)
+- Fix the behaviour of input history down button. [pull/328](https://github.com/sourcegraph/cody/pull/328)
 
 ### Changed
 


### PR DESCRIPTION
This PR closes #316. It disables the looping around down button after the last input history.


## Test plan
I tested it manually. 
To test, start the extension and press the Down Button. After it reaches the end, it won't loop around the first history input.
