### PR TITLE
add cody.experimental.nonStop as setting for internal discoverability

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -772,6 +772,12 @@
           "markdownDescription": "Experimental feature for internal use.",
           "default": false
         },
+        "cody.experimental.nonStop": {
+          "order": 9,
+          "type": "boolean",
+          "markdownDescription": "Experimental feature for internal use.",
+          "default": false
+        },
         "cody.debug.enable": {
           "order": 99,
           "type": "boolean",

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -67,7 +67,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         experimentalChatPredictions: config.get(CONFIG_KEY.experimentalChatPredictions, isTesting),
         inlineChat: config.get(CONFIG_KEY.inlineChatEnabled, true),
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
-        experimentalNonStop: config.get('cody.experimental.nonStop' as any, isTesting),
+        experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
         autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(


### PR DESCRIPTION
I got confused by not seeing it there. :)

## Test plan

n/a