### PR TITLE
Completion: fix bad trailing `}` completion 

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -947,13 +947,48 @@ describe('Cody completions', () => {
                 `
                 if (check) {
                     ${CURSOR_MARKER}
-                    console.log('two')
+                    const d = 5;
                 `,
                 [
                     createCompletionResponse(`
                     console.log('one')
                     }`),
                 ]
+            )
+
+            expect(completions[0].insertText).toBe("console.log('one')")
+        })
+
+        it('does not include block end character if there is already closed bracket', async () => {
+            const { completions } = await complete(
+                `
+                if (check) {
+                    ${CURSOR_MARKER}
+                }`,
+                [createCompletionResponse('}')]
+            )
+
+            expect(completions.length).toBe(0)
+        })
+
+        it('does not include block end character if there is already closed bracket [sort example]', async () => {
+            const { completions } = await complete(
+                `
+                 function bubbleSort(arr: number[]): number[] {
+                   for (let i = 0; i < arr.length; i++) {
+                     for (let j = 0; j < (arr.length - i - 1); j++) {
+                       if (arr[j] > arr[j + 1]) {
+                         // swap elements
+                         let temp = arr[j];
+                         arr[j] = arr[j + 1];
+                         arr[j + 1] = temp;
+                       }
+                       ${CURSOR_MARKER}
+                     }
+                   }
+                   return arr;
+                 }`,
+                [createCompletionResponse('}')]
             )
 
             expect(completions.length).toBe(0)

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -451,7 +451,7 @@ describe('Cody completions', () => {
                 ]
             )
 
-            expect(completions[0].insertText).toBe("if (foo) {\n            console.log('foo1');\n        }")
+            expect(completions[0].insertText).toBe("if (foo) {\n            console.log('foo1');")
             expect(completions[1].insertText).toBe("console.log('foo')")
         })
 

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -451,7 +451,7 @@ describe('Cody completions', () => {
                 ]
             )
 
-            expect(completions[0].insertText).toBe("if (foo) {\n            console.log('foo1');")
+            expect(completions[0].insertText).toBe("if (foo) {\n            console.log('foo1');\n        }")
             expect(completions[1].insertText).toBe("console.log('foo')")
         })
 

--- a/vscode/src/completions/language.ts
+++ b/vscode/src/completions/language.ts
@@ -4,6 +4,7 @@ interface LanguageConfig {
     blockEnd: string | null
     commentStart: string
 }
