### PR TITLE
get 3 completions when manually triggered

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+- If you run the `Trigger Inline Suggestion` VS Code action, 3 suggestions instead of just 1 will be shown.
+
 ## [0.6.1]
 
 ### Added

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -282,7 +282,9 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 this.config.providerConfig.create({
                     id: 'single-line-suffix',
                     ...sharedProviderOptions,
-                    n: 1, // 1 vs. 3 improves perf
+                    // Show more if manually triggered (but only showing 1 is faster, so we use it
+                    // in the automatic trigger case).
+                    n: context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic ? 1 : 3,
                     multiline: false,
                 })
             )


### PR DESCRIPTION
In VS Code, if you run the `Trigger Inline Suggestion` action manually (instead of just typing to trigger completions), 3 suggestions will be fetched instead of 1. This is because the user's intent in this case is more likely to get multiple options, and latency is not as critical.

<img width="775" alt="image" src="https://github.com/sourcegraph/cody/assets/1976/3564e60e-e4af-4a93-a557-421ce766c982">


## Test plan

Run `Trigger Inline Suggestion` and ensure there are 3 suggestions provided. Hover over the gray ghost text to see the button to cycle through the other suggestions.