### PR TITLE
Autocomplete: Update Hugging Face inference endpoint for StarCoder prompt

### DIFF
--- a/vscode/src/completions/language.ts
+++ b/vscode/src/completions/language.ts
@@ -1,0 +1,35 @@
+interface LanguageConfig {
+    blockStart: string
+    blockElseTest: RegExp
+    blockEnd: string | null
+    commentStart: string
+}
+export function getLanguageConfig(languageId: string): LanguageConfig | null {
+    switch (languageId) {
+        case 'c':
+        case 'cpp':
+        case 'csharp':
+        case 'go':
+        case 'java':
+        case 'javascript':
+        case 'javascriptreact':
+        case 'typescript':
+        case 'typescriptreact':
+            return {
+                blockStart: '{',
+                blockElseTest: /^[\t ]*} else/,
+                blockEnd: '}',
+                commentStart: '// ',
+            }
+        case 'python': {
+            return {
+                blockStart: ':',
+                blockElseTest: /^[\t ]*(elif |else:)/,
+                blockEnd: null,
+                commentStart: '# ',
+            }
+        }
+        default:
+            return null
+    }
+}

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -1,5 +1,6 @@
 import detectIndent from 'detect-indent'
 
+import { getLanguageConfig } from './language'
 import { getEditorTabSize, indentation, PrefixComponents } from './text-processing'
 
 const BRACKET_PAIR = {
@@ -192,37 +193,4 @@ export function truncateMultilineCompletion(
     }
 
     return lines.slice(0, cutOffIndex).join('\n')
-}
-
-interface LanguageConfig {
-    blockStart: string
-    blockElseTest: RegExp
-    blockEnd: string | null
-}
-function getLanguageConfig(languageId: string): LanguageConfig | null {
-    switch (languageId) {
-        case 'c':
-        case 'cpp':
-        case 'csharp':
-        case 'go':
-        case 'java':
-        case 'javascript':
-        case 'javascriptreact':
-        case 'typescript':
-        case 'typescriptreact':
-            return {
-                blockStart: '{',
-                blockElseTest: /^[\t ]*} else/,
-                blockEnd: '}',
-            }
-        case 'python': {
-            return {
-                blockStart: ':',
-                blockElseTest: /^[\t ]*(elif |else:)/,
-                blockEnd: null,
-            }
-        }
-        default:
-            return null
-    }
 }

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -54,8 +54,6 @@ export class UnstableHuggingFaceProvider extends Provider {
                 .map(line => (languageConfig ? languageConfig.commentStart + line : ''))
                 .join('\n')
 
-            console.log({ introString })
-
             // Prompt format is taken form https://huggingface.co/bigcode/starcoder#fill-in-the-middle
             prompt = `<fim_prefix>${introString}${this.options.prefix}<fim_suffix>${this.options.suffix}<fim_middle>`
         }

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -2,6 +2,8 @@ import fetch from 'isomorphic-fetch'
 
 import { Completion } from '..'
 import { logger } from '../../log'
+import { ReferenceSnippet } from '../context'
+import { getLanguageConfig } from '../language'
 import { isAbortError } from '../utils'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
@@ -13,6 +15,7 @@ interface UnstableHuggingFaceOptions {
 
 const PROVIDER_IDENTIFIER = 'huggingface'
 const STOP_WORD = '<|endoftext|>'
+const CONTEXT_WINDOW_CHARS = 4000 // ~ 1280 token limit
 
 export class UnstableHuggingFaceProvider extends Provider {
     private serverEndpoint: string
@@ -24,10 +27,44 @@ export class UnstableHuggingFaceProvider extends Provider {
         this.accessToken = unstableHuggingFaceOptions.accessToken
     }
 
-    public async generateCompletions(abortSignal: AbortSignal): Promise<Completion[]> {
-        // TODO: Add context and language
-        // Prompt format is taken form https://huggingface.co/bigcode/starcoder#fill-in-the-middle
-        const prompt = `<fim_prefix>${this.options.prefix}<fim_suffix>${this.options.suffix}<fim_middle>`
+    private createPrompt(snippets: ReferenceSnippet[]): string {
+        const maxPromptChars = CONTEXT_WINDOW_CHARS - CONTEXT_WINDOW_CHARS * this.options.responsePercentage
+
+        const intro: string[] = []
+        let prompt = ''
+
+        const languageConfig = getLanguageConfig(this.options.languageId)
+        if (languageConfig) {
+            intro.push(`Path: ${this.options.fileName}`)
+        }
+
+        for (let snippetsToInclude = 0; snippetsToInclude < snippets.length + 1; snippetsToInclude++) {
+            if (prompt.length >= maxPromptChars) {
+                return prompt
+            }
+
+            if (snippetsToInclude > 0) {
+                const snippet = snippets[snippetsToInclude - 1]
+                intro.push(`Here is a reference snippet of code from ${snippet.fileName}:\n${snippet.content}`)
+            }
+
+            const introString = intro
+                .join('\n\n')
+                .split('\n')
+                .map(line => (languageConfig ? languageConfig.commentStart + line : ''))
+                .join('\n')
+
+            console.log({ introString })
+
+            // Prompt format is taken form https://huggingface.co/bigcode/starcoder#fill-in-the-middle
+            prompt = `<fim_prefix>${introString}${this.options.prefix}<fim_suffix>${this.options.suffix}<fim_middle>`
+        }
+
+        return prompt
+    }
+
+    public async generateCompletions(abortSignal: AbortSignal, snippets: ReferenceSnippet[]): Promise<Completion[]> {
+        const prompt = this.createPrompt(snippets)
 
         const request = {
             inputs: prompt,
@@ -35,7 +72,7 @@ export class UnstableHuggingFaceProvider extends Provider {
                 num_return_sequences: 1,
                 // To speed up sample generation in single-line case, we request a lower token limit
                 // since we can't terminate on the first `\n`.
-                max_new_tokens: this.options.multiline ? 64 : 256,
+                max_new_tokens: this.options.multiline ? 50 : 256,
             },
         }
 
@@ -92,12 +129,11 @@ function postProcess(content: string, multiline: boolean): string {
 }
 
 export function createProviderConfig(unstableHuggingFaceOptions: UnstableHuggingFaceOptions): ProviderConfig {
-    const contextWindowChars = 8_000 // ~ 2k token limit
     return {
         create(options: ProviderOptions) {
             return new UnstableHuggingFaceProvider(options, unstableHuggingFaceOptions)
         },
-        maximumContextCharacters: contextWindowChars,
+        maximumContextCharacters: CONTEXT_WINDOW_CHARS,
         enableExtendedMultilineTriggers: true,
         identifier: PROVIDER_IDENTIFIER,
     }


### PR DESCRIPTION
This tweaks the existing Hugging Face inference endpoint provider option to better work with the OG StarCoder model. This also now adds context in form of comments in the prefix to the prompt.

Two observations:

- StarCoder only supports 1k token prompt and up to 500 token response. I believe this is slower than WizardCoder
- Lots of model tuning still to be done of course. This is only a very rough first pass to evaluate it against other OS LLMs

## Test plan

- Run it locally using these settings:
```
  "cody.autocomplete.advanced.accessToken": "ping me",
  "cody.autocomplete.advanced.serverEndpoint": "ping me",
  "cody.autocomplete.advanced.provider": "unstable-huggingface"
```

<!--
All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Some examples:

// Just a doc change
none - docs change

// Unit tests got your back?
Unit tests

// Tested it manually and CI will also pitch in?
Manually tested and CI
-->
