### PR TITLE
misc vscode refactors

### DIFF
--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -133,6 +133,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     ): Promise<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
         try {
             return await this.provideInlineCompletionItemsInner(document, position, context, token)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             this.stopLoading()
 
@@ -141,6 +142,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             }
 
             console.error(error)
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
             debug('CodyCompletionProvider:inline:error', `${error.toString()}\n${error.stack}`)
             return []
         }
@@ -170,7 +172,6 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
-        const languageId = document.languageId
         const { prefix, suffix, prevNonEmptyLine } = docContext
 
         // Text before the cursor on the same line.
@@ -184,7 +185,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             prevNonEmptyLine,
             sameLinePrefix,
             sameLineSuffix,
-            languageId,
+            document.languageId,
             this.providerConfig.enableExtendedMultilineTriggers
         )
 
@@ -198,14 +199,22 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             // again
             const cachedCompletions = this.completionsCache?.get(prefix, false)
             if (cachedCompletions?.isExactPrefix) {
-                return handleCacheHit(cachedCompletions, document, position, prefix, suffix, multiline, languageId)
+                return handleCacheHit(
+                    cachedCompletions,
+                    document,
+                    position,
+                    prefix,
+                    suffix,
+                    multiline,
+                    document.languageId
+                )
             }
             return []
         }
 
         const cachedCompletions = this.completionsCache?.get(prefix)
         if (cachedCompletions) {
-            return handleCacheHit(cachedCompletions, document, position, prefix, suffix, multiline, languageId)
+            return handleCacheHit(cachedCompletions, document, position, prefix, suffix, multiline, document.languageId)
         }
 
         const completers: Provider[] = []
@@ -243,7 +252,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             prefix,
             suffix,
             fileName: path.normalize(vscode.workspace.asRelativePath(document.fileName ?? '')),
-            languageId,
+            languageId: document.languageId,
             responsePercentage: this.responsePercentage,
             prefixPercentage: this.prefixPercentage,
             suffixPercentage: this.suffixPercentage,
@@ -305,7 +314,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             type: 'inline',
             multiline,
             providerIdentifier: this.providerConfig.identifier,
-            languageId,
+            languageId: document.languageId,
             contextSummary,
             triggeredMoreEagerly,
             triggeredForSuggestWidgetSelection: triggeredForSuggestWidgetSelection !== undefined,
@@ -334,7 +343,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         )
 
         // Shared post-processing logic
-        const processedCompletions = processCompletions(completions, prefix, suffix, multiline, languageId)
+        const processedCompletions = processCompletions(completions, prefix, suffix, multiline, document.languageId)
         stopLoading()
 
         if (processedCompletions.length > 0) {

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -48,40 +48,7 @@ export interface ProviderOptions {
 }
 
 export abstract class Provider {
-    public readonly id: string
-    protected prefix: string
-    protected suffix: string
-    protected fileName: string
-    protected languageId: string
-    protected multiline: boolean
-    protected responsePercentage: number
-    protected prefixPercentage: number
-    protected suffixPercentage: number
-    protected n: number
-
-    constructor({
-        id,
-        prefix,
-        suffix,
-        fileName,
-        languageId,
-        multiline,
-        responsePercentage,
-        prefixPercentage,
-        suffixPercentage,
-        n = 1,
-    }: ProviderOptions) {
-        this.id = id
-        this.prefix = prefix
-        this.suffix = suffix
-        this.fileName = fileName
-        this.languageId = languageId
-        this.multiline = multiline
-        this.responsePercentage = responsePercentage
-        this.prefixPercentage = prefixPercentage
-        this.suffixPercentage = suffixPercentage
-        this.n = n
-    }
+    constructor(public readonly options: Readonly<ProviderOptions>) {}
 
     public abstract generateCompletions(abortSignal: AbortSignal, snippets: ReferenceSnippet[]): Promise<Completion[]>
 }

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -24,17 +24,17 @@ export class UnstableCodeGenProvider extends Provider {
     public async generateCompletions(abortSignal: AbortSignal, snippets: ReferenceSnippet[]): Promise<Completion[]> {
         const params = {
             debug_ext_path: 'cody',
-            lang_prefix: `<|${mapVSCodeLanguageIdToModelId(this.languageId)}|>`,
-            prefix: this.prefix,
-            suffix: this.suffix,
+            lang_prefix: `<|${mapVSCodeLanguageIdToModelId(this.options.languageId)}|>`,
+            prefix: this.options.prefix,
+            suffix: this.options.suffix,
             top_p: 0.95,
             temperature: 0.2,
-            max_tokens: this.multiline ? 40 : 128,
+            max_tokens: this.options.multiline ? 40 : 128,
             // The backend expects an even number of requests since it will
             // divide it into two different batches.
             batch_size: makeEven(4),
             // TODO: Figure out the exact format to attach context
-            context: JSON.stringify(prepareContext(snippets, this.fileName)),
+            context: JSON.stringify(prepareContext(snippets, this.options.fileName)),
             completion_type: 'automatic',
         }
 
@@ -55,11 +55,11 @@ export class UnstableCodeGenProvider extends Provider {
         try {
             const data = (await response.json()) as { completions: { completion: string }[] }
 
-            const completions: string[] = data.completions.map(c => postProcess(c.completion, this.multiline))
+            const completions: string[] = data.completions.map(c => postProcess(c.completion, this.options.multiline))
             log?.onComplete(completions)
 
             return completions.map(content => ({
-                prefix: this.prefix,
+                prefix: this.options.prefix,
                 content,
             }))
         } catch (error: any) {

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -27,7 +27,7 @@ export class UnstableHuggingFaceProvider extends Provider {
     public async generateCompletions(abortSignal: AbortSignal): Promise<Completion[]> {
         // TODO: Add context and language
         // Prompt format is taken form https://huggingface.co/bigcode/starcoder#fill-in-the-middle
-        const prompt = `<fim_prefix>${this.prefix}<fim_suffix>${this.suffix}<fim_middle>`
+        const prompt = `<fim_prefix>${this.options.prefix}<fim_suffix>${this.options.suffix}<fim_middle>`
 
         const request = {
             inputs: prompt,
@@ -35,7 +35,7 @@ export class UnstableHuggingFaceProvider extends Provider {
                 num_return_sequences: 1,
                 // To speed up sample generation in single-line case, we request a lower token limit
                 // since we can't terminate on the first `\n`.
-                max_new_tokens: this.multiline ? 64 : 256,
+                max_new_tokens: this.options.multiline ? 64 : 256,
             },
         }
 
@@ -62,11 +62,11 @@ export class UnstableHuggingFaceProvider extends Provider {
                 throw new Error(data.error)
             }
 
-            const completions: string[] = data.map(c => postProcess(c.generated_text, this.multiline))
+            const completions: string[] = data.map(c => postProcess(c.generated_text, this.options.multiline))
             log?.onComplete(completions)
 
             return completions.map(content => ({
-                prefix: this.prefix,
+                prefix: this.options.prefix,
                 content,
             }))
         } catch (error: any) {

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -20,7 +20,7 @@ class MockProvider extends Provider {
         this.didFinishNetworkRequest = true
         this.resolve(
             completions.map(content => ({
-                prefix: this.prefix,
+                prefix: this.options.prefix,
                 content,
             }))
         )


### PR DESCRIPTION
- reuse ProviderOptions type
- only vscode.InlineCompletionList not type union
- add eslint disable rules
- refer to document.languageId

## Test plan

n/a