### PR TITLE
fix: chat history command and remove setTab

### DIFF
--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -10,7 +10,7 @@ import {
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
-import { numResults } from './helpers'
+import { isSingleWord, numResults } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class ChatQuestion implements Recipe {
@@ -49,9 +49,12 @@ export class ChatQuestion implements Recipe {
         const contextMessages: ContextMessage[] = []
         // If input is less than 2 words, it means it's most likely a statement or a follow-up question that does not require additional context
         // e,g. "hey", "hi", "why", "explain" etc.
-        const isTextTooShort = text.split(' ').length < 2
-        const isCodebaseContextRequired =
-            !isTextTooShort && (firstInteraction || (await intentDetector.isCodebaseContextRequired(text)))
+        const isTextTooShort = isSingleWord(text)
+        if (isTextTooShort) {
+            return contextMessages
+        }
+
+        const isCodebaseContextRequired = firstInteraction || (await intentDetector.isCodebaseContextRequired(text))
 
         this.debug('ChatQuestion:getContextMessages', 'isCodebaseContextRequired', isCodebaseContextRequired)
         if (isCodebaseContextRequired) {

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -76,3 +76,7 @@ export const numResults = {
     numCodeResults: NUM_CODE_RESULTS,
     numTextResults: NUM_TEXT_RESULTS,
 }
+
+export function isSingleWord(str: string): boolean {
+    return str.trim().split(/\s+/).length === 1
+}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Bug: Chat History command shows chat view instead of history view. [pull/414](https://github.com/sourcegraph/cody/pull/414)
+
 ### Changed
 
 ## [0.6.3]

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -48,7 +48,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                 await this.abortCompletion()
                 break
             case 'executeRecipe':
-                this.showTab('chat')
+                await this.setWebviewView('chat')
                 await this.executeRecipe(message.recipe)
                 break
             case 'auth':
@@ -147,14 +147,9 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         this.telemetryService.log('CodyVSCodeExtension:custom-recipe:clicked')
         debug('ChatViewProvider:onCustomRecipeClicked', title)
         if (!this.isCustomRecipeAction(title)) {
-            this.showTab('chat')
+            await this.setWebviewView('chat')
         }
         await this.executeCustomRecipe(title, recipeType)
-    }
-
-    public showTab(tab: string): void {
-        void vscode.commands.executeCommand('cody.chat.focus')
-        void this.webview?.postMessage({ type: 'showTab', tab })
     }
 
     /**
@@ -225,9 +220,9 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     /**
      * Set webview view
      */
-    public setWebviewView(view: View): void {
-        void vscode.commands.executeCommand('cody.chat.focus')
-        void this.webview?.postMessage({
+    public async setWebviewView(view: View): Promise<void> {
+        await vscode.commands.executeCommand('cody.chat.focus')
+        await this.webview?.postMessage({
             type: 'view',
             messages: view,
         })

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -39,7 +39,6 @@ export type WebviewMessage =
  * A message sent from the extension host to the webview.
  */
 export type ExtensionMessage =
-    | { type: 'showTab'; tab: string }
     | { type: 'config'; config: ConfigurationSubsetForWebview & LocalEnv; authStatus: AuthStatus }
     | { type: 'login'; authStatus: AuthStatus }
     | { type: 'history'; messages: UserLocalHistory | null }

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -26,7 +26,7 @@ export async function beforeIntegrationTest(): Promise<void> {
     // Configure extension.
     const config = vscode.workspace.getConfiguration()
     await config.update('cody.serverEndpoint', mockServer.SERVER_URL)
-    await ensureExecuteCommand('cody.test.token', [mockServer.VALID_TOKEN])
+    await ensureExecuteCommand('cody.test.token', mockServer.VALID_TOKEN)
 }
 
 /**

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -66,11 +66,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         break
                     case 'login':
                         break
-                    case 'showTab':
-                        if (message.tab === 'chat') {
-                            setView('chat')
-                        }
-                        break
                     case 'history':
                         setInputHistory(message.messages?.input ?? [])
                         setUserHistory(message.messages?.chat ?? null)


### PR DESCRIPTION
Current the `Chat History` command does not show you the Chat History view:
![image](https://github.com/sourcegraph/cody/assets/68532117/2a9e94a1-7454-4aca-a537-6c7c43d0de19)

This is because chat history command was using showTab('history') is doing the same thing as the `setWebviewView(view)` but only accepts `chat` as the view, which is confusing and redundant.

TIncluded in this PR:
- removed `showTab` and move to `setWebviewView`
- moved `isTextTooShort` to helper function ([context](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1690215101604749?thread_ts=1690214874.981619&cid=C04MSD3DP5L))
- updated type error for the test token command

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

locally tested and all the tests are still passing after the change
