### PR TITLE
never build deasync to speed up and de-flake builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
           "tslib": "^2.1.0"
         }
       }
-    }
+    },
+    "neverBuiltDependencies": [
+      "deasync"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+neverBuiltDependencies:
+  - deasync
+
 overrides:
   tslib: 2.1.0
 
@@ -7813,7 +7816,6 @@ packages:
   /deasync@0.1.28:
     resolution: {integrity: sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==}
     engines: {node: '>=0.11.0'}
-    requiresBuild: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 1.7.2


### PR DESCRIPTION
The completions-review-tool uses remix, which uses deasync, which only has prebuilt binaries for older Node.js versions (https://github.com/abbr/deasync-bin). This means that CI takes 1-2 extra minutes and is flakier due to node-gyp being invoked each time. This commit skips the node-gyp build of deasync. It may break some aspects of the completion-review-tool (although it seems to work fine), but that's an acceptable tradeoff for now because that is a dev-only tool and we can revert this commit if it is needed.



## Test plan

n/a