### PR TITLE
skip flaky `Cody Fixup Task Controller` integration test

### DIFF
--- a/vscode/test/integration/task-controller.test.ts
+++ b/vscode/test/integration/task-controller.test.ts
@@ -12,7 +12,8 @@ async function getFixupController(): Promise<FixupController> {
     return fixups
 }
 
-suite('Cody Fixup Task Controller', function () {
+// TODO: Skipped due to flakiness (https://github.com/sourcegraph/cody/pull/481).
+suite.skip('Cody Fixup Task Controller', function () {
     this.beforeEach(() => beforeIntegrationTest())
     this.afterEach(() => afterIntegrationTest())
 


### PR DESCRIPTION
Example of flake: https://github.com/sourcegraph/cody/actions/runs/5722519632/job/15505777631



## Test plan

n/a