### PR TITLE
fix default of triggerMoreEagerly in code

### DIFF
--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -31,7 +31,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteAdvancedCache: true,
             autocompleteAdvancedEmbeddings: true,
-            autocompleteExperimentalTriggerMoreEagerly: false,
+            autocompleteExperimentalTriggerMoreEagerly: true,
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
         })
     })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -76,7 +76,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         autocompleteAdvancedEmbeddings: config.get(CONFIG_KEY.autocompleteAdvancedEmbeddings, true),
         autocompleteExperimentalTriggerMoreEagerly: config.get(
             CONFIG_KEY.autocompleteExperimentalTriggerMoreEagerly,
-            false
+            true
         ),
         autocompleteExperimentalCompleteSuggestWidgetSelection: config.get(
             CONFIG_KEY.autocompleteExperimentalCompleteSuggestWidgetSelection,


### PR DESCRIPTION
The default of triggerMoreEagerly was changed in vscode/package.json but not in code. The prior change was sufficient to make the default true, but the code was misleading. (We could improve this by making the TypeScript code in configuration.ts be aware of the JSON Schema of our configuration.)



## Test plan

n/a