### PR TITLE
rm unneeded check for cody scheme

### DIFF
--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -160,10 +160,6 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             this.abortOpenCompletions = () => abortController.abort()
         }
 
-        if (!vscode.window.activeTextEditor || document.uri.scheme === 'cody') {
-            return emptyCompletions()
-        }
-
         const docContext = getCurrentDocContext(document, position, this.maxPrefixChars, this.maxSuffixChars)
         if (!docContext) {
             return emptyCompletions()


### PR DESCRIPTION
This was only needed for the `cody:`-scheme document used for showing manual completions, which was removed (https://github.com/sourcegraph/cody/pull/326).



## Test plan

n/a