### PR TITLE
reuse CodyCompletionItemProviderConfig

### DIFF
--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -19,7 +19,7 @@ interface Request {
 export class RequestManager {
     private readonly requests: Map<string, Request[]> = new Map()
 
-    constructor(private completionsCache: CompletionsCache | undefined) {}
+    constructor(private completionsCache: CompletionsCache | null) {}
 
     public async request(
         documentUri: string,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -368,7 +368,7 @@ function createCompletionsProvider(
         history,
         statusBar,
         codebaseContext,
-        cache: config.autocompleteAdvancedCache ? new CompletionsCache() : undefined,
+        cache: config.autocompleteAdvancedCache ? new CompletionsCache() : null,
         isEmbeddingsContextEnabled: config.autocompleteAdvancedEmbeddings,
         triggerMoreEagerly: config.autocompleteExperimentalTriggerMoreEagerly,
         completeSuggestWidgetSelection: config.autocompleteExperimentalCompleteSuggestWidgetSelection,

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -54,7 +54,7 @@ async function initCompletionsProvider(): Promise<CodyCompletionItemProvider> {
         codebaseContext,
         disableTimeouts: true,
         triggerMoreEagerly: false,
-        cache: undefined,
+        cache: null,
         isEmbeddingsContextEnabled: true,
     })
 


### PR DESCRIPTION
Instead of repeating the property names and types in the `interface CodyCompletionItemProviderConfig` and the class members of `CodyCompletionItemProvider`, just use the type.



## Test plan

Tests suffice.