### PR TITLE
Simplify: Split configuration logic out of ContextProvider

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -285,6 +285,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         this.webview = webviewView.webview
         this.authProvider.webview = webviewView.webview
         this.contextProvider.webview = webviewView.webview
+        this.configProvider.webview = webviewView.webview
 
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
 

--- a/vscode/src/chat/ConfigProvider.ts
+++ b/vscode/src/chat/ConfigProvider.ts
@@ -1,0 +1,130 @@
+import * as vscode from 'vscode'
+
+import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
+
+import { getFullConfig } from '../configuration'
+import { debug } from '../log'
+import { AuthProvider } from '../services/AuthProvider'
+import { logEvent } from '../services/EventLogger'
+import { LocalStorage } from '../services/LocalStorageProvider'
+import { SecretStorage } from '../services/SecretStorageProvider'
+
+import { ChatViewProviderWebview } from './ChatViewProvider'
+import { ConfigurationSubsetForWebview, DOTCOM_URL, isLocalApp, LocalEnv } from './protocol'
+
+export type Config = Pick<
+    ConfigurationWithAccessToken,
+    | 'codebase'
+    | 'serverEndpoint'
+    | 'debugEnable'
+    | 'debugFilter'
+    | 'debugVerbose'
+    | 'customHeaders'
+    | 'accessToken'
+    | 'useContext'
+    | 'experimentalChatPredictions'
+    | 'experimentalGuardrails'
+    | 'experimentalCustomRecipes'
+    | 'pluginsEnabled'
+    | 'pluginsConfig'
+    | 'pluginsDebugEnabled'
+>
+
+export enum ContextEvent {
+    Auth = 'auth',
+}
+
+export class ConfigProvider implements vscode.Disposable {
+    // We fire messages from ContextProvider to the sidebar webview.
+    // TODO(umpox): Should we add support for showing context in other places (i.e. within inline chat)?
+    public webview?: ChatViewProviderWebview
+
+    // Fire event to let subscribers know that the configuration has changed
+    public configurationChangeEvent = new vscode.EventEmitter<void>()
+
+    protected disposables: vscode.Disposable[] = []
+
+    constructor(
+        public config: Omit<Config, 'codebase'>, // should use codebaseContext.getCodebase() rather than config.codebase
+        private secretStorage: SecretStorage,
+        private localStorage: LocalStorage,
+        private authProvider: AuthProvider
+    ) {
+        this.disposables.push(this.configurationChangeEvent)
+        this.disposables.push(vscode.commands.registerCommand('cody.auth.sync', () => this.syncAuthStatus()))
+    }
+
+    public onConfigurationChange(newConfig: Config): void {
+        debug('ContextProvider:onConfigurationChange', '')
+        this.config = newConfig
+        const authStatus = this.authProvider.getAuthStatus()
+        if (authStatus.endpoint) {
+            this.config.serverEndpoint = authStatus.endpoint
+        }
+        this.configurationChangeEvent.fire()
+    }
+
+    /**
+     * Save, verify, and sync authStatus between extension host and webview
+     * activate extension when user has valid login
+     */
+    public async syncAuthStatus(): Promise<void> {
+        const authStatus = this.authProvider.getAuthStatus()
+        // Update config to the latest one and fire configure change event to update external services
+        const newConfig = await getFullConfig(this.secretStorage, this.localStorage)
+        await this.publishConfig()
+        this.onConfigurationChange(newConfig)
+        // When logged out, user's endpoint will be set to null
+        const isLoggedOut = !authStatus.isLoggedIn && !authStatus.endpoint
+        const isAppEvent = isLocalApp(authStatus.endpoint || '') ? 'app:' : ''
+        const eventValue = isLoggedOut ? 'disconnected' : authStatus.isLoggedIn ? 'connected' : 'failed'
+        // e.g. auth:app:connected, auth:app:disconnected, auth:failed
+        this.sendEvent(ContextEvent.Auth, isAppEvent + eventValue)
+    }
+
+    /**
+     * Publish the config to the webview.
+     */
+    private async publishConfig(): Promise<void> {
+        const send = async (): Promise<void> => {
+            this.config = await getFullConfig(this.secretStorage, this.localStorage)
+
+            // check if the new configuration change is valid or not
+            const authStatus = this.authProvider.getAuthStatus()
+            const localProcess = await this.authProvider.appDetector.getProcessInfo(authStatus.isLoggedIn)
+            const configForWebview: ConfigurationSubsetForWebview & LocalEnv = {
+                ...localProcess,
+                debugEnable: this.config.debugEnable,
+                serverEndpoint: this.config.serverEndpoint,
+                pluginsEnabled: this.config.pluginsEnabled,
+                pluginsDebugEnabled: this.config.pluginsDebugEnabled,
+            }
+
+            await this.webview?.postMessage({ type: 'config', config: configForWebview, authStatus })
+            debug('Cody:publishConfig', 'configForWebview', { verbose: configForWebview })
+        }
+
+        this.disposables.push(this.configurationChangeEvent.event(() => send()))
+        await send()
+    }
+
+    /**
+     * Log Events - naming convention: source:feature:action
+     */
+    public sendEvent(event: ContextEvent, value: string): void {
+        const endpoint = this.config.serverEndpoint || DOTCOM_URL.href
+        const endpointUri = { serverEndpoint: endpoint }
+        switch (event) {
+            case 'auth':
+                logEvent(`CodyVSCodeExtension:Auth:${value}`, endpointUri, endpointUri)
+                break
+        }
+    }
+
+    public dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose()
+        }
+        this.disposables = []
+    }
+}