+
 export function getLanguageConfig(languageId: string): LanguageConfig | null {
     switch (languageId) {
         case 'c':

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -1,14 +1,9 @@
 import detectIndent from 'detect-indent'
 
 import { getLanguageConfig } from './language'
-import { getEditorTabSize, indentation, PrefixComponents } from './text-processing'
+import { indentation } from './text-processing'
+import { getEditorTabSize, OPENING_BRACKET_REGEX, shouldIncludeClosingLine } from './utils/text-utils'
 
-const BRACKET_PAIR = {
-    '(': ')',
-    '[': ']',
-    '{': '}',
-} as const
-const OPENING_BRACKET_REGEX = /([([{])$/
 export function detectMultiline(
     prefix: string,
     prevNonEmptyLine: string,
@@ -38,12 +33,6 @@ export function detectMultiline(
     }
 
     return false
-}
-
-// Detect if completion starts with a space followed by any non-space character.
-export const ODD_INDENTATION_REGEX = /^ [^ ]/
-export function checkOddIndentation(completion: string, prefix: PrefixComponents): boolean {
-    return completion.length > 0 && ODD_INDENTATION_REGEX.test(completion) && prefix.tail.rearSpace.length > 0
 }
 
 /**
@@ -85,52 +74,6 @@ function ensureSameOrLargerIndentation(completion: string): string {
     }
 
     return completion
-}
-
-/**
- * If a completion starts with an opening bracket and a suffix starts with
- * the corresponding closing bracket, we include the last closing bracket of the completion.
- * E.g., function foo(__CURSOR__)
- *
- * We can do this because we know that the existing block is already closed, which means that
- * new blocks need to be closed separately.
- * E.g. function foo() { console.log('hello') }
- */
-function shouldIncludeClosingLineBasedOnBrackets(
-    prefixIndentationWithFirstCompletionLine: string,
-    suffix: string
-): boolean {
-    const matches = prefixIndentationWithFirstCompletionLine.match(OPENING_BRACKET_REGEX)
-
-    if (matches && matches.length > 0) {
-        const openingBracket = matches[0] as keyof typeof BRACKET_PAIR
-        const closingBracket = BRACKET_PAIR[openingBracket]
-
-        return Boolean(openingBracket) && suffix.startsWith(closingBracket)
-    }
-
-    return false
-}
-
-/**
- * Only include a closing line (e.g. `}`) if the block is empty yet if the block is already closed.
- * We detect this by looking at the indentation of the next non-empty line.
- */
-function shouldIncludeClosingLine(prefixIndentationWithFirstCompletionLine: string, suffix: string): boolean {
-    const includeClosingLineBasedOnBrackets = shouldIncludeClosingLineBasedOnBrackets(
-        prefixIndentationWithFirstCompletionLine,
-        suffix
-    )
-    const startIndent = indentation(prefixIndentationWithFirstCompletionLine)
-
-    const firstNewLineIndex = suffix.indexOf('\n') + 1
-    const nextNonEmptyLine =
-        suffix
-            .slice(firstNewLineIndex)
-            .split('\n')
-            .find(line => line.trim().length > 0) ?? ''
-
-    return indentation(nextNonEmptyLine) < startIndent || includeClosingLineBasedOnBrackets
 }
 
 export function truncateMultilineCompletion(

--- a/vscode/src/completions/shared-post-process.ts
+++ b/vscode/src/completions/shared-post-process.ts
@@ -24,7 +24,7 @@ export function sharedPostProcess({
     if (multiline) {
         content = truncateMultilineCompletion(content, prefix, suffix, languageId)
     }
-    content = trimUntilSuffix(content, prefix, suffix)
+    content = trimUntilSuffix(content, prefix, suffix, languageId)
     content = collapseDuplicativeWhitespace(prefix, content)
 
     return {

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -1,6 +1,6 @@
 import { getLanguageConfig } from './language'
 import { isAlmostTheSameString } from './utils/string-comparator'
-import { getEditorTabSize, shouldIncludeClosingLine } from './utils/text-utils'
+import { getEditorTabSize } from './utils/text-utils'
 
 export const OPENING_CODE_TAG = '<CODE5711>'
 export const CLOSING_CODE_TAG = '</CODE5711>'
@@ -152,7 +152,6 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
     const suffixIndent = indentation(firstNonEmptySuffixLine)
     const hasEmptyCompletionLine = prefixIndentationWithFirstCompletionLine.trim() === ''
 
-    const includeClosingLine = shouldIncludeClosingLine(prefixIndentationWithFirstCompletionLine, suffix)
     const insertionLines = insertion.split('\n')
     let cutOffIndex = insertionLines.length
 
@@ -167,12 +166,7 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
         const lineIndentation = indentation(line)
         const isSameIndentation = lineIndentation <= suffixIndent
 
-        if (
-            hasEmptyCompletionLine &&
-            includeClosingLine &&
-            config.blockEnd &&
-            line.trim().startsWith(config.blockEnd)
-        ) {
+        if (hasEmptyCompletionLine && config.blockEnd && line.trim().startsWith(config.blockEnd)) {
             cutOffIndex = i
             break
         }

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -132,10 +132,6 @@ function trimSpace(s: string): TrimmedString {
 export function trimUntilSuffix(insertion: string, prefix: string, suffix: string, languageId: string): string {
     const config = getLanguageConfig(languageId)
 
-    if (!config) {
-        return insertion
-    }
-
     insertion = insertion.trimEnd()
 
     const firstNonEmptySuffixLine = getFirstNonEmptyLine(suffix)
@@ -169,7 +165,7 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
 
         if (
             hasEmptyCompletionLine &&
-            config.blockEnd &&
+            config?.blockEnd &&
             line.trim().startsWith(config.blockEnd) &&
             startIndent === lineIndentation &&
             insertionLines.length === 1

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -150,6 +150,7 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
     const prefixLastNewLine = prefix.lastIndexOf('\n')
     const prefixIndentationWithFirstCompletionLine = prefix.slice(prefixLastNewLine + 1)
     const suffixIndent = indentation(firstNonEmptySuffixLine)
+    const startIndent = indentation(prefixIndentationWithFirstCompletionLine)
     const hasEmptyCompletionLine = prefixIndentationWithFirstCompletionLine.trim() === ''
 
     const insertionLines = insertion.split('\n')
@@ -166,7 +167,12 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
         const lineIndentation = indentation(line)
         const isSameIndentation = lineIndentation <= suffixIndent
 
-        if (hasEmptyCompletionLine && config.blockEnd && line.trim().startsWith(config.blockEnd)) {
+        if (
+            hasEmptyCompletionLine &&
+            config.blockEnd &&
+            line.trim().startsWith(config.blockEnd) &&
+            startIndent === lineIndentation
+        ) {
             cutOffIndex = i
             break
         }

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -171,7 +171,8 @@ export function trimUntilSuffix(insertion: string, prefix: string, suffix: strin
             hasEmptyCompletionLine &&
             config.blockEnd &&
             line.trim().startsWith(config.blockEnd) &&
-            startIndent === lineIndentation
+            startIndent === lineIndentation &&
+            insertionLines.length === 1
         ) {
             cutOffIndex = i
             break

--- a/vscode/src/completions/utils/text-utils.ts
+++ b/vscode/src/completions/utils/text-utils.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode'
+
+export const INDENTATION_REGEX = /^[\t ]*/
+export const OPENING_BRACKET_REGEX = /([([{])$/
+
+export const BRACKET_PAIR = {
+    '(': ')',
+    '[': ']',
+    '{': '}',
+} as const
+
+export function getEditorTabSize(): number {
+    return vscode.window.activeTextEditor ? (vscode.window.activeTextEditor.options.tabSize as number) : 2
+}
+
+/**
+ * Counts space or tabs in the beginning of a line.
+ *
+ * Since Cody can sometimes respond in a mix of tab and spaces, this function
+ * normalizes the whitespace first using the currently enabled tabSize option.
+ */
+export function indentation(line: string): number {
+    const tabSize = getEditorTabSize()
+
+    const regex = line.match(INDENTATION_REGEX)
+    if (regex) {
+        const whitespace = regex[0]
+        return [...whitespace].reduce((p, c) => p + (c === '\t' ? tabSize : 1), 0)
+    }
+
+    return 0
+}
+
+/**
+ * If a completion starts with an opening bracket and a suffix starts with
+ * the corresponding closing bracket, we include the last closing bracket of the completion.
+ * E.g., function foo(__CURSOR__)
+ *
+ * We can do this because we know that the existing block is already closed, which means that
+ * new blocks need to be closed separately.
+ * E.g. function foo() { console.log('hello') }
+ */
+function shouldIncludeClosingLineBasedOnBrackets(
+    prefixIndentationWithFirstCompletionLine: string,
+    suffix: string
+): boolean {
+    const matches = prefixIndentationWithFirstCompletionLine.match(OPENING_BRACKET_REGEX)
+
+    if (matches && matches.length > 0) {
+        const openingBracket = matches[0] as keyof typeof BRACKET_PAIR
+        const closingBracket = BRACKET_PAIR[openingBracket]
+
+        return Boolean(openingBracket) && suffix.startsWith(closingBracket)
+    }
+
+    return false
+}
+
+/**
+ * Only include a closing line (e.g. `}`) if the block is empty yet if the block is already closed.
+ * We detect this by looking at the indentation of the next non-empty line.
+ */
+export function shouldIncludeClosingLine(prefixIndentationWithFirstCompletionLine: string, suffix: string): boolean {
+    const includeClosingLineBasedOnBrackets = shouldIncludeClosingLineBasedOnBrackets(
+        prefixIndentationWithFirstCompletionLine,
+        suffix
+    )
+
+    const startIndent = indentation(prefixIndentationWithFirstCompletionLine)
+
+    const firstNewLineIndex = suffix.indexOf('\n') + 1
+    const nextNonEmptyLine =
+        suffix
+            .slice(firstNewLineIndex)
+            .split('\n')
+            .find(line => line.trim().length > 0) ?? ''
+
+    return indentation(nextNonEmptyLine) < startIndent || includeClosingLineBasedOnBrackets
+}


### PR DESCRIPTION
Fixes bad completion case https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6531096

After hours of catching corner cases, I think we can't rely on regexp-based `shouldIncludeClosingLine` logic here. Counting brackets doesn't provide much value when we don't know about the structure of the expression where we try to insert completions. This PR just tries to handle the simple case with an empty completion line with a closed bracket symbol and cut off this completion. 

@philipp-spiess I don't think I fully understand how this is possible, but unit tests tell me that completion should be cut off, but vscode manual test shows that this problem is still there. Let me know if you have a minute for a quick pair on this.

## Test plan
- Try to force `}` completion (see original GitHub discussion thread for the example)
- Check that there is no `}` compleation 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
