### PR TITLE
left-align items in the cody status bar enable menu

### DIFF
--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -14,6 +14,9 @@ export interface CodyStatusBar {
 const DEFAULT_TEXT = '$(cody-logo-heavy)'
 const DEFAULT_TOOLTIP = 'Cody Settings'
 
+const QUICK_PICK_ITEM_CHECKED_PREFIX = '$(check) '
+const QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX = '\u00A0\u00A0\u00A0\u00A0 '
+
 export function createStatusBar(): CodyStatusBar {
     const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right)
     statusBarItem.text = DEFAULT_TEXT
@@ -35,9 +38,9 @@ export function createStatusBar(): CodyStatusBar {
         ): vscode.QuickPickItem & { onSelect: () => Promise<void> } {
             const isEnabled = getValue(config)
             return {
-                label: (isEnabled ? '$(check) ' : '') + name,
+                label: (isEnabled ? QUICK_PICK_ITEM_CHECKED_PREFIX : QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX) + name,
                 description,
-                detail,
+                detail: QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX + detail,
                 onSelect: async () => {
                     await workspaceConfig.update(setting, !isEnabled, vscode.ConfigurationTarget.Global)
 


### PR DESCRIPTION
The checkboxes now occupy the left column and the text is aligned.

New:

![image](https://github.com/sourcegraph/cody/assets/1976/00ba7932-2510-48e2-bb7b-247ea25e2b4a)

Compare to the current (not left-aligned):

![image](https://github.com/sourcegraph/cody/assets/1976/62958457-7388-44ca-948b-9ca98edb19ad)



## Test plan

n/a