### PR TITLE
add rules to promptmixing

### DIFF
--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -27,7 +27,8 @@ export class PromptMixin {
      * Prepends all mixins to `humanMessage`. Modifies and returns `humanMessage`.
      */
     public static mixInto(humanMessage: InteractionMessage): InteractionMessage {
-        const mixins = [...this.mixins, ...this.customMixin].map(mixin => mixin.prompt).join('\n\n')
+        const rule = newPromptMixin(rules)
+        const mixins = [rule, ...this.customMixin, ...this.mixins].map(mixin => mixin.prompt).join('\n\n')
         if (mixins) {
             // Stuff the prompt mixins at the start of the human text.
             // Note we do not reflect them in displayText.
@@ -48,10 +49,13 @@ export class PromptMixin {
  */
 export function languagePromptMixin(languageCode: string): PromptMixin {
     return new PromptMixin(
-        `(Reply as Cody developed by Sourcegraph in the language with RFC5646/ISO language code "${languageCode}" unless instructed) Hi, I need your help.`
+        `(Reply as Cody developed by Sourcegraph in the language with RFC5646/ISO language code "${languageCode}".)Hi, I need your help.`
     )
 }
 
 export function newPromptMixin(text: string): PromptMixin {
     return new PromptMixin(text)
 }
+
+const rules =
+    'Rules: Answer questions only if certain. Reference only verified file names/paths. Provide full code where applicable. State if unsure. Do not guess or fabricate information. Think step-by-step.'

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -49,7 +49,7 @@ export class PromptMixin {
  */
 export function languagePromptMixin(languageCode: string): PromptMixin {
     return new PromptMixin(
-        `(Reply as Cody developed by Sourcegraph in the language with RFC5646/ISO language code "${languageCode}".)Hi, I need your help.`
+        `(Reply as Cody created and developed by Sourcegraph in the language with RFC5646/ISO language code "${languageCode}".)Hi, I need your help.`
     )
 }
 


### PR DESCRIPTION
I was playing around Custom Recipes and noticed Cody did very well when we provide detailed instruction in each prompt. However, it would keep forgetting its name after a few questions and a dozen context were added to the transcript. 
BUT if I add "replying as Cody" in each recipe, and ask Cody for its name, it would always answer Cody.

This is when I notice this is because we define Cody at the very beginning of the conversation, but once the attention has shift when the conversation has gotten longer, what is defined at the beginning doesn't matter anymore. This is why adding a "reminder" would help.

This PR should fix issues where Cody:
- forgot its identity
- Not providing full code when answering code-related questions
- hallucinate answers (TBC)

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

| Before (v0.4.2) | After |
| - | - |
| <img width="1060" src="https://github.com/sourcegraph/cody/assets/68532117/12d28a1d-0554-4aaa-8bc2-b385e89a551e"> | <img width="1060" src="https://github.com/sourcegraph/cody/assets/68532117/26c8150b-8905-454e-b59a-03a3d3d630e6"> |

Output from the same prompt

v0.4.2
![image](https://github.com/sourcegraph/cody/assets/68532117/61c39fdd-7795-4ad9-b872-e6bed4af68ee)

After
![image](https://github.com/sourcegraph/cody/assets/68532117/5f342d01-c4a5-44d5-8845-077d2a967c22)
