### PR TITLE
Autocomplete: Only ever complete a single line in single-line mode and reduce the output token limit

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -22,6 +22,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Exclude context for chat input with only one word. [pull/279](https://github.com/sourcegraph/cody/pull/279)
 - [Internal Only] `Custom Recipe`: Store `cody.json` file for user recipes within the `.vscode` folder located in the $HOME directory. [pull/279](https://github.com/sourcegraph/cody/pull/279)
+- Various autocomplete improvements. [pull/344](https://github.com/sourcegraph/cody/pull/344)
 
 ## [0.4.4]
 

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -249,21 +249,7 @@ describe('Cody completions', () => {
         expect(completions[0].insertText).toBe("'bar'")
     })
 
-    it('completes up to two lines in single line mode', async () => {
-        const { completions } = await complete(
-            `
-        function test() {
-            console.log(1);
-            ${CURSOR_MARKER}
-        }
-        `,
-            [createCompletionResponse('console.log(2);\n    console.log(3);\n    console.log(4);')]
-        )
-
-        expect(completions[0].insertText).toBe('console.log(2);\n    console.log(3);')
-    })
-
-    it('only complete one line if the second line is indented in single line mode', async () => {
+    it('only complete one line in single line mode', async () => {
         const { completions } = await complete(
             `
         function test() {


### PR DESCRIPTION
Ensure that single-line mode completions are only ever returning a single line.

Since we no longer have two lines, I thought it's also okay to decrease the response token limit a bit. While there's still some variations, this seems to make it much more common for me when testing to get sub 800ms responses (compared to ~1sec before). I wasn't able to find an instance where 60 tokens weren't enough for single line completions yet.

## Test plan

Updated test suite. Tested the latency locally.

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->
