### PR TITLE
Cody: Add dev:insiders command for VS Code

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -9,7 +9,9 @@
   "description": "Code AI with codebase context",
   "scripts": {
     "dev": "pnpm run -s dev:desktop",
+    "dev:insiders": "pnpm run -s dev:desktop:insiders",
     "dev:desktop": "pnpm run -s build:dev:desktop && CODY_FOCUS_SIDEBAR_ON_STARTUP=1 NODE_ENV=development code --extensionDevelopmentPath=. --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 --new-window . --goto ./src/logged-rerank.ts:16:5",
+    "dev:desktop:insiders": "pnpm run -s build:dev:desktop && CODY_FOCUS_SIDEBAR_ON_STARTUP=1 NODE_ENV=development code-insiders --extensionDevelopmentPath=. --disable-extension=sourcegraph.cody-ai --disable-extension=github.copilot --disable-extension=github.copilot-nightly --inspect-extensions=9333 --new-window . --goto ./src/logged-rerank.ts:16:5",
     "dev:web": "pnpm run -s build:dev:web && pnpm run -s _dev:vscode-test-web --browserType none",
     "watch:dev:web": "concurrently \"pnpm run -s watch:build:dev:web\" \"pnpm run -s _dev:vscode-test-web --browserType none\"",
     "_dev:vscode-test-web": "vscode-test-web --extensionDevelopmentPath=. ${WORKSPACE-test/fixtures/workspace}",


### PR DESCRIPTION
## Description

Quick command to run local dev in vscode insiders.

Aside from being a good way of testing new features, it has another benefit that it makes it super easy to open Cody in the same folder as you're currently working. Meaning you can dogfood stuff like `/fix` changes easier.

## Test plan

Checked runs locally