### PR TITLE
refactor telemetry service for VS Code extension

### DIFF
--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -1,26 +1,14 @@
 import { ConfigurationWithAccessToken } from '../configuration'
 import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 
+import { TelemetryEventProperties } from '.'
+
 export interface ExtensionDetails {
     ide: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
     ideExtensionType: 'Cody' | 'CodeSearch'
 
     /** Version number for the extension. */
     version: string
-}
-
-/**
- * An event's properties.
- */
-export interface TelemetryEventProperties {
-    [key: string]:
-        | string
-        | number
-        | boolean
-        | null
-        | undefined
-        | string[]
-        | { [key: string]: string | number | boolean | null | undefined }
 }
 
 export class EventLogger {

--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -6,6 +6,20 @@ export interface ExtensionDetails {
     ideExtensionType: 'Cody' | 'CodeSearch'
 }
 
+/**
+ * An event's properties.
+ */
+export interface TelemetryEventProperties {
+    [key: string]:
+        | string
+        | number
+        | boolean
+        | null
+        | undefined
+        | string[]
+        | { [key: string]: string | number | boolean | null | undefined }
+}
+
 export class EventLogger {
     private gqlAPIClient: SourcegraphGraphQLAPIClient
 
@@ -29,19 +43,27 @@ export class EventLogger {
     }
 
     /**
-     * Logs an event.
+     * Log a telemetry event.
      *
-     * PRIVACY: Do NOT include any potentially private information in this
-     * field. These properties get sent to our analytics tools for Cloud, so
-     * must not include private information, such as search queries or
-     * repository names.
+     * PRIVACY: Do NOT include any potentially private information in `eventProperties`. These
+     * properties may get sent to analytics tools, so must not include private information, such as
+     * search queries or repository names.
      *
      * @param eventName The name of the event.
      * @param anonymousUserID The randomly generated unique user ID.
-     * @param eventProperties The additional argument information.
-     * @param publicProperties Public argument information.
+     * @param eventProperties Event properties. This may contain private info such as repository
+     * names or search queries. If audit logging is enabled, this data is stored on the associated
+     * Sourcegraph instance.
+     * @param publicProperties Event properties that include only public information. Do NOT include
+     * any private information, such as full URLs that may contain private repository names or
+     * search queries.
      */
-    public log(eventName: string, anonymousUserID: string, eventProperties?: any, publicProperties?: any): void {
+    public log(
+        eventName: string,
+        anonymousUserID: string,
+        eventProperties?: TelemetryEventProperties,
+        publicProperties?: TelemetryEventProperties
+    ): void {
         const configurationDetails = {
             contextSelection: this.config.useContext,
             chatPredictions: this.config.experimentalChatPredictions,

--- a/lib/shared/src/telemetry/index.ts
+++ b/lib/shared/src/telemetry/index.ts
@@ -1,0 +1,38 @@
+/**
+ * A service to log telemetry data.
+ */
+export interface TelemetryService {
+    /**
+     * Log a telemetry event.
+     *
+     * PRIVACY: Do NOT include any potentially private information in `eventProperties`. These
+     * properties may get sent to analytics tools, so must not include private information, such as
+     * search queries or repository names.
+     *
+     * @param eventName The name of the event.
+     * @param properties Event properties. Do NOT include any private information, such as full URLs
+     * that may contain private repository names or search queries.
+     */
+    log(eventName: string, properties?: TelemetryEventProperties): void
+}
+
+/**
+ * Properties related to a telemetry event.
+ */
+export interface TelemetryEventProperties {
+    [key: string]:
+        | string
+        | number
+        | boolean
+        | null
+        | undefined
+        | string[]
+        | { [key: string]: string | number | boolean | null | undefined }
+}
+
+/** For testing. */
+export const NOOP_TELEMETRY_SERVICE: TelemetryService = {
+    log() {
+        /* noop */
+    },
+}

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -7,10 +7,9 @@ import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat
 import { View } from '../../webviews/NavBar'
 import { debug } from '../log'
 import { CodyPromptType } from '../my-cody/types'
-import { logEvent } from '../services/EventLogger'
 
 import { MessageProvider, MessageProviderOptions } from './MessageProvider'
-import { ExtensionMessage, WebviewEvent, WebviewMessage } from './protocol'
+import { ExtensionMessage, WebviewMessage } from './protocol'
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {
     postMessage(message: ExtensionMessage): Thenable<boolean>
@@ -58,7 +57,8 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                 if (message.type === 'app' && message.endpoint) {
                     await this.authProvider.appAuth(message.endpoint)
                     // Log app button click events: e.g. app:download:clicked or app:connect:clicked
-                    this.sendEvent(WebviewEvent.Click, message.value === 'download' ? 'app:download' : 'app:connect')
+                    const value = message.value === 'download' ? 'app:download' : 'app:connect'
+                    this.telemetryService.log(`CodyVSCodeExtension:${value}:clicked`) // TODO(sqs): remove when new events are working
                     break
                 }
                 if (message.type === 'callback' && message.endpoint) {
@@ -72,7 +72,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                 await this.insertAtCursor(message.text)
                 break
             case 'event':
-                this.sendEvent(message.event, message.value)
+                this.telemetryService.log(message.eventName, message.properties)
                 break
             case 'removeHistory':
                 await this.clearHistory()
@@ -134,7 +134,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     private async onHumanMessageSubmitted(text: string, submitType: 'user' | 'suggestion'): Promise<void> {
         debug('ChatViewProvider:onHumanMessageSubmitted', '', { verbose: { text, submitType } })
         if (submitType === 'suggestion') {
-            logEvent('CodyVSCodeExtension:chatPredictions:used')
+            this.telemetryService.log('CodyVSCodeExtension:chatPredictions:used')
         }
         MessageProvider.inputHistory.push(text)
         if (this.contextProvider.config.experimentalChatPredictions) {
@@ -147,7 +147,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
      * Process custom recipe click
      */
     private async onCustomRecipeClicked(title: string, recipeType: CodyPromptType = 'user'): Promise<void> {
-        this.sendEvent(WebviewEvent.Click, 'custom-recipe')
+        this.telemetryService.log('CodyVSCodeExtension:custom-recipe:clicked')
         debug('ChatViewProvider:onCustomRecipeClicked', title)
         if (!this.isCustomRecipeAction(title)) {
             this.showTab('chat')
@@ -223,25 +223,6 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
             prompts,
             isEnabled,
         })
-    }
-
-    /**
-     * Log Events - naming convention: source:feature:action
-     */
-    public sendEvent(event: WebviewEvent, value: string): void {
-        switch (event) {
-            case 'feedback':
-                logEvent(`CodyVSCodeExtension:codyFeedback:${value}`, {
-                    lastChatUsedEmbeddings: this.transcript
-                        .toChat()
-                        .at(-1)
-                        ?.contextFiles?.some(file => file.source === 'embeddings'),
-                })
-                break
-            case 'click':
-                logEvent(`CodyVSCodeExtension:${value}:clicked`)
-                break
-        }
     }
 
     /**

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -233,36 +233,16 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         const endpointUri = { serverEndpoint: endpoint }
         switch (event) {
             case 'feedback':
-                logEvent(`CodyVSCodeExtension:codyFeedback:${value}`, null, this.codyFeedbackPayload())
+                logEvent(`CodyVSCodeExtension:codyFeedback:${value}`, undefined, {
+                    lastChatUsedEmbeddings: this.transcript
+                        .toChat()
+                        .at(-1)
+                        ?.contextFiles?.some(file => file.source === 'embeddings'),
+                })
                 break
             case 'click':
                 logEvent(`CodyVSCodeExtension:${value}:clicked`, endpointUri, endpointUri)
                 break
-        }
-    }
-
-    private codyFeedbackPayload(): { chatTranscript: ChatMessage[] | null; lastChatUsedEmbeddings: boolean } | null {
-        const endpoint = this.contextProvider.config.serverEndpoint || DOTCOM_URL.href
-        const isPrivateInstance = new URL(endpoint).href !== DOTCOM_URL.href
-
-        // The user should only be able to submit feedback on transcripts, but just in case we guard against this happening.
-        const privateChatTranscript = this.transcript.toChat()
-        if (privateChatTranscript.length === 0) {
-            return null
-        }
-
-        const lastContextFiles = privateChatTranscript.at(-1)?.contextFiles
-        const lastChatUsedEmbeddings = lastContextFiles
-            ? lastContextFiles.some(file => file.source === 'embeddings')
-            : false
-
-        // We only include full chat transcript for dot com users with connected codebase
-        const chatTranscript =
-            !isPrivateInstance && this.contextProvider.context.getCodebase() ? privateChatTranscript : null
-
-        return {
-            chatTranscript,
-            lastChatUsedEmbeddings,
         }
     }
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -10,7 +10,7 @@ import { CodyPromptType } from '../my-cody/types'
 import { logEvent } from '../services/EventLogger'
 
 import { MessageProvider, MessageProviderOptions } from './MessageProvider'
-import { DOTCOM_URL, ExtensionMessage, WebviewEvent, WebviewMessage } from './protocol'
+import { ExtensionMessage, WebviewEvent, WebviewMessage } from './protocol'
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {
     postMessage(message: ExtensionMessage): Thenable<boolean>
@@ -229,11 +229,9 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
      * Log Events - naming convention: source:feature:action
      */
     public sendEvent(event: WebviewEvent, value: string): void {
-        const endpoint = this.contextProvider.config.serverEndpoint || DOTCOM_URL.href
-        const endpointUri = { serverEndpoint: endpoint }
         switch (event) {
             case 'feedback':
-                logEvent(`CodyVSCodeExtension:codyFeedback:${value}`, undefined, {
+                logEvent(`CodyVSCodeExtension:codyFeedback:${value}`, {
                     lastChatUsedEmbeddings: this.transcript
                         .toChat()
                         .at(-1)
@@ -241,7 +239,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                 })
                 break
             case 'click':
-                logEvent(`CodyVSCodeExtension:${value}:clicked`, endpointUri, endpointUri)
+                logEvent(`CodyVSCodeExtension:${value}:clicked`)
                 break
         }
     }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -22,7 +22,7 @@ import { LocalStorage } from '../services/LocalStorageProvider'
 import { SecretStorage } from '../services/SecretStorageProvider'
 
 import { ChatViewProviderWebview } from './ChatViewProvider'
-import { ConfigurationSubsetForWebview, DOTCOM_URL, isLocalApp, LocalEnv } from './protocol'
+import { ConfigurationSubsetForWebview, isLocalApp, LocalEnv } from './protocol'
 import { convertGitCloneURLToCodebaseName } from './utils'
 
 export type Config = Pick<
@@ -206,11 +206,9 @@ export class ContextProvider implements vscode.Disposable {
      * Log Events - naming convention: source:feature:action
      */
     public sendEvent(event: ContextEvent, value: string): void {
-        const endpoint = this.config.serverEndpoint || DOTCOM_URL.href
-        const endpointUri = { serverEndpoint: endpoint }
         switch (event) {
             case 'auth':
-                logEvent(`CodyVSCodeExtension:Auth:${value}`, endpointUri, endpointUri)
+                logEvent(`CodyVSCodeExtension:Auth:${value}`)
                 break
         }
     }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -8,6 +8,7 @@ import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/confi
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { getFullConfig } from '../configuration'
@@ -17,7 +18,6 @@ import { LocalKeywordContextFetcher } from '../local-context/local-keyword-conte
 import { debug } from '../log'
 import { getRerankWithLog } from '../logged-rerank'
 import { AuthProvider } from '../services/AuthProvider'
-import { logEvent } from '../services/EventLogger'
 import { LocalStorage } from '../services/LocalStorageProvider'
 import { SecretStorage } from '../services/SecretStorageProvider'
 
@@ -68,7 +68,8 @@ export class ContextProvider implements vscode.Disposable {
         private secretStorage: SecretStorage,
         private localStorage: LocalStorage,
         private rgPath: string | null,
-        private authProvider: AuthProvider
+        private authProvider: AuthProvider,
+        private telemetryService: TelemetryService
     ) {
         this.disposables.push(this.configurationChangeEvent)
 
@@ -113,7 +114,13 @@ export class ContextProvider implements vscode.Disposable {
         }
         this.currentWorkspaceRoot = workspaceRoot
 
-        const codebaseContext = await getCodebaseContext(this.config, this.rgPath, this.editor, this.chat)
+        const codebaseContext = await getCodebaseContext(
+            this.config,
+            this.rgPath,
+            this.editor,
+            this.chat,
+            this.telemetryService
+        )
         if (!codebaseContext) {
             return
         }
@@ -137,7 +144,13 @@ export class ContextProvider implements vscode.Disposable {
         const newConfig = await getFullConfig(this.secretStorage, this.localStorage)
         if (authStatus.siteVersion) {
             // Update codebase context
-            const codebaseContext = await getCodebaseContext(newConfig, this.rgPath, this.editor, this.chat)
+            const codebaseContext = await getCodebaseContext(
+                newConfig,
+                this.rgPath,
+                this.editor,
+                this.chat,
+                this.telemetryService
+            )
             if (codebaseContext) {
                 this.codebaseContext = codebaseContext
             }
@@ -205,10 +218,10 @@ export class ContextProvider implements vscode.Disposable {
     /**
      * Log Events - naming convention: source:feature:action
      */
-    public sendEvent(event: ContextEvent, value: string): void {
+    private sendEvent(event: ContextEvent, value: string): void {
         switch (event) {
             case 'auth':
-                logEvent(`CodyVSCodeExtension:Auth:${value}`)
+                this.telemetryService.log(`CodyVSCodeExtension:Auth:${value}`)
                 break
         }
     }
@@ -233,7 +246,8 @@ export async function getCodebaseContext(
     config: Config,
     rgPath: string | null,
     editor: Editor,
-    chatClient: ChatClient
+    chatClient: ChatClient,
+    telemetryService: TelemetryService
 ): Promise<CodebaseContext | null> {
     const client = new SourcegraphGraphQLAPIClient(config)
     const workspaceRoot = editor.getWorkspaceRootPath()
@@ -260,7 +274,7 @@ export async function getCodebaseContext(
         config,
         codebase,
         embeddingsSearch,
-        rgPath ? new LocalKeywordContextFetcher(rgPath, editor, chatClient) : null,
+        rgPath ? new LocalKeywordContextFetcher(rgPath, editor, chatClient, telemetryService) : null,
         rgPath ? new FilenameContextFetcher(rgPath, editor, chatClient) : null,
         undefined,
         getRerankWithLog(chatClient)

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -172,7 +172,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
 
     public async clearAndRestartSession(): Promise<void> {
         await this.saveTranscriptToChatHistory()
-        await this.setAnonymousUserID()
         this.createNewChatID()
         this.cancelCompletion()
         this.isMessageInProgress = false
@@ -186,10 +185,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         MessageProvider.chatHistory = {}
         MessageProvider.inputHistory = []
         await this.localStorage.removeChatHistory()
-    }
-
-    public async setAnonymousUserID(): Promise<void> {
-        await this.localStorage.setAnonymousUserID()
     }
 
     /**

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -319,11 +319,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (enabledPlugins.length === 0) {
             return {}
         }
-        logEvent(
-            'CodyVSCodeExtension:getPluginsContext:enabledPlugins',
-            { names: enabledPluginNames },
-            { names: enabledPluginNames }
-        )
+        logEvent('CodyVSCodeExtension:getPluginsContext:enabledPlugins', { names: enabledPluginNames })
 
         this.transcript.addAssistantResponse('', 'Identifying applicable plugins...\n')
         this.sendTranscript()
@@ -343,11 +339,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 enabledPlugins,
                 previousMessages
             )
-            logEvent(
-                'CodyVSCodeExtension:getPluginsContext:descriptorsFound',
-                { count: descriptors.length },
-                { count: descriptors.length }
-            )
+            logEvent('CodyVSCodeExtension:getPluginsContext:descriptorsFound', { count: descriptors.length })
             if (descriptors.length !== 0) {
                 this.transcript.addAssistantResponse(
                     '',
@@ -357,15 +349,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 )
                 this.sendTranscript()
 
-                logEvent(
-                    'CodyVSCodeExtension:getPluginsContext:runPluginFunctionsCalled',
-                    {
-                        count: descriptors.length,
-                    },
-                    {
-                        count: descriptors.length,
-                    }
-                )
+                logEvent('CodyVSCodeExtension:getPluginsContext:runPluginFunctionsCalled', {
+                    count: descriptors.length,
+                })
                 return await plugins.runPluginFunctions(descriptors, this.contextProvider.config.pluginsConfig)
             }
         } catch (error) {
@@ -506,11 +492,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
 
         // Only log telemetry if we did work (ie had to annotate something).
         if (result.codeBlocks > 0) {
-            const event = {
+            logEvent('CodyVSCodeExtension:guardrails:annotate', {
                 codeBlocks: result.codeBlocks,
                 duration: result.duration,
-            }
-            logEvent('CodyVSCodeExtension:guardrails:annotate', event, event)
+            })
         }
 
         return result.text

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -3,14 +3,10 @@ import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import type { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { View } from '../../webviews/NavBar'
 import { CodyPromptType } from '../my-cody/types'
-
-export enum WebviewEvent {
-    Feedback = 'feedback',
-    Click = 'click',
-}
 
 /**
  * A message sent from the webview to the extension host.
@@ -18,7 +14,7 @@ export enum WebviewEvent {
 export type WebviewMessage =
     | { command: 'ready' }
     | { command: 'initialized' }
-    | { command: 'event'; event: WebviewEvent; value: string }
+    | { command: 'event'; eventName: string; properties: TelemetryEventProperties | undefined } // new event log internal API (use createWebviewTelemetryService wrapper)
     | { command: 'submit'; text: string; submitType: 'user' | 'suggestion' }
     | { command: 'executeRecipe'; recipe: RecipeID }
     | { command: 'removeHistory' }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,7 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
-import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
+import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { ConfigKeys } from '../configuration-keys'
 import { debug } from '../log'

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,6 +1,8 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
+import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
+
 import { ConfigKeys } from '../configuration-keys'
 import { debug } from '../log'
 import { logEvent } from '../services/EventLogger'
@@ -61,7 +63,7 @@ const displayedCompletions = new LRUCache<string, CompletionEvent>({
     max: 100, // Maximum number of completions that we are keeping track of
 })
 
-export function logCompletionEvent(name: string, params?: unknown): void {
+export function logCompletionEvent(name: string, params?: TelemetryEventProperties): void {
     logEvent(`CodyVSCodeExtension:completion:${name}`, params, params)
 }
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -64,7 +64,7 @@ const displayedCompletions = new LRUCache<string, CompletionEvent>({
 })
 
 export function logCompletionEvent(name: string, params?: TelemetryEventProperties): void {
-    logEvent(`CodyVSCodeExtension:completion:${name}`, params, params)
+    logEvent(`CodyVSCodeExtension:completion:${name}`, params)
 }
 
 export function start(inputParams: Omit<CompletionEvent['params'], 'multilineMode'>): string {

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -8,7 +8,6 @@ import type {
 
 import { DOTCOM_URL } from './chat/protocol'
 import { CONFIG_KEY, ConfigKeys } from './configuration-keys'
-import { logEvent } from './services/EventLogger'
 import { LocalStorage } from './services/LocalStorageProvider'
 import { getAccessToken, SecretStorage } from './services/SecretStorageProvider'
 
@@ -129,62 +128,4 @@ export const getFullConfig = async (
     config.serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
     const accessToken = (await getAccessToken(secretStorage)) || null
     return { ...config, accessToken }
-}
-
-// We run this callback on extension startup
-export async function migrateConfiguration(): Promise<void> {
-    let didMigrate = false
-    didMigrate ||= await migrateDeprecatedConfigOption(
-        CONFIG_KEY.experimentalSuggestions,
-        CONFIG_KEY.autocompleteEnabled
-    )
-    didMigrate ||= await migrateDeprecatedConfigOption(
-        CONFIG_KEY.completionsAdvancedProvider,
-        CONFIG_KEY.autocompleteAdvancedProvider
-    )
-    didMigrate ||= await migrateDeprecatedConfigOption(
-        CONFIG_KEY.completionsAdvancedServerEndpoint,
-        CONFIG_KEY.autocompleteAdvancedServerEndpoint
-    )
-    didMigrate ||= await migrateDeprecatedConfigOption(
-        CONFIG_KEY.completionsAdvancedAccessToken,
-        CONFIG_KEY.autocompleteAdvancedAccessToken
-    )
-    didMigrate ||= await migrateDeprecatedConfigOption(
-        CONFIG_KEY.completionsAdvancedCache,
-        CONFIG_KEY.autocompleteAdvancedCache
-    )
-    didMigrate ||= await migrateDeprecatedConfigOption(
-        CONFIG_KEY.completionsAdvancedEmbeddings,
-        CONFIG_KEY.autocompleteAdvancedEmbeddings
-    )
-
-    if (didMigrate) {
-        logEvent('CodyVSCodeExtension:configMigrator:migrated')
-    }
-}
-
-async function migrateDeprecatedConfigOption(
-    oldKey: (typeof CONFIG_KEY)[ConfigKeys],
-    newKey: (typeof CONFIG_KEY)[ConfigKeys]
-): Promise<boolean> {
-    const config = vscode.workspace.getConfiguration()
-    const value = config.get(oldKey)
-    const inspect = config.inspect(oldKey)
-
-    if (inspect === undefined || value === inspect.defaultValue) {
-        return false
-    }
-
-    const scope =
-        inspect.workspaceFolderValue !== undefined
-            ? vscode.ConfigurationTarget.WorkspaceFolder
-            : inspect?.workspaceValue !== undefined
-            ? vscode.ConfigurationTarget.Workspace
-            : vscode.ConfigurationTarget.Global
-
-    await config.update(newKey, value, scope)
-    await config.update(oldKey, undefined, scope)
-
-    return true
 }

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -10,6 +10,7 @@ import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/in
 import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { FilenameContextFetcher } from './local-context/filename-context-fetcher'
@@ -36,7 +37,8 @@ type ExternalServicesConfiguration = Pick<
 export async function configureExternalServices(
     initialConfig: ExternalServicesConfiguration,
     rgPath: string | null,
-    editor: Editor
+    editor: Editor,
+    telemetryService: TelemetryService
 ): Promise<ExternalServices> {
     const client = new SourcegraphGraphQLAPIClient(initialConfig)
     const completions = new SourcegraphNodeCompletionsClient(initialConfig, logger)
@@ -55,7 +57,7 @@ export async function configureExternalServices(
         initialConfig,
         initialConfig.codebase,
         embeddingsSearch,
-        rgPath ? new LocalKeywordContextFetcher(rgPath, editor, chatClient) : null,
+        rgPath ? new LocalKeywordContextFetcher(rgPath, editor, chatClient, telemetryService) : null,
         rgPath ? new FilenameContextFetcher(rgPath, editor, chatClient) : null,
         undefined,
         getRerankWithLog(chatClient)

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -9,9 +9,9 @@ import winkUtils from 'wink-nlp-utils'
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult, KeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { debug } from '../log'
-import { logEvent } from '../services/EventLogger'
 
 /**
  * Exclude files without extensions and hidden files (starts with '.')
@@ -92,7 +92,8 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
     constructor(
         private rgPath: string,
         private editor: Editor,
-        private chatClient: ChatClient
+        private chatClient: ChatClient,
+        private telemetryService: TelemetryService
     ) {}
 
     /**
@@ -128,7 +129,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
             })
         )
         const searchDuration = performance.now() - startTime
-        logEvent('CodyVSCodeExtension:keywordContext:searchDuration', { searchDuration })
+        this.telemetryService.log('CodyVSCodeExtension:keywordContext:searchDuration', { searchDuration })
         debug('LocalKeywordContextFetcher:getContext', JSON.stringify({ searchDuration }))
 
         return messagePairs.reverse().flat()

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -128,7 +128,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
             })
         )
         const searchDuration = performance.now() - startTime
-        logEvent('CodyVSCodeExtension:keywordContext:searchDuration', searchDuration, searchDuration)
+        logEvent('CodyVSCodeExtension:keywordContext:searchDuration', undefined, { searchDuration })
         debug('LocalKeywordContextFetcher:getContext', JSON.stringify({ searchDuration }))
 
         return messagePairs.reverse().flat()

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -128,7 +128,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
             })
         )
         const searchDuration = performance.now() - startTime
-        logEvent('CodyVSCodeExtension:keywordContext:searchDuration', undefined, { searchDuration })
+        logEvent('CodyVSCodeExtension:keywordContext:searchDuration', { searchDuration })
         debug('LocalKeywordContextFetcher:getContext', JSON.stringify({ searchDuration }))
 
         return messagePairs.reverse().flat()

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -25,7 +25,7 @@ import { FixupController } from './non-stop/FixupController'
 import { showSetupNotification } from './notifications/setup-notification'
 import { getRgPath } from './rg'
 import { AuthProvider } from './services/AuthProvider'
-import { createOrUpdateEventLogger, logEvent } from './services/EventLogger'
+import { createOrUpdateEventLogger } from './services/EventLogger'
 import { showFeedbackSupportQuickPick } from './services/FeedbackOptions'
 import { GuardrailsProvider } from './services/GuardrailsProvider'
 import { Comment, InlineController } from './services/InlineController'
@@ -37,6 +37,7 @@ import {
     VSCodeSecretStorage,
 } from './services/SecretStorageProvider'
 import { CodyStatusBar, createStatusBar } from './services/StatusBar'
+import { createVSCodeTelemetryService } from './services/telemetry'
 import { TestSupport } from './test-support'
 
 /**
@@ -86,10 +87,11 @@ const register = async (
 }> => {
     const disposables: vscode.Disposable[] = []
 
-    // Controller for Inline Chat
     await createOrUpdateEventLogger(initialConfig, localStorage)
+    const telemetryService = createVSCodeTelemetryService()
+
     // Controller for inline Chat
-    const commentController = new InlineController(context.extensionPath)
+    const commentController = new InlineController(context.extensionPath, telemetryService)
     // Controller for Non-Stop Cody
     const fixup = new FixupController()
     disposables.push(fixup)
@@ -111,9 +113,9 @@ const register = async (
         completionsClient,
         guardrails,
         onConfigurationChange: externalServicesOnDidConfigurationChange,
-    } = await configureExternalServices(initialConfig, rgPath, editor)
+    } = await configureExternalServices(initialConfig, rgPath, editor, telemetryService)
 
-    const authProvider = new AuthProvider(initialConfig, secretStorage, localStorage)
+    const authProvider = new AuthProvider(initialConfig, secretStorage, localStorage, telemetryService)
     await authProvider.init()
 
     const contextProvider = new ContextProvider(
@@ -124,7 +126,8 @@ const register = async (
         secretStorage,
         localStorage,
         rgPath,
-        authProvider
+        authProvider,
+        telemetryService
     )
     disposables.push(contextProvider)
 
@@ -138,6 +141,7 @@ const register = async (
         rgPath,
         authProvider,
         contextProvider,
+        telemetryService,
     }
 
     const inlineChatManager = new InlineChatViewManager(messageProviderOptions)
@@ -197,7 +201,7 @@ const register = async (
             const isFixMode = /^\/f(ix)?\s/i.test(comment.text.trimStart())
             const inlineChatProvider = inlineChatManager.getProviderForThread(comment.thread)
             await inlineChatProvider.addChat(comment.text, isFixMode)
-            logEvent(`CodyVSCodeExtension:inline-assist:${isFixMode ? 'fixup' : 'chat'}`)
+            telemetryService.log(`CodyVSCodeExtension:inline-assist:${isFixMode ? 'fixup' : 'chat'}`)
         }),
         vscode.commands.registerCommand('cody.comment.delete', (thread: vscode.CommentThread) => {
             inlineChatManager.removeProviderForThread(thread)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -17,7 +17,7 @@ import { History } from './completions/history'
 import * as CompletionsLogger from './completions/logger'
 import { createProviderConfig } from './completions/providers/createProvider'
 import { registerAutocompleteTraceView } from './completions/tracer/traceView'
-import { getConfiguration, getFullConfig, migrateConfiguration } from './configuration'
+import { getConfiguration, getFullConfig } from './configuration'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { configureExternalServices } from './external-services'
 import { MyPromptController } from './my-cody/MyPromptController'
@@ -43,8 +43,6 @@ import { TestSupport } from './test-support'
  * Start the extension, watching all relevant configuration and secrets for changes.
  */
 export async function start(context: vscode.ExtensionContext): Promise<vscode.Disposable> {
-    await migrateConfiguration()
-
     const secretStorage =
         process.env.CODY_TESTING === 'true' || process.env.CODY_PROFILE_TEMP === 'true'
             ? new InMemorySecretStorage()

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { ChatViewProviderWebview } from '../chat/ChatViewProvider'
@@ -19,7 +20,6 @@ import { newAuthStatus } from '../chat/utils'
 import { debug } from '../log'
 
 import { AuthMenu, LoginStepInputBox, TokenInputBox } from './AuthMenus'
-import { logEvent } from './EventLogger'
 import { LocalAppDetector } from './LocalAppDetector'
 import { LocalStorage } from './LocalStorageProvider'
 import { SecretStorage } from './SecretStorageProvider'
@@ -37,7 +37,8 @@ export class AuthProvider {
     constructor(
         private config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>,
         private secretStorage: SecretStorage,
-        private localStorage: LocalStorage
+        private localStorage: LocalStorage,
+        private telemetryService: TelemetryService
     ) {
         this.authStatus.endpoint = 'init'
         this.loadEndpointHistory()
@@ -61,12 +62,13 @@ export class AuthProvider {
     public async signinMenu(type?: 'enterprise' | 'dotcom' | 'token' | 'app', uri?: string): Promise<void> {
         const mode = this.authStatus.isLoggedIn ? 'switch' : 'signin'
         debug('AuthProvider:signinMenu', mode)
-        logEvent('CodyVSCodeExtension:login:clicked')
+        this.telemetryService.log('CodyVSCodeExtension:login:clicked')
         const item = await AuthMenu(mode, this.endpointHistory)
         if (!item) {
             return
         }
         const menuID = type || item?.id
+        this.telemetryService.log('CodyVSCodeExtension:auth:selectSigninMenu', { menuID })
         switch (menuID) {
             case 'enterprise': {
                 const input = await LoginStepInputBox(item.uri, 1, false)
@@ -86,7 +88,10 @@ export class AuthProvider {
                 if (!input?.endpoint || !input?.token) {
                     return
                 }
-                await this.auth(input.endpoint, input.token)
+                const authState = await this.auth(input.endpoint, input.token)
+                this.telemetryService.log('CodyVSCodeExtension:auth:fromToken', {
+                    success: Boolean(authState?.isLoggedIn),
+                })
                 break
             }
             case 'app': {
@@ -137,7 +142,7 @@ export class AuthProvider {
 
     // Display quickpick to select endpoint to sign out of
     public async signoutMenu(): Promise<void> {
-        logEvent('CodyVSCodeExtension:logout:clicked')
+        this.telemetryService.log('CodyVSCodeExtension:logout:clicked')
         const endpointQuickPickItem = this.authStatus.endpoint ? [this.authStatus.endpoint] : []
         const endpoint = await AuthMenu('signout', endpointQuickPickItem)
         if (!endpoint?.uri) {
@@ -278,6 +283,11 @@ export class AuthProvider {
             return
         }
         const authState = await this.auth(endpoint, token, customHeaders)
+        this.telemetryService.log('CodyVSCodeExtension:auth:fromCallback', {
+            type: 'callback',
+            from: isApp ? 'app' : 'web',
+            success: Boolean(authState?.isLoggedIn),
+        })
         if (authState?.isLoggedIn) {
             const successMessage = isApp ? 'Connected to Cody App' : `Signed in to ${endpoint}`
             await vscode.window.showInformationMessage(successMessage)

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -7,7 +7,7 @@ import { debug } from '../log'
 import { LocalStorage } from './LocalStorageProvider'
 
 export let eventLogger: EventLogger | null = null
-let anonymousUserID: string
+let globalAnonymousUserID: string
 
 const extensionDetails: ExtensionDetails = { ide: 'VSCode', ideExtensionType: 'Cody' }
 
@@ -15,13 +15,14 @@ export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
     localStorage: LocalStorage
 ): Promise<void> {
-    const status = await localStorage.setAnonymousUserID()
-    anonymousUserID = localStorage.getAnonymousUserID() || ''
+    const { anonymousUserID, created } = await localStorage.anonymousUserID()
+    globalAnonymousUserID = anonymousUserID
+
     const serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
 
     if (!eventLogger) {
         eventLogger = new EventLogger(serverEndpoint, extensionDetails, config)
-        if (status === 'installed') {
+        if (created) {
             logEvent('CodyInstalled')
         } else {
             logEvent('CodyVSCodeExtension:CodySavedLogin:executed')
@@ -43,7 +44,7 @@ export async function createOrUpdateEventLogger(
  * @param publicProperties Public argument information.
  */
 export function logEvent(eventName: string, eventProperties?: any, publicProperties?: any): void {
-    if (!eventLogger || !anonymousUserID) {
+    if (!eventLogger || !globalAnonymousUserID) {
         return
     }
     const argument = {
@@ -56,7 +57,7 @@ export function logEvent(eventName: string, eventProperties?: any, publicPropert
     }
     try {
         debug('EventLogger', eventName, JSON.stringify(argument, null, 2))
-        eventLogger.log(eventName, anonymousUserID, argument, publicArgument)
+        eventLogger.log(eventName, globalAnonymousUserID, argument, publicArgument)
     } catch (error) {
         console.error(error)
     }

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -1,9 +1,6 @@
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import {
-    EventLogger,
-    ExtensionDetails,
-    TelemetryEventProperties,
-} from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
+import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
+import { EventLogger, ExtensionDetails } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
 
 import { version as packageVersion } from '../../package.json'
 import { debug } from '../log'
@@ -39,13 +36,15 @@ export async function createOrUpdateEventLogger(
 /**
  * Log a telemetry event.
  *
- * PRIVACY: Do NOT include any potentially private information in `eventProperties`. These
- * properties may get sent to analytics tools, so must not include private information, such as
- * search queries or repository names.
+ * PRIVACY: Do NOT include any potentially private information in `properties`. These properties may
+ * get sent to analytics tools, so must not include private information, such as search queries or
+ * repository names.
  *
  * @param eventName The name of the event.
  * @param properties Event properties. Do NOT include any private information, such as full URLs
  * that may contain private repository names or search queries.
+ *
+ * @deprecated Use TelemetryService instead.
  */
 export function logEvent(eventName: string, properties?: TelemetryEventProperties): void {
     if (!eventLogger || !globalAnonymousUserID) {

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -13,7 +13,7 @@ import { LocalStorage } from './LocalStorageProvider'
 export let eventLogger: EventLogger | null = null
 let globalAnonymousUserID: string
 
-const extensionDetails: ExtensionDetails = { ide: 'VSCode', ideExtensionType: 'Cody' }
+const extensionDetails: ExtensionDetails = { ide: 'VSCode', ideExtensionType: 'Cody', version: packageVersion }
 
 export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
@@ -44,32 +44,16 @@ export async function createOrUpdateEventLogger(
  * search queries or repository names.
  *
  * @param eventName The name of the event.
- * @param eventProperties Event properties. This may contain private info such as repository
- * names or search queries. If audit logging is enabled, this data is stored on the associated
- * Sourcegraph instance.
- * @param publicProperties Event properties that include only public information. Do NOT include
- * any private information, such as full URLs that may contain private repository names or
- * search queries.
+ * @param properties Event properties. Do NOT include any private information, such as full URLs
+ * that may contain private repository names or search queries.
  */
-export function logEvent(
-    eventName: string,
-    eventProperties?: TelemetryEventProperties,
-    publicProperties?: TelemetryEventProperties
-): void {
+export function logEvent(eventName: string, properties?: TelemetryEventProperties): void {
     if (!eventLogger || !globalAnonymousUserID) {
         return
     }
     try {
-        debug('EventLogger', eventName, eventProperties, publicProperties)
-        eventLogger.log(
-            eventName,
-            globalAnonymousUserID,
-            { ...eventProperties, version: packageVersion },
-            {
-                ...publicProperties,
-                version: packageVersion,
-            }
-        )
+        debug('EventLogger', eventName, properties)
+        eventLogger.log(eventName, globalAnonymousUserID, properties)
     } catch (error) {
         console.error(error)
     }

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -3,11 +3,11 @@ import * as vscode from 'vscode'
 
 import { ActiveTextEditorSelection, VsCodeInlineController } from '@sourcegraph/cody-shared/src/editor'
 import { SURROUNDING_LINES } from '@sourcegraph/cody-shared/src/prompt/constants'
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { CodyTaskState } from '../non-stop/utils'
 
 import { CodeLensProvider } from './CodeLensProvider'
-import { logEvent } from './EventLogger'
 import { editDocByUri, getIconPath, updateRangeOnDocChange } from './InlineAssist'
 
 const initPost = new vscode.Position(0, 0)
@@ -55,7 +55,10 @@ export class InlineController implements VsCodeInlineController {
     public isInProgress = false
     private codeLenses: Map<string, CodeLensProvider> = new Map()
 
-    constructor(private extensionPath: string) {
+    constructor(
+        private extensionPath: string,
+        private telemetryService: TelemetryService
+    ) {
         this.codyIcon = getIconPath('cody', this.extensionPath)
         this.userIcon = getIconPath('user', this.extensionPath)
         this.commentController = this.init()
@@ -322,7 +325,7 @@ export class InlineController implements VsCodeInlineController {
             this.thread.state = error ? 1 : 0
         }
         this.currentTaskId = ''
-        logEvent('CodyVSCodeExtension:inline-assist:stopFixup')
+        this.telemetryService.log('CodyVSCodeExtension:inline-assist:stopFixup')
         if (!error) {
             await vscode.commands.executeCommand('workbench.action.collapseAllComments')
         }
@@ -409,7 +412,7 @@ export class InlineController implements VsCodeInlineController {
             lens?.storeContext(this.currentTaskId, documentUri, original, replacement)
 
             await this.stopFixMode(false, newRange)
-            logEvent('CodyVSCodeExtension:inline-assist:replaced')
+            this.telemetryService.log('CodyVSCodeExtension:inline-assist:replaced')
         } catch (error) {
             await this.stopFixMode(true)
             console.error(error)

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -1,7 +1,4 @@
-// VS Code Docs https://code.visualstudio.com/api/references/vscode-api#Memento
-// A memento represents a storage utility. It can store and retrieve values.
 import * as uuid from 'uuid'
-// import * as vscode from 'vscode'
 import { Memento } from 'vscode'
 
 import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -86,22 +86,23 @@ export class LocalStorage {
         }
     }
 
-    public getAnonymousUserID(): string | null {
-        const anonUserID = this.storage.get(this.ANONYMOUS_USER_ID_KEY, null)
-        return anonUserID
-    }
-
-    public async setAnonymousUserID(): Promise<string | null> {
-        if (this.getAnonymousUserID()) {
-            return null
+    /**
+     * Return the anonymous user ID stored in local storage or create one if none exists (which
+     * occurs on a fresh installation).
+     */
+    public async anonymousUserID(): Promise<{ anonymousUserID: string; created: boolean }> {
+        let id = this.storage.get<string>(this.ANONYMOUS_USER_ID_KEY)
+        let created = false
+        if (!id) {
+            created = true
+            id = uuid.v4()
+            try {
+                await this.storage.update(this.ANONYMOUS_USER_ID_KEY, id)
+            } catch (error) {
+                console.error(error)
+            }
         }
-        const anonUserID = uuid.v4()
-        try {
-            await this.storage.update(this.ANONYMOUS_USER_ID_KEY, anonUserID)
-        } catch (error) {
-            console.error(error)
-        }
-        return 'installed'
+        return { anonymousUserID: id, created }
     }
 
     public async setEnabledPlugins(plugins: string[]): Promise<void> {

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -1,0 +1,12 @@
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+
+import { logEvent } from './EventLogger'
+
+export function createVSCodeTelemetryService(): TelemetryService {
+    return {
+        log(eventName, properties) {
+            // eslint-disable-next-line etc/no-deprecated
+            logEvent(eventName, properties)
+        },
+    }
+}

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import { NoopEditor } from '@sourcegraph/cody-shared/src/editor'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { CodyCompletionItemProvider } from '../../src/completions'
 import { GetContextResult } from '../../src/completions/context'
@@ -36,7 +37,8 @@ async function initCompletionsProvider(context: GetContextResult): Promise<CodyC
     const { completionsClient, codebaseContext } = await configureExternalServices(
         initialConfig,
         'rg',
-        new NoopEditor()
+        new NoopEditor(),
+        NOOP_TELEMETRY_SERVICE
     )
 
     const history = new History()

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import './App.css'
 
@@ -19,6 +19,7 @@ import { NavBar, View } from './NavBar'
 import { Plugins } from './Plugins'
 import { Recipes } from './Recipes'
 import { UserHistory } from './UserHistory'
+import { createWebviewTelemetryService } from './utils/telemetry'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
@@ -137,6 +138,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         [enabledPlugins, vscodeAPI]
     )
 
+    const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
+
     if (!view || !authStatus || !config) {
         return <LoadingPage />
     }
@@ -151,6 +154,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     isAppInstalled={isAppInstalled}
                     isAppRunning={config?.isAppRunning}
                     vscodeAPI={vscodeAPI}
+                    telemetryService={telemetryService}
                     appOS={config?.os}
                     appArch={config?.arch}
                     callbackScheme={config?.uriScheme}
@@ -191,6 +195,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             suggestions={suggestions}
                             pluginsDevMode={Boolean(config?.pluginsDebugEnabled)}
                             setSuggestions={setSuggestions}
+                            telemetryService={telemetryService}
                         />
                     )}
                 </>

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import {
     ChatButtonProps,
     Chat as ChatUI,
@@ -15,8 +16,6 @@ import {
     FeedbackButtonsProps,
 } from '@sourcegraph/cody-ui/src/Chat'
 import { SubmitSvg } from '@sourcegraph/cody-ui/src/utils/icons'
-
-import { WebviewEvent } from '../src/chat/protocol'
 
 import { FileLink } from './FileLink'
 import { VSCodeWrapper } from './utils/VSCodeApi'
@@ -34,6 +33,7 @@ interface ChatboxProps {
     inputHistory: string[]
     setInputHistory: (history: string[]) => void
     vscodeAPI: VSCodeWrapper
+    telemetryService: TelemetryService
     suggestions?: string[]
     setSuggestions?: (suggestions: undefined | string[]) => void
     pluginsDevMode?: boolean
@@ -50,6 +50,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     inputHistory,
     setInputHistory,
     vscodeAPI,
+    telemetryService,
     suggestions,
     setSuggestions,
     pluginsDevMode,
@@ -78,9 +79,14 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 
     const onFeedbackBtnClick = useCallback(
         (text: string) => {
-            vscodeAPI.postMessage({ command: 'event', event: WebviewEvent.Feedback, value: text })
+            telemetryService.log(`CodyVSCodeExtension:codyFeedback:${text}`, {
+                value: text,
+                lastChatUsedEmbeddings: Boolean(
+                    transcript.at(-1)?.contextFiles?.some(file => file.source === 'embeddings')
+                ),
+            })
         },
-        [vscodeAPI]
+        [telemetryService, transcript]
     )
 
     const onCopyBtnClick = useCallback(
@@ -88,10 +94,13 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             if (isInsert) {
                 vscodeAPI.postMessage({ command: 'insert', text })
             }
-            const eventName = isInsert ? 'insert' : 'copy'
-            vscodeAPI.postMessage({ command: 'event', event: WebviewEvent.Click, value: eventName + 'Button' })
+            const op = isInsert ? 'insert' : 'copy'
+            telemetryService.log(`CodyVSCodeExtension:${op}Button:clicked`, {
+                op,
+                textLength: text.length,
+            })
         },
-        [vscodeAPI]
+        [telemetryService, vscodeAPI]
     )
 
     const onChatButtonClick = useCallback(

--- a/vscode/webviews/Login.story.tsx
+++ b/vscode/webviews/Login.story.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared/src/telemetry'
+
 import { AuthStatus, defaultAuthStatus, unauthenticatedStatus } from '../src/chat/protocol'
 
 import { Login } from './Login'
@@ -51,6 +53,7 @@ export const Simple: ComponentStoryObj<typeof Login> = {
                 authStatus={validAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
@@ -67,6 +70,7 @@ export const InvalidLogin: ComponentStoryObj<typeof Login> = {
                 authStatus={invalidAccessTokenAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
@@ -83,6 +87,7 @@ export const UnverifiedEmailLogin: ComponentStoryObj<typeof Login> = {
                 authStatus={requiresVerifiedEmailAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
@@ -99,6 +104,7 @@ export const LoginWithAppInstalled: ComponentStoryObj<typeof Login> = {
                 authStatus={validAuthStatus}
                 isAppInstalled={true}
                 vscodeAPI={vscodeAPI}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
@@ -115,6 +121,7 @@ export const UnsupportedAppOS: ComponentStoryObj<typeof Login> = {
                 authStatus={validAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
                 onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={unsupportedAppOS}

--- a/vscode/webviews/utils/telemetry.ts
+++ b/vscode/webviews/utils/telemetry.ts
@@ -1,0 +1,14 @@
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+
+import { VSCodeWrapper } from './VSCodeApi'
+
+/**
+ * Create a new {@link TelemetryService} for use in the VS Code webviews.
+ */
+export function createWebviewTelemetryService(vscodeAPI: VSCodeWrapper): TelemetryService {
+    return {
+        log: (eventName, properties) => {
+            vscodeAPI.postMessage({ command: 'event', eventName, properties })
+        },
+    }
+}


### PR DESCRIPTION
There is no significant change to the telemetry event data that is sent up (except for a few reductions in the event properties when we were sending up complex objects).

- Add a few more tracked events related to the signup flow.
- Introduce a new `TelemetryService` with the same API as `logEvent` but that is not global.
- Use the `TelemetryService` interface in the VS Code webviews as well instead of manually passing events.
- Clean up other code.
- Simplify EventLogger.log to only take public event props. Previously, the event logger took 2 args: event properties and public properties. The former was a superset of the latter and contained private information that could end up in, for example, the audit log. This is not needed for Cody's telemetry. See https://sourcegraph.slack.com/archives/CN4FC7XT4/p1690356187459289 for more context.
  - Also removes unnecessary passing along of the serverEndpoint (which is added globally).
- Simplify LocalStorage.{get,set}AnonymousUserID.
  - Remove the `setAnonymousUserID` call from MessageProvider because there was no call to `getAnonymousUserID` that would depend on it being called there.
  - Combine into a single `LocalStorage.anonymousUserID` method and document it.

## Test plan

Run the extension with `cody.debug.enable` on and verify in the output channel that the logged events look correct.