### PR TITLE
use separate vscode webview source map to cut bundle by 17MB

### DIFF
--- a/vscode/webviews/vite.config.ts
+++ b/vscode/webviews/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
         target: 'esnext',
         assetsDir: '.',
         minify: false,
-        sourcemap: 'inline',
+        sourcemap: true,
         reportCompressedSize: false,
         rollupOptions: {
             watch: {


### PR DESCRIPTION
With an inline sourcemap, `vscode/dist/webviews/index.js` is 18.8MB. With a separate sourcemap file, it is 1.8MB. The sourcemap file is 13MB, so even including it, there's still a big reduction. And now the sourcemap is only loaded for debugging, not for routine execution, which surely must be a perf improvement.



## Test plan

n/a