### PR TITLE
default `cody.autocomplete.experimental.triggerMoreEagerly` to true

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -892,7 +892,7 @@
         },
         "cody.autocomplete.experimental.triggerMoreEagerly": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Trigger autocomplete when the cursor is at the end of a word (instead of waiting for a space or other non-word character). Share feedback at https://github.com/sourcegraph/cody/discussions/274."
         },
         "cody.autocomplete.experimental.completeSuggestWidgetSelection": {


### PR DESCRIPTION
This setting makes it so that autocomplete is triggered when you are still typing a word, without waiting for you to press space, return, `(`, etc.

This has been an experimental setting for 10 days (see internal discussion at https://sourcegraph.slack.com/archives/C05AGQYD528/p1689990943908639).


## Test plan

n/a