### PR TITLE
Autocomplete: Use the 7b version of StarCoder by default

### DIFF
--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -77,7 +77,7 @@ export class UnstableFireworksProvider extends Provider {
             min_tokens: 1,
             n: this.options.n,
             echo: false,
-            model: 'accounts/fireworks/models/fireworks-starcoder-16b-w8a16',
+            model: 'accounts/fireworks/models/fireworks-starcoder-7b-w8a16-1gpu',
         }
 
         const log = logger.startCompletion({


### PR DESCRIPTION
Changing the default model used for the fireworks config to use the 7b one.

## Test plan

👀 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
