### PR TITLE
reuse SourcegraphCompletionsClient.complete across browser/node

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -1,13 +1,9 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source'
 
 import { SourcegraphCompletionsClient } from './client'
-import type { CompletionCallbacks, CompletionParameters, CompletionResponse, Event } from './types'
+import type { CompletionCallbacks, CompletionParameters, Event } from './types'
 
 export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsClient {
-    public complete(): Promise<CompletionResponse> {
-        throw new Error('SourcegraphBrowserCompletionsClient.complete not implemented')
-    }
-
     public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
         const abort = new AbortController()
         const headersInstance = new Headers(this.config.customHeaders as HeadersInit)

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -56,6 +56,45 @@ export abstract class SourcegraphCompletionsClient {
         }
     }
 
+    public async complete(params: CompletionParameters, abortSignal?: AbortSignal): Promise<CompletionResponse> {
+        const log = this.logger?.startCompletion(params)
+
+        const headers = new Headers(this.config.customHeaders as HeadersInit)
+        if (this.config.accessToken) {
+            headers.set('Authorization', `token ${this.config.accessToken}`)
+        }
+
+        const response = await fetch(this.codeCompletionsEndpoint, {
+            method: 'POST',
+            body: JSON.stringify(params),
+            headers,
+            signal: abortSignal,
+        })
+
+        const result = await response.text()
+
+        // When rate-limiting occurs, the response is an error message
+        if (response.status === 429) {
+            throw new Error(result)
+        }
+
+        try {
+            const response = JSON.parse(result) as CompletionResponse
+
+            if (typeof response.completion !== 'string' || typeof response.stopReason !== 'string') {
+                const message = `response does not satisfy CodeCompletionResponse: ${result}`
+                log?.onError(message)
+                throw new Error(message)
+            } else {
+                log?.onComplete(response)
+                return response
+            }
+        } catch (error) {
+            const message = `error parsing response CodeCompletionResponse: ${error}, response text: ${result}`
+            log?.onError(message)
+            throw new Error(message)
+        }
+    }
+
     public abstract stream(params: CompletionParameters, cb: CompletionCallbacks): () => void
-    public abstract complete(params: CompletionParameters, abortSignal?: AbortSignal): Promise<CompletionResponse>
 }


### PR DESCRIPTION
They both use the standard `fetch` API, so the impl can be shared.

Nothing was using the browser complete method yet, so this does not change anything today, it only allows future use of this by browser clients.

## Test plan

n/a