### PR TITLE
remove unnecessary vite globals

### DIFF
--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -4,7 +4,5 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
     logLevel: 'warn',
-    test: {
-        globals: true,
-    },
+    test: {},
 })

--- a/lib/shared/vitest.config.ts
+++ b/lib/shared/vitest.config.ts
@@ -5,7 +5,6 @@ import { defineConfig } from 'vite'
 export default defineConfig({
     logLevel: 'warn',
     test: {
-        globals: true,
         environment: 'jsdom', // needed for DOMPurify
     },
 })

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { defaultAuthStatus, unauthenticatedStatus } from './protocol'
 import { convertGitCloneURLToCodebaseName, newAuthStatus } from './utils'

--- a/vscode/src/non-stop/utils.test.ts
+++ b/vscode/src/non-stop/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import { getFileNameAfterLastDash } from './utils'
 

--- a/vscode/src/services/InlineAssist.test.ts
+++ b/vscode/src/services/InlineAssist.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import * as vscode from 'vscode'
 
 import { editDocByUri, updateRangeOnDocChange } from './InlineAssist'

--- a/vscode/vite.config.ts
+++ b/vscode/vite.config.ts
@@ -49,7 +49,6 @@ export default defineConfig({
         },
     },
     test: {
-        globals: true,
         include: ['src/**/*.test.ts?(x)'],
         setupFiles: ['src/testutils/vscode.ts'],
     },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -36,5 +36,4 @@ export default defineConfig({
             },
         },
     },
-    test: { globals: true },
 })


### PR DESCRIPTION
All test files explicitly import the `describe`, `test`, `it`, etc., bindings, so this is no longer needed.



## Test plan

Confirm that unit test suite typechecks in CI.