### PR TITLE
disable commands code lens and editor title icon by default

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -645,7 +645,7 @@
       "editor/title": [
         {
           "command": "cody.action.commands.menu",
-          "when": "cody.activated",
+          "when": "cody.activated && config.cody.experimental.editorTitleCommandIcon",
           "group": "navigation",
           "visibility": "visible"
         },
@@ -779,7 +779,13 @@
           "order": 8,
           "type": "boolean",
           "markdownDescription": "[Experimental] Adds code lenses to current file for quick access to Cody commands.",
-          "default": true
+          "default": false
+        },
+        "cody.experimental.editorTitleCommandIcon": {
+          "order": 8,
+          "type": "boolean",
+          "markdownDescription": "[Experimental] Adds an editor title menu icon for quick access to Cody commands.",
+          "default": false
         },
         "cody.experimental.guardrails": {
           "order": 9,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -17,7 +17,7 @@ describe('getConfiguration', () => {
             codebase: '',
             useContext: 'embeddings',
             autocomplete: true,
-            experimentalCommandLenses: true,
+            experimentalCommandLenses: false,
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
             inlineChat: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -68,7 +68,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         inlineChat: config.get(CONFIG_KEY.inlineChatEnabled, true),
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
         experimentalNonStop: config.get('cody.experimental.nonStop' as any, isTesting),
-        experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, true),
+        experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
         autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,


### PR DESCRIPTION
I personally found these distracting to have on by default (although I am super happy to see the commands stuff in!!), and I bet users would agree (especially users who haven't started using the features yet). I am sure they help with feature discovery, but let's run with them disabled-by-default for a bit until we can find a better way for discovery and/or until this feature is really lovable.



## Test plan

n/a