### PR TITLE
Add naive html escaping for inline chat.

### DIFF
--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -494,10 +494,18 @@ export class Comment implements vscode.Comment {
     }
 
     /**
+     * Naive Html Escape, only does brackets for now, but works well enough to get tags showing up in inline
+     * comments that make reference to them.
+     */
+    private naiveHtmlEscape(text: string) : string {
+            return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    }
+
+    /**
      * Turns string into Markdown string
      */
     private markdown(text: string): vscode.MarkdownString {
-        const markdownText = new vscode.MarkdownString(text)
+        const markdownText = new vscode.MarkdownString(this.naiveHtmlEscape(text))
         markdownText.isTrusted = true
         markdownText.supportHtml = true
         return markdownText

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -497,8 +497,8 @@ export class Comment implements vscode.Comment {
      * Naive Html Escape, only does brackets for now, but works well enough to get tags showing up in inline
      * comments that make reference to them.
      */
-    private naiveHtmlEscape(text: string) : string {
-            return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+    private naiveHtmlEscape(text: string): string {
+        return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
     }
 
     /**


### PR DESCRIPTION
This handles issue #169 .
## Test plan
I tested manually with responses in the form of a paragraph.  
![image](https://github.com/sourcegraph/cody/assets/79379/bc945dfa-6cb7-44da-9d84-335933d0c5d6)

