### PR TITLE
try to show completion when suggest widget is showing

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 
 import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { ConfigKeys } from '../configuration-keys'
 import { debug } from '../log'
 import { logEvent } from '../services/EventLogger'
 
@@ -14,15 +13,6 @@ interface CompletionEvent {
         multilineMode: null | 'block'
         providerIdentifier: string
         languageId: string
-
-        /**
-         * Whether the completion was triggered only because of the experimental setting
-         * `cody.autocomplete.experimental.completeSuggestWidgetSelection`.
-         */
-        triggeredForSuggestWidgetSelection: boolean
-
-        /** Relevant user settings. */
-        settings: Record<Extract<ConfigKeys, 'autocompleteExperimentalCompleteSuggestWidgetSelection'>, boolean>
     }
     // The timestamp when the request started
     startedAt: number

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
@@ -264,16 +264,15 @@ describe('Cody completions', () => {
         `)
     })
 
-    it('does not make a request when context has a selectedCompletionInfo', async () => {
-        const { requests } = await complete('foo = █', undefined, undefined, {
+    it('makes a request when context has a selectedCompletionInfo', async () => {
+        const { completions } = await complete('foo█', [completion`123`], undefined, {
             selectedCompletionInfo: {
                 range: new vsCodeMocks.Range(0, 0, 0, 3),
-                text: 'something',
+                text: 'foo123',
             },
             triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Invoke,
         })
-
-        expect(requests).toHaveLength(0)
+        expect(completions[0].insertText).toBe('123')
     })
 
     it('preserves leading whitespace when prefix has no trailing whitespace', async () => {

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -170,17 +170,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             this.config.providerConfig.enableExtendedMultilineTriggers
         )
 
-        let triggeredForSuggestWidgetSelection: string | undefined
-        if (context.selectedCompletionInfo) {
-            if (this.config.completeSuggestWidgetSelection) {
-                triggeredForSuggestWidgetSelection = context.selectedCompletionInfo.text
-            } else {
-                // Don't show completions if the suggest widget (which shows language autocomplete)
-                // is showing.
-                return emptyCompletions()
-            }
-        }
-
         // If we have a suffix in the same line as the cursor and the suffix contains any word
         // characters, do not attempt to make a completion. This means we only make completions if
         // we have a suffix in the same line for special characters like `)]}` etc.
@@ -229,12 +218,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                   multiline,
                   providerIdentifier: this.config.providerConfig.identifier,
                   languageId: document.languageId,
-                  triggeredForSuggestWidgetSelection: triggeredForSuggestWidgetSelection !== undefined,
-                  settings: {
-                      autocompleteExperimentalCompleteSuggestWidgetSelection: Boolean(
-                          this.config.completeSuggestWidgetSelection
-                      ),
-                  },
               })
         this.previousCompletionLogId = logId
 


### PR DESCRIPTION
Even when `cody.autocomplete.experimental.completeSuggestWidgetSelection` is false, still try to return a completion even if the suggest widget is showing. This completion will often not be shown to the user (but we now check for that case in telemetry). This removes complexity from the provider code.

## Test plan

Set `editor.inlineSuggest.suppressSuggestions` to true. See that Cody autocomplete shows up when the insertText of the suggest widget selection matches the prefix of the completion (even without enabling the Cody experimental setting).