### PR TITLE
Potential bug fix in next questions recipe

### DIFF
--- a/lib/shared/src/chat/recipes/next-questions.ts
+++ b/lib/shared/src/chat/recipes/next-questions.ts
@@ -32,7 +32,6 @@ export class NextQuestions implements Recipe {
                     prefix: assistantResponsePrefix,
                     text: assistantResponsePrefix,
                 },
-                // file bug, promptMessage should be truncatedText
                 this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext),
                 []
             )

--- a/lib/shared/src/chat/recipes/next-questions.ts
+++ b/lib/shared/src/chat/recipes/next-questions.ts
@@ -32,7 +32,8 @@ export class NextQuestions implements Recipe {
                     prefix: assistantResponsePrefix,
                     text: assistantResponsePrefix,
                 },
-                this.getContextMessages(promptMessage, context.editor, context.intentDetector, context.codebaseContext),
+                // file bug, promptMessage should be truncatedText
+                this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext),
                 []
             )
         )


### PR DESCRIPTION
When working on a proof of concept for using ML to determine if code context is needed for Cody, @novoselrok and I noticed that my "is context needed" classifier was getting hit with text which included messages about next questions. It turns out that the `NextQuestions` recipe calls the `getContextMessages` function with the full prompt message as the text, including the recipe specific prompt prefix / suffix. @novoselrok and I believed that this was unintentional/likely a bug and that `getContextMessages` was meant to be called with only the text of the user query, `truncatedText`.

This PR changes the call to `getContextMessages` to use `truncatedText` instead of the fully prompt with the recipe specific info. If we misunderstood and the status quo is intended behavior, then please feel free to close.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

n/a