### PR TITLE
fix Cody status bar icon in release builds

### DIFF
--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -8,7 +8,6 @@ playwright.config.ts
 vite.config.ts
 pnpm-lock.yaml
 node_modules/
-!node_modules/cody-icons-font/font/cody-icons.woff
 tsconfig.json
 .eslintignore
 scripts/

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -967,14 +967,14 @@
       "cody-logo": {
         "description": "Cody logo",
         "default": {
-          "fontPath": "node_modules/cody-icons-font/font/cody-icons.woff",
+          "fontPath": "resources/cody-icons.woff",
           "fontCharacter": "\\0041"
         }
       },
       "cody-logo-heavy": {
         "description": "Cody logo heavy",
         "default": {
-          "fontPath": "node_modules/cody-icons-font/font/cody-icons.woff",
+          "fontPath": "resources/cody-icons.woff",
           "fontCharacter": "\\0042"
         }
       }

--- a/vscode/resources/cody-icons.woff
+++ b/vscode/resources/cody-icons.woff
@@ -1,0 +1,1 @@
+../../lib/icons/font/cody-icons.woff


### PR DESCRIPTION
Even though the `.vscodeignore` intended to un-ignore `cody-icons.woff`, it was being ignored during the packaging process and the status bar icon was showing as a character similar to `B`.



## Test plan

Install from `.vsix` and confirm the status bar icon is correct.