### PR TITLE
Autocomplete: Use tabby style helpers for completion strings in tests

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -15,6 +15,14 @@ import { CompletionsCache } from './cache'
 import { History } from './history'
 import { createProviderConfig } from './providers/anthropic'
 
+const CURSOR_MARKER = '║'
+
+// The dedent package seems to replace `\t` to `\\t` so in order to insert a tab
+// character, we have to use interpolation. We abbreviate this to `T` because
+// ${T} is exactly 4 characters, mimicking the default indentation of four
+// spaces
+const T = '\t'
+
 vi.mock('vscode', () => ({
     ...vsCodeMocks,
     InlineCompletionTriggerKind: {
@@ -41,7 +49,20 @@ vi.mock('./context-embeddings.ts', () => ({
     getContextFromEmbeddings: () => [],
 }))
 
-function createCompletionResponse(completion: string): CompletionResponse {
+// `├` start of the inline completion to insert
+// `┤` end of the inline completion to insert
+// `┴` use for indent placeholder, should be placed at last line after `┤`
+function completion(string: TemplateStringsArray, ...values: any): CompletionResponse {
+    const raw = dedent(string, ...values)
+    let completion = raw
+
+    const start = raw.lastIndexOf('┤')
+    const end = raw.lastIndexOf('┤')
+
+    if (start >= 0 && end >= 0) {
+        completion = raw.slice(raw.indexOf('├') + 1, raw.lastIndexOf('┤'))
+    }
+
     return {
         completion,
         stopReason: 'unknown',
@@ -52,8 +73,6 @@ const noopStatusBar = {
     startLoading: () => () => {},
 } as any
 
-const CURSOR_MARKER = '🔥'
-
 describe('Cody completions', () => {
     /**
      * A test helper to trigger a completion request. The code example must include
@@ -62,7 +81,7 @@ describe('Cody completions', () => {
      * @example
      *   complete(`
      * async function foo() {
-     *   ${CURSOR_MARKER}
+     *   ║
      * }`)
      */
     let complete: (
@@ -114,7 +133,7 @@ describe('Cody completions', () => {
             })
 
             if (!code.includes(CURSOR_MARKER)) {
-                throw new Error('The test code must include a | to denote the cursor position')
+                throw new Error('The test code must include a ║ to denote the cursor position')
             }
 
             const cursorIndex = code.indexOf(CURSOR_MARKER)
@@ -187,7 +206,7 @@ describe('Cody completions', () => {
                 public end: Position
 
                 constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
-                    this.startLine = ${CURSOR_MARKER}
+                    this.startLine = ║
                     this.startCharacter = startCharacter
                     this.endLine = endLine
                     this.endCharacter = endCharacter
@@ -210,23 +229,17 @@ describe('Cody completions', () => {
     })
 
     it('makes a request when in the middle of a word when triggerMoreEagerly is true', async () => {
-        const { requests } = await complete(
-            `foo${CURSOR_MARKER}`,
-            [createCompletionResponse('()')],
-            undefined,
-            undefined,
-            true
-        )
+        const { requests } = await complete('foo║', [completion`()`], undefined, undefined, true)
         expect(requests).toHaveLength(1)
     })
 
     it('does not make a request when in the middle of a word when triggerMoreEagerly is false', async () => {
-        const { requests } = await complete(`foo${CURSOR_MARKER}`, undefined, undefined, undefined, false)
+        const { requests } = await complete('foo║', undefined, undefined, undefined, false)
         expect(requests).toHaveLength(0)
     })
 
     it('completes a single-line at the end of a sentence', async () => {
-        const { completions } = await complete(`foo = ${CURSOR_MARKER}`, [createCompletionResponse("'bar'")])
+        const { completions } = await complete('foo = ║', [completion`'bar'`])
 
         expect(completions[0].insertText).toBe("'bar'")
     })
@@ -236,29 +249,31 @@ describe('Cody completions', () => {
             `
         function test() {
             console.log(1);
-            ${CURSOR_MARKER}
+            ║
         }
         `,
-            [createCompletionResponse('if (true) {\n        console.log(3);\n    }\n    console.log(4);')]
+            [
+                completion`
+                    ├if (true) {
+                        console.log(3);
+                    }
+                    console.log(4);┤
+                ┴┴┴┴`,
+            ]
         )
 
         expect(completions[0].insertText).toBe('if (true) {')
     })
 
     it('completes a single-line at the middle of a sentence', async () => {
-        const { completions } = await complete(`function bubbleSort(${CURSOR_MARKER})`, [
-            createCompletionResponse('array) {'),
-            createCompletionResponse('items) {'),
-        ])
+        const { completions } = await complete('function bubbleSort(║)', [completion`array) {`, completion`items) {`])
 
         expect(completions[0].insertText).toBe('array) {')
         expect(completions[1].insertText).toBe('items) {')
     })
 
     it('marks the rest of the line as to be replaced so closing characters in the same line suffix are properly merged', async () => {
-        const { completions } = await complete(`function bubbleSort(${CURSOR_MARKER})`, [
-            createCompletionResponse('array) {'),
-        ])
+        const { completions } = await complete('function bubbleSort(║)', [completion`array) {`])
 
         expect(completions[0].range).toMatchInlineSnapshot(`
           Range {
@@ -275,7 +290,7 @@ describe('Cody completions', () => {
     })
 
     it('does not make a request when context has a selectedCompletionInfo', async () => {
-        const { requests } = await complete(`foo = ${CURSOR_MARKER}`, undefined, undefined, {
+        const { requests } = await complete('foo = ║', undefined, undefined, {
             selectedCompletionInfo: {
                 range: {} as any,
                 text: 'something',
@@ -287,43 +302,43 @@ describe('Cody completions', () => {
     })
 
     it('preserves leading whitespace when prefix has no trailing whitespace', async () => {
-        const { completions } = await complete(`const isLocalHost = window.location.host${CURSOR_MARKER}`, [
-            createCompletionResponse(" === 'localhost'"),
+        const { completions } = await complete('const isLocalHost = window.location.host║', [
+            completion`├ === 'localhost'┤`,
         ])
         expect(completions[0].insertText).toBe(" === 'localhost'")
     })
 
     it('collapses leading whitespace when prefix has trailing whitespace', async () => {
-        const { completions } = await complete(`const x = ${CURSOR_MARKER}`, [createCompletionResponse('\t7')])
+        const { completions } = await complete('const x = ║', [completion`├${T}7┤`])
         expect(completions[0].insertText).toBe('7')
     })
 
     it('should not trigger a request if there is text in the suffix for the same line', async () => {
-        const { requests } = await complete(`foo: ${CURSOR_MARKER} = 123;`)
+        const { requests } = await complete('foo: ║ = 123;')
         expect(requests).toHaveLength(0)
     })
 
     it('should trigger a request if the suffix of the same line is only special tags', async () => {
-        const { requests } = await complete(`if(${CURSOR_MARKER}) {`)
+        const { requests } = await complete('if(║) {')
         expect(requests).toHaveLength(3)
     })
 
     describe('bad completion starts', () => {
         it.each([
-            ['➕     1', '1'],
-            ['\u200B   1', '1'],
-            ['.      1', '1'],
-            ['+  1', '1'],
-            ['-  1', '1'],
+            [completion`├➕     1┤`, '1'],
+            [completion`├${'\u200B'}   1┤`, '1'],
+            [completion`├.      1┤`, '1'],
+            [completion`├+  1┤`, '1'],
+            [completion`├-  1┤`, '1'],
         ])('fixes %s to %s', async (completion, expected) => {
-            const { completions } = await complete(CURSOR_MARKER, [createCompletionResponse(completion)])
+            const { completions } = await complete(CURSOR_MARKER, [completion])
             expect(completions[0].insertText).toBe(expected)
         })
     })
 
     describe('odd indentation', () => {
         it('filters out odd indentation in single-line completions', async () => {
-            const { completions } = await complete(`const foo = ${CURSOR_MARKER}`, [createCompletionResponse(' 1')])
+            const { completions } = await complete('const foo = ║', [completion`├ 1┤`])
             expect(completions[0].insertText).toBe('1')
         })
     })
@@ -332,18 +347,19 @@ describe('Cody completions', () => {
         it('honors a leading new line in the completion', async () => {
             const { completions } = await complete(
                 dedent`
-            describe('bubbleSort', () => {
-                it('bubbleSort test case', () => {${CURSOR_MARKER}
+                    describe('bubbleSort', () => {
+                        it('bubbleSort test case', () => {║
 
-                })
-            })
-            `,
+                        })
+                    })`,
                 [
-                    createCompletionResponse(`  \n        const unsortedArray = [4,3,78,2,0,2]
-        const sortedArray = bubbleSort(unsortedArray)
-        expect(sortedArray).toEqual([0,2,2,3,4,78])
-    })
-})`),
+                    completion`
+                            ├${'  '}
+                            const unsortedArray = [4,3,78,2,0,2]
+                            const sortedArray = bubbleSort(unsortedArray)
+                            expect(sortedArray).toEqual([0,2,2,3,4,78])
+                        })
+                    }┤`,
                 ]
             )
 
@@ -358,19 +374,18 @@ describe('Cody completions', () => {
         it('cuts-off redundant closing brackets on the start indent level', async () => {
             const { completions } = await complete(
                 dedent`
-            describe('bubbleSort', () => {
-                it('bubbleSort test case', () => {${CURSOR_MARKER}
+                    describe('bubbleSort', () => {
+                        it('bubbleSort test case', () => {║
 
-                })
-            })
-            `,
+                        })
+                    })`,
                 [
-                    createCompletionResponse(dedent`
-                    const unsortedArray = [4,3,78,2,0,2]
+                    completion`
+                            ├const unsortedArray = [4,3,78,2,0,2]
                             const sortedArray = bubbleSort(unsortedArray)
                             expect(sortedArray).toEqual([0,2,2,3,4,78])
                         })
-                    })`),
+                    }┤`,
                 ]
             )
 
@@ -382,15 +397,22 @@ describe('Cody completions', () => {
         })
 
         it('keeps the closing bracket', async () => {
-            const { completions } = await complete(`function printHello(${CURSOR_MARKER})`, [
-                createCompletionResponse(" {\n    console.log('Hello');\n}"),
+            const { completions } = await complete('function printHello(║)', [
+                completion`
+                ├) {
+                    console.log('Hello');
+                }┤`,
             ])
 
-            expect(completions[0].insertText).toBe(" {\n    console.log('Hello');\n}")
+            expect(completions[0].insertText).toMatchInlineSnapshot(`
+              ") {
+                  console.log('Hello');
+              }"
+            `)
         })
 
         it('triggers a multi-line completion at the start of a block', async () => {
-            const { requests } = await complete(`function bubbleSort() {\n  ${CURSOR_MARKER}`)
+            const { requests } = await complete('function bubbleSort() {\n  ║')
 
             expect(requests).toHaveLength(3)
             expect(requests[0].stopSequences).not.toContain('\n')
@@ -399,28 +421,31 @@ describe('Cody completions', () => {
         it('uses an indentation based approach to cut-off completions', async () => {
             const { completions } = await complete(
                 dedent`
-                class Foo {
-                    constructor() {
-                        ${CURSOR_MARKER}
+                    class Foo {
+                        constructor() {
+                            ║
+                        }
                     }
-                }`,
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('foo')
+                    completion`
+                            ├console.log('foo')
                         }
 
                         add() {
                             console.log('bar')
-                        }`),
-                    createCompletionResponse(dedent`
-                    if (foo) {
+                        }┤
+                    ┴┴┴┴`,
+                    completion`
+                            ├if (foo) {
                                 console.log('foo1');
                             }
                         }
 
                         add() {
                             console.log('bar')
-                        }`),
+                        }┤
+                    ┴┴┴┴`,
                 ]
             )
 
@@ -431,15 +456,16 @@ describe('Cody completions', () => {
         it('cuts-off the whole completions when suffix is very similar to suffix line', async () => {
             const { completions } = await complete(
                 dedent`
-                function() {
-                    ${CURSOR_MARKER}
-                    console.log('bar')
-                }`,
-                [
-                    createCompletionResponse(dedent`
-                    console.log('foo')
+                    function() {
+                        ║
                         console.log('bar')
-                    }`),
+                    }
+                `,
+                [
+                    completion`
+                        ├console.log('foo')
+                        console.log('bar')
+                    }┤`,
                 ]
             )
 
@@ -447,14 +473,14 @@ describe('Cody completions', () => {
         })
 
         it('does not support multi-line completion on unsupported languages', async () => {
-            const { requests } = await complete(`function looksLegit() {\n  ${CURSOR_MARKER}`, undefined, 'elixir')
+            const { requests } = await complete('function looksLegit() {\n  ║', undefined, 'elixir')
 
             expect(requests).toHaveLength(1)
             expect(requests[0].stopSequences).toContain('\n\n')
         })
 
         it('requires an indentation to start a block', async () => {
-            const { requests } = await complete(`function bubbleSort() {\n${CURSOR_MARKER}`)
+            const { requests } = await complete('function bubbleSort() {\n║')
 
             expect(requests).toHaveLength(1)
             expect(requests[0].stopSequences).toContain('\n\n')
@@ -463,19 +489,20 @@ describe('Cody completions', () => {
         it('works with python', async () => {
             const { completions, requests } = await complete(
                 dedent`
-                for i in range(11):
-                    if i % 2 == 0:
-                        ${CURSOR_MARKER}`,
+                    for i in range(11):
+                        if i % 2 == 0:
+                            ║
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    print(i)
+                    completion`
+                            ├print(i)
                         elif i % 3 == 0:
                             print(f"Multiple of 3: {i}")
                         else:
                             print(f"ODD {i}")
 
                     for i in range(12):
-                        print("unrelated")`),
+                        print("unrelated")┤`,
                 ],
                 'python'
             )
@@ -494,12 +521,13 @@ describe('Cody completions', () => {
         it('works with java', async () => {
             const { completions, requests } = await complete(
                 dedent`
-                for (int i = 0; i < 11; i++) {
-                    if (i % 2 == 0) {
-                        ${CURSOR_MARKER}`,
+                    for (int i = 0; i < 11; i++) {
+                        if (i % 2 == 0) {
+                            ║
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    System.out.println(i);
+                    completion`
+                            ├System.out.println(i);
                         } else if (i % 3 == 0) {
                             System.out.println("Multiple of 3: " + i);
                         } else {
@@ -509,7 +537,7 @@ describe('Cody completions', () => {
 
                     for (int i = 0; i < 12; i++) {
                         System.out.println("unrelated");
-                    }`),
+                    }┤`,
                 ],
                 'java'
             )
@@ -530,13 +558,14 @@ describe('Cody completions', () => {
         it('works with csharp', async () => {
             const { completions, requests } = await complete(
                 dedent`
-                for (int i = 0; i < 11; i++) {
-                    if (i % 2 == 0)
-                    {
-                        ${CURSOR_MARKER}`,
+                    for (int i = 0; i < 11; i++) {
+                        if (i % 2 == 0)
+                        {
+                            ║
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    Console.WriteLine(i);
+                    completion`
+                            ├Console.WriteLine(i);
                         }
                         else if (i % 3 == 0)
                         {
@@ -552,7 +581,7 @@ describe('Cody completions', () => {
                     for (int i = 0; i < 12; i++)
                     {
                         Console.WriteLine("unrelated");
-                    }`),
+                    }┤`,
                 ],
                 'csharp'
             )
@@ -568,12 +597,13 @@ describe('Cody completions', () => {
         it('works with c++', async () => {
             const { completions, requests } = await complete(
                 dedent`
-                for (int i = 0; i < 11; i++) {
-                    if (i % 2 == 0) {
-                        ${CURSOR_MARKER}`,
+                    for (int i = 0; i < 11; i++) {
+                        if (i % 2 == 0) {
+                            ║
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    std::cout << i;
+                    completion`
+                            ├std::cout << i;
                         } else if (i % 3 == 0) {
                             std::cout << "Multiple of 3: " << i;
                         } else  {
@@ -583,7 +613,7 @@ describe('Cody completions', () => {
 
                     for (int i = 0; i < 12; i++) {
                         std::cout << "unrelated";
-                    }`),
+                    }┤`,
                 ],
                 'cpp'
             )
@@ -603,12 +633,13 @@ describe('Cody completions', () => {
         it('works with c', async () => {
             const { completions, requests } = await complete(
                 dedent`
-                for (int i = 0; i < 11; i++) {
-                    if (i % 2 == 0) {
-                        ${CURSOR_MARKER}`,
+                    for (int i = 0; i < 11; i++) {
+                        if (i % 2 == 0) {
+                            ║
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    printf("%d", i);
+                    completion`
+                            ├printf("%d", i);
                         } else if (i % 3 == 0) {
                             printf("Multiple of 3: %d", i);
                         } else {
@@ -618,7 +649,7 @@ describe('Cody completions', () => {
 
                     for (int i = 0; i < 12; i++) {
                         printf("unrelated");
-                    }`),
+                    }┤`,
                 ],
                 'c'
             )
@@ -638,18 +669,20 @@ describe('Cody completions', () => {
         it('skips over empty lines', async () => {
             const { completions } = await complete(
                 dedent`
-                class Foo {
-                    constructor() {
-                        ${CURSOR_MARKER}
+                    class Foo {
+                        constructor() {
+                            ║
+                        }
                     }
-                }`,
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('foo')
+                    completion`
+                            ├console.log('foo')
 
                             console.log('bar')
 
-                            console.log('baz')`),
+                            console.log('baz')┤
+                    ┴┴┴┴┴┴┴┴`,
                 ]
             )
 
@@ -665,15 +698,16 @@ describe('Cody completions', () => {
         it('skips over else blocks', async () => {
             const { completions } = await complete(
                 dedent`
-                if (check) {
-                    ${CURSOR_MARKER}
-                }`,
+                    if (check) {
+                        ║
+                    }
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('one')
+                    completion`
+                        ├console.log('one')
                     } else {
                         console.log('two')
-                    }`),
+                    }┤`,
                 ]
             )
 
@@ -688,12 +722,12 @@ describe('Cody completions', () => {
             const { completions } = await complete(
                 dedent`
                 if (check) {
-                    ${CURSOR_MARKER}
+                    ║
                 `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('one')
-                    }`),
+                    completion`
+                        ├console.log('one')
+                    }┤`,
                 ]
             )
 
@@ -707,17 +741,17 @@ describe('Cody completions', () => {
             const { completions } = await complete(
                 dedent`
                 function myFunction() {
-                    ${CURSOR_MARKER}
+                    ║
                     console.log('three')
                 }
                 `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('one')
+                    completion`
+                        ├console.log('one')
                         console.log('two')
                         console.log('three')
                         console.log('four')
-                    }`),
+                    }┤`,
                 ]
             )
 
@@ -727,16 +761,16 @@ describe('Cody completions', () => {
         it('stops when the next non-empty line of the suffix matches exactly with one line completion', async () => {
             const { completions } = await complete(
                 dedent`
-                function myFunction() {
-                    console.log('one')
-                    ${CURSOR_MARKER}
-                    console.log('three')
-                }
+                    function myFunction() {
+                        console.log('one')
+                        ║
+                        console.log('three')
+                    }
                 `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('three')
-                    }`),
+                    completion`
+                        ├console.log('three')
+                    }┤`,
                 ]
             )
 
@@ -746,36 +780,35 @@ describe('Cody completions', () => {
         it('cuts off a matching line with the next line even if the completion is longer', async () => {
             const { completions } = await complete(
                 dedent`
-            function bubbleSort() {
-                ${CURSOR_MARKER}
-                do {
-                    swapped = false;
-                    for (let i = 0; i < array.length - 1; i++) {
-                        if (array[i] > array[i + 1]) {
-                            let temp = array[i];
-                            array[i] = array[i + 1];
-                            array[i + 1] = temp;
-                            swapped = true;
-                        }
-                    }
-                } while (swapped);
-            }
-            `,
-                [
-                    createCompletionResponse(dedent`
-                    let swapped;
-                    do {
-                        swapped = false;
-                        for (let i = 0; i < array.length - 1; i++) {
-                            if (array[i] > array[i + 1]) {
-                                let temp = array[i];
-                                array[i] = array[i + 1];
-                                array[i + 1] = temp;
-                                swapped = true;
+                    function bubbleSort() {
+                        ║
+                        do {
+                            swapped = false;
+                            for (let i = 0; i < array.length - 1; i++) {
+                                if (array[i] > array[i + 1]) {
+                                    let temp = array[i];
+                                    array[i] = array[i + 1];
+                                    array[i + 1] = temp;
+                                    swapped = true;
+                                }
                             }
-                        }
-                    } while (swapped);
-                `),
+                        } while (swapped);
+                    }`,
+                [
+                    completion`
+                        ├let swapped;
+                        do {
+                            swapped = false;
+                            for (let i = 0; i < array.length - 1; i++) {
+                                if (array[i] > array[i + 1]) {
+                                    let temp = array[i];
+                                    array[i] = array[i + 1];
+                                    array[i + 1] = temp;
+                                    swapped = true;
+                                }
+                            }
+                        } while (swapped);┤
+                    ┴┴┴┴`,
                 ]
             )
 
@@ -786,13 +819,12 @@ describe('Cody completions', () => {
             it('simple example', async () => {
                 const { completions } = await complete(
                     dedent`
-                          path: $GITHUB_WORKSPACE/vscode/.vscod-etest/${CURSOR_MARKER}
-                          key: {{ runner.os }}-pnpm-store-{{ hashFiles('**/pnpm-lock.yaml') }}`,
+                        path: $GITHUB_WORKSPACE/vscode/.vscode-test/║
+                        key: {{ runner.os }}-pnpm-store-{{ hashFiles('**/pnpm-lock.yaml') }}`,
                     [
-                        createCompletionResponse(dedent`
-                                    pnpm-store
-                                        key: {{ runner.os }}-pnpm-{{ steps.pnpm-cache.outputs.STORE_PATH }}
-                                    }`),
+                        completion`
+                            ├pnpm-store
+                            key: {{ runner.os }}-pnpm-{{ steps.pnpm-cache.outputs.STORE_PATH }}┤`,
                     ]
                 )
 
@@ -802,14 +834,14 @@ describe('Cody completions', () => {
             it('example with return', async () => {
                 const { completions } = await complete(
                     dedent`
-                          console.log('<< stop completion: ${CURSOR_MARKER}')
-                          return []
+                        console.log('<< stop completion: ║')
+                        return []
                     `,
                     [
-                        createCompletionResponse(dedent`
-                                    lastChange was delete')
-                                    return []
-                        `),
+                        completion`
+                            lastChange was delete')
+                            return []
+                        `,
                     ]
                 )
 
@@ -819,14 +851,14 @@ describe('Cody completions', () => {
             it('example with inline comment', async () => {
                 const { completions } = await complete(
                     dedent`
-                    // ${CURSOR_MARKER}
-                    const currentFilePath = path.normalize(document.fileName)
+                        // ║
+                        const currentFilePath = path.normalize(document.fileName)
                     `,
                     [
-                        createCompletionResponse(dedent`
+                        completion`
                             Get the file path
                             const filePath = normalize(document.fileName)
-                        `),
+                        `,
                     ]
                 )
 
@@ -837,22 +869,25 @@ describe('Cody completions', () => {
         it('ranks results by number of lines', async () => {
             const { completions } = await complete(
                 dedent`
-                function test() {
-                    ${CURSOR_MARKER}`,
+                    function test() {
+                        ║
+                `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('foo')
+                    completion`
+                        ├console.log('foo')
+                        console.log('foo')┤
+                    ┴┴┴┴
+                    `,
+                    completion`
+                        ├console.log('foo')
                         console.log('foo')
-                    `),
-                    createCompletionResponse(dedent`
-                    console.log('foo')
                         console.log('foo')
                         console.log('foo')
-                        console.log('foo')
-                        console.log('foo')`),
-                    createCompletionResponse(dedent`
-                    console.log('foo')
-                    `),
+                        console.log('foo')┤
+                    ┴┴┴┴`,
+                    completion`
+                        ├console.log('foo')┤
+                    `,
                 ]
             )
 
@@ -873,13 +908,10 @@ describe('Cody completions', () => {
         it('dedupes duplicate results', async () => {
             const { completions } = await complete(
                 dedent`
-                function test() {
-                    ${CURSOR_MARKER}`,
-                [
-                    createCompletionResponse('return true'),
-                    createCompletionResponse('return true'),
-                    createCompletionResponse('return true'),
-                ]
+                    function test() {
+                        ║
+                `,
+                [completion`return true`, completion`return true`, completion`return true`]
             )
 
             expect(completions.length).toBe(1)
@@ -889,13 +921,20 @@ describe('Cody completions', () => {
         it('handles tab/newline interop in completion truncation', async () => {
             const { completions } = await complete(
                 dedent`
-                class Foo {
-                    constructor() {
-                        ${CURSOR_MARKER}`,
+                    class Foo {
+                        constructor() {
+                            ║
+                `,
                 [
-                    createCompletionResponse(
-                        "console.log('foo')\n\t\tif (yes) {\n\t\t    sure()\n\t\t}\n\t}\n\n\tadd() {\n"
-                    ),
+                    completion`
+                        ├console.log('foo')
+                ${T}${T}if (yes) {
+                ${T}${T}    sure()
+                ${T}${T}}
+                ${T}}
+
+                ${T}add() {┤
+                ┴┴┴┴`,
                 ]
             )
 
@@ -911,14 +950,14 @@ describe('Cody completions', () => {
         it('does not include block end character if there is already content in the block', async () => {
             const { completions } = await complete(
                 dedent`
-                if (check) {
-                    ${CURSOR_MARKER}
-                    const d = 5;
+                    if (check) {
+                        ║
+                        const d = 5;
                 `,
                 [
-                    createCompletionResponse(dedent`
-                    console.log('one')
-                    }`),
+                    completion`
+                        ├console.log('one')
+                    }┤`,
                 ]
             )
 
@@ -931,7 +970,7 @@ describe('Cody completions', () => {
                 if (check) {
                     ${CURSOR_MARKER}
                 }`,
-                [createCompletionResponse('}')]
+                [completion`}`]
             )
 
             expect(completions.length).toBe(0)
@@ -954,7 +993,7 @@ describe('Cody completions', () => {
                    }
                    return arr;
                  }`,
-                [createCompletionResponse('}')]
+                [completion`}`]
             )
 
             expect(completions.length).toBe(0)
@@ -962,9 +1001,16 @@ describe('Cody completions', () => {
 
         it('normalizes Cody responses starting with an empty line and following the exact same indentation as the start line', async () => {
             const { completions } = await complete(
-                `function test() {
-                    ${CURSOR_MARKER}`,
-                [createCompletionResponse("\n    console.log('foo')")]
+                dedent`
+                    function test() {
+                        ║
+                `,
+                [
+                    completion`
+                        ├
+                        console.log('foo')┤
+                    ┴┴┴┴`,
+                ]
             )
 
             expect(completions[0].insertText).toBe("console.log('foo')")
@@ -973,9 +1019,9 @@ describe('Cody completions', () => {
 
     describe('completions cache', () => {
         it('synthesizes a completion from a prior request', async () => {
-            await complete(`console.${CURSOR_MARKER}`, [createCompletionResponse("log('Hello, world!');")])
+            await complete('console.║', [completion`log('Hello, world!');`])
 
-            const { completions } = await complete(`console.log(${CURSOR_MARKER}`, 'stall')
+            const { completions } = await complete('console.log(║', 'stall')
 
             expect(completions[0].insertText).toBe("'Hello, world!');")
         })


### PR DESCRIPTION
c.f. https://github.com/sourcegraph/cody/pull/393

This changes the completion examples in the docs once again to match the style of tabby: https://sourcegraph.com/github.com/TabbyML/tabby/-/blob/clients/tabby-agent/src/postprocess/testUtils.ts?L22:17-22:23

## Test plan

- Tests pass

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
