### PR TITLE
extract History to DocumentHistory

### DIFF
--- a/vscode/src/completions/completion.test.ts
+++ b/vscode/src/completions/completion.test.ts
@@ -12,7 +12,7 @@ import { vsCodeMocks } from '../testutils/mocks'
 
 import { CodyCompletionItemProvider } from '.'
 import { CompletionsCache } from './cache'
-import { History } from './history'
+import { VSCodeDocumentHistory } from './history'
 import { createProviderConfig } from './providers/anthropic'
 
 const CURSOR_MARKER = '█'
@@ -126,7 +126,7 @@ describe('Cody completions', () => {
             const completionProvider = new CodyCompletionItemProvider({
                 providerConfig,
                 statusBar: noopStatusBar,
-                history: new History(),
+                history: new VSCodeDocumentHistory(),
                 codebaseContext: null as any,
                 disableTimeouts: true,
                 triggerMoreEagerly,

--- a/vscode/src/completions/context-local.ts
+++ b/vscode/src/completions/context-local.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode'
 
 import { bestJaccardMatch, JaccardMatch } from './bestJaccardMatch'
 import type { ReferenceSnippet } from './context'
-import { History } from './history'
+import { DocumentHistory } from './history'
 
 interface JaccardMatchWithFilename extends JaccardMatch {
     fileName: string
@@ -12,7 +12,7 @@ interface JaccardMatchWithFilename extends JaccardMatch {
 
 interface Options {
     document: vscode.TextDocument
-    history: History
+    history: DocumentHistory
     prefix: string
     jaccardDistanceWindowSize: number
 }
@@ -57,7 +57,10 @@ interface FileContents {
  * For every file, we will load up to 10.000 lines to avoid OOMing when working with very large
  * files.
  */
-async function getRelevantFiles(currentDocument: vscode.TextDocument, history: History): Promise<FileContents[]> {
+async function getRelevantFiles(
+    currentDocument: vscode.TextDocument,
+    history: DocumentHistory
+): Promise<FileContents[]> {
     const files: FileContents[] = []
 
     const curLang = currentDocument.languageId

--- a/vscode/src/completions/context.ts
+++ b/vscode/src/completions/context.ts
@@ -4,7 +4,7 @@ import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 
 import { getContextFromEmbeddings } from './context-embeddings'
 import { getContextFromCurrentEditor } from './context-local'
-import { History } from './history'
+import { DocumentHistory } from './history'
 
 /**
  * Keep property names in sync with the `EmbeddingsSearchResult` type.
@@ -16,7 +16,7 @@ export interface ReferenceSnippet {
 
 export interface GetContextOptions {
     document: vscode.TextDocument
-    history: History
+    history: DocumentHistory
     prefix: string
     suffix: string
     jaccardDistanceWindowSize: number

--- a/vscode/src/completions/history.ts
+++ b/vscode/src/completions/history.ts
@@ -4,7 +4,12 @@ export interface HistoryItem {
     document: Pick<vscode.TextDocument, 'uri' | 'languageId'>
 }
 
-export class History implements vscode.Disposable {
+export interface DocumentHistory {
+    addItem(newItem: HistoryItem): void
+    lastN(n: number, languageId?: string, ignoreUris?: vscode.Uri[]): HistoryItem[]
+}
+
+export class VSCodeDocumentHistory implements DocumentHistory, vscode.Disposable {
     private window = 50
 
     // tracks history in chronological order (latest at the end of the array)

--- a/vscode/src/completions/index.ts
+++ b/vscode/src/completions/index.ts
@@ -11,7 +11,7 @@ import { CodyStatusBar } from '../services/StatusBar'
 import { CachedCompletions, CompletionsCache } from './cache'
 import { getContext, GetContextOptions, GetContextResult } from './context'
 import { getCurrentDocContext } from './document'
-import { History } from './history'
+import { DocumentHistory } from './history'
 import * as CompletionLogger from './logger'
 import { detectMultiline } from './multiline'
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './providers/provider'
@@ -22,7 +22,7 @@ import { isAbortError, SNIPPET_WINDOW_SIZE } from './utils'
 
 interface CodyCompletionItemProviderConfig {
     providerConfig: ProviderConfig
-    history: History
+    history: DocumentHistory
     statusBar: CodyStatusBar
     codebaseContext: CodebaseContext
     responsePercentage?: number

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -12,7 +12,7 @@ import { MessageProviderOptions } from './chat/MessageProvider'
 import { CODY_FEEDBACK_URL } from './chat/protocol'
 import { CodyCompletionItemProvider } from './completions'
 import { CompletionsCache } from './completions/cache'
-import { History } from './completions/history'
+import { VSCodeDocumentHistory } from './completions/history'
 import * as CompletionsLogger from './completions/logger'
 import { createProviderConfig } from './completions/providers/createProvider'
 import { registerAutocompleteTraceView } from './completions/tracer/traceView'
@@ -413,7 +413,7 @@ function createCompletionsProvider(
 ): vscode.Disposable {
     const disposables: vscode.Disposable[] = []
 
-    const history = new History()
+    const history = new VSCodeDocumentHistory()
     const providerConfig = createProviderConfig(config, webviewErrorMessenger, completionsClient)
     const completionsProvider = new CodyCompletionItemProvider({
         providerConfig,

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -13,7 +13,7 @@ import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { CodyCompletionItemProvider } from '../../src/completions'
 import { GetContextResult } from '../../src/completions/context'
-import { History } from '../../src/completions/history'
+import { VSCodeDocumentHistory } from '../../src/completions/history'
 import { createProviderConfig } from '../../src/completions/providers/createProvider'
 import { getFullConfig } from '../../src/configuration'
 import { configureExternalServices } from '../../src/external-services'
@@ -50,7 +50,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<CodyC
         { createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args) }
     )
 
-    const history = new History()
+    const history = new VSCodeDocumentHistory()
 
     const providerConfig = createProviderConfig(initialConfig, console.error, completionsClient)
 

--- a/vscode/test/integration/api.test.ts
+++ b/vscode/test/integration/api.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 import * as vscode from 'vscode'
 
-import { History } from '../../src/completions/history'
+import { VSCodeDocumentHistory } from '../../src/completions/history'
 
 suite('API tests', () => {
     test('Cody registers some commands', async () => {
@@ -13,7 +13,7 @@ suite('API tests', () => {
     })
 
     test('History', () => {
-        const h = new History(() => null)
+        const h = new VSCodeDocumentHistory(() => null)
         h.addItem({
             document: {
                 uri: vscode.Uri.file('foo.ts'),


### PR DESCRIPTION
`class History -> interface DocumentHistory, class VSCodeDocumentHistory`

Just a code refactor.



## Test plan

n/a