### PR TITLE
return completions from the start of current line to reduce VS Code UI jitter

### DIFF
--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
@@ -131,11 +131,21 @@ describe('Cody completions', () => {
 
             const { document, position } = documentAndPosition(code, languageId)
 
-            const completions = await completionProvider.provideInlineCompletionItems(document, position, context)
+            const result = await completionProvider.provideInlineCompletionItems(document, position, context)
+            const completions = 'items' in result ? result.items : result
+
+            // The provider returns completions with text starting at the beginning of the
+            // current line (to reduce jitter in VS Code), but for testing, it's simpler to
+            // omit that prefix.
+            const completionsWithCurrentLinePrefixRemoved = completions.map(c => ({
+                ...c,
+                insertText: (c.insertText as string).slice(position.character),
+                range: c.range?.with({ start: position }),
+            }))
 
             return {
                 requests,
-                completions: 'items' in completions ? completions.items : completions,
+                completions: completionsWithCurrentLinePrefixRemoved,
             }
         }
     })

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -469,13 +469,16 @@ function toInlineCompletionItems(
 ): vscode.InlineCompletionList {
     return {
         items: completions.map(completion => {
-            const lines = completion.content.split(/\r\n|\r|\n/).length
-            const currentLineText = document.lineAt(position)
-            const endOfLine = currentLineText.range.end
-            return new vscode.InlineCompletionItem(completion.content, new vscode.Range(position, endOfLine), {
+            // Return the completion from the start of the current line (instead of starting at the
+            // given position). This avoids UI jitter in VS Code; when typing or deleting individual
+            // characters, VS Code reuses the existing completion while it waits for the new one to
+            // come in.
+            const currentLine = document.lineAt(position)
+            const currentLinePrefix = document.getText(currentLine.range.with({ end: position }))
+            return new vscode.InlineCompletionItem(currentLinePrefix + completion.content, currentLine.range, {
                 title: 'Completion accepted',
                 command: 'cody.autocomplete.inline.accepted',
-                arguments: [{ codyLogId: logId, codyLines: lines }],
+                arguments: [{ codyLogId: logId, codyLines: completion.content.split(/\r\n|\r|\n/).length }],
             })
         }),
     }


### PR DESCRIPTION
This reduces UI jitter in VS Code; when typing or deleting individual characters, VS Code reuses the existing completion while it waits for the new one to come in. This is also accomplished by our existing caching when forward-typing, but this even further reduces it.



## Test plan

Type `const country =` and wait for it to suggest something like `'USA'`. Type the first few letters of the suggestion then delete. With this change, the suggestion still displays. Without this change, it disappears.