### PR TITLE
Feedback overlap fix

### DIFF
--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -29,6 +29,10 @@
     background-image: linear-gradient(to bottom, #b200f8, #ff5543, #00cbec);
 }
 
+.assistant-row:last-child {
+    padding-bottom: calc(var(--spacing) * 1.9);
+}
+
 .row:hover > .header-container,
 .row:hover > .footer-container {
     visibility: visible;


### PR DESCRIPTION
Closes #[55187](https://github.com/sourcegraph/sourcegraph/issues/55187) - adds bottom padding to last assistant row to avoid feedback hover overlap.

Web before
![image](https://github.com/sourcegraph/cody/assets/59381432/4f0cd686-3383-43fc-91ee-91fa7c8651d8)

Web after
![Screenshot 2023-07-25 at 10 28 51 AM](https://github.com/sourcegraph/cody/assets/59381432/550ef47c-051c-4478-b856-9f2795132824)

VS Code before
![Screenshot 2023-07-25 at 10 29 21 AM](https://github.com/sourcegraph/cody/assets/59381432/5bb8617e-3d8b-4c82-850e-3058fa0c439c)

VS Code after
![Screenshot 2023-07-25 at 10 29 33 AM](https://github.com/sourcegraph/cody/assets/59381432/996881f0-3c0c-45f1-8575-7e74684692bd)

## Test plan
- Ensure compatibility across Clients