### PR TITLE
Autocomplete: Remove multilineMode in favor of a simple boolean

### DIFF
--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -344,7 +344,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
 
         // Shared post-processing logic
         const processedCompletions = completions.map(completion =>
-            sharedPostProcess({ prefix, suffix, multiline: multiline !== null, languageId, completion })
+            sharedPostProcess({ prefix, suffix, multiline, languageId, completion })
         )
 
         // Filter results

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -7,6 +7,7 @@ import { logEvent } from '../event-logger'
 interface CompletionEvent {
     params: {
         type: 'inline' | 'manual'
+        multiline: boolean
         multilineMode: null | 'block'
         providerIdentifier: string
         contextSummary: {
@@ -63,7 +64,13 @@ export function logCompletionEvent(name: string, params?: unknown): void {
     logEvent(`CodyVSCodeExtension:completion:${name}`, params, params)
 }
 
-export function start(params: CompletionEvent['params']): string {
+export function start(inputParams: Omit<CompletionEvent['params'], 'multilineMode'>): string {
+    const params: CompletionEvent['params'] = {
+        ...inputParams,
+        // Keep the legacy name for backward compatibility in analytics
+        multilineMode: inputParams.multiline ? 'block' : null,
+    }
+
     const id = createId()
     displayedCompletions.set(id, {
         params,

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -8,21 +8,21 @@ const BRACKET_PAIR = {
     '{': '}',
 } as const
 const OPENING_BRACKET_REGEX = /([([{])$/
-export function detectMultilineMode(
+export function detectMultiline(
     prefix: string,
     prevNonEmptyLine: string,
     sameLinePrefix: string,
     sameLineSuffix: string,
     languageId: string,
     enableExtendedTriggers: boolean
-): null | 'block' {
+): boolean {
     const config = getLanguageConfig(languageId)
     if (!config) {
-        return null
+        return false
     }
 
     if (enableExtendedTriggers && sameLinePrefix.match(OPENING_BRACKET_REGEX)) {
-        return 'block'
+        return true
     }
 
     if (
@@ -33,10 +33,10 @@ export function detectMultilineMode(
         // Only trigger multiline suggestions when the new current line is indented
         indentation(prevNonEmptyLine) < indentation(sameLinePrefix)
     ) {
-        return 'block'
+        return true
     }
 
-    return null
+    return false
 }
 
 // Detect if completion starts with a space followed by any non-space character.

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -128,7 +128,7 @@ export class AnthropicProvider extends Provider {
         completion = fixBadCompletionStart(completion)
 
         // Remove incomplete lines in single-line completions
-        if (this.multiline) {
+        if (!this.multiline) {
             let allowedNewlines = 2
             const lines = completion.split('\n')
             if (lines.length >= allowedNewlines) {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -128,7 +128,7 @@ export class AnthropicProvider extends Provider {
         completion = fixBadCompletionStart(completion)
 
         // Remove incomplete lines in single-line completions
-        if (this.multilineMode === null) {
+        if (this.multiline) {
             let allowedNewlines = 2
             const lines = completion.split('\n')
             if (lines.length >= allowedNewlines) {
@@ -154,27 +154,19 @@ export class AnthropicProvider extends Provider {
             throw new Error('prompt length exceeded maximum alloted chars')
         }
 
-        let args: CompletionParameters
-        switch (this.multilineMode) {
-            case 'block': {
-                args = {
-                    temperature: 0.5,
-                    messages: prompt,
-                    maxTokensToSample: this.responseTokens,
-                    stopSequences: [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG],
-                }
-                break
-            }
-            default: {
-                args = {
-                    temperature: 0.5,
-                    messages: prompt,
-                    maxTokensToSample: Math.min(100, this.responseTokens),
-                    stopSequences: [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG, '\n\n'],
-                }
-                break
-            }
-        }
+        const args: CompletionParameters = this.multiline
+            ? {
+                  temperature: 0.5,
+                  messages: prompt,
+                  maxTokensToSample: this.responseTokens,
+                  stopSequences: [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG],
+              }
+            : {
+                  temperature: 0.5,
+                  messages: prompt,
+                  maxTokensToSample: Math.min(100, this.responseTokens),
+                  stopSequences: [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG, '\n\n'],
+              }
 
         // Issue request
         const responses = await batchCompletions(this.completionsClient, args, this.n, abortSignal)

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -38,7 +38,7 @@ export interface ProviderOptions {
     suffix: string
     fileName: string
     languageId: string
-    multilineMode: null | 'block'
+    multiline: boolean
     // Relative length to `maximumContextCharacters`
     responsePercentage: number
     prefixPercentage: number
@@ -53,7 +53,7 @@ export abstract class Provider {
     protected suffix: string
     protected fileName: string
     protected languageId: string
-    protected multilineMode: null | 'block'
+    protected multiline: boolean
     protected responsePercentage: number
     protected prefixPercentage: number
     protected suffixPercentage: number
@@ -65,7 +65,7 @@ export abstract class Provider {
         suffix,
         fileName,
         languageId,
-        multilineMode,
+        multiline,
         responsePercentage,
         prefixPercentage,
         suffixPercentage,
@@ -76,7 +76,7 @@ export abstract class Provider {
         this.suffix = suffix
         this.fileName = fileName
         this.languageId = languageId
-        this.multilineMode = multilineMode
+        this.multiline = multiline
         this.responsePercentage = responsePercentage
         this.prefixPercentage = prefixPercentage
         this.suffixPercentage = suffixPercentage

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -29,7 +29,7 @@ export class UnstableCodeGenProvider extends Provider {
             suffix: this.suffix,
             top_p: 0.95,
             temperature: 0.2,
-            max_tokens: this.multilineMode === null ? 40 : 128,
+            max_tokens: this.multiline ? 40 : 128,
             // The backend expects an even number of requests since it will
             // divide it into two different batches.
             batch_size: makeEven(4),
@@ -55,7 +55,7 @@ export class UnstableCodeGenProvider extends Provider {
         try {
             const data = (await response.json()) as { completions: { completion: string }[] }
 
-            const completions: string[] = data.completions.map(c => postProcess(c.completion, this.multilineMode))
+            const completions: string[] = data.completions.map(c => postProcess(c.completion, this.multiline))
             log?.onComplete(completions)
 
             return completions.map(content => ({
@@ -72,10 +72,10 @@ export class UnstableCodeGenProvider extends Provider {
     }
 }
 
-function postProcess(content: string, multilineMode: null | 'block'): string {
+function postProcess(content: string, multiline: boolean): string {
     // The model might return multiple lines for single line completions because
     // we are only able to specify a token limit.
-    if (multilineMode === null && content.includes('\n')) {
+    if (multiline && content.includes('\n')) {
         content = content.slice(0, content.indexOf('\n'))
     }
 

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -35,7 +35,7 @@ export class UnstableHuggingFaceProvider extends Provider {
                 num_return_sequences: 1,
                 // To speed up sample generation in single-line case, we request a lower token limit
                 // since we can't terminate on the first `\n`.
-                max_new_tokens: this.multilineMode === null ? 64 : 256,
+                max_new_tokens: this.multiline ? 64 : 256,
             },
         }
 
@@ -62,7 +62,7 @@ export class UnstableHuggingFaceProvider extends Provider {
                 throw new Error(data.error)
             }
 
-            const completions: string[] = data.map(c => postProcess(c.generated_text, this.multilineMode))
+            const completions: string[] = data.map(c => postProcess(c.generated_text, this.multiline))
             log?.onComplete(completions)
 
             return completions.map(content => ({
@@ -79,12 +79,12 @@ export class UnstableHuggingFaceProvider extends Provider {
     }
 }
 
-function postProcess(content: string, multilineMode: null | 'block'): string {
+function postProcess(content: string, multiline: boolean): string {
     content = content.replace(STOP_WORD, '')
 
     // The model might return multiple lines for single line completions because
     // we are only able to specify a token limit.
-    if (multilineMode === null && content.includes('\n')) {
+    if (multiline && content.includes('\n')) {
         content = content.slice(0, content.indexOf('\n'))
     }
 


### PR DESCRIPTION
Renaming all occurrences of `multilineMode` to a `multiline` boolean flag instead. My idea of having more modes in the future didn't pan out and this was just adding confusion.

The old field name is still kept in analytics for a bit so we can keep comparing data with the past. We can rm that in the future once we have more data with the new format.

## Test plan

Tests are green

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->
