### PR TITLE
add dev helpers to focus sidebar on startup or open trace view

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
       "outFiles": ["${workspaceRoot}/vscode/dist/**/*.js"],
       "env": {
         "NODE_ENV": "development",
-        "CODY_FOCUS_ON_STARTUP": "1"
+        "CODY_DEBUG_ENABLE": "true"
       }
     },
     {
@@ -39,8 +39,7 @@
       "env": {
         "NODE_ENV": "development",
         "CODY_PROFILE_TEMP": "true",
-        "CODY_DEBUG_ENABLE": "true",
-        "CODY_FOCUS_ON_STARTUP": "1"
+        "CODY_DEBUG_ENABLE": "true"
       }
     },
     {

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -69,3 +69,9 @@ VS Code will preserve some extension state (e.g., configuration settings) even w
 ```shell
 code --user-data-dir=/tmp/separate-vscode-instance --profile-temp
 ```
+
+## Development tips
+
+To open the Cody sidebar, autocomplete trace view, etc., when debugging starts, you can set hidden
+VS Code user settings. See [`src/dev/helpers.ts`](src/dev/helpers.ts) for a list of available
+options.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -9,7 +9,7 @@
   "description": "Code AI with codebase context",
   "scripts": {
     "dev": "pnpm run -s dev:desktop",
-    "dev:desktop": "pnpm run -s build:dev:desktop && CODY_FOCUS_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=. --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 --new-window . --goto ./src/logged-rerank.ts:16:5",
+    "dev:desktop": "pnpm run -s build:dev:desktop && CODY_FOCUS_SIDEBAR_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=. --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 --new-window . --goto ./src/logged-rerank.ts:16:5",
     "dev:web": "pnpm run -s build:dev:web && pnpm run -s _dev:vscode-test-web --browserType none",
     "watch:dev:web": "concurrently \"pnpm run -s watch:build:dev:web\" \"pnpm run -s _dev:vscode-test-web --browserType none\"",
     "_dev:vscode-test-web": "vscode-test-web --extensionDevelopmentPath=. ${WORKSPACE-test/fixtures/workspace}",

--- a/vscode/src/dev/helpers.ts
+++ b/vscode/src/dev/helpers.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode'
+
+/**
+ * A development helper that runs on activation to make the edit-debug loop easier by (e.g.) opening
+ * the Cody sidebar automatically on launch.
+ *
+ * The following VS Code settings are respected. (They are not part of this extension's contributed
+ * configuration JSON Schema, so they will not validate in your VS Code user settings file.)
+ *
+ * - `cody.dev.focusSidebarOnStartup`: boolean (or env var `CODY_FOCUS_SIDEBAR_ON_STARTUP`)
+ * - `cody.dev.openAutocompleteTraceView`: boolean
+ */
+export function onActivationDevelopmentHelpers(): void {
+    const settings = vscode.workspace.getConfiguration('cody.dev')
+
+    if (settings.get('focusSidebarOnStartup') || process.env.CODY_FOCUS_SIDEBAR_ON_STARTUP) {
+        void vscode.commands.executeCommand('cody.chat.focus')
+    }
+
+    if (settings.get('openAutocompleteTraceView')) {
+        void vscode.commands.executeCommand('cody.autocomplete.openTraceView')
+    }
+}

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -5,6 +5,7 @@ import { languagePromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/p
 import type { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/browserClient'
 import type { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
+import { onActivationDevelopmentHelpers } from './dev/helpers'
 import { ExtensionApi } from './extension-api'
 import type { FilenameContextFetcher } from './local-context/filename-context-fetcher'
 import type { LocalKeywordContextFetcher } from './local-context/local-keyword-context-fetcher'
@@ -32,18 +33,16 @@ export function activate(context: vscode.ExtensionContext, platformContext: Plat
     const api = new ExtensionApi()
     PromptMixin.add(languagePromptMixin(vscode.env.language))
 
-    if (process.env.CODY_FOCUS_ON_STARTUP) {
-        setTimeout(() => {
-            void vscode.commands.executeCommand('cody.chat.focus')
-        }, 250)
-    }
-
     start(context, platformContext)
         .then(disposable => {
             if (!context.globalState.get('extension.hasActivatedPreviously')) {
                 void context.globalState.update('extension.hasActivatedPreviously', 'true')
             }
             context.subscriptions.push(disposable)
+
+            if (process.env.NODE_ENV === 'development') {
+                onActivationDevelopmentHelpers()
+            }
         })
         .catch(error => console.error(error))
 


### PR DESCRIPTION
Previously, the Cody sidebar *always* opened upon startup during debugging. This was not needed for development on non-sidebar-related features. It is also nice to have a way to open the autocomplete trace view on startup.



## Test plan

n/a