### PR TITLE
extract DocumentContext and rename currentLine{Prefix,Suffix}

### DIFF
--- a/vscode/src/completions/document.ts
+++ b/vscode/src/completions/document.ts
@@ -1,5 +1,19 @@
 import * as vscode from 'vscode'
 
+export interface DocumentContext {
+    prefix: string
+    suffix: string
+
+    /** Text before the cursor on the same line. */
+    currentLinePrefix: string
+
+    /** Text after the cursor on the same line. */
+    currentLineSuffix: string
+
+    prevNonEmptyLine: string
+    nextNonEmptyLine: string
+}
+
 /**
  * Get the current document context based on the cursor position in the current document.
  *
@@ -22,13 +36,7 @@ export function getCurrentDocContext(
     position: vscode.Position,
     maxPrefixLength: number,
     maxSuffixLength: number
-): {
-    prefix: string
-    suffix: string
-    prevLine: string
-    prevNonEmptyLine: string
-    nextNonEmptyLine: string
-} | null {
+): DocumentContext | null {
     const offset = document.offsetAt(position)
 
     const prefixLines = document.getText(new vscode.Range(new vscode.Position(0, 0), position)).split('\n')
@@ -61,7 +69,7 @@ export function getCurrentDocContext(
         }
     }
 
-    const prevLine = prefixLines[prefixLines.length - 1]
+    const currentLinePrefix = prefixLines[prefixLines.length - 1]
 
     let prefix: string
     if (offset > maxPrefixLength) {
@@ -90,10 +98,13 @@ export function getCurrentDocContext(
     }
     const suffix = suffixLines.slice(0, endLine).join('\n')
 
+    const currentLineSuffix = suffixLines[0]
+
     return {
         prefix,
         suffix,
-        prevLine,
+        currentLinePrefix,
+        currentLineSuffix,
         prevNonEmptyLine,
         nextNonEmptyLine,
     }

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -1,14 +1,17 @@
 import detectIndent from 'detect-indent'
 
+import { DocumentContext } from './document'
 import { getLanguageConfig } from './language'
 import { indentation } from './text-processing'
 import { getEditorTabSize, OPENING_BRACKET_REGEX, shouldIncludeClosingLine } from './utils/text-utils'
 
 export function detectMultiline(
-    prefix: string,
-    prevNonEmptyLine: string,
-    sameLinePrefix: string,
-    sameLineSuffix: string,
+    {
+        prefix,
+        prevNonEmptyLine,
+        currentLinePrefix,
+        currentLineSuffix,
+    }: Pick<DocumentContext, 'prefix' | 'prevNonEmptyLine' | 'currentLinePrefix' | 'currentLineSuffix'>,
     languageId: string,
     enableExtendedTriggers: boolean
 ): boolean {
@@ -17,17 +20,17 @@ export function detectMultiline(
         return false
     }
 
-    if (enableExtendedTriggers && sameLinePrefix.match(OPENING_BRACKET_REGEX)) {
+    if (enableExtendedTriggers && currentLinePrefix.match(OPENING_BRACKET_REGEX)) {
         return true
     }
 
     if (
-        sameLinePrefix.trim() === '' &&
-        sameLineSuffix.trim() === '' &&
+        currentLinePrefix.trim() === '' &&
+        currentLineSuffix.trim() === '' &&
         // Only trigger multiline suggestions for the beginning of blocks
         prefix.trim().at(prefix.trim().length - config.blockStart.length) === config.blockStart &&
         // Only trigger multiline suggestions when the new current line is indented
-        indentation(prevNonEmptyLine) < indentation(sameLinePrefix)
+        indentation(prevNonEmptyLine) < indentation(currentLinePrefix)
     ) {
         return true
     }


### PR DESCRIPTION
Just a type and naming improvement.



## Test plan

n/a; just a code refactor