### PR TITLE
fix event name for copy and insert events

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -87,7 +87,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 vscodeAPI.postMessage({ command: 'insert', text })
             }
             const eventName = isInsert ? 'insert:' : 'copy:'
-            vscodeAPI.postMessage({ command: 'event', event: 'click', value: eventName + text })
+            vscodeAPI.postMessage({ command: 'event', event: 'click', value: eventName })
         },
         [vscodeAPI]
     )

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -86,7 +86,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             if (isInsert) {
                 vscodeAPI.postMessage({ command: 'insert', text })
             }
-            const eventName = isInsert ? 'insert:' : 'copy:'
+            const eventName = isInsert ? 'insert' : 'copy'
             vscodeAPI.postMessage({ command: 'event', event: 'click', value: eventName + 'Button' })
         },
         [vscodeAPI]

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -87,7 +87,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 vscodeAPI.postMessage({ command: 'insert', text })
             }
             const eventName = isInsert ? 'insert:' : 'copy:'
-            vscodeAPI.postMessage({ command: 'event', event: 'click', value: eventName })
+            vscodeAPI.postMessage({ command: 'event', event: 'click', value: eventName + 'Button' })
         },
         [vscodeAPI]
     )


### PR DESCRIPTION
issue: `click` event name for copy and insert actions including the context value.
fix: remove text from event value

## Test plan

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->

@akalia25 can you confirm if the changes in this branch work?
