### PR TITLE
fall back to less context if `rg` is not available

### DIFF
--- a/lib/shared/src/hallucinations-detector/index.ts
+++ b/lib/shared/src/hallucinations-detector/index.ts
@@ -17,7 +17,7 @@ interface HighlightTokensResult {
 
 export async function highlightTokens(
     text: string,
-    filesExist: (filePaths: string[]) => Promise<{ [filePath: string]: boolean }>,
+    filesExist: (filePaths: string[]) => Promise<{ [filePath: string]: boolean } | null>,
     workspaceRootPath?: string
 ): Promise<HighlightTokensResult> {
     const markdownTokens = parseMarkdown(text)
@@ -40,7 +40,7 @@ export async function highlightTokens(
 
 async function detectTokens(
     tokens: marked.Token[],
-    filesExist: (filePaths: string[]) => Promise<{ [filePath: string]: boolean }>
+    filesExist: (filePaths: string[]) => Promise<{ [filePath: string]: boolean } | null>
 ): Promise<HighlightedToken[]> {
     // mapping from file path to full match
     const filePathToFullMatch: { [filePath: string]: Set<string> } = {}
@@ -64,6 +64,10 @@ async function detectTokens(
     }
 
     const filePathsExist = await filesExist([...Object.keys(filePathToFullMatch)])
+    if (filePathsExist === null) {
+        // If filesExist is unable to determine results, do not highlight any tokens.
+        return []
+    }
     const highlightedTokens: HighlightedToken[] = []
     for (const [filePath, fullMatches] of Object.entries(filePathToFullMatch)) {
         const exists = filePathsExist[filePath]

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -118,7 +118,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         private editor: VSCodeEditor,
         private secretStorage: SecretStorage,
         private localStorage: LocalStorage,
-        private rgPath: string,
+        private rgPath: string | null,
         private authProvider: AuthProvider
     ) {
         if (TestSupport.instance) {
@@ -372,10 +372,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 const lastInteraction = this.transcript.getLastInteraction()
                 if (lastInteraction) {
                     const displayText = reformatBotMessage(text, responsePrefix)
-                    const fileExistFunc = (filePaths: string[]): Promise<{ [filePath: string]: boolean }> => {
+                    const fileExistFunc = (filePaths: string[]): Promise<{ [filePath: string]: boolean } | null> => {
                         const rootPath = this.editor.getWorkspaceRootPath()
-                        if (!rootPath) {
-                            return Promise.resolve({})
+                        if (!rootPath || !this.rgPath) {
+                            return Promise.resolve(null)
                         }
                         return fastFilesExist(this.rgPath, rootPath, filePaths)
                     }
@@ -1136,7 +1136,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
  */
 export async function getCodebaseContext(
     config: Config,
-    rgPath: string,
+    rgPath: string | null,
     editor: Editor,
     chatClient: ChatClient
 ): Promise<CodebaseContext | null> {
@@ -1165,8 +1165,8 @@ export async function getCodebaseContext(
         config,
         codebase,
         embeddingsSearch,
-        new LocalKeywordContextFetcher(rgPath, editor, chatClient),
-        new FilenameContextFetcher(rgPath, editor, chatClient),
+        rgPath ? new LocalKeywordContextFetcher(rgPath, editor, chatClient) : null,
+        rgPath ? new FilenameContextFetcher(rgPath, editor, chatClient) : null,
         undefined,
         getRerankWithLog(chatClient)
     )

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -35,7 +35,7 @@ type ExternalServicesConfiguration = Pick<
 
 export async function configureExternalServices(
     initialConfig: ExternalServicesConfiguration,
-    rgPath: string,
+    rgPath: string | null,
     editor: Editor
 ): Promise<ExternalServices> {
     const client = new SourcegraphGraphQLAPIClient(initialConfig)
@@ -55,8 +55,8 @@ export async function configureExternalServices(
         initialConfig,
         initialConfig.codebase,
         embeddingsSearch,
-        new LocalKeywordContextFetcher(rgPath, editor, chatClient),
-        new FilenameContextFetcher(rgPath, editor, chatClient),
+        rgPath ? new LocalKeywordContextFetcher(rgPath, editor, chatClient) : null,
+        rgPath ? new FilenameContextFetcher(rgPath, editor, chatClient) : null,
         undefined,
         getRerankWithLog(chatClient)
     )

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -152,7 +152,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (message: string, statusCode?: number) => {
+                    onError: (message: string) => {
                         reject(new Error(message))
                     },
                 },

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -79,7 +79,7 @@ const register = async (
     initialConfig: ConfigurationWithAccessToken,
     secretStorage: SecretStorage,
     localStorage: LocalStorage,
-    rgPath: string
+    rgPath: string | null
 ): Promise<{
     disposable: vscode.Disposable
     onConfigurationChange: (newConfig: ConfigurationWithAccessToken) => void

--- a/vscode/src/rg.ts
+++ b/vscode/src/rg.ts
@@ -6,7 +6,7 @@ import { promisify } from 'util'
 
 const exec = promisify(exec_)
 
-export async function getRgPath(extensionPath: string): Promise<string> {
+export async function getRgPath(extensionPath: string): Promise<string | null> {
     if (process.env.MOCK_RG_PATH) {
         return process.env.MOCK_RG_PATH
     }
@@ -34,7 +34,7 @@ export async function getRgPath(extensionPath: string): Promise<string> {
         return 'rg'
     } catch (error) {
         console.error(error)
-        return 'rg'
+        return null
     }
 }
 

--- a/vscode/test/integration/local-search.test.ts
+++ b/vscode/test/integration/local-search.test.ts
@@ -26,6 +26,7 @@ suite('Local search', function () {
         assert.ok(workspaceFolders.length >= 1)
 
         const rgPath = await getRgPath(path.join(__dirname, '..', '..', '..', '..'))
+        assert.ok(rgPath)
         const filesExistMap = await fastFilesExist(rgPath, workspaceFolders[0].uri.fsPath, [
             'lib',
             'batches',


### PR DESCRIPTION
Instead of falling back to exec'ing `rg` on the `$PATH` if no `ripgrep` binary is found, return null and do not attempt to exec `rg` elsewhere.



## Test plan

Ensure `rg` on your system is not provided. Ensure that chat responses are still shown (with no file path hallucination filtering).