### PR TITLE
support working with recipes, etc., on virtual files

### DIFF
--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -54,7 +54,7 @@ export class VSCodeEditor implements Editor {
 
     private getActiveTextEditorInstance(): vscode.TextEditor | null {
         const activeEditor = vscode.window.activeTextEditor
-        return activeEditor && activeEditor.document.uri.scheme === 'file' ? activeEditor : null
+        return activeEditor ?? null
     }
 
     public getActiveTextEditorSelection(): ActiveTextEditorSelection | null {


### PR DESCRIPTION
Recipes that provide information about code (such as an explanation) should work on read-only files.

Recipes that modify files in-place should use the VS Code `vscode.workspace.fs.isWritableFileSystem` extension API to see if the document's URI scheme is writable. This commit does NOT update all recipes to check that because that is a fairly rare case and we are evolving the recipes UX right now.



## Test plan

Open a virtual file (such as using the RemoteHub extension). Try running a recipe on it. It should succeed.