### PR TITLE
fix `pnpm run dev` when run from the vscode/ dir

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -8,7 +8,7 @@
   "icon": "resources/cody.png",
   "description": "Code AI with codebase context",
   "scripts": {
-    "dev:instance": "CODY_FOCUS_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=\"$INIT_CWD/vscode\" --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 . --goto ./src/logged-rerank.ts:16:5",
+    "dev:instance": "CODY_FOCUS_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=$PWD --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 --new-window . --goto ./src/logged-rerank.ts:16:5",
     "dev": "pnpm run build:dev && pnpm run dev:instance",
     "generate:completions": "OUTFILE=/tmp/run-code-completions-on-dataset.js && esbuild ./test/completions/run-code-completions-on-dataset.ts --bundle --external:vscode --outfile=$OUTFILE --format=cjs --platform=node --sourcemap=inline && node --enable-source-maps $OUTFILE",
     "build": "scripts/download-rg.sh && tsc --build && pnpm run esbuild --minify && vite build --mode production",


### PR DESCRIPTION
The `INIT_CWD` env var is set to the dir from which `pnpm` is run, not the current package.json dir (https://docs.npmjs.com/cli/v9/commands/npm-run-script#description). This means that `$INIT_CWD/vscode` when run from the `vscode/` dir points to a nonexistent dir.



## Test plan

Run `pnpm -C vscode run dev` and `cd vscode && pnpm run dev` from the repository root and confirm both work.