### PR TITLE
Autocomplete: Use IDE code navigation for context

### DIFF
--- a/vscode/src/completions/context/context-embeddings.ts
+++ b/vscode/src/completions/context/context-embeddings.ts
@@ -6,8 +6,9 @@ import * as vscode from 'vscode'
 
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 
+import { logCompletionEvent } from '../logger'
+
 import type { ReferenceSnippet } from './context'
-import { logCompletionEvent } from './logger'
 
 interface Options {
     document: vscode.TextDocument
@@ -84,6 +85,8 @@ async function fetchAndSaveEmbeddings(options: FetchEmbeddingsOptions): Promise<
             fileName: path.normalize(result.fileName),
         }))
         .filter(result => !currentFilePath.endsWith(result.fileName))
+
+    console.log({ embeddingResultsWithoutCurrentFile })
 
     embeddingsPerFile.set(currentFilePath, {
         embeddings: embeddingResultsWithoutCurrentFile.slice(0, NUM_CODE_RESULTS + NUM_TEXT_RESULTS - 1),

--- a/vscode/src/completions/context/context-local.ts
+++ b/vscode/src/completions/context/context-local.ts
@@ -2,9 +2,10 @@ import path from 'path'
 
 import * as vscode from 'vscode'
 
-import { bestJaccardMatch, JaccardMatch } from './bestJaccardMatch'
+import { bestJaccardMatch, JaccardMatch } from '../bestJaccardMatch'
+import { History } from '../history'
+
 import type { ReferenceSnippet } from './context'
-import { History } from './history'
 
 interface JaccardMatchWithFilename extends JaccardMatch {
     fileName: string

--- a/vscode/src/completions/context/context-vscode-nav.ts
+++ b/vscode/src/completions/context/context-vscode-nav.ts
@@ -1,0 +1,156 @@
+import * as vscode from 'vscode'
+
+import { debug } from '../../log'
+
+import type { ReferenceSnippet } from './context'
+
+interface Options {
+    document: vscode.TextDocument
+    position: vscode.Position
+}
+
+export async function getContextFromCodeNav(options: Options): Promise<ReferenceSnippet[]> {
+    function time<T>(promise: Thenable<T>, label: string): Promise<T> {
+        const start = performance.now()
+
+        return Promise.resolve(promise).then(result => {
+            console.log(`${label} duration`, performance.now() - start)
+            return result
+        })
+    }
+
+    const [
+        hoverResults,
+        // definitionResults,
+        typeDefinitionResults,
+        referenceResults,
+        // declarationsResults,
+        // implementationResults,
+    ] = await Promise.all([
+        time(
+            vscode.commands.executeCommand<vscode.Hover[]>(
+                'vscode.executeHoverProvider',
+                options.document.uri,
+                options.position
+            ),
+            'hover'
+        ),
+        // time(
+        //     vscode.commands.executeCommand<(vscode.Location | vscode.LocationLink)[]>(
+        //         'vscode.executeDefinitionProvider',
+        //         options.document.uri,
+        //         options.position
+        //     ),
+        //     'definition'
+        // ),
+        time(
+            vscode.commands.executeCommand<(vscode.Location | vscode.LocationLink)[]>(
+                'vscode.executeTypeDefinitionProvider',
+                options.document.uri,
+                options.position
+            ),
+            'typeDefinition'
+        ),
+        time(
+            vscode.commands.executeCommand<vscode.Location[]>(
+                'vscode.executeReferenceProvider',
+                options.document.uri,
+                options.position
+            ),
+            'reference'
+        ),
+        // time(
+        //     vscode.commands.executeCommand<(vscode.Location | vscode.LocationLink)[]>(
+        //         'vscode.executeDeclarationProvider',
+        //         options.document.uri,
+        //         options.position
+        //     ),
+        //     'declaration'
+        // ),
+        // time(
+        //     vscode.commands.executeCommand<(vscode.Location | vscode.LocationLink)[]>(
+        //         'vscode.executeImplementationProvider',
+        //         options.document.uri,
+        //         options.position
+        //     ),
+        //     'implementation'
+        // ),
+    ])
+
+    const hoverSnippets = hoverResults.flatMap(hoverToSnippets)
+
+    const [typeDefinitionSnippets, referenceSnippets] = await Promise.all([
+        Promise.all(typeDefinitionResults.flatMap(l => locationToSnippet('type-definition', l))),
+        Promise.all(referenceResults.flatMap(l => locationToSnippet('references', l))),
+    ])
+
+    console.log(typeDefinitionSnippets, referenceSnippets)
+    // console.log('code nav duration', performance.now() - start)
+
+    debug(
+        'CodeNavStuff',
+        'hover',
+        JSON.stringify(
+            {
+                hoverSnippets,
+                typeDefinitionSnippets,
+                referenceSnippets,
+            },
+            null,
+            2
+        )
+    )
+
+    return []
+}
+
+async function locationToSnippet(
+    label: string,
+    location: vscode.Location | vscode.LocationLink
+): Promise<ReferenceSnippet> {
+    const uri = 'uri' in location ? location.uri : location.targetUri
+    const doc = await vscode.workspace.openTextDocument(uri)
+    const range = 'range' in location ? location.range : location.targetRange
+    const content = doc.lineAt(range.start.line).text
+    return {
+        fileName: `${label}-context.${uri.toString().split('.').pop()}`,
+        content,
+    }
+}
+
+function hoverToSnippets(hover: vscode.Hover): ReferenceSnippet[] {
+    return (
+        hover.contents
+            .map((content: any) => content.value)
+            // This is a starter to detect errors shown in the hover widget, like the ones added via
+            // Pretty TypeScript Errors
+            .filter(content => !content.startsWith('<span'))
+            .map((content: string, index) => ({ content, fileName: `hover-context-${index}.md` }))
+    )
+}
+
+// new ApiCommand(
+//     'vscode.executeDefinitionProvider', '_executeDefinitionProvider', 'Execute all definition providers.',
+//     [ApiCommandArgument.Uri, ApiCommandArgument.Position],
+//     new ApiCommandResult<(languages.Location | languages.LocationLink)[], (types.Location | vscode.LocationLink)[] | undefined>('A promise that resolves to an array of Location or LocationLink instances.', mapLocationOrLocationLink)
+// ),
+// new ApiCommand(
+//     'vscode.executeTypeDefinitionProvider', '_executeTypeDefinitionProvider', 'Execute all type definition providers.',
+//     [ApiCommandArgument.Uri, ApiCommandArgument.Position],
+//     new ApiCommandResult<(languages.Location | languages.LocationLink)[], (types.Location | vscode.LocationLink)[] | undefined>('A promise that resolves to an array of Location or LocationLink instances.', mapLocationOrLocationLink)
+// ),
+// new ApiCommand(
+//     'vscode.executeDeclarationProvider', '_executeDeclarationProvider', 'Execute all declaration providers.',
+//     [ApiCommandArgument.Uri, ApiCommandArgument.Position],
+//     new ApiCommandResult<(languages.Location | languages.LocationLink)[], (types.Location | vscode.LocationLink)[] | undefined>('A promise that resolves to an array of Location or LocationLink instances.', mapLocationOrLocationLink)
+// ),
+// new ApiCommand(
+//     'vscode.executeImplementationProvider', '_executeImplementationProvider', 'Execute all implementation providers.',
+//     [ApiCommandArgument.Uri, ApiCommandArgument.Position],
+//     new ApiCommandResult<(languages.Location | languages.LocationLink)[], (types.Location | vscode.LocationLink)[] | undefined>('A promise that resolves to an array of Location or LocationLink instances.', mapLocationOrLocationLink)
+// ),
+// new ApiCommand(
+//     'vscode.executeReferenceProvider', '_executeReferenceProvider', 'Execute all reference providers.',
+//     [ApiCommandArgument.Uri, ApiCommandArgument.Position],
+//     new ApiCommandResult<languages.Location[], types.Location[] | undefined>('A promise that resolves to an array of Location-instances.', tryMapWith(typeConverters.location.to))
+// ),

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -9,7 +9,7 @@ import { debug } from '../log'
 import { CodyStatusBar } from '../services/StatusBar'
 
 import { CachedCompletions, CompletionsCache } from './cache'
-import { getContext, GetContextOptions, GetContextResult } from './context'
+import { getContext, GetContextOptions, GetContextResult } from './context/context'
 import { getCurrentDocContext } from './document'
 import { History } from './history'
 import * as CompletionLogger from './logger'
@@ -350,6 +350,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
 
         const contextResult = await this.config.contextFetcher({
             document,
+            position,
             prefix,
             suffix,
             history: this.config.history,


### PR DESCRIPTION

<img width="1251" alt="Screenshot 2023-07-31 at 13 27 31" src="https://github.com/sourcegraph/cody/assets/458591/ced9b9d6-744a-4a37-91ed-271c2368725c">
<img width="1163" alt="Screenshot 2023-07-31 at 13 26 18" src="https://github.com/sourcegraph/cody/assets/458591/89031b70-d7ef-4ab5-8e11-4c3af504b7f0">

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
