### PR TITLE
add cody.telemetry.level VS Code setting to control telemetry

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -7,6 +7,7 @@ export interface Configuration {
     debugEnable: boolean
     debugFilter: RegExp | null
     debugVerbose: boolean
+    telemetryLevel: 'all' | 'off'
     useContext: ConfigurationUseContext
     customHeaders: Record<string, string>
     autocomplete: boolean

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -839,6 +839,20 @@
           "type": "string",
           "markdownDescription": "Regular expression to filter debug output. If empty, defaults to '.*', which prints all messages."
         },
+        "cody.telemetry.level": {
+          "order": 99,
+          "type": "string",
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
+          "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
+          "default": "all"
+        },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "anthropic",

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -26,6 +26,7 @@ describe('getConfiguration', () => {
             debugEnable: false,
             debugVerbose: false,
             debugFilter: null,
+            telemetryLevel: 'all',
             autocompleteAdvancedProvider: 'anthropic',
             autocompleteAdvancedServerEndpoint: null,
             autocompleteAdvancedAccessToken: null,
@@ -69,6 +70,8 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.debug.filter':
                         return /.*/
+                    case 'cody.telemetry.level':
+                        return 'off'
                     case 'cody.autocomplete.advanced.provider':
                         return 'unstable-codegen'
                     case 'cody.autocomplete.advanced.serverEndpoint':
@@ -116,6 +119,7 @@ describe('getConfiguration', () => {
             debugEnable: true,
             debugVerbose: true,
             debugFilter: /.*/,
+            telemetryLevel: 'off',
             autocompleteAdvancedProvider: 'unstable-codegen',
             autocompleteAdvancedServerEndpoint: 'https://example.com/llm',
             autocompleteAdvancedAccessToken: 'foobar',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -60,6 +60,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         debugEnable: config.get<boolean>(CONFIG_KEY.debugEnable, false),
         debugVerbose: config.get<boolean>(CONFIG_KEY.debugVerbose, false),
         debugFilter: debugRegex,
+        telemetryLevel: config.get<'all' | 'off'>(CONFIG_KEY.telemetryLevel, 'all'),
         autocomplete: config.get(CONFIG_KEY.autocompleteEnabled, true),
         experimentalChatPredictions: config.get(CONFIG_KEY.experimentalChatPredictions, isTesting),
         inlineChat: config.get(CONFIG_KEY.inlineChatEnabled, true),

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -16,6 +16,11 @@ export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
     localStorage: LocalStorage
 ): Promise<void> {
+    if (config.telemetryLevel === 'off') {
+        eventLogger = null
+        return
+    }
+
     const { anonymousUserID, created } = await localStorage.anonymousUserID()
     globalAnonymousUserID = anonymousUserID
 
@@ -47,11 +52,11 @@ export async function createOrUpdateEventLogger(
  * @deprecated Use TelemetryService instead.
  */
 export function logEvent(eventName: string, properties?: TelemetryEventProperties): void {
+    debug(`logEvent${eventLogger === null ? ' (telemetry disabled)' : ''}`, eventName, JSON.stringify(properties))
     if (!eventLogger || !globalAnonymousUserID) {
         return
     }
     try {
-        debug('EventLogger', eventName, properties)
         eventLogger.log(eventName, globalAnonymousUserID, properties)
     } catch (error) {
         console.error(error)


### PR DESCRIPTION
Makes it possible for users to disable Cody's extension telemetry.



## Test plan

Set `cody.telemetry.level` to `off` and run Cody. Ensure `cody.debug.enabled` is `true`. Note in the output channel that there are lines starting `logEvent (telemetry disabled)`, which indicate a noop call to telemetry logging.