### PR TITLE
Autocomplete: Only ever complete a single line in single-line mode unless the current line is empty

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -277,6 +277,19 @@ describe('Cody completions', () => {
         expect(completions[0].insertText).toBe('if (true) {')
     })
 
+    it('only complete one line if the current line is not empty', async () => {
+        const { completions } = await complete(
+            `
+        function test() {
+            console.log(1, ${CURSOR_MARKER});
+        }
+        `,
+            [createCompletionResponse('2);\n    console.log(3);')]
+        )
+
+        expect(completions[0].insertText).toBe('2);')
+    })
+
     it('completes a single-line at the middle of a sentence', async () => {
         const { completions } = await complete(`function bubbleSort(${CURSOR_MARKER})`, [
             createCompletionResponse('array) {'),

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -115,6 +115,9 @@ export class AnthropicProvider extends Provider {
         let completion = extractFromCodeBlock(rawResponse)
         const startIndentation = indentation(lastNLines(this.prefix, 1) + completion.split('\n')[0])
 
+        const sameLinePrefix = this.prefix.slice(this.prefix.lastIndexOf('\n') + 1)
+        const sameLineSuffix = this.suffix.slice(0, this.suffix.indexOf('\n'))
+
         const trimmedPrefixContainNewline = this.prefix.slice(this.prefix.trimEnd().length).includes('\n')
         if (trimmedPrefixContainNewline) {
             // The prefix already contains a `\n` that Claude was not aware of, so we remove any
@@ -131,11 +134,16 @@ export class AnthropicProvider extends Provider {
         if (this.multilineMode === null) {
             let allowedNewlines = 2
             const lines = completion.split('\n')
-            if (lines.length >= allowedNewlines) {
+            if (lines.length >= 1) {
                 // Only select two lines if they have the same indentation, otherwise only show one
                 // line. This will then most-likely trigger a multi-line completion after accepting
                 // and result in a better experience.
                 if (lines.length > 1 && startIndentation !== indentation(lines[1])) {
+                    allowedNewlines = 1
+                }
+
+                // When the current line has any content, we only allow a single line completion.
+                if (sameLinePrefix.trim() !== '' || sameLineSuffix.trim() !== '') {
                     allowedNewlines = 1
                 }
 


### PR DESCRIPTION
c.f.: https://sourcegraph.slack.com/archives/C05AGQYD528/p1689784503627479

This shields against cases where you're focused inside the current line and then the recommendation adds stuff in the line below, like:

![image](https://github.com/sourcegraph/cody/assets/458591/82ee6ed1-1731-4edd-ba86-4a2c27861cfa)


## Test plan

Added a test case

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->
