### PR TITLE
Autocomplete: Add infilling test case and capture new StarCoder 7b results

### DIFF
--- a/completions-review-tool/data/anthropic-1690966785443.json
+++ b/completions-review-tool/data/anthropic-1690966785443.json
@@ -1,10 +1,10 @@
 [
   {
     "completions": [
-      "signale.info(message)"
+      "    signale.info(message)"
     ],
-    "elapsed": 1499,
-    "timestamp": "1690287745522",
+    "elapsed": 869,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [],
       "fileName": "logger.ts",
@@ -14,10 +14,12 @@
   },
   {
     "completions": [
-      "const date = new Date()\n    const dateString = date.toISOString()\n    const filePath = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(filePath, dateString)"
+      "    const dateString = new Date().toLocaleString()  \n    const filePath = path.join(__dirname, 'date.txt')  \n    fs.writeFile(filePath, dateString, err => {\n        if (err) {\n            console.error(err)\n            return\n        }\n        console.log(`The current date has been written to ${filePath}`)  \n    })",
+      "    const dateString = new Date().toLocaleString()  \n    const filePath = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(filePath, dateString, 'utf8')",
+      "    const dateString = new Date().toDateString()  \n    const filePath = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(filePath, dateString)"
     ],
-    "elapsed": 4389,
-    "timestamp": "1690287745522",
+    "elapsed": 3457,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [],
       "fileName": "writer.ts",
@@ -27,10 +29,12 @@
   },
   {
     "completions": [
-      "if (typeof position === 'number') {\n            position = new vscode.Position(position, 0)\n        }\n        let lineText = this.lines[position.line]\n        return new TextLine(this, position, lineText)"
+      "        const lineNumber = position instanceof vscode.Position ? position.line : Math.floor(position / this.lines[0].length);\n        return {\n            text: this.lines[lineNumber],\n            range: new vscode.Range(position, position)\n        }",
+      "        let lineNumber = position.line || this.lineAt(position).line\n        return new vscode.TextLine(this, lineNumber)",
+      "        const line = Math.floor(position / this.getLineLength(position)) + 1\n        return new vscode.TextLine(this, line)"
     ],
-    "elapsed": 15840,
-    "timestamp": "1690287745522",
+    "elapsed": 3177,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [],
       "fileName": "text-document.ts",
@@ -40,10 +44,12 @@
   },
   {
     "completions": [
-      "return null\n    }"
+      "        try {\n                const { platform } = require('os');\n                return platform; \n            } catch (err) {\n                return null;\n            }\n        }\n        return null;",
+      "        try {\n            const {platform} = require('os'); \n            return platform;  \n        } catch(err) { \n            return null;\n        }\n    }",
+      "        try {\n            return execFileSync('uname').toString().trim()\n        } catch (e) {\n            return null\n        }\n    }"
     ],
-    "elapsed": 25022,
-    "timestamp": "1690287745522",
+    "elapsed": 3374,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [],
       "fileName": "getOs.ts",
@@ -53,10 +59,10 @@
   },
   {
     "completions": [
-      "Media('(prefers-color-scheme: dark)').matches;"
+      "    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;"
     ],
-    "elapsed": 1968,
-    "timestamp": "1690287745522",
+    "elapsed": 720,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [],
       "fileName": "isDarkColorScheme.ts",
@@ -66,10 +72,10 @@
   },
   {
     "completions": [
-      ".includes(\"localhost\")"
+      "    return window.location.host === 'localhost';"
     ],
-    "elapsed": 1019,
-    "timestamp": "1690287745522",
+    "elapsed": 819,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [],
       "fileName": "isLocalhost.ts",
@@ -79,10 +85,25 @@
   },
   {
     "completions": [
-      "return text.replace(/[^\\w-]+/g, \"-\").replace(/(^-+|-+$)/g, \"\");"
+      "     * Wether to include documentation comments in the completion."
     ],
-    "elapsed": 7792,
-    "timestamp": "1690287745522",
+    "elapsed": 1068,
+    "timestamp": "1690966785443",
+    "sample": {
+      "context": [],
+      "fileName": "interface.ts",
+      "languageId": "typescript",
+      "content": "interface CacheRequest {\n    /**\n     * The prefix (up to the cursor) of the source file where the completion was requested\n     */\n    prefix: string\n    /**\n     * Wether to ️🔥\n     */\n    trim: boolean\n}"
+    }
+  },
+  {
+    "completions": [
+      "    return text\n    .toLowerCase()\n    .replace(/[^\\w ]+/g, \"\")\n    .replace(/ +/g, \"-\");",
+      "    return text\n    .toLowerCase()  \n    .replace(/[^\\w ]+/g,'')    \n    .replace(/ +/g,'-');",
+      "    return text.toLowerCase().replace(/\\W/g, \"-\");"
+    ],
+    "elapsed": 3179,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [
         {
@@ -109,10 +130,12 @@
   },
   {
     "completions": [
-      "var mockAnthropicValidResponseLines = []string{`{\"result\": {\"completions\": [{\"label\": \"foo\", \"detail\": \"bar\", \"textEdit\": {\"newText\": \"foo\", \"range\": {\"start\": {\"line\": 0, \"character\": 0}, \"end\": {\"line\": 0, \"character\": 0}}}}]}}`, `{\"result\": {\"completions\": [{\"label\": \"foo\", \"detail\": \"bar\", \"textEdit\": {\"newText\": \"foo\", \"range\": {\"start\": {\"line\": 0, \"character\": 0}, \"end\": {\"line\": 0, \"character\": 0}}}}]}}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicValidResponseLines))\n\n    completions, err := mockClient.GetCompletions(context.Background(), \"foo.go\", 0, 0)\n    require.NoError(t, err)\n    assert.Equal(t, []types.CompletionItem{{Label: \"foo\", Detail: \"bar\", TextEdit: types.TextEdit{NewText: \"foo\", Range: types.Range{Start: types.Position{Line: 0,"
+      "    responseBody := linesToResponse([]string{\n        \"import\",\n        \"class\",\n        \"function\",\n    })\n\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    assert.Equal(t, 0, len(events))\n\n    err := client.Stream(context.Background(), types.CompletionsFeatureCode, types.CompletionRequestParameters{}, func(event types.CompletionEvent) {\n        events = append(events, event) \n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 3, len(events))\n    assert.Equal(t, \"import\", events[0].Completion)\n    assert.Equal(t, \"class\", events[1].Completion)\n    assert.Equal(t, \"function\", events[2].Completion)\n}",
+      "    responseBody := linesToResponse([]string{\n        \"import\",\n        \"import {\",\n        \"import { Foo } from\",\n    })\n\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    err := client.Stream(context.Background(), types.CompletionsFeatureAnthropic, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n        events = append(events, event)\n    })\n\n    assert.NoError(t, err)\n    assert.Len(t, events, 3)\n    assert.Equal(t, \"import\", events[0].Completion.Completion)\n    assert.Equal(t, \"import {\", events[1].Completion.Completion)\n    assert.Equal(t, \"import { Foo } from\", events[2].Completion.Completion)\n}",
+      "    responseBody := linesToResponse([]string{\"foo\", \"bar\", \"baz\"})\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    err := client.Stream(context.Background(), types.CompletionsFeatureAnthropic, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n            events = append(events, event)\n        })\n\n    require.NoError(t, err)\n    assert.Equal(t, []types.CompletionEvent{\n        {Completion: \"foo\"},\n        {Completion: \"bar\"},\n        {Completion: \"baz\"},\n    }, events)\n}"
     ],
-    "elapsed": 25153,
-    "timestamp": "1690287745522",
+    "elapsed": 5279,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [
         {
@@ -139,10 +162,12 @@
   },
   {
     "completions": [
-      "\"\"\"Test get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert isinstance(issues, list)\n    assert len(issues) > 0\n    assert isinstance(issues[0], Issue)"
+      "    \"\"\"Test getting open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert isinstance(issues, list)\n    assert len(issues) > 0",
+      "    \"\"\"Test that we can get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert issues",
+      "    \"\"\"Test that we can get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert len(issues) > 0"
     ],
-    "elapsed": 5137,
-    "timestamp": "1690287745522",
+    "elapsed": 2656,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [
         {
@@ -173,10 +198,10 @@
   },
   {
     "completions": [
-      "from_browser("
+      "            tool_cls.from_toolkit(self)"
     ],
-    "elapsed": 3369,
-    "timestamp": "1690287745522",
+    "elapsed": 2048,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [
         {
@@ -199,10 +224,12 @@
   },
   {
     "completions": [
-      "cache,\n                providerConfig,\n                triggerMoreEagerly,"
+      "                cache,\n                history: new History(),\n                providerConfig,\n                statusBar: noopStatusBar,",
+      "                cache,\n                config: providerConfig,\n                history: new History(),\n                statusBar: noopStatusBar,",
+      "                config: providerConfig,\n                cache,\n                history: new History(),\n                statusBar: noopStatusBar,"
     ],
-    "elapsed": 24921,
-    "timestamp": "1690287745522",
+    "elapsed": 4709,
+    "timestamp": "1690966785443",
     "sample": {
       "context": [
         {
@@ -224,7 +251,7 @@
       ],
       "fileName": "src/completions/completion.test.ts",
       "languageId": "typescript",
-      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { CompletionsCache } from './cache'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n        triggerMoreEagerly?: boolean\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        const cache = new CompletionsCache()\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n            triggerMoreEagerly = true\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
+      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { CompletionsCache } from './cache'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        const cache = new CompletionsCache()\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
     }
   }
 ]

--- a/completions-review-tool/data/starcoder-16b-fireworks-1690965883693.json
+++ b/completions-review-tool/data/starcoder-16b-fireworks-1690965883693.json
@@ -1,10 +1,12 @@
 [
   {
     "completions": [
-      "signale.info(message)"
+      "    signale.log(message)",
+      "    signale.info(message)",
+      "    signale.success(message)"
     ],
-    "elapsed": 1362,
-    "timestamp": "1690539528108",
+    "elapsed": 634,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [],
       "fileName": "logger.ts",
@@ -14,12 +16,12 @@
   },
   {
     "completions": [
-      "const dateString = new Date().toUTCString()  \n    const filePath = path.join(__dirname, 'date.txt')  \n    fs.writeFileSync(filePath, dateString, 'utf8')",
-      "const date = new Date()  \n    const filePath = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(filePath, date.toString())",
-      "const date = new Date()  \n    const fileName = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(fileName, date.toString())"
+      "    const date = new Date()\n    const dateString = date.toString()\n    const filePath = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(filePath, dateString)",
+      "    const date = new Date()\n    const filePath = path.join(__dirname, 'date.txt')\n    const fileContent = date.toString()\n    fs.writeFileSync(filePath, fileContent)",
+      "    const date = new Date()\n    const filePath = path.join(__dirname, 'date.txt')\n    fs.writeFileSync(filePath, date.toString())"
     ],
-    "elapsed": 1038,
-    "timestamp": "1690539528108",
+    "elapsed": 1175,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [],
       "fileName": "writer.ts",
@@ -29,12 +31,12 @@
   },
   {
     "completions": [
-      "const lineNumber = position.line + 1\n        return {\n            text: this.lines[position.line],\n            range: new vscode.Range(\n                this.positionAt(position.line), \n                this.positionAt(position.line + 1)\n            )\n        }",
-      "let lineNumber = position.line + 1\n        return {\n            text: this.lines[position.line],\n            range: new vscode.Range(\n                this.positionAt(position.line), \n                this.positionAt(position.line + 1))\n        }",
-      "const lineNumber = position.line + 1\n        return {\n            text: this.lines[position.line],\n            lineNumber: lineNumber\n        }"
+      "        const lineNo = this.positionAt(position).line\n        const text = this.lines[lineNo]\n        return new TextLine(this, lineNo, text)",
+      "        let line = this.lines[position.line]\n        return new TextLine(line)",
+      "        let line = this.lines[position.line]\n        return new TextLine(line, position.line, this)"
     ],
-    "elapsed": 1709,
-    "timestamp": "1690539528108",
+    "elapsed": 4629,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [],
       "fileName": "text-document.ts",
@@ -44,12 +46,12 @@
   },
   {
     "completions": [
-      "try {\n                return execFileSync('uname', ['-s']).toString().trim()\n            } catch (err) {\n                return null;\n            }  \n        }\n        return null;\n    }",
-      "try {\n                return execFileSync('uname').toString().trim()\n            } catch (err) {\n                return null;\n            }\n        } else {\n            return null;\n        }",
-      "try {\n            const {platform} = require('os');\n            return platform;   \n        } catch (err) {\n            return null; \n        }\n    }"
+      "        const osName = execFileSync('uname', ['-s']).toString().trim()\n        if (osName === 'Darwin') {\n            return 'osx'\n        } else if (osName === 'Linux') {\n            return 'linux'\n        } else if (osName === 'Windows_NT') {\n            return 'windows'\n        } else {\n            return null\n        }\n    } else {\n        return window.navigator.platform\n    }",
+      "        return process.platform\n    }",
+      "        return null\n    }"
     ],
-    "elapsed": 2064,
-    "timestamp": "1690539528108",
+    "elapsed": 4281,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [],
       "fileName": "getOs.ts",
@@ -59,10 +61,10 @@
   },
   {
     "completions": [
-      "Media && window.matchMedia('(prefers-color-scheme: dark)').matches;"
+      "    return window.matchMedia('(prefers-color-scheme: dark)').matches;"
     ],
-    "elapsed": 689,
-    "timestamp": "1690539528108",
+    "elapsed": 581,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [],
       "fileName": "isDarkColorScheme.ts",
@@ -72,10 +74,10 @@
   },
   {
     "completions": [
-      " === 'localhost' || window.location.host === '127.0.0.1';"
+      "    return window.location.host.startsWith(\"localhost\")"
     ],
-    "elapsed": 727,
-    "timestamp": "1690539528108",
+    "elapsed": 599,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [],
       "fileName": "isLocalhost.ts",
@@ -85,11 +87,25 @@
   },
   {
     "completions": [
-      "return text.toLowerCase().replace(/[^a-z0-9]/g, \"-\");",
-      "return text.toLowerCase().replace(/\\s/g, \"-\");"
+      "     * Wether to trim the prefix from the start of the completion items"
     ],
-    "elapsed": 1298,
-    "timestamp": "1690539528108",
+    "elapsed": 661,
+    "timestamp": "1690965883693",
+    "sample": {
+      "context": [],
+      "fileName": "interface.ts",
+      "languageId": "typescript",
+      "content": "interface CacheRequest {\n    /**\n     * The prefix (up to the cursor) of the source file where the completion was requested\n     */\n    prefix: string\n    /**\n     * Wether to ️🔥\n     */\n    trim: boolean\n}"
+    }
+  },
+  {
+    "completions": [
+      "    return text.replace(/[^a-z0-9]/gi, \"-\").toLowerCase();",
+      "    return text.replace(/[^a-z0-9]+/gi, \"-\").toLowerCase();",
+      "    return text.replace(/ /g, \"-\").toLowerCase();"
+    ],
+    "elapsed": 5027,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [
         {
@@ -116,12 +132,12 @@
   },
   {
     "completions": [
-      "responseBody := linesToResponse([]string{\n        \"import foo\",\n        \"foo.bar(\",\n    })\n\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    assert.NoError(t, client.Stream(context.Background(), types.CompletionFeatureCode, types.CompletionRequestParameters{}, func(event types.CompletionEvent) {\n        events = append(events, event)\n    }))\n\n    assert.Len(t, events, 2)\n    assert.Equal(t, \"import foo\", events[0].Completion)\n    assert.Equal(t, \"foo.bar(\", events[1].Completion)\n}",
-      "responseBody := linesToResponse([]string{\"completion1\", \"completion2\"})\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    err := client.Stream(context.Background(), types.CompletionFeatureCode, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n            events = append(events, event)\n        })\n    assert.NoError(t, err)\n    assert.Len(t, events, 2)\n    assert.Equal(t, \"completion1\", events[0].Completion)\n    assert.Equal(t, \"completion2\", events[1].Completion)\n}",
-      "responseBody := linesToResponse([]string{\"completion1\", \"completion2\", \"completion3\"})\n\n    client := getMockClient(responseBody)\n\n    var completions []string\n    err := client.Stream(context.Background(), types.CompletionsFeatureLSP, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n            completions = append(completions, event.Completion)\n        })\n\n    require.NoError(t, err)\n    assert.Equal(t, []string{\"completion1\", \"completion2\", \"completion3\"}, completions)\n}"
+      "    var mockAnthropicValidResponseLines = []string{`{\n        \"completions\": [\n            {\n                \"label\": \"foo\",\n                \"filterText\": \"foo\",\n                \"insertText\": \"foo\",\n                \"kind\": 1,\n                \"detail\": \"bar\",\n                \"documentation\": \"baz\",\n                \"sortText\": \"foo\",\n                \"textEdit\": {\n                    \"range\": {\n                        \"start\": {\n                            \"line\": 0,\n                            \"character\": 0\n                        },\n                        \"end\": {\n                            \"line\": 0,\n                            \"character\": 0\n                        }\n                    },\n                    \"newText\": \"foo\"\n                }\n            }\n        ]\n    }`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicValidResponseLines))\n\n    response, err := mockClient.Stream(context.Background(), types.CompletionRequest{\n        Repo: \"github.com/sourcegraph/sourcegraph\",\n        CommitID: \"abc123\",\n        File: \"foo.go\",\n        Line: 1,\n        Column: 1,\n    })\n    require.NoError(t, err)\n\n    var autogold = autogold.New()\n    autogold.Equal",
+      "    var mockAnthropicValidResponseLines = []string{`{\"result\": {\"completions\": [{\"label\": \"test\", \"detail\": \"test\", \"insertText\": \"test\", \"kind\": 12}]}}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicValidResponseLines))\n    completions, err := mockClient.StreamCompletions(context.Background(), \"test\", \"test\", \"test\", 1, 2)\n    require.NoError(t, err)\n    assert.Equal(t, []types.CompletionItem{{Label: \"test\", Detail: \"test\", InsertText: \"test\", Kind: 12}}, completions)\n}",
+      "    var mockAnthropicValidResponseLines = []string{`{\"jsonrpc\":\"2.0\",\"id\":0,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":1,\"result\":{\"id\":"
     ],
-    "elapsed": 4220,
-    "timestamp": "1690539528108",
+    "elapsed": 4776,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [
         {
@@ -148,12 +164,12 @@
   },
   {
     "completions": [
-      "\"\"\"Test getting open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert isinstance(issues, list)\n    assert len(issues) > 0",
-      "\"\"\"Test getting open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert issues\n    assert isinstance(issues, list)",
-      "\"\"\"Test getting open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert len(issues) > 0"
+      "    \"\"\"Test get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert isinstance(issues, list)\n    assert len(issues) > 0\n    for issue in issues:\n        assert isinstance(issue, Issue)",
+      "    \"\"\"Test get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert issues is not None\n    assert len(issues) > 0\n    for issue in issues:\n        assert isinstance(issue, Issue)",
+      "    \"\"\"Test that we can get open issues from GitHub.\"\"\"\n    open_issues = api_client.get_open_issues()\n    assert isinstance(open_issues, list)\n    assert len(open_issues) > 0\n    assert isinstance(open_issues[0], Issue)"
     ],
-    "elapsed": 3660,
-    "timestamp": "1690539528108",
+    "elapsed": 1700,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [
         {
@@ -184,10 +200,10 @@
   },
   {
     "completions": [
-      "from_toolkit(self)"
+      "            tool_cls.from_toolkit(self)"
     ],
-    "elapsed": 941,
-    "timestamp": "1690539528108",
+    "elapsed": 543,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [
         {
@@ -210,12 +226,12 @@
   },
   {
     "completions": [
-      "config: providerConfig,\n                cache,\n                history: new History(),\n                statusBar: noopStatusBar,\n                triggerMoreEagerly,",
-      "cache,\n                providerConfig,\n                history: new History(),\n                statusBar: noopStatusBar,\n                triggerMoreEagerly,",
-      "cache,\n                history: new History(),\n                providerConfig,\n                noopStatusBar,\n                triggerMoreEagerly,"
+      "                cache,\n                providerConfig,\n                logger: new Logger({}),\n                languageId,\n                logger: new Logger({}),\n                codyConfig: {\n                    completions: {\n                        enabled: true,\n                        cache: {\n                            enabled: true,\n                        },\n                        filterAndSort: {\n                            enabled: true,\n                            sortText: 'priority',\n                        },\n                        resolve: {\n                            enabled: true,\n                        },\n                    },\n                },",
+      "                cache,\n                providerConfig,\n                logger: createLogger(),\n                clientConfig: createClientConfig(),\n                context,\n                parser: createParser({ languageId }),\n                document: createDocument(code, languageId),",
+      "                cache,\n                providerConfig,\n                logger: createLogger(),"
     ],
-    "elapsed": 3628,
-    "timestamp": "1690539528108",
+    "elapsed": 4682,
+    "timestamp": "1690965883693",
     "sample": {
       "context": [
         {
@@ -237,7 +253,7 @@
       ],
       "fileName": "src/completions/completion.test.ts",
       "languageId": "typescript",
-      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { CompletionsCache } from './cache'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n        triggerMoreEagerly?: boolean\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        const cache = new CompletionsCache()\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n            triggerMoreEagerly = true\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
+      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { CompletionsCache } from './cache'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        const cache = new CompletionsCache()\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
     }
   }
 ]

--- a/completions-review-tool/data/starcoder-7b-fireworks-1690965610208.json
+++ b/completions-review-tool/data/starcoder-7b-fireworks-1690965610208.json
@@ -1,10 +1,11 @@
 [
   {
     "completions": [
-      "signale.info(message)"
+      "    signale.info(message)",
+      "    signale.log(message)"
     ],
-    "elapsed": 2362,
-    "timestamp": "1690288005200",
+    "elapsed": 779,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [],
       "fileName": "logger.ts",
@@ -14,12 +15,12 @@
   },
   {
     "completions": [
-      "const date = new Date() \n    const filename = path.join(__dirname, 'date.txt')  \n    fs.writeFileSync(filename, date.toString())",
-      "const dateString = new Date().toISOString() \n    const filePath = path.join(__dirname, 'date.txt')  \n    fs.writeFileSync(filePath, dateString)",
-      "const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')  \n    fs.writeFileSync(filename, date.toLocaleString(), 'utf8')"
+      "    const date = new Date()\n    const fileName = path.join(__dirname, 'date.txt')\n    const file = fs.createWriteStream(fileName)\n    file.write(date.toString())\n    file.end()",
+      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n    const file = fs.createWriteStream(filename)\n    file.write(date.toString())",
+      "    console.log('writeDateToDisk');"
     ],
-    "elapsed": 2008,
-    "timestamp": "1690288005200",
+    "elapsed": 1323,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [],
       "fileName": "writer.ts",
@@ -29,12 +30,12 @@
   },
   {
     "completions": [
-      "let lineNumber = 0\n        let lineStart = 0\n\n        for (let i = 0; i < this.lines.length; i++) {\n            const line = this.lines[i]\n            const lineLength = line.length\n\n            if (lineStart + lineLength > position) {\n                lineNumber = i\n                break\n            }\n\n            lineStart += lineLength + 1 // +1 for newline\n        }\n\n        return {\n            text: this.lines[lineNumber],\n            range: new vscode.Range(\n                this.positionAt(lineStart), \n                this.positionAt(lineStart + this.lines[lineNumber].length)\n            )\n        }",
-      "const lineNumber = position instanceof vscode.Position ? position.line : Math.floor(position / this.lineLength(position))\n        const start = this.text.slice(0, this.getLineStartPosition(lineNumber))\n        const end = this.getLineEndPosition(lineNumber)\n        return {\n            text: this.text.slice(start.length, end),\n            range: new vscode.Range(lineNumber, 0, lineNumber, this.lineLength(end))\n        }",
-      "const lineNumber = position instanceof vscode.Position ? position.line : Math.floor(position / this.getLineLength(position));\n        const lineText = this.lines[lineNumber];\n\n        return {\n            text: lineText,\n            range: new vscode.Range(position, position + lineText.length)\n        }"
+      "        const line = this.lines[position]\n        return new TextLine(this, position, line)",
+      "        const line = this.lines[position]\n        return new vscode.TextLine(this.uri, position, line.length, line)",
+      "        return new TextLine(this.lines[position], position)"
     ],
-    "elapsed": 6555,
-    "timestamp": "1690288005200",
+    "elapsed": 4506,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [],
       "fileName": "text-document.ts",
@@ -44,12 +45,12 @@
   },
   {
     "completions": [
-      "try {\n            return execFileSync('uname', ['-a']).toString().trim()\n        } catch (err) {\n            return null;\n        }\n    } else {\n        return null;\n    }",
-      "try {\n            return execFileSync('uname', ['-s']).toString().trim()\n        } catch (err) {\n            return null\n        }\n    } else {\n        return null\n    }",
-      "try {\n                return execFileSync('uname').toString().trim();  \n            } catch (err) {\n                return null;\n            }\n        } \n        return null;"
+      "        const os = execFileSync('uname', ['-s']).toString().toLowerCase()\n        if (os.includes('darwin')) {\n            return 'darwin'\n        } else if (os.includes('win')) {\n            return 'win32'\n        } else if (os.includes('linux')) {\n            return 'linux'\n        }\n    }",
+      "        const osName = execFileSync('uname', ['-s']).toString()\n        return osName.trim()\n    }",
+      "        return execFileSync('uname', ['-s']).toString().trim()\n    }"
     ],
-    "elapsed": 1263,
-    "timestamp": "1690288005200",
+    "elapsed": 1637,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [],
       "fileName": "getOs.ts",
@@ -59,10 +60,10 @@
   },
   {
     "completions": [
-      "Media &&"
+      "    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;"
     ],
-    "elapsed": 858,
-    "timestamp": "1690288005200",
+    "elapsed": 714,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [],
       "fileName": "isDarkColorScheme.ts",
@@ -72,10 +73,10 @@
   },
   {
     "completions": [
-      " === 'localhost';"
+      "    return window.location.host.indexOf(\"localhost\")!== -1;"
     ],
-    "elapsed": 742,
-    "timestamp": "1690288005200",
+    "elapsed": 611,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [],
       "fileName": "isLocalhost.ts",
@@ -85,11 +86,25 @@
   },
   {
     "completions": [
-      "return text\n    .toLowerCase()\n    .replace(/[^\\w ]+/g, \"\")\n    .replace(/ +/g, \"-\");",
-      "return text.toLowerCase().replace(/\\W/g, \"-\");"
+      "     * Wether to trim the prefix (up to the cursor) of the source file where the completion was requested"
     ],
-    "elapsed": 2471,
-    "timestamp": "1690288005200",
+    "elapsed": 823,
+    "timestamp": "1690965610208",
+    "sample": {
+      "context": [],
+      "fileName": "interface.ts",
+      "languageId": "typescript",
+      "content": "interface CacheRequest {\n    /**\n     * The prefix (up to the cursor) of the source file where the completion was requested\n     */\n    prefix: string\n    /**\n     * Wether to ️🔥\n     */\n    trim: boolean\n}"
+    }
+  },
+  {
+    "completions": [
+      "    return text\n       .replace(/[.]/g, \"\")\n       .replace(/[-]/g, \" \")\n       .replace(/[^\\w\\s]/gi, \"\")\n       .replace(/[\\s]+/g, \"-\")\n       .toLowerCase();",
+      "    return text\n       .toLowerCase()\n       .replace(/[^a-z0-9]+/g, \"-\")\n       .replace(/^-+|-+$/g, \"\");",
+      "    return text.toLowerCase().replace(/[^a-z0-9]/g, \"-\");"
+    ],
+    "elapsed": 2423,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [
         {
@@ -116,12 +131,12 @@
   },
   {
     "completions": [
-      "responseBody := linesToResponse([]string{\n        \"import foo\",\n        \"foo.bar()\",\n        \"foo.baz()\"\n    })\n\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    err := client.Stream(context.Background(), types.CompletionFeatureCode, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n            events = append(events, event)\n        })\n    \n    assert.NoError(t, err)\n    assert.Equal(t, 3, len(events))\n}",
-      "responseBody := linesToResponse([]string{\"foo\", \"bar\"})\n    client := getMockClient(responseBody)\n\n    var received []string\n    var err error\n\n    err = client.Stream(context.Background(), types.CompletionsFeatureAnthropic, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n            received = append(received, event.Completion)\n        })\n\n    require.NoError(t, err)\n    assert.Equal(t, []string{\"foo\", \"bar\"}, received)\n}",
-      "responseBody := linesToResponse([]string{\"import\", \"foo\", \"bar\", \"baz\"})\n\n    client := getMockClient(responseBody)\n\n    var events []types.CompletionEvent\n    err := client.Stream(context.Background(), types.CompletionsFeatureAnthropic, types.CompletionRequestParameters{}, \n        func(event types.CompletionEvent) {\n            events = append(events, event)\n        })\n\n    require.NoError(t, err)\n    assert.Equal(t, []string{\"import\", \"foo\", \"bar\", \"baz\"}, autogold.Strings(events))\n}"
+      "    var mockAnthropicResponseLines = []string{`{\"data\": \"foo\", \"meta\": {\"type\": \"symbol\"}}`, `{\"data\": \"bar\", \"meta\": {\"type\": \"symbol\"}}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n\n    ctx := context.Background()\n    completions, err := mockClient.GetCompletions(ctx, \"foo\", 0, 10)\n    require.NoError(t, err)\n\n    assert.Equal(t, []types.Completion{\n        {\n            Label: \"foo\",\n            Kind:  types.Symbol,\n        },\n        {\n            Label: \"bar\",\n            Kind:  types.Symbol,\n        },\n    }, completions)\n}",
+      "    var mockAnthropicResponseLines = []string{`{\"name\": \"foo\", \"value\": \"bar\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    completions, err := mockClient.GetCompletions(context.Background(), \"foo\", \"bar\", \"test\", 100)\n    require.NoError(t, err)\n\n    expected := []types.Completion{\n        {\n            Name:  \"foo\",\n            Value: \"bar\",\n        },\n    }\n    autogold.Equal(t, expected, completions)",
+      "    var mockAnthropicResponseLines = []string{`{`, `    \"name\": \"foo\",`, `    \"description\": \"bar\",`, `    \"detail\": \"baz\",`, `    \"kind\": \"symbol\",`, `    \"sortText\": \"qux\",`, `    \"filterText\": \"quux\",`, `    \"insertText\": \"corge\",`, `    \"insertTextFormat\": 1,`, `    \"textEdit\": {`, `        \"range\": {`, `            \"start\": {`, `                \"line\": 1,`, `                \"character\": 2`, `            },`, `            \"end\": {`, `                \"line\": 3,`, `                \"character\": 4`, `            }`, `        },`, `        \"newText\": \"grault\"`, `    },`, `    \"additionalTextEdits\": [`, `        {`, `            \"range\": {`, `                \"start\": {`, `                    \"line\": 5,`, `                    \"character\": 6`, `                },`, `                \"end\": {`, `                    \"line\": 7,`, `                    \"character\": 8`,"
     ],
-    "elapsed": 6708,
-    "timestamp": "1690288005200",
+    "elapsed": 4441,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [
         {
@@ -148,12 +163,12 @@
   },
   {
     "completions": [
-      "\"\"\"Test that we can get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert isinstance(issues, list)\n    assert len(issues) > 0",
-      "\"\"\"Test that we can get open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert len(issues) > 0",
-      "\"\"\"Test getting open issues.\"\"\"\n    issues = api_client.get_open_issues()\n    assert len(issues) > 0"
+      "    issues = api_client.get_open_issues()\n\n    assert isinstance(issues, list)\n    assert len(issues) > 0\n    assert isinstance(issues[0], Issue)",
+      "    issues = api_client.get_open_issues()\n    assert isinstance(issues, list)\n    assert all(isinstance(issue, Issue) for issue in issues)",
+      "    assert isinstance(api_client.get_open_issues(), List)\n    assert isinstance(api_client.get_open_issues()[0], Issue)"
     ],
-    "elapsed": 6158,
-    "timestamp": "1690288005200",
+    "elapsed": 1523,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [
         {
@@ -184,10 +199,10 @@
   },
   {
     "completions": [
-      "create_tool("
+      "            tool_cls.from_browser("
     ],
-    "elapsed": 1360,
-    "timestamp": "1690288005200",
+    "elapsed": 827,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [
         {
@@ -210,11 +225,12 @@
   },
   {
     "completions": [
-      "cache,\n                history: new History(),\n                providerConfig,\n                statusBar: noopStatusBar,\n                triggerMoreEagerly,",
-      "cache,\n                history: new History(),\n                providerConfig,\n                triggerMoreEagerly,\n                statusBar: noopStatusBar,"
+      "                config: providerConfig,\n                cache,\n                languageId,\n                context,",
+      "                cache,\n                providerConfig,\n                languageId,\n                context,",
+      "                cache,\n                providerConfig,\n                languageId,"
     ],
-    "elapsed": 6548,
-    "timestamp": "1690288005200",
+    "elapsed": 923,
+    "timestamp": "1690965610208",
     "sample": {
       "context": [
         {
@@ -236,7 +252,7 @@
       ],
       "fileName": "src/completions/completion.test.ts",
       "languageId": "typescript",
-      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { CompletionsCache } from './cache'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n        triggerMoreEagerly?: boolean\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        const cache = new CompletionsCache()\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n            triggerMoreEagerly = true\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
+      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { CompletionsCache } from './cache'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        const cache = new CompletionsCache()\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
     }
   }
 ]

--- a/completions-review-tool/src/components/CompletionsTable.module.css
+++ b/completions-review-tool/src/components/CompletionsTable.module.css
@@ -9,6 +9,10 @@
     position: relative;
 }
 
+.table td {
+    position: relative;
+}
+
 .table thead tr > th {
     background: #ccc;
     position: sticky;
@@ -27,4 +31,11 @@
     position: sticky;
     z-index: 1;
     left: 0;
+}
+
+:global(.elapsed) {
+    position: absolute;
+    right: 0;
+    top: 0;
+    font-size: 0.75rem;
 }

--- a/completions-review-tool/src/routes/_index.tsx
+++ b/completions-review-tool/src/routes/_index.tsx
@@ -50,13 +50,15 @@ export default function Index() {
                 bgColor: '#f7f7f7',
             }
 
-            entries.forEach(({ completions, snapshotFileName }: any) => {
+            entries.forEach(({ completions, snapshotFileName, elapsed }: any) => {
                 const columnKey = snapshotFileName
 
                 extraColumns.add(columnKey)
 
                 // All completions are displayed in the same cell separated by <hr />.
-                row[columnKey] = completions.map(renderMarkdown).join('<hr />')
+                row[columnKey] = `<div class="elapsed">${elapsed}ms</div>${completions
+                    .map(renderMarkdown)
+                    .join('<hr />')}`
             })
 
             rows.push(row)

--- a/vscode/test/completions/completions-dataset.ts
+++ b/vscode/test/completions/completions-dataset.ts
@@ -85,6 +85,22 @@ export const completionsDataset: Sample[] = [
             }`,
     },
     {
+        context: [],
+        fileName: 'interface.ts',
+        languageId: 'typescript',
+        content: `
+            interface CacheRequest {
+                /**
+                 * The prefix (up to the cursor) of the source file where the completion was requested
+                 */
+                prefix: string
+                /**
+                 * Wether to ${CURSOR}
+                 */
+                trim: boolean
+            }`,
+    },
+    {
         // prettier-ignore
         context: [
             {'fileName':'lib/parser/excerpt.ts','content':'export function excerpt(text: string, limit: number = 144) {\n  let result = "";\n\n  for (const word of text.split(" ")) {\n    if (result.length + word.length + 1 <= limit) {\n      result += " " + word;\n    } else {\n      // Fix trailing comma. Might need a more generic solution at some point :D\n      if (result.endsWith(",")) {\n        result = result.slice(0, -1);\n      }\n      result += "…";\n      break;\n    }\n  }\n\n  return result;\n}\n'},

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -164,6 +164,7 @@ async function generateCompletionsForDataset(codeSamples: Sample[]): Promise<voi
         throw new Error('No provider name')
     }
     const filename = path.join(ENVIRONMENT_CONFIG.OUTPUT_PATH, `${providerName}-${timestamp}.json`)
+    fs.mkdirSync(ENVIRONMENT_CONFIG.OUTPUT_PATH, { recursive: true })
     fs.writeFileSync(filename, JSON.stringify(results, null, 2))
     console.log('\n✅ Completions saved to:', filename)
 }


### PR DESCRIPTION
StarCoder (the OSS code completion LLM) has recently released a new 7b version of their model. I wanted to post a brief update about that:

- The performance difference between the 15.5b and 7b models aren’t super big
  - I think the biggest improvement we can make at this point is for either provider (including Anthropic) to use the streaming APIs and terminate the request if we detect the end since they all might overshoot (and every subsequent unused token just incurs a waiting time). We could do this on the client or on the server but the latter might require us to port more logic to Go.
- The hosted OSS models are actually performing really well in terms of latency. I know this is a limited data and the anthropic request is also routed via the SG server where as the other isn’t, but this feels very good to use already when I turn it on in VS Code.
- Quality of the OSS fill-in-the-middle trained models seem better. The difference between the 15.5b and 7b models doesn’t appear super big either in the sample of TS/Python cases I looked at.

## Test plan

<img width="2412" alt="Screenshot 2023-08-02 at 11 01 54" src="https://github.com/sourcegraph/cody/assets/458591/2450b991-0bf6-4080-901c-5e0c7ca6466b">
<img width="2414" alt="Screenshot 2023-08-02 at 11 01 41" src="https://github.com/sourcegraph/cody/assets/458591/4eef2b80-1888-46ec-86a9-2024d59dd84b">
<img width="2414" alt="Screenshot 2023-08-02 at 11 01 27" src="https://github.com/sourcegraph/cody/assets/458591/45809292-fe47-42bd-ade7-e78484cf7bd3">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
