### PR TITLE
fix problem with github copilot suppressing ctrl+enter in comment UI

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -471,6 +471,10 @@
         "key": "ctrl+shift+v",
         "mac": "cmd+shift+v",
         "when": "cody.activated && editorFocus"
+      },
+      {
+        "command": "-github.copilot.generate",
+        "key": "ctrl+enter"
       }
     ],
     "submenus": [


### PR DESCRIPTION
In the VS Code comment UI, ctrl+enter/cmd+enter should submit the comment. Unfortunately, when GitHub Copilot is activated, it does nothing. This is likely a bug in GitHub Copilot's overly greedy keyboard bindings (it should have `&& !commentEditorFocused` in the `when` for `github.copilot.generate`).

To make that keybinding submit the comment in VS Code's comment UI again, work around this by disabling that keybinding when Cody is running (it is not possible to be more selective about when we disable the keybinding). This is reasonable because that is not a frequently used keybinding anymore for Copilot.



## Test plan

Run VS Code with both Cody and GitHub Copilot. Open our inline chat and try pressing ctrl+enter/cmd+enter after you've typed a comment to submit it. It should work.