### PR TITLE
disable telemetry when extension is running in dev or test mode

### DIFF
--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext, platformContext: Plat
             }
             context.subscriptions.push(disposable)
 
-            if (process.env.NODE_ENV === 'development') {
+            if (context.extensionMode === vscode.ExtensionMode.Development) {
                 onActivationDevelopmentHelpers()
             }
         })

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -87,7 +87,10 @@ const register = async (
 }> => {
     const disposables: vscode.Disposable[] = []
 
-    await createOrUpdateEventLogger(initialConfig, localStorage)
+    const isExtensionModeDevOrTest =
+        context.extensionMode === vscode.ExtensionMode.Development ||
+        context.extensionMode === vscode.ExtensionMode.Test
+    await createOrUpdateEventLogger(initialConfig, localStorage, isExtensionModeDevOrTest)
     const telemetryService = createVSCodeTelemetryService()
 
     // Controller for inline Chat
@@ -165,7 +168,7 @@ const register = async (
         contextProvider.configurationChangeEvent.event(async () => {
             const newConfig = await getFullConfig(secretStorage, localStorage)
             externalServicesOnDidConfigurationChange(newConfig)
-            await createOrUpdateEventLogger(newConfig, localStorage)
+            await createOrUpdateEventLogger(newConfig, localStorage, isExtensionModeDevOrTest)
         })
     )
 
@@ -399,7 +402,7 @@ const register = async (
         onConfigurationChange: newConfig => {
             contextProvider.onConfigurationChange(newConfig)
             externalServicesOnDidConfigurationChange(newConfig)
-            void createOrUpdateEventLogger(newConfig, localStorage)
+            void createOrUpdateEventLogger(newConfig, localStorage, isExtensionModeDevOrTest)
         },
     }
 }

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -14,9 +14,10 @@ const extensionDetails: ExtensionDetails = { ide: 'VSCode', ideExtensionType: 'C
 
 export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
-    localStorage: LocalStorage
+    localStorage: LocalStorage,
+    isExtensionModeDevOrTest: boolean
 ): Promise<void> {
-    if (config.telemetryLevel === 'off') {
+    if (config.telemetryLevel === 'off' || isExtensionModeDevOrTest) {
         eventLogger = null
         return
     }


### PR DESCRIPTION
I noticed this interfering with my own "organic" telemetry and making it harder for me to understand my own usage of Cody. Now, only usage in the main VS Code window (not in a test, and not in a debug extension host instance) counts. This could increase the likelihood of errors in our actual telemetry, but that is mitigated by our heavy use of the Cody insiders build.



## Test plan

n/a