### PR TITLE
Add optional data parameter for client requests

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -97,6 +97,7 @@ export class Agent extends MessageHandler {
             }
             await client.executeRecipe(data.id, {
                 humanChatInput: data.humanChatInput,
+                data: data.data,
             })
             return null
         })

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -138,4 +138,5 @@ export interface RecipeInfo {
 export interface ExecuteRecipeParams {
     id: RecipeID
     humanChatInput: string
+    data?: any
 }

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -76,7 +76,7 @@ export type Notifications = {
     // The server received new messages for the ongoing 'chat/executeRecipe'
     // request. The server should never send this notification outside of a
     // 'chat/executeRecipe' request.
-    'chat/updateMessageInProgress': [ChatMessage | null]
+    'chat/updateMessageInProgress': [ChatMessage | null | { data?: any }]
 }
 
 export interface ClientInfo {

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -44,6 +44,7 @@ export interface Client {
         options?: {
             prefilledOptions?: PrefilledOptions
             humanChatInput?: string
+            data?: any // returned as is
         }
     ) => Promise<void>
     reset: () => void

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -15,6 +15,7 @@ export interface ChatMessage extends Message {
     contextFiles?: ContextFile[]
     pluginExecutionInfos?: PluginFunctionExecutionInfo[]
     buttons?: ChatButton[]
+    data?: any
 }
 
 export interface InteractionMessage extends Message {


### PR DESCRIPTION
Add an optional `data?: any` parameter that's returned as-is to clients. This allows us to add something like a `messageID` to completion requests and keep track of which request we're receiving back.

This is especially useful for streaming responses, where we'd like to be able to handle different streamed responses concurrently, and route them based on the message ID.

Also, instead of returning `null` when the message is done, it returns only the `data` field (if present). This way we know that that message is finished and we can handle it appropriately.

## Test plan

🤞 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
