### PR TITLE
shorten test plan in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,4 @@
 
 ## Test plan
 
-<!--
-All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles
-
-Some examples:
-
-// Just a doc change
-none - docs change
-
-// Unit tests got your back?
-Unit tests
-
-// Tested it manually and CI will also pitch in?
-Manually tested and CI
--->
+<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->


### PR DESCRIPTION
I've seen some commit messages from merged PRs (such as https://sourcegraph.com/github.com/sourcegraph/cody/-/commit/323160ccac317c18dc3cc55fa3174a6b4e3a25da?visible=9) that include the entire comment, which adds noise to the `git log`.



## Test plan

n/a