### PR TITLE
Revert "chore(deps): update pnpm to v8.6.11"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 20.4.0
-pnpm 8.6.11
+pnpm 8.6.7

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": "^v20.4.0",
-    "pnpm": "^8.6.11"
+    "pnpm": "^8.6.7"
   },
   "scripts": {
     "build": "tsc --build",
@@ -60,7 +60,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
-  "packageManager": "pnpm@8.6.11",
+  "packageManager": "pnpm@8.6.7",
   "resolutions": {
     "tslib": "2.1.0"
   },


### PR DESCRIPTION
Reverts sourcegraph/cody#497

Some weird build issues is happening since this was merged. Here's an example log: https://github.com/sourcegraph/cody/actions/runs/5762909352/job/15623607192

CI is complaining that the pnpm version on CI is not `8.6.11` but the `pnpm/action-setup@v2` [should read the correct version](https://github.com/pnpm/action-setup#version) via `packageManager` from the package.json 🤔 

Let's revert for now and I can take a closer look next week if no-one else has any ideas? 

## Test plan

This is a revert