### PR TITLE
Autocomplete: Use enum for finite config options

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -852,6 +852,11 @@
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": "anthropic",
+          "enum": [
+            "anthropic",
+            "unstable-codegen",
+            "unstable-huggingface"
+          ],
           "markdownDescription": "Overwrite the provider used for code autocomplete. Only supported values at the moment are `anthropic` (default), `unstable-codegen`, or `unstable-huggingface`."
         },
         "cody.completions.advanced.serverEndpoint": {


### PR DESCRIPTION
Just learned about this when reviewing @sqs's changes. 🙈 

## Test plan

<img width="821" alt="Screenshot 2023-07-27 at 10 58 03" src="https://github.com/sourcegraph/cody/assets/458591/a50f75b5-1b63-41d0-9aa2-35f6d8724189">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
