### PR TITLE
Cody: Rename confusing `selection` to `selectionRange`

### DIFF
--- a/lib/shared/src/chat/context.ts
+++ b/lib/shared/src/chat/context.ts
@@ -6,6 +6,6 @@ export interface ChatContextStatus {
     connection?: boolean
     codebase?: string
     filePath?: string
-    selection?: ActiveTextEditorSelectionRange
+    selectionRange?: ActiveTextEditorSelectionRange
     supportsKeyword?: boolean
 }

--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -5,7 +5,7 @@ export interface ActiveTextEditor {
     filePath: string
     repoName?: string
     revision?: string
-    selection?: ActiveTextEditorSelectionRange
+    selectionRange?: ActiveTextEditorSelectionRange
 }
 
 export interface ActiveTextEditorSelectionRange {

--- a/lib/ui/src/chat/inputContext/ChatInputContext.story.tsx
+++ b/lib/ui/src/chat/inputContext/ChatInputContext.story.tsx
@@ -60,7 +60,7 @@ export const CodebaseAndFileWithSelections: StoryObj<typeof meta> = {
                     codebase: 'github.com/sourcegraph/about',
                     filePath: 'path/to/file.go',
                     mode: 'embeddings',
-                    selection: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                    selectionRange: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                 }}
             />
             <ChatInputContext
@@ -68,7 +68,7 @@ export const CodebaseAndFileWithSelections: StoryObj<typeof meta> = {
                     codebase: 'github.com/sourcegraph/about',
                     filePath: 'path/to/file.go',
                     mode: 'embeddings',
-                    selection: { start: { line: 0, character: 0 }, end: { line: 1, character: 0 } },
+                    selectionRange: { start: { line: 0, character: 0 }, end: { line: 1, character: 0 } },
                 }}
             />
             <ChatInputContext
@@ -76,7 +76,7 @@ export const CodebaseAndFileWithSelections: StoryObj<typeof meta> = {
                     codebase: 'github.com/sourcegraph/about',
                     filePath: 'path/to/file.go',
                     mode: 'embeddings',
-                    selection: { start: { line: 0, character: 0 }, end: { line: 3, character: 0 } },
+                    selectionRange: { start: { line: 0, character: 0 }, end: { line: 3, character: 0 } },
                 }}
             />
             <ChatInputContext
@@ -84,7 +84,7 @@ export const CodebaseAndFileWithSelections: StoryObj<typeof meta> = {
                     codebase: 'github.com/sourcegraph/about',
                     filePath: 'path/to/file.go',
                     mode: 'embeddings',
-                    selection: { start: { line: 42, character: 333 }, end: { line: 420, character: 999 } },
+                    selectionRange: { start: { line: 42, character: 333 }, end: { line: 420, character: 999 } },
                 }}
             />
         </div>

--- a/lib/ui/src/chat/inputContext/ChatInputContext.tsx
+++ b/lib/ui/src/chat/inputContext/ChatInputContext.tsx
@@ -9,7 +9,7 @@ import { Icon } from '../../utils/Icon'
 
 import styles from './ChatInputContext.module.css'
 
-const formatFilePath = (filePath: string, selection: ChatContextStatus['selection']): string => {
+const formatFilePath = (filePath: string, selection: ChatContextStatus['selectionRange']): string => {
     const fileName = basename(filePath)
 
     if (!selection) {
@@ -57,7 +57,7 @@ export const ChatInputContext: React.FunctionComponent<{
             )}
             {contextStatus.filePath && (
                 <p className={styles.file} title={contextStatus.filePath}>
-                    {formatFilePath(contextStatus.filePath, contextStatus.selection)}
+                    {formatFilePath(contextStatus.filePath, contextStatus.selectionRange)}
                 </p>
             )}
         </div>

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -179,7 +179,7 @@ export class ContextProvider implements vscode.Disposable {
                     connection: this.codebaseContext.checkEmbeddingsConnection(),
                     codebase: this.codebaseContext.getCodebase(),
                     filePath: editorContext ? vscode.workspace.asRelativePath(editorContext.filePath) : undefined,
-                    selection: editorContext ? editorContext.selection : undefined,
+                    selectionRange: editorContext ? editorContext.selectionRange : undefined,
                     supportsKeyword: true,
                 },
             })

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -55,7 +55,7 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, M
         return {
             content: documentText,
             filePath: documentUri.fsPath,
-            selection: !documentSelection.isEmpty ? documentSelection : undefined,
+            selectionRange: !documentSelection.isEmpty ? documentSelection : undefined,
         }
     }
 


### PR DESCRIPTION
## Description

`ActiveTextEditor.selection` is super confusing because we also have `ActiveTextEditorSelection`. The latter is just for the selection contents, whereas the former is for the selection range.

Rename so people don't have to run into the same pain that I did

## Test plan

Name change only. Quick check that we don't have any usage that isn't picked up by TS