### PR TITLE
fix: handle errors from Git extension APIs

### DIFF
--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -7,22 +7,27 @@ export function repositoryRemoteUrl(uri: vscode.Uri): string | undefined {
 }
 
 function gitRepositoryRemoteUrl(uri: vscode.Uri): string | undefined {
-    const extension = vscode.extensions.getExtension<GitExtension>('vscode.git')
-    if (!extension) {
-        console.warn('Git extension not available')
-        return undefined
-    }
-    if (!extension.isActive) {
-        console.warn('Git extension not active')
-        return undefined
-    }
+    try {
+        const extension = vscode.extensions.getExtension<GitExtension>('vscode.git')
+        if (!extension) {
+            console.warn('Git extension not available')
+            return undefined
+        }
+        if (!extension.isActive) {
+            console.warn('Git extension not active')
+            return undefined
+        }
 
-    const git = extension.exports.getAPI(1)
-    const repository = git.getRepository(uri)
-    if (!repository) {
-        console.warn('No Git repository for URI', uri)
+        const git = extension.exports.getAPI(1)
+        const repository = git.getRepository(uri)
+        if (!repository) {
+            console.warn('No Git repository for URI', uri)
+            return undefined
+        }
+
+        return repository.state.remotes[0]?.fetchUrl
+    } catch (error) {
+        console.error(error)
         return undefined
     }
-
-    return repository.state.remotes[0]?.fetchUrl
 }


### PR DESCRIPTION
fix: handle errors from Git extension APIs

Wrap calls to Git extension APIs in try/catch blocks to avoid crashes if APIs throw errors or are unavailable.

Log warnings if extension is unavailable or inactive instead of throwing errors.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

added error handling