### PR TITLE
always use triggerMoreEagerly behavior (remove config to disable it)

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -26,7 +26,6 @@ export interface Configuration {
     autocompleteAdvancedAccessToken: string | null
     autocompleteAdvancedCache: boolean
     autocompleteAdvancedEmbeddings: boolean
-    autocompleteExperimentalTriggerMoreEagerly: boolean
     autocompleteExperimentalCompleteSuggestWidgetSelection?: boolean
     pluginsEnabled?: boolean
     pluginsDebugEnabled?: boolean

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -896,11 +896,6 @@
           "default": true,
           "markdownDescription": "Enables the use of embeddings as code completions context."
         },
-        "cody.autocomplete.experimental.triggerMoreEagerly": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Trigger autocomplete when the cursor is at the end of a word (instead of waiting for a space or other non-word character). Share feedback at https://github.com/sourcegraph/cody/discussions/274."
-        },
         "cody.autocomplete.experimental.completeSuggestWidgetSelection": {
           "type": "boolean",
           "default": false,

--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -89,8 +89,7 @@ describe('Cody completions', () => {
         code: string,
         responses?: CompletionResponse[] | 'stall',
         languageId?: string,
-        context?: vscode.InlineCompletionContext,
-        triggerMoreEagerly?: boolean
+        context?: vscode.InlineCompletionContext
     ) => Promise<{
         requests: CompletionParameters[]
         completions: vscode.InlineCompletionItem[]
@@ -101,8 +100,7 @@ describe('Cody completions', () => {
             code: string,
             responses?: CompletionResponse[] | 'stall',
             languageId: string = 'typescript',
-            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },
-            triggerMoreEagerly = true
+            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined }
         ): Promise<{
             requests: CompletionParameters[]
             completions: vscode.InlineCompletionItem[]
@@ -129,7 +127,6 @@ describe('Cody completions', () => {
                 history: new History(),
                 codebaseContext: null as any,
                 disableTimeouts: true,
-                triggerMoreEagerly,
                 cache,
             })
 
@@ -229,14 +226,9 @@ describe('Cody completions', () => {
         expect(requests[0].stopSequences).toEqual(['\n\nHuman:', '</CODE5711>', '\n\n'])
     })
 
-    it('makes a request when in the middle of a word when triggerMoreEagerly is true', async () => {
-        const { requests } = await complete('foo█', [completion`()`], undefined, undefined, true)
+    it('makes a request when in the middle of a word', async () => {
+        const { requests } = await complete('foo█', [completion`()`], undefined, undefined)
         expect(requests).toHaveLength(1)
-    })
-
-    it('does not make a request when in the middle of a word when triggerMoreEagerly is false', async () => {
-        const { requests } = await complete('foo█', undefined, undefined, undefined, false)
-        expect(requests).toHaveLength(0)
     })
 
     it('completes a single-line at the end of a sentence', async () => {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -16,25 +16,13 @@ interface CompletionEvent {
         languageId: string
 
         /**
-         * Whether the completion was triggered only because of the experimental settting
-         * `cody.autocomplete.experimental.triggerMoreEagerly`.
-         */
-        triggeredMoreEagerly: boolean
-
-        /**
          * Whether the completion was triggered only because of the experimental setting
          * `cody.autocomplete.experimental.completeSuggestWidgetSelection`.
          */
         triggeredForSuggestWidgetSelection: boolean
 
         /** Relevant user settings. */
-        settings: Record<
-            Extract<
-                ConfigKeys,
-                'autocompleteExperimentalTriggerMoreEagerly' | 'autocompleteExperimentalCompleteSuggestWidgetSelection'
-            >,
-            boolean
-        >
+        settings: Record<Extract<ConfigKeys, 'autocompleteExperimentalCompleteSuggestWidgetSelection'>, boolean>
     }
     // The timestamp when the request started
     startedAt: number

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -32,7 +32,6 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteAdvancedCache: true,
             autocompleteAdvancedEmbeddings: true,
-            autocompleteExperimentalTriggerMoreEagerly: true,
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
         })
     })
@@ -82,8 +81,6 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.advanced.embeddings':
                         return false
-                    case 'cody.autocomplete.experimental.triggerMoreEagerly':
-                        return false
                     case 'cody.autocomplete.experimental.completeSuggestWidgetSelection':
                         return false
                     case 'cody.plugins.enabled':
@@ -125,7 +122,6 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteAdvancedCache: false,
             autocompleteAdvancedEmbeddings: false,
-            autocompleteExperimentalTriggerMoreEagerly: false,
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
         })
     })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -77,10 +77,6 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         autocompleteAdvancedAccessToken: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedAccessToken, null),
         autocompleteAdvancedCache: config.get(CONFIG_KEY.autocompleteAdvancedCache, true),
         autocompleteAdvancedEmbeddings: config.get(CONFIG_KEY.autocompleteAdvancedEmbeddings, true),
-        autocompleteExperimentalTriggerMoreEagerly: config.get(
-            CONFIG_KEY.autocompleteExperimentalTriggerMoreEagerly,
-            true
-        ),
         autocompleteExperimentalCompleteSuggestWidgetSelection: config.get(
             CONFIG_KEY.autocompleteExperimentalCompleteSuggestWidgetSelection,
             false

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -422,7 +422,6 @@ function createCompletionsProvider(
         codebaseContext,
         cache: config.autocompleteAdvancedCache ? new CompletionsCache() : null,
         isEmbeddingsContextEnabled: config.autocompleteAdvancedEmbeddings,
-        triggerMoreEagerly: config.autocompleteExperimentalTriggerMoreEagerly,
         completeSuggestWidgetSelection: config.autocompleteExperimentalCompleteSuggestWidgetSelection,
     })
 

--- a/vscode/test/completions/completions-dataset.ts
+++ b/vscode/test/completions/completions-dataset.ts
@@ -560,7 +560,6 @@ export const completionsDataset: Sample[] = [
                 responses?: CompletionResponse[] | 'stall',
                 languageId?: string,
                 context?: vscode.InlineCompletionContext,
-                triggerMoreEagerly?: boolean
             ) => Promise<{
                 requests: CompletionParameters[]
                 completions: vscode.InlineCompletionItem[]
@@ -572,7 +571,6 @@ export const completionsDataset: Sample[] = [
                     responses?: CompletionResponse[] | 'stall',
                     languageId: string = 'typescript',
                     context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },
-                    triggerMoreEagerly = true
                 ): Promise<{
                     requests: CompletionParameters[]
                     completions: vscode.InlineCompletionItem[]

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -63,7 +63,6 @@ async function initCompletionsProvider(context: GetContextResult): Promise<CodyC
         history,
         codebaseContext,
         disableTimeouts: true,
-        triggerMoreEagerly: true,
         cache: null,
         isEmbeddingsContextEnabled: true,
         contextFetcher: () => Promise.resolve(context),


### PR DESCRIPTION
This behavior has been available for 3 weeks and default for 1 week. It has not generated any complaints, and it has coincided with a significant increase in completion acceptance rate and usage. Removing the ability to disable it seems safe and simplifies the code.



## Test plan

n/a