### PR TITLE
use simpler XML parsing lib in reranking

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -30,7 +30,7 @@
     "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.21",
     "marked": "^4.0.16",
-    "xml2js": "^0.6.0"
+    "x2js": "^3.4.4"
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.2",
@@ -38,7 +38,6 @@
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/lodash": "^4.14.195",
     "@types/marked": "^4.0.3",
-    "@types/vscode": "^1.80.0",
-    "@types/xml2js": "^0.4.11"
+    "@types/vscode": "^1.80.0"
   }
 }

--- a/lib/shared/src/codebase-context/rerank.test.ts
+++ b/lib/shared/src/codebase-context/rerank.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, test } from 'vitest'
 import { parseFileExplanations } from './rerank'
 
 describe('parseFileExplanations', () => {
-    test('parses filenames', async () => {
+    test('parses filenames', () => {
         expect(
-            await parseFileExplanations(
+            parseFileExplanations(
                 '<list><item><filename>filename 1</filename><explanation>this is why I chose this item</explanation></item><item><filename>filename 2</filename><explanation>why I chose this item</explanation></item></list>'
             )
         ).toEqual(['filename 1', 'filename 2'])

--- a/lib/shared/src/codebase-context/rerank.test.ts
+++ b/lib/shared/src/codebase-context/rerank.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+
+import { parseFileExplanations } from './rerank'
+
+describe('parseFileExplanations', () => {
+    test('parses filenames', async () => {
+        expect(
+            await parseFileExplanations(
+                '<list><item><filename>filename 1</filename><explanation>this is why I chose this item</explanation></item><item><filename>filename 2</filename><explanation>why I chose this item</explanation></item></list>'
+            )
+        ).toEqual(['filename 1', 'filename 2'])
+    })
+})

--- a/lib/shared/src/codebase-context/rerank.ts
+++ b/lib/shared/src/codebase-context/rerank.ts
@@ -57,7 +57,7 @@ export class LLMReranker implements Reranker {
         if (out.indexOf('</list>') !== out.length - '</list>'.length) {
             out = out.slice(0, out.indexOf('</list>') + '</list>'.length)
         }
-        const boostedFilenames = await parseXml(out)
+        const boostedFilenames = await parseFileExplanations(out)
 
         const resultsMap = Object.fromEntries(results.map(r => [r.fileName, r]))
         const boostedNames = new Set<string>()
@@ -81,7 +81,7 @@ export class LLMReranker implements Reranker {
     }
 }
 
-async function parseXml(xml: string): Promise<string[]> {
+export async function parseFileExplanations(xml: string): Promise<string[]> {
     const result = await parseStringPromise(xml)
     const items = result.list.item
     const files: { filename: string; explanation: string }[] = items.map((item: any) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,9 @@ importers:
       marked:
         specifier: ^4.0.16
         version: 4.0.16
-      xml2js:
-        specifier: ^0.6.0
-        version: 0.6.0
+      x2js:
+        specifier: ^3.4.4
+        version: 3.4.4
     devDependencies:
       '@types/dompurify':
         specifier: ^3.0.2
@@ -246,9 +246,6 @@ importers:
       '@types/vscode':
         specifier: ^1.80.0
         version: 1.80.0
-      '@types/xml2js':
-        specifier: ^0.4.11
-        version: 0.4.11
 
   lib/ui:
     dependencies:
@@ -5833,12 +5830,6 @@ packages:
       '@types/node': 20.4.0
     dev: false
 
-  /@types/xml2js@0.4.11:
-    resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
-    dependencies:
-      '@types/node': 20.4.0
-    dev: true
-
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
     dev: true
@@ -6276,6 +6267,11 @@ packages:
 
   /@xmldom/xmldom@0.7.11:
     resolution: {integrity: sha512-UDi3g6Jss/W5FnSzO9jCtQwEpfymt0M+sPPlmLhDH6h2TJ8j4ESE/LpmNPBij15J5NKkk4/cg/qoVMdWI3vnlQ==}
+    engines: {node: '>=10.0.0'}
+    dev: false
+
+  /@xmldom/xmldom@0.8.10:
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
     dev: false
 
@@ -16350,6 +16346,12 @@ packages:
         optional: true
     dev: true
 
+  /x2js@3.4.4:
+    resolution: {integrity: sha512-yG/ThaBCgnsa3aoMPAe7QwDpcyU4D70hjXC4Y1lZSfD/Tgd0MpE19FnZZRAjekryw0c8cffpOt9zsPEiqktO6Q==}
+    dependencies:
+      '@xmldom/xmldom': 0.8.10
+    dev: false
+
   /xdm@2.1.0:
     resolution: {integrity: sha512-3LxxbxKcRogYY7cQSMy1tUuU1zKNK9YPqMT7/S0r7Cz2QpyF8O9yFySGD7caOZt+LWUOQioOIX+6ZzCoBCpcAA==}
     dependencies:
@@ -16392,17 +16394,10 @@ packages:
       xmlbuilder: 11.0.1
     dev: true
 
-  /xml2js@0.6.0:
-    resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      sax: 1.2.4
-      xmlbuilder: 11.0.1
-    dev: false
-
   /xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+    dev: true
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}


### PR DESCRIPTION
The x2js library is much smaller and does not require non-browser (Node.js) deps. The total number of bytes parsed is small, so performance is not a major consideration. Also adds a test case.

## Test plan

n/a