### PR TITLE
fix tsconfig excludes

### DIFF
--- a/vscode/test/completions/tsconfig.json
+++ b/vscode/test/completions/tsconfig.json
@@ -6,5 +6,6 @@
     "outDir": "../../dist/tsc/test/completions",
   },
   "references": [{ "path": "../../" }],
-  "include": ["*", "**/*"],
+  "include": ["*.ts"],
+  "exclude": [],
 }

--- a/vscode/test/integration/tsconfig.json
+++ b/vscode/test/integration/tsconfig.json
@@ -5,9 +5,8 @@
     "rootDir": ".",
     "outDir": "../../dist/tsc/test/integration",
     "types": ["mocha", "node"],
-    "jsx": "react-jsx",
   },
   "references": [{ "path": "../../" }],
-  "include": ["*", "**/*", "../fixtures/mock-server.ts"],
+  "include": ["*.ts"],
   "exclude": ["testdata"],
 }

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -17,8 +17,7 @@
     "webpack.config.js",
     "package.json",
     ".storybook/*.ts",
-    "test/completions/completions-dataset.ts",
   ],
-  "exclude": ["scripts", "dist", "test/integration"],
+  "exclude": ["scripts", "dist", "test/integration", "test/completions"],
   "references": [{ "path": "../lib/shared" }, { "path": "../lib/ui" }],
 }


### PR DESCRIPTION
Fixes an issue where `vscode/tsconfig.json` incorrectly included `test/completions` and caused errors when running `tsc -b` from various directories.



## Test plan

CI is sufficient.