### PR TITLE
move provider to vscodeInlineCompletionItemProvider.ts

### DIFF
--- a/vscode/src/completions/cache.ts
+++ b/vscode/src/completions/cache.ts
@@ -1,7 +1,7 @@
 import { LRUCache } from 'lru-cache'
 
-import { Completion } from '.'
 import { trimEndOnLastLineIfWhitespaceOnly } from './text-processing'
+import { Completion } from './vscodeInlineCompletionItemProvider'
 
 export interface CachedCompletions {
     logId: string

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -4,7 +4,6 @@ import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
 import { CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-import { Completion } from '..'
 import { ReferenceSnippet } from '../context'
 import {
     CLOSING_CODE_TAG,
@@ -16,6 +15,7 @@ import {
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
 import { batchCompletions, messagesToText } from '../utils'
+import { Completion } from '../vscodeInlineCompletionItemProvider'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -1,7 +1,7 @@
 import { CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-import { Completion } from '..'
 import { ReferenceSnippet } from '../context'
+import { Completion } from '../vscodeInlineCompletionItemProvider'
 
 export interface ProviderConfig {
     /**

--- a/vscode/src/completions/providers/unstable-azure-openai.ts
+++ b/vscode/src/completions/providers/unstable-azure-openai.ts
@@ -1,7 +1,7 @@
-import { Completion } from '..'
 import { logger } from '../../log'
 import { ReferenceSnippet } from '../context'
 import { getHeadAndTail } from '../text-processing'
+import { Completion } from '../vscodeInlineCompletionItemProvider'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -1,9 +1,9 @@
 import fetch from 'isomorphic-fetch'
 
-import { Completion } from '..'
 import { logger } from '../../log'
 import { ReferenceSnippet } from '../context'
 import { isAbortError } from '../utils'
+import { Completion } from '../vscodeInlineCompletionItemProvider'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -1,10 +1,10 @@
 import fetch from 'isomorphic-fetch'
 
-import { Completion } from '..'
 import { logger } from '../../log'
 import { ReferenceSnippet } from '../context'
 import { getLanguageConfig } from '../language'
 import { isAbortError } from '../utils'
+import { Completion } from '../vscodeInlineCompletionItemProvider'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -1,10 +1,10 @@
 import fetch from 'isomorphic-fetch'
 
-import { Completion } from '..'
 import { logger } from '../../log'
 import { ReferenceSnippet } from '../context'
 import { getLanguageConfig } from '../language'
 import { isAbortError } from '../utils'
+import { Completion } from '../vscodeInlineCompletionItemProvider'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { vsCodeMocks } from '../testutils/mocks'
 
-import { Completion } from '.'
 import { CompletionsCache } from './cache'
 import { Provider } from './providers/provider'
 import { RequestManager } from './request-manager'
+import { Completion } from './vscodeInlineCompletionItemProvider'
 
 vi.mock('vscode', () => vsCodeMocks)
 

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -1,8 +1,8 @@
-import { Completion } from '.'
 import { CompletionsCache } from './cache'
 import { ReferenceSnippet } from './context'
 import { logCompletionEvent } from './logger'
 import { CompletionProviderTracer, Provider } from './providers/provider'
+import { Completion } from './vscodeInlineCompletionItemProvider'
 
 interface Request {
     prefix: string

--- a/vscode/src/completions/shared-post-process.ts
+++ b/vscode/src/completions/shared-post-process.ts
@@ -1,6 +1,6 @@
-import { Completion } from '.'
 import { truncateMultilineCompletion } from './multiline'
 import { collapseDuplicativeWhitespace, trimUntilSuffix } from './text-processing'
+import { Completion } from './vscodeInlineCompletionItemProvider'
 
 /**
  * This function implements post-processing logic that is applied regardless of

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { isDefined } from '@sourcegraph/cody-shared'
 import { renderMarkdown } from '@sourcegraph/cody-shared/src/common/markdown'
 
-import { CodyCompletionItemProvider } from '..'
+import { InlineCompletionItemProvider } from '../vscodeInlineCompletionItemProvider'
 
 import { ProvideInlineCompletionsItemTraceData } from '.'
 
@@ -11,7 +11,7 @@ import { ProvideInlineCompletionsItemTraceData } from '.'
  * Registers a command `Cody: Open Autocomplete Trace View` that shows the context and prompt used
  * for autocomplete.
  */
-export function registerAutocompleteTraceView(completionsProvider: CodyCompletionItemProvider): vscode.Disposable {
+export function registerAutocompleteTraceView(provider: InlineCompletionItemProvider): vscode.Disposable {
     let panel: vscode.WebviewPanel | null = null
     let latestInvocationSequence = 0
 
@@ -26,13 +26,13 @@ export function registerAutocompleteTraceView(completionsProvider: CodyCompletio
                 }
             )
             panel.onDidDispose(() => {
-                completionsProvider.setTracer(null)
+                provider.setTracer(null)
                 panel = null
             })
 
             panel.webview.html = renderWebviewHtml(undefined)
 
-            completionsProvider.setTracer(data => {
+            provider.setTracer(data => {
                 if (!panel) {
                     return
                 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
@@ -14,10 +14,10 @@ import { CodyStatusBar } from '../services/StatusBar'
 import { vsCodeMocks } from '../testutils/mocks'
 import { wrapVSCodeTextDocument } from '../testutils/textDocument'
 
-import { CodyCompletionItemProvider } from '.'
 import { CompletionsCache } from './cache'
 import { DocumentHistory } from './history'
 import { createProviderConfig } from './providers/anthropic'
+import { InlineCompletionItemProvider } from './vscodeInlineCompletionItemProvider'
 
 const CURSOR_MARKER = '█'
 
@@ -138,7 +138,7 @@ describe('Cody completions', () => {
                 completionsClient,
                 contextWindowTokens: 2048,
             })
-            const completionProvider = new CodyCompletionItemProvider({
+            const completionProvider = new InlineCompletionItemProvider({
                 providerConfig,
                 statusBar: NOOP_STATUS_BAR,
                 history: DUMMY_DOCUMENT_HISTORY,

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -36,7 +36,7 @@ interface CodyCompletionItemProviderConfig {
     contextFetcher?: (options: GetContextOptions) => Promise<GetContextResult>
 }
 
-export class CodyCompletionItemProvider implements vscode.InlineCompletionItemProvider {
+export class InlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private promptChars: number
     private maxPrefixChars: number
     private maxSuffixChars: number

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -10,12 +10,12 @@ import { ContextProvider } from './chat/ContextProvider'
 import { InlineChatViewManager } from './chat/InlineChatViewProvider'
 import { MessageProviderOptions } from './chat/MessageProvider'
 import { CODY_FEEDBACK_URL } from './chat/protocol'
-import { CodyCompletionItemProvider } from './completions'
 import { CompletionsCache } from './completions/cache'
 import { VSCodeDocumentHistory } from './completions/history'
 import * as CompletionsLogger from './completions/logger'
 import { createProviderConfig } from './completions/providers/createProvider'
 import { registerAutocompleteTraceView } from './completions/tracer/traceView'
+import { InlineCompletionItemProvider } from './completions/vscodeInlineCompletionItemProvider'
 import { getConfiguration, getFullConfig } from './configuration'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { PlatformContext } from './extension.common'
@@ -418,7 +418,7 @@ function createCompletionsProvider(
 
     const history = new VSCodeDocumentHistory()
     const providerConfig = createProviderConfig(config, webviewErrorMessenger, completionsClient)
-    const completionsProvider = new CodyCompletionItemProvider({
+    const completionsProvider = new InlineCompletionItemProvider({
         providerConfig,
         history,
         statusBar,

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -11,10 +11,10 @@ import { NoopEditor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { CodyCompletionItemProvider } from '../../src/completions'
 import { GetContextResult } from '../../src/completions/context'
 import { VSCodeDocumentHistory } from '../../src/completions/history'
 import { createProviderConfig } from '../../src/completions/providers/createProvider'
+import { InlineCompletionItemProvider } from '../../src/completions/vscodeInlineCompletionItemProvider'
 import { getFullConfig } from '../../src/configuration'
 import { configureExternalServices } from '../../src/external-services'
 import { InMemorySecretStorage } from '../../src/services/SecretStorageProvider'
@@ -27,7 +27,7 @@ import { findSubstringPosition } from './utils'
 let didLogConfig = false
 let providerName: string
 
-async function initCompletionsProvider(context: GetContextResult): Promise<CodyCompletionItemProvider> {
+async function initCompletionsProvider(context: GetContextResult): Promise<InlineCompletionItemProvider> {
     const secretStorage = new InMemorySecretStorage()
     await secretStorage.store('cody.access-token', ENVIRONMENT_CONFIG.SOURCEGRAPH_ACCESS_TOKEN)
 
@@ -54,7 +54,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<CodyC
 
     const providerConfig = createProviderConfig(initialConfig, console.error, completionsClient)
 
-    const completionsProvider = new CodyCompletionItemProvider({
+    const completionsProvider = new InlineCompletionItemProvider({
         providerConfig,
         statusBar: {
             startLoading: () => () => {},


### PR DESCRIPTION
No impl changes. This is just so that we can better separate the VS Code-specific stuff from the rest (and helps with future commits).

This is an intermediate commit that will make our history cleaner. I submitted it as a separate PR so that the Git history includes the rename as an atomic operation.

## Test plan

n/a