--- a/vscode/src/chat/ConfigProvider.ts
+++ b/vscode/src/chat/ConfigProvider.ts
@@ -30,13 +30,13 @@ export type Config = Pick<
     | 'pluginsDebugEnabled'
 >
 
-export enum ContextEvent {
+enum ConfigEvent {
     Auth = 'auth',
 }
 
 export class ConfigProvider implements vscode.Disposable {
-    // We fire messages from ContextProvider to the sidebar webview.
-    // TODO(umpox): Should we add support for showing context in other places (i.e. within inline chat)?
+    // We fire messages from ConfigProvider to the sidebar webview.
+    // TODO(umpox): Should we add support for showing config in other places (i.e. within inline chat)?
     public webview?: ChatViewProviderWebview
 
     // Fire event to let subscribers know that the configuration has changed
@@ -55,7 +55,7 @@ export class ConfigProvider implements vscode.Disposable {
     }
 
     public onConfigurationChange(newConfig: Config): void {
-        debug('ContextProvider:onConfigurationChange', '')
+        debug('ConfigProvider:onConfigurationChange', '')
         this.config = newConfig
         const authStatus = this.authProvider.getAuthStatus()
         if (authStatus.endpoint) {
@@ -79,7 +79,7 @@ export class ConfigProvider implements vscode.Disposable {
         const isAppEvent = isLocalApp(authStatus.endpoint || '') ? 'app:' : ''
         const eventValue = isLoggedOut ? 'disconnected' : authStatus.isLoggedIn ? 'connected' : 'failed'
         // e.g. auth:app:connected, auth:app:disconnected, auth:failed
-        this.sendEvent(ContextEvent.Auth, isAppEvent + eventValue)
+        this.sendEvent(ConfigEvent.Auth, isAppEvent + eventValue)
     }
 
     /**
@@ -111,7 +111,7 @@ export class ConfigProvider implements vscode.Disposable {
     /**
      * Log Events - naming convention: source:feature:action
      */
-    public sendEvent(event: ContextEvent, value: string): void {
+    public sendEvent(event: ConfigEvent, value: string): void {
         const endpoint = this.config.serverEndpoint || DOTCOM_URL.href
         const endpointUri = { serverEndpoint: endpoint }
         switch (event) {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -76,6 +76,14 @@ export class ContextProvider implements vscode.Disposable {
                 await this.updateCodebaseContext()
             }),
             configProvider.configurationChangeEvent.event(async () => {
+                // TODO: Still needed?
+                // if (authStatus.siteVersion) {
+                //     // Update codebase context
+                //     const codebaseContext = await getCodebaseContext(newConfig, this.rgPath, this.editor, this.chat)
+                //     if (codebaseContext) {
+                //         this.codebaseContext = codebaseContext
+                //     }
+                // }
                 await this.updateCodebaseContext()
             })
         )
@@ -171,6 +179,7 @@ export class ContextProvider implements vscode.Disposable {
                 },
             })
         }
+        this.disposables.push(this.configProvider.configurationChangeEvent.event(() => send()))
         this.disposables.push(vscode.window.onDidChangeTextEditorSelection(() => send()))
         return send()
     }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode'
 
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
-import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
@@ -21,35 +20,10 @@ import { ChatViewProviderWebview } from './ChatViewProvider'
 import { isLocalApp } from './protocol'
 import { convertGitCloneURLToCodebaseName } from './utils'
 
-export type Config = Pick<
-    ConfigurationWithAccessToken,
-    | 'codebase'
-    | 'serverEndpoint'
-    | 'debugEnable'
-    | 'debugFilter'
-    | 'debugVerbose'
-    | 'customHeaders'
-    | 'accessToken'
-    | 'useContext'
-    | 'experimentalChatPredictions'
-    | 'experimentalGuardrails'
-    | 'experimentalCustomRecipes'
-    | 'pluginsEnabled'
-    | 'pluginsConfig'
-    | 'pluginsDebugEnabled'
->
-
-export enum ContextEvent {
-    Auth = 'auth',
-}
-
 export class ContextProvider implements vscode.Disposable {
     // We fire messages from ContextProvider to the sidebar webview.
     // TODO(umpox): Should we add support for showing context in other places (i.e. within inline chat)?
     public webview?: ChatViewProviderWebview
-
-    // Fire event to let subscribers know that the context has changed
-    public contextChangeEvent = new vscode.EventEmitter<void>()
 
     public currentWorkspaceRoot: string
 
@@ -66,7 +40,6 @@ export class ContextProvider implements vscode.Disposable {
         private telemetryService: TelemetryService,
         private platform: PlatformContext
     ) {
-        this.disposables.push(this.contextChangeEvent)
         this.currentWorkspaceRoot = ''
         this.disposables.push(
             vscode.window.onDidChangeActiveTextEditor(async () => {
@@ -76,14 +49,6 @@ export class ContextProvider implements vscode.Disposable {
                 await this.updateCodebaseContext()
             }),
             configProvider.configurationChangeEvent.event(async () => {
-                // TODO: Still needed?
-                // if (authStatus.siteVersion) {
-                //     // Update codebase context
-                //     const codebaseContext = await getCodebaseContext(newConfig, this.rgPath, this.editor, this.chat)
-                //     if (codebaseContext) {
-                //         this.codebaseContext = codebaseContext
-                //     }
-                // }
                 await this.updateCodebaseContext()
             })
         )

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -117,10 +117,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         // chat id is used to identify chat session
         this.createNewChatID()
 
-        this.configProvider.configurationChangeEvent.event(async () =>
-            // Listen to configuration changes to possibly enable custom recipes
-            this.sendMyPrompts()
-        )
+        // Listen to configuration changes to possibly enable custom recipes
+        this.configProvider.configurationChangeEvent.event(() => this.sendMyPrompts())
     }
 
     protected async init(): Promise<void> {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -388,7 +388,7 @@ const register = async (
     return {
         disposable: vscode.Disposable.from(...disposables),
         onConfigurationChange: newConfig => {
-            contextProvider.onConfigurationChange(newConfig)
+            configProvider.onConfigurationChange(newConfig)
             externalServicesOnDidConfigurationChange(newConfig)
             void createOrUpdateEventLogger(newConfig, localStorage)
         },


### PR DESCRIPTION
## Description

Splits configuration related logic out of `ContextProvider`. Simplifies both providers

## Test plan

Tested locally