### PR TITLE
use consistent language for insiders (builds vs. releases vs. channel)

### DIFF
--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Tip: Enable `cody.debug.enable` and `cody.debug.verbose` in VS Code settings dur
 
 ## Releases
 
-### Stable channel
+### Stable builds
 
 To publish a new release to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai):
 
@@ -35,11 +35,19 @@ To publish a new release to the [VS Code Marketplace](https://marketplace.visual
 1. `git push --tags`
 1. Wait for the [vscode-stable-release workflow](https://github.com/sourcegraph/cody/actions/workflows/vscode-stable-release.yml) run to finish.
 
-### Insiders channel
+### Insiders builds
 
 Insiders builds are nightly (or more frequent) builds with the latest from `main`. They're less stable but have the latest changes. Only use the insiders build if you want to test the latest changes.
 
-To use the Cody insiders build, install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and then select **Switch to Prerelease Version** in the extension's page.
+#### Using the insiders build
+
+To use the Cody insiders build in VS Code:
+
+1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+1. Select **Switch to Pre-release Version** in the extension's page in VS Code.
+1. Wait for it to download and install, and then reload (by pressing **Reload Required**).
+
+#### Publishing a new insiders build
 
 Insiders builds are published automatically daily at 1500 UTC using the [vscode-insiders-release workflow](https://github.com/sourcegraph/cody/actions/workflows/vscode-insiders-release.yml).
 

--- a/vscode/doc/releases.md
+++ b/vscode/doc/releases.md
@@ -6,16 +6,16 @@ Releases of Cody for VS Code are available at:
 - [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai)
 - [Manual `.vsix` downloads via GitHub releases](https://github.com/sourcegraph/cody/releases)
 
-## Stable releases
+## Stable builds
 
-Stable releases are published periodically to both marketplaces (generally several times per week) and have version numbers of the form `0.even.n`, where `even` is an even number (such as `0.6.5`).
+Stable builds are released periodically (generally several times per week) and have version numbers of the form `0.even.n`, where `even` is an even number (such as `0.6.5`).
 
-## Insiders releases
+## Insiders builds
 
-Insiders releases are published at least daily and have version numbers of the form `0.odd.timestamp`, where `odd` is an odd number (such as `0.7.1690496380`).
+Insiders builds are for early adopters who want to test the latest changes. They are published at least daily and have version numbers of the form `0.odd.timestamp`, where `odd` is an odd number (such as `0.7.1690496380`).
 
-In VS Code, to get the Cody insiders release:
+To use the Cody insiders build in VS Code:
 
-1. Install the Cody extension following the usual steps.
-1. In the VS Code extension sidebar, click on the gear icon next to Cody's entry in the list and select **Switch to Pre-release Version**.
+1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+1. Select **Switch to Pre-release Version** in the extension's page in VS Code.
 1. Wait for it to download and install, and then reload (by pressing **Reload Required**).


### PR DESCRIPTION
## Test plan

n/a; docs only