### PR TITLE
fix: relative patterns for file watchers

### DIFF
--- a/vscode/src/custom-prompts/utils/helpers.ts
+++ b/vscode/src/custom-prompts/utils/helpers.ts
@@ -1,8 +1,6 @@
-import path from 'path'
-
 import * as vscode from 'vscode'
 
-import { CodyPromptType, ConfigFileName } from '@sourcegraph/cody-shared/src/chat/prompts'
+import { CodyPromptType } from '@sourcegraph/cody-shared/src/chat/prompts'
 
 export function constructFileUri(fileName: string, rootDirPath?: string): vscode.Uri | undefined {
     if (!rootDirPath) {
@@ -48,15 +46,15 @@ export async function saveJSONFile(context: string, filePath: vscode.Uri, isSave
 
 // Create a file watcher for each .vscode/cody.json file
 export function createFileWatchers(fsPath?: string): vscode.FileSystemWatcher | null {
-    if (!fsPath) {
+    const uri = constructFileUri('.vscode', fsPath)
+    if (!uri) {
         return null
     }
-
     // Use the file as the first arg to RelativePattern because a file watcher will be set up on the
     // first arg given. If this is a directory with many files, such as the user's home directory,
     // it will cause a very large number of watchers to be created, which will exhaust the system.
     // This occurs even if the second arg is a relative file path with no wildcards.
-    const watchPattern = new vscode.RelativePattern(vscode.Uri.file(path.join(fsPath, ConfigFileName.vscode)), '')
+    const watchPattern = new vscode.RelativePattern(uri, 'cody.json')
     const watcher = vscode.workspace.createFileSystemWatcher(watchPattern)
     return watcher
 }

--- a/vscode/src/custom-prompts/utils/helpers.ts
+++ b/vscode/src/custom-prompts/utils/helpers.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { CodyPromptType } from '@sourcegraph/cody-shared/src/chat/prompts'
+import { CodyPromptType, ConfigFileName } from '@sourcegraph/cody-shared/src/chat/prompts'
 
 export function constructFileUri(fileName: string, rootDirPath?: string): vscode.Uri | undefined {
     if (!rootDirPath) {
@@ -46,15 +46,15 @@ export async function saveJSONFile(context: string, filePath: vscode.Uri, isSave
 
 // Create a file watcher for each .vscode/cody.json file
 export function createFileWatchers(fsPath?: string): vscode.FileSystemWatcher | null {
-    const uri = constructFileUri('.vscode', fsPath)
-    if (!uri) {
+    const fileUri = constructFileUri(ConfigFileName.vscode, fsPath)
+    if (!fileUri) {
         return null
     }
     // Use the file as the first arg to RelativePattern because a file watcher will be set up on the
     // first arg given. If this is a directory with many files, such as the user's home directory,
     // it will cause a very large number of watchers to be created, which will exhaust the system.
     // This occurs even if the second arg is a relative file path with no wildcards.
-    const watchPattern = new vscode.RelativePattern(uri, 'cody.json')
+    const watchPattern = new vscode.RelativePattern(fileUri, '*')
     const watcher = vscode.workspace.createFileSystemWatcher(watchPattern)
     return watcher
 }

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 
 import { version } from '../../package.json'
 import { isOsSupportedByApp, LOCAL_APP_URL, LocalEnv } from '../chat/protocol'
+import { constructFileUri } from '../custom-prompts/utils/helpers'
 import { debug } from '../log'
 
 import { AppJson, LOCAL_APP_LOCATIONS } from './LocalAppFsPaths'
@@ -59,8 +60,11 @@ export class LocalAppDetector implements vscode.Disposable {
         const markers = this.localAppMarkers
         for (const marker of markers) {
             const dirPath = expandHomeDir(marker.dir, homeDir)
-            const dirUri = vscode.Uri.file(dirPath)
-            const watchPattern = new vscode.RelativePattern(dirUri, marker.file)
+            const fileUri = constructFileUri(marker.file, marker.dir)
+            if (!fileUri) {
+                return
+            }
+            const watchPattern = new vscode.RelativePattern(fileUri, '*')
             const watcher = vscode.workspace.createFileSystemWatcher(watchPattern)
             watcher.onDidChange(() => this.fetchApp())
             this._watchers.push(watcher)


### PR DESCRIPTION
Noticed the file watchers for the custom commands config file (cody.json) are currently not working as the second param is set to empty when we created the `RelativePattern`.

Based on the [vscode API docs](https://code.visualstudio.com/api/references/vscode-api#workspace.createFileSystemWatcher), the second param should be set to `*` for watching changes in a specific file (when first param is set to file path, TIL!).

I've also updated the file watchers we added to watch `Cody.app` to reflect this:
```
// AFTER
TRACE [File Watcher (node.js)] Started watching: '/Applications/Cody.app'
// BEFORE
TRACE [File Watcher (node.js)] Started watching: '/Applications'
```

https://github.com/microsoft/vscode/blob/a330b89e5d83293bacee75ac910626b64ad8c3fd/src/vscode-dts/vscode.d.ts#L11339-L11343

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

make changes to the .vscode/cody.json before entering `/` in your chat box, you should see the changes you made in the slash command list:
<img width="662" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/faa1f2ea-5631-49ff-9f32-ea5e8d091553">

Also confirmed file watchers were created for `cody.json` and `Cody.app` specifically, and not for the whole directory.

<img width="1225" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/f7a730dd-5bbb-4e30-9131-7ab10559ebe3">

### Video Demos

After: https://www.loom.com/share/2a77f405cabc4ef29b7036fb15900cf1

https://github.com/sourcegraph/cody/assets/68532117/5f48b341-2a9d-4a14-9089-6b5b01d8c551

Before: https://www.loom.com/share/f0a36422b3cb4f11b70c149c563dfbbe

https://github.com/sourcegraph/cody/assets/68532117/b9d27c32-b2cd-49b4-b13c-73cd3d907e35


