### PR TITLE
Autocomplete: Do not route completion start events via Enterprise instances

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -335,7 +335,14 @@ export class SourcegraphGraphQLAPIClient {
             console.log(`not logging ${event.event} in test mode`)
             return {}
         }
-        if (this.config.serverEndpoint === this.dotcomUrl) {
+
+        // The below events are high volume and cause a lot of noise and pressure on the backend.
+        // Since we only need them for debugging, we don't nee to route them to custom instances.
+        const exclusivelyRouteToDotcom =
+            event.event === 'CodyVSCodeExtension:completion:started' ||
+            event.event === 'CodyVSCodeExtension:completion:networkRequestStarted'
+
+        if (exclusivelyRouteToDotcom || this.config.serverEndpoint === this.dotcomUrl) {
             return this.sendEventLogRequestToDotComAPI(event)
         }
         const responses = await Promise.all([


### PR DESCRIPTION
The completion start events are only used for advanced analytics and are not necessary to collect on Enterprise instances. Furthermore they are actually causing a very high load and since Enterprise instances store these events in a pg table, we may run into issue if we collect them "just in case".

c.f. https://sourcegraph.slack.com/archives/CN4FC7XT4/p1690523927239279

## Test plan

- Add logging to both fetch methods
- Observe the right implementations are called

### When connected to S2
<img width="1305" alt="Screenshot 2023-07-31 at 13 45 30" src="https://github.com/sourcegraph/cody/assets/458591/28860e1a-d277-411a-822f-c23af9940916">

### When connected to Dotcom
<img width="1294" alt="Screenshot 2023-07-31 at 13 42 47" src="https://github.com/sourcegraph/cody/assets/458591/41c4eeea-79c0-4d0c-9470-e48a32695b47">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
