### PR TITLE
Clean up Custom Recipes UX

### DIFF
--- a/vscode/src/my-cody/InputMenu.ts
+++ b/vscode/src/my-cody/InputMenu.ts
@@ -5,40 +5,34 @@ import { defaultCodyPromptContext } from '@sourcegraph/cody-shared/src/chat/reci
 import { prompt_creation_title } from './helper'
 import { CodyPrompt, CodyPromptType } from './types'
 
-export type answerType = 'add' | 'file' | 'delete' | 'list' | 'open' | 'cancel'
+export type answerType = 'add' | 'open-workspace' | 'open-user' | 'delete'
 
 export async function showCustomRecipeMenu(): Promise<answerType | void> {
     const options = [
-        { kind: -1, label: 'recipes manager', id: 'seperator' },
-        { kind: 0, label: 'Create New User Recipe', id: 'add' },
-        { kind: 0, label: 'My Custom Recipes', id: 'list' },
-        { kind: -1, label: '.vscode/cody.json', id: 'seperator' },
-        { kind: 0, label: 'Generate Recipes Config File', id: 'file' },
-        { kind: 0, label: 'Delete Recipes Config File', id: 'delete' },
-        { kind: 0, label: 'Open Recipes Config File', id: 'open' },
+        { kind: 0, label: 'Create New Recipe...', id: 'add' },
+        { kind: 0, label: 'Open Workspace Recipe Settings (JSON)', description: '.vscode/cody.json', id: 'open-workspace' },
+        { kind: 0, label: 'Open User Recipe Settings (JSON)', description: '~/.vscode/cody.json', id: 'open-user' },
+        { kind: 0, label: 'Open Recipe Examples (JSON)', id: 'open-examples' },
     ]
     const inputOptions = {
-        title: 'Cody: Custom Recipes (Internal Experimental)',
-        placeHolder: 'Select an option to continue or ESC to cancel',
+        title: 'Configure Custom Cody Recipes',
+        placeHolder: 'Select an option',
     }
     const selectedOption = await vscode.window.showQuickPick(options, inputOptions)
     if (!selectedOption) {
         return
     }
     switch (selectedOption.label) {
-        case 'Create New User Recipe': {
+        case 'Create New Recipe...': {
             return 'add'
         }
-        case 'My Custom Recipes': {
-            return 'list'
+        case 'Open Workspace Recipe Settings (JSON)': {
+            return 'open-workspace'
         }
-        case 'Open Recipes Config File': {
-            return 'open'
+        case 'Open User Recipe Settings (JSON)': {
+            return 'open-user'
         }
-        case 'Generate Recipes Config File': {
-            return 'file'
-        }
-        case 'Delete Recipes Config File': {
+        case 'Open Recipe Examples (JSON)': {
             return 'delete'
         }
         default:
@@ -51,7 +45,7 @@ export async function recipePicker(promptList: string[] = []): Promise<string> {
     return selectedRecipe
 }
 
-// This allows users to create a new prompt via UI using the input box and quick pick without having to manually edit the cody.json file
+// This allows users to create a new recipe via UI using the input box and quick pick without having to manually edit the cody.json file
 export async function createNewPrompt(promptName?: string): Promise<CodyPrompt | null> {
     if (!promptName) {
         return null

--- a/vscode/webviews/Recipes.module.css
+++ b/vscode/webviews/Recipes.module.css
@@ -1,28 +1,35 @@
-.recipes {
+.container {
     padding: 1rem;
     display: flex;
     flex-direction: column;
+}
+
+.heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: var(--vscode-editor-font-size);
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+}
+
+.tag {
+    font-weight: normal;
+    margin-left: 0.25rem;
+}
+
+.recipes-container {
+    display: flex;
+    flex-direction: column;
     gap: 1rem;
+}
+
+.recipes-container + .heading {
+    margin-top: 1rem;
 }
 
 /* Extra styles for the big buttons */
 .recipe-button {
     padding-top: 0.5rem;
     padding-bottom: 0.5rem;
-}
-
-.recipes-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    font-size: 0.8rem;
-    font-weight: bold;
-}
-
-.recipes-notes {
-    display: flex;
-    align-items: center;
-    margin: 0.1rem 0;
-    font-size: small;
 }

--- a/vscode/webviews/Recipes.tsx
+++ b/vscode/webviews/Recipes.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
+import { VSCodeButton, VSCodeTag } from '@vscode/webview-ui-toolkit/react'
 
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 
@@ -36,79 +36,58 @@ export const Recipes: React.FunctionComponent<{
     return (
         <div className="inner-container">
             <div className="non-transcript-container">
-                <div className={styles.recipes}>
+                <div className={styles.container}>
                     {myPromptsEnabled && (
                         <>
-                            <div>
-                                <div
-                                    title="Custom Recipes let you build your own reusable prompts with tailored contexts. Update the recipes field in your `.vscode/cody.json` file to add or remove a recipe."
-                                    className={styles.recipesHeader}
-                                >
-                                    <span>Custom Recipes - Experimental</span>
-                                    {myPrompts?.length > 0 && (
-                                        <VSCodeButton
-                                            type="button"
-                                            appearance="icon"
-                                            onClick={() => onMyPromptClick('menu')}
-                                        >
-                                            <i className="codicon codicon-tools" title="Update your custom recipes" />
-                                        </VSCodeButton>
-                                    )}
-                                </div>
-                                {myPrompts?.length === 0 && (
-                                    <small className={styles.recipesNotes}>
-                                        To get started, select a custom recipe type below to generate a new `cody.json`
-                                        file containing sample recipes.
-                                    </small>
-                                )}
-                            </div>
-                            {!myPrompts?.length && (
-                                <>
-                                    <VSCodeButton
-                                        className={styles.recipeButton}
-                                        type="button"
-                                        onClick={() => onMyPromptClick('add-user-file')}
-                                        title="User Recipes are accessible only to you across
-                                        Workspaces"
-                                    >
-                                        User Recipes
-                                    </VSCodeButton>
-                                    <VSCodeButton
-                                        className={styles.recipeButton}
-                                        type="button"
-                                        onClick={() => onMyPromptClick('add-workspace-file')}
-                                        title="Workspace Recipes are available to all users in your current
-                                        repository"
-                                    >
-                                        Workspace Recipes
-                                    </VSCodeButton>
-                                </>
-                            )}
-                            {myPrompts?.map(promptID => (
+                            <div className={styles.heading}>
+                                <span>Custom Recipes <VSCodeTag className={styles.tag}>Experimental</VSCodeTag></span>
                                 <VSCodeButton
-                                    key={promptID}
-                                    className={styles.recipeButton}
                                     type="button"
-                                    onClick={() => onMyPromptClick(promptID)}
+                                    appearance="icon"
+                                    onClick={() => onMyPromptClick('menu')}
+                                    className={styles.headerButton}
                                 >
-                                    {promptID}
+                                    <i className="codicon codicon-gear" title="Configure Custom Recipes" />
                                 </VSCodeButton>
-                            ))}
-                            <div className={styles.recipesHeader}>
-                                <span>Featured Recipes</span>
+                            </div>
+                            <div className={styles.recipesContainer}>
+                                {myPrompts?.length === 0 && (
+                                    <VSCodeButton
+                                        className={styles.recipeButton}
+                                        type="button"
+                                        onClick={() => onMyPromptClick('menu')}
+                                    >
+                                        Get Started with Custom Recipes
+                                    </VSCodeButton>
+                                )}
+                                {myPrompts?.map(promptID => (
+                                    <VSCodeButton
+                                        key={promptID}
+                                        className={styles.recipeButton}
+                                        type="button"
+                                        onClick={() => onMyPromptClick(promptID)}
+                                    >
+                                        {promptID}
+                                    </VSCodeButton>
+                                ))}
+                            </div>
+                            <div className={styles.heading}>
+                                <span>Built-In Recipes</span>
                             </div>
                         </>
                     )}
-                    {Object.entries(recipesList).map(([key, value]) => (
-                        <VSCodeButton
-                            key={key}
-                            className={styles.recipeButton}
-                            type="button"
-                            onClick={() => onRecipeClick(key as RecipeID)}
-                        >
-                            {value}
-                        </VSCodeButton>
-                    ))}
+                    <div className={styles.recipesContainer}>
+                        {Object.entries(recipesList).map(([key, value]) => (
+                            <VSCodeButton
+                                key={key}
+                                className={styles.recipeButton}
+                                type="button"
+                                onClick={() => onRecipeClick(key as RecipeID)}
+                            >
+                                {value}
+                            </VSCodeButton>
+                        ))}
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This updates the custom recipes:
- Cleaned up recipes view
- New quickpick that features both workspace and user
- Don't auto-add in all the examples when creating a new blank file, but instead open an examples next to it they can copy+paste
- Removes the delete quickpicks (shouldn't be too hard for users to figure out how to do this if they want)
- Removes the list quickpick (we can bring back listing all the recipes in a new recipe quickpick that includes built-in and custom)

| Before | After |
| - | - |
| <img width="1060" alt="Screenshot 2023-07-25 at 9 32 19 pm" src="https://github.com/sourcegraph/cody/assets/153/b616400f-61ec-40b3-950f-7d95a5e9f1d8"> | <img width="1060" alt="Screenshot 2023-07-25 at 9 31 23 pm" src="https://github.com/sourcegraph/cody/assets/153/30cf98d4-21d5-4174-ab4c-9e3eeef47c42"> |
| <img width="1060" alt="Screenshot 2023-07-25 at 9 32 34 pm" src="https://github.com/sourcegraph/cody/assets/153/babd5d63-0ae4-4df6-a474-0eb709335aa6"> | <img width="1060" alt="Screenshot 2023-07-25 at 9 37 10 pm" src="https://github.com/sourcegraph/cody/assets/153/e7d5208c-af30-481e-b9a9-a9d3ae789ae2"> |

Todo:
- [x] Recipe view
- [ ] Fix the recipe examples quickpick so it opens a `cody.example.json` file
- [ ] Fix the "Open [Workspace/User] Recipe Settings (JSON)" quickpicks options:
  - If the file exists, open it
  - If the file doesn't exist, create it with `{\n}`, open alongside `cody.example.json` for easy copy pasta

## Test plan

- View recipes tab
- Verify looks okay
- Enable custom recipes setting
- View recipes tab
- Verify looks okay
- Click configure
- Verify quickpick options work