### PR TITLE
run full vscode test suite before release

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -18,7 +18,9 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           run_install: true
-      - run: xvfb-run -a pnpm run test
+      - run: pnpm run test
+      - run: xvfb-run -a pnpm -C vscode run test:integration
+      - run: xvfb-run -a pnpm -C vscode run test:e2e
       - run: CODY_RELEASE_TYPE=insiders pnpm -C vscode run release
         if: github.ref == 'refs/heads/main' && github.repository == 'sourcegraph/cody'
         env:

--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -37,7 +37,9 @@ jobs:
             echo "Release tag and version in vscode/package.json do not match: '${TAGGED_VERSION}' vs. '${WRITTEN_VERSION}'"
             exit 1
           fi
-      - run: xvfb-run -a pnpm run test
+      - run: pnpm run test
+      - run: xvfb-run -a pnpm -C vscode run test:integration
+      - run: xvfb-run -a pnpm -C vscode run test:e2e
       - run: CODY_RELEASE_TYPE=stable pnpm -C vscode run release
         if: github.repository == 'sourcegraph/cody'
         env:


### PR DESCRIPTION
Previously only the unit tests were being run. (The full test suite was being run in the normal post-push CI, but not for releases specifically. It should be run for releases in case someone wants to tag or trigger an arbitrary commit that's not the HEAD of a pushed branch to be a release commit.)

## Test plan

n/a