### PR TITLE
Add provider name to generated completions datasets

### DIFF
--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -106,10 +106,8 @@ const iterationsPerCodeSample = parseInt(process.env.ITER || '1', 10)
 // TODO: use VSCode mocked APIs to provide context for the completions provider
 // See vscode/src/completions/context.ts:10:23
 async function generateCompletionsForDataset(codeSamples: Sample[]): Promise<void> {
-    console.error('Generarting completions for dataset')
     const timestamp = Date.now().toString()
     const results: CompletionResult[] = []
-    console.log('We have entries', codeSamples.length)
     for (const [index, sample] of codeSamples.entries()) {
         const { content, fileName, languageId } = sample
         if (sampleIndex !== null && sampleIndex !== index) {


### PR DESCRIPTION
Small improvement to the `run-code-completions-on-dataset.ts` script. Use the provider name to name the generated completions dataset file.

## Test plan

- Generate test completions
- Dataset file will use the name of the configured provider
