### PR TITLE
helpful VS Code launch profile for running a separate instance

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,29 @@
         "NODE_ENV": "development",
         "CODY_FOCUS_ON_STARTUP": "1"
       }
+    },
+    {
+      "name": "Launch VS Code Extension (Separate Instance)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "preLaunchTask": "Build VS Code Extension",
+      "args": [
+        "--user-data-dir=/tmp/vscode-cody-extension-dev-host",
+        "--profile-temp",
+        "--extensionDevelopmentPath=${workspaceRoot}/vscode",
+        "--disable-extension=sourcegraph.cody-ai",
+        "--disable-extension=github.copilot",
+        "--disable-extension=github.copilot-nightly"
+      ],
+      "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/vscode/dist/**/*.js"],
+      "env": {
+        "NODE_ENV": "development",
+        "CODY_PROFILE_TEMP": "true",
+        "CODY_DEBUG_ENABLE": "true",
+        "CODY_FOCUS_ON_STARTUP": "1"
+      }
     }
   ]
 }

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -30,7 +30,9 @@ export function debug(filterLabel: string, text: string, ...args: unknown[]): vo
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
 
-    if (!outputChannel || !config.debugEnable) {
+    const debugEnable = process.env.CODY_DEBUG_ENABLE === 'true' || config.debugEnable
+
+    if (!outputChannel || !debugEnable) {
         return
     }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -46,7 +46,9 @@ export async function start(context: vscode.ExtensionContext): Promise<vscode.Di
     await migrateConfiguration()
 
     const secretStorage =
-        process.env.CODY_TESTING === 'true' ? new InMemorySecretStorage() : new VSCodeSecretStorage(context.secrets)
+        process.env.CODY_TESTING === 'true' || process.env.CODY_PROFILE_TEMP === 'true'
+            ? new InMemorySecretStorage()
+            : new VSCodeSecretStorage(context.secrets)
     const localStorage = new LocalStorage(context.globalState)
     const rgPath = await getRgPath(context.extensionPath)
 


### PR DESCRIPTION
This makes it easier to test settings and auth in the extension host without interfering with your main instance of VS Code.



## Test plan

n/a; dev only