### PR TITLE
do not swallow provideInlineCompletionItems exception

### DIFF
--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -139,7 +139,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 debug('CodyCompletionProvider:inline:error', `${error.toString()}\n${error.stack}`)
             }
 
-            return emptyCompletions()
+            throw error
         }
     }
 


### PR DESCRIPTION
Previously, we swallowed any exceptions here and just returned empty. Now we re-throw the error after logging it. This has no change in behavior, since VS Code already catches and logs any exceptions from inline completion item providers, treating them as `[]`. It does make it easier for us to identify bugs.

To confirm that VS Code catches these exceptions and logs them, see the `Extension Host` output channel:

```
2023-07-31 21:25:37.693 [error] [sourcegraph.cody-ai] provider FAILED
2023-07-31 21:25:37.694 [error] Error: asdf
    at InlineCompletionItemProvider.provideInlineCompletionItems (/home/sqs/src/github.com/sourcegraph/cody/vscode/src/completions/vscodeInlineCompletionItemProvider.ts:129:19)
...
```

I also triggered it more than 10 times to see if it eventually would terminate a provider that frequently errors. It does not.



## Test plan

As described above.