### PR TITLE
fix ~/.vscode/cody.json recipes file watch that exhausted system

### DIFF
--- a/vscode/src/custom-prompts/utils/helpers.ts
+++ b/vscode/src/custom-prompts/utils/helpers.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import * as vscode from 'vscode'
 
 import { CodyPromptType, ConfigFileName } from '@sourcegraph/cody-shared/src/chat/prompts'
@@ -49,7 +51,12 @@ export function createFileWatchers(fsPath?: string): vscode.FileSystemWatcher | 
     if (!fsPath) {
         return null
     }
-    const watchPattern = new vscode.RelativePattern(fsPath, ConfigFileName.vscode)
+
+    // Use the file as the first arg to RelativePattern because a file watcher will be set up on the
+    // first arg given. If this is a directory with many files, such as the user's home directory,
+    // it will cause a very large number of watchers to be created, which will exhaust the system.
+    // This occurs even if the second arg is a relative file path with no wildcards.
+    const watchPattern = new vscode.RelativePattern(vscode.Uri.file(path.join(fsPath, ConfigFileName.vscode)), '')
     const watcher = vscode.workspace.createFileSystemWatcher(watchPattern)
     return watcher
 }


### PR DESCRIPTION
This fixes an issue where Cody (on Linux at least) would watch the user's home directory and exhaust the system's open files limit. This appears to be due to a bug or limitation in VS Code's `createFileSystemWatcher` API where `RelativePattern` globs are not optimized and instead set up recursive watchers on the first arg given (which, for the user's home dir, causes a very large number to be created).

To reproduce the issue, uncomment this code and then look for the following in the VS Code logs for file watchers (see below for how to enable these):

```
TRACE [File Watcher (parcel)] Request to start watching: /home/sqs
```

(`/home/sqs` is my home directory, and the file watcher then starts to traverse all dirs and set up ~250,000+ inotify watches.)

See https://github.com/microsoft/vscode/wiki/File-Watcher-Issues#logging-local for instructions on how to enable logging of file watchers to reproduce this.



## Test plan

See above.