### PR TITLE
disable slow eslint no-deprecated rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ const config = {
   rules: {
     'import/order': 'off',
     'id-length': 'off',
+    'etc/no-deprecated': 'off', // slow
   },
   overrides: [
     {


### PR DESCRIPTION
Adds about ~500ms to some eslint invocations and is not critical.

## Test plan

n/a