### PR TITLE
add `Cody: Open Autocomplete Trace View` and associated view

### DIFF
--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -58,6 +58,7 @@ export const renderMarkdown = (
         /** Strip off any HTML and return a plain text string, useful for previews */
         plainText?: boolean
         dompurifyConfig?: DOMPurifyConfig & { RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false }
+        noDomPurify?: boolean
 
         /**
          * Add target="_blank" and rel="noopener" to all <a> links that have a
@@ -113,7 +114,7 @@ export const renderMarkdown = (
         })
     }
 
-    const result = DOMPurify.sanitize(rendered, dompurifyConfig).trim()
+    const result = options.noDomPurify ? rendered : DOMPurify.sanitize(rendered, dompurifyConfig).trim()
 
     if (options.addTargetBlankToAllLinks) {
         // Because DOMPurify doesn't have a way to set hooks per individual call

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -438,6 +438,12 @@
         "when": "cody.activated",
         "enablement": "config.cody.experimental.customRecipes",
         "icon": "$(bookmark)"
+      },
+      {
+        "command": "cody.autocomplete.openTraceView",
+        "category": "Cody",
+        "title": "Open Autocomplete Trace View",
+        "when": "cody.activated && config.cody.autocomplete && config.cody.debug.enable && editorHasFocus && !editorReadonly"
       }
     ],
     "keybindings": [

--- a/vscode/src/completions/context.ts
+++ b/vscode/src/completions/context.ts
@@ -25,7 +25,7 @@ interface GetContextOptions {
     isEmbeddingsContextEnabled?: boolean
 }
 
-interface GetContextResult {
+export interface GetContextResult {
     context: ReferenceSnippet[]
     logSummary: {
         embeddings?: number

--- a/vscode/src/completions/tracer/index.ts
+++ b/vscode/src/completions/tracer/index.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode'
+
+import { GetContextResult } from '../context'
+import { Provider } from '../providers/provider'
+
+/**
+ * Traces invocations of {@link CodyCompletionItemProvider.provideInlineCompletionItems}.
+ *
+ * The tracer API assumes that only a single in-flight completion request can exist at a time.
+ *
+ * The tracer function is called when there is an update to the trace data. Because only a single
+ * in-flight request can exist at a time, this call will overwrite the previous trace data.
+ */
+export type ProvideInlineCompletionItemsTracer = (data: ProvideInlineCompletionsItemTraceData) => void
+
+/**
+ * Trace data for a completion request.
+ *
+ * This type is intentionally tied to the implementation of the completion provider (so that you can
+ * trace its execution), and it should change if the provider implementation changes.
+ */
+export interface ProvideInlineCompletionsItemTraceData {
+    invocationSequence: number
+    params?: {
+        document: vscode.TextDocument
+        position: vscode.Position
+        context: vscode.InlineCompletionContext
+    }
+    completers?: Provider['options'][]
+    context?: GetContextResult
+    result?: vscode.InlineCompletionList
+    cacheHit?: boolean
+    error?: string
+}

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -1,0 +1,208 @@
+import * as vscode from 'vscode'
+
+import { isDefined } from '@sourcegraph/cody-shared'
+import { renderMarkdown } from '@sourcegraph/cody-shared/src/common/markdown'
+
+import { CodyCompletionItemProvider } from '..'
+
+import { ProvideInlineCompletionsItemTraceData } from '.'
+
+/**
+ * Registers a command `Cody: Open Autocomplete Trace View` that shows the context and prompt used
+ * for autocomplete.
+ */
+export function registerAutocompleteTraceView(completionsProvider: CodyCompletionItemProvider): vscode.Disposable {
+    let panel: vscode.WebviewPanel | null = null
+    let latestInvocationSequence = 0
+
+    return vscode.Disposable.from(
+        vscode.commands.registerCommand('cody.autocomplete.openTraceView', () => {
+            panel = vscode.window.createWebviewPanel(
+                'codyAutocompleteTraceView',
+                'Cody Autocomplete Trace View',
+                vscode.ViewColumn.Two,
+                {
+                    enableFindWidget: true,
+                }
+            )
+            panel.onDidDispose(() => {
+                completionsProvider.setTracer(null)
+                panel = null
+            })
+
+            panel.webview.html = renderWebviewHtml(undefined)
+
+            completionsProvider.setTracer(data => {
+                if (!panel) {
+                    return
+                }
+
+                // Only show data from the latest invocation.
+                if (data.invocationSequence > latestInvocationSequence) {
+                    latestInvocationSequence = data.invocationSequence
+                } else if (data.invocationSequence < latestInvocationSequence) {
+                    return
+                }
+
+                panel.webview.html = renderWebviewHtml(data)
+            })
+        }),
+        {
+            dispose() {
+                if (panel) {
+                    panel.dispose()
+                    panel = null
+                }
+            },
+        }
+    )
+}
+
+function renderWebviewHtml(data: ProvideInlineCompletionsItemTraceData | undefined): string {
+    const markdownSource = [
+        `# Cody autocomplete trace view${data ? ` (#${data.invocationSequence})` : ''}`,
+        data ? null : 'Waiting for you to trigger a completion...',
+        data?.params &&
+            `
+## Params
+
+- ${markdownInlineCode(data.params.document.fileName)} @ ${data.params.position.line + 1}:${
+                data.params.position.character + 1
+            }
+- selectedCompletionInfo: ${
+                data.params.context.selectedCompletionInfo
+                    ? selectedCompletionInfoDescription(
+                          data.params.context.selectedCompletionInfo,
+                          data.params.document
+                      )
+                    : 'none'
+            }
+`,
+        data?.completers &&
+            `
+## Completers
+
+${data.completers?.map(
+    ({ id, prefix, suffix, ...otherOptions }) =>
+        `
+### ${id}
+
+${codeDetailsWithSummary('Prefix', prefix, 'end')}
+${codeDetailsWithSummary('Suffix', suffix, 'start')}
+
+${markdownList(otherOptions)}
+`
+)}`,
+        data?.context &&
+            `
+## Context
+
+${markdownList(data.context.logSummary)}
+
+${
+    data.context.context.length === 0
+        ? 'No context.'
+        : data.context.context
+              .map(({ content, fileName }) =>
+                  codeDetailsWithSummary(`${fileName} (${content.length} chars)`, content, 'start')
+              )
+              .join('\n\n')
+}
+`,
+        data?.result &&
+            `
+## Completions (cache ${data.cacheHit === true ? 'hit' : data.cacheHit === false ? 'miss' : 'unknown'})
+
+${
+    data.result.items.length === 0
+        ? 'No completions.'
+        : data.result.items
+              .map(item => inlineCompletionItemDescription(item, data.params?.document))
+              .join('\n\n---\n\n')
+}`,
+
+        data?.error &&
+            `
+## Error
+
+${markdownCodeBlock(data.error)}
+`,
+    ]
+        .filter(isDefined)
+        .map(s => s.trim())
+        .join('\n\n---\n\n')
+
+    return renderMarkdown(markdownSource, { noDomPurify: true })
+}
+
+function codeDetailsWithSummary(title: string, value: string, anchor: 'start' | 'end', excerptLength = 50): string {
+    const excerpt = anchor === 'start' ? value.slice(0, excerptLength) : value.slice(-excerptLength)
+    return `
+<details>
+<summary>${title}: <code>${anchor === 'end' ? '⋯' : ''}${withVisibleWhitespace(excerpt)
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')}${anchor === 'start' ? '⋯' : ''}</code></summary>
+
+${markdownCodeBlock(value)}
+
+</details>`
+}
+
+function markdownInlineCode(value: string): string {
+    return '`' + value.replace(/`/g, '\\`') + '`'
+}
+
+function markdownCodeBlock(value: string): string {
+    return '```\n' + value.replace(/`/g, '\\`') + '\n```\n'
+}
+
+function markdownList(object: { [key: string]: string | number | boolean }): string {
+    return Object.keys(object)
+        .sort()
+        .map(key => `- ${key}: ${JSON.stringify(object[key as keyof typeof object])}`)
+        .join('\n')
+}
+
+function selectedCompletionInfoDescription(
+    { range, text }: NonNullable<vscode.InlineCompletionContext['selectedCompletionInfo']>,
+    document: vscode.TextDocument
+): string {
+    return `${markdownInlineCode(withVisibleWhitespace(text))}, replacing ${rangeDescriptionWithCurrentText(
+        range,
+        document
+    )}`
+}
+
+function inlineCompletionItemDescription(
+    item: vscode.InlineCompletionItem,
+    document: vscode.TextDocument | undefined
+): string {
+    return `${markdownCodeBlock(
+        withVisibleWhitespace(typeof item.insertText === 'string' ? item.insertText : item.insertText.value)
+    )}
+${item.range ? `replacing ${rangeDescriptionWithCurrentText(item.range, document)}` : 'inserting at cursor'}`
+}
+
+function rangeDescription(range: vscode.Range): string {
+    // The VS Code extension API uses 0-indexed lines and columns, but the UI (and humans) use
+    // 1-indexed lines and columns. Show the latter.
+    return `${range.start.line + 1}:${range.start.character + 1}${
+        range.isEmpty
+            ? ''
+            : `-${range.end.line !== range.start.line ? `${range.end.line + 1}:` : ''}${range.end.character + 1}`
+    }`
+}
+
+function rangeDescriptionWithCurrentText(range: vscode.Range, document?: vscode.TextDocument): string {
+    return `${rangeDescription(range)} (${
+        range.isEmpty
+            ? 'empty'
+            : document
+            ? markdownInlineCode(withVisibleWhitespace(document.getText(range)))
+            : 'unknown replacement text'
+    })`
+}
+
+function withVisibleWhitespace(text: string): string {
+    return text.replace(/ /g, '·').replace(/\t/g, '⇥').replace(/\r?\n/g, '↵')
+}

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -16,6 +16,7 @@ import { createProviderConfig as createAnthropicProviderConfig } from './complet
 import { ProviderConfig } from './completions/providers/provider'
 import { createProviderConfig as createUnstableCodeGenProviderConfig } from './completions/providers/unstable-codegen'
 import { createProviderConfig as createUnstableHuggingFaceProviderConfig } from './completions/providers/unstable-huggingface'
+import { registerAutocompleteTraceView } from './completions/tracer/traceView'
 import { getConfiguration, getFullConfig, migrateConfiguration } from './configuration'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { configureExternalServices } from './external-services'
@@ -378,7 +379,8 @@ function createCompletionsProvider(
         vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyLines }) => {
             CompletionsLogger.accept(codyLogId, codyLines)
         }),
-        vscode.languages.registerInlineCompletionItemProvider('*', completionsProvider)
+        vscode.languages.registerInlineCompletionItemProvider('*', completionsProvider),
+        registerAutocompleteTraceView(completionsProvider)
     )
     return {
         dispose: () => {

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -105,10 +105,15 @@ async function generateCompletionsForDataset(codeSamples: string[]): Promise<voi
         const codeSampleResults: CompletionResult[] = []
         for (let i = 0; i < iterationsPerCodeSample; i++) {
             const start = Date.now()
-            const completionItems = await completionsProvider.provideInlineCompletionItems(textDocument, position, {
-                triggerKind: 1,
-                selectedCompletionInfo: undefined,
-            })
+            const completionItems = await completionsProvider.provideInlineCompletionItems(
+                textDocument,
+                position,
+                {
+                    triggerKind: 1,
+                    selectedCompletionInfo: undefined,
+                },
+                undefined
+            )
 
             const completions = ('items' in completionItems ? completionItems.items : completionItems).map(item =>
                 typeof item.insertText === 'string' ? item.insertText : ''


### PR DESCRIPTION
Added a `Cody: Open Autocomplete Trace View` command palette action opens a webview with trace info about the most recently triggered completion. This helps understand what params, prefix, suffix, context, etc., was used. It is only shown in the command palette when `cody.debug.enabled` is `true`.

### Video

https://github.com/sourcegraph/cody/assets/1976/fa83e9d1-1528-4f42-8f07-ad5f027f87fa

### Screenshot

![image](https://github.com/sourcegraph/cody/assets/1976/0b578037-81a5-41ba-addb-e576cbba6877)

## Test plan

Set `cody.debug.enabled` to `true`, run the new command palette action (`Cody: Open Autocomplete Trace View`), and then trigger completions.