### PR TITLE
Autocomplete: Use correct range for fill-in-middle models

### DIFF
--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -30,6 +30,11 @@ export interface ProviderConfig {
      * A string identifier for the provider config used in event logs.
      */
     identifier: string
+
+    /**
+     * Indicating whether the provider supports infilling.
+     */
+    supportsInfilling: boolean
 }
 
 export interface ProviderOptions {

--- a/vscode/src/completions/providers/unstable-azure-openai.ts
+++ b/vscode/src/completions/providers/unstable-azure-openai.ts
@@ -120,5 +120,6 @@ export function createProviderConfig(unstableAzureOpenAIOptions: UnstableAzureOp
         maximumContextCharacters: contextWindowChars,
         enableExtendedMultilineTriggers: false,
         identifier: PROVIDER_IDENTIFIER,
+        supportsInfilling: false,
     }
 }

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -153,5 +153,6 @@ export function createProviderConfig(unstableCodeGenOptions: UnstableCodeGenOpti
         maximumContextCharacters: contextWindowChars,
         enableExtendedMultilineTriggers: false,
         identifier: PROVIDER_IDENTIFIER,
+        supportsInfilling: true,
     }
 }

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -146,5 +146,6 @@ export function createProviderConfig(unstableFireworksOptions: UnstableFireworks
         maximumContextCharacters: CONTEXT_WINDOW_CHARS,
         enableExtendedMultilineTriggers: true,
         identifier: PROVIDER_IDENTIFIER,
+        supportsInfilling: true,
     }
 }

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -140,5 +140,6 @@ export function createProviderConfig(unstableHuggingFaceOptions: UnstableHugging
         maximumContextCharacters: CONTEXT_WINDOW_CHARS,
         enableExtendedMultilineTriggers: true,
         identifier: PROVIDER_IDENTIFIER,
+        supportsInfilling: true,
     }
 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -167,33 +167,47 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
 
         return {
-            items: result ? processInlineCompletionsForVSCode(result.logId, document, position, result.items) : [],
+            items: result ? this.processInlineCompletionsForVSCode(result.logId, document, position, result.items) : [],
         }
     }
-}
 
-/**
- * Process completions items in VS Code-specific ways.
- */
-function processInlineCompletionsForVSCode(
-    logId: string,
-    document: vscode.TextDocument,
-    position: vscode.Position,
-    items: InlineCompletionItem[]
-): vscode.InlineCompletionItem[] {
-    return items.map(completion => {
-        // Return the completion from the start of the current line (instead of starting at the
-        // given position). This avoids UI jitter in VS Code; when typing or deleting individual
-        // characters, VS Code reuses the existing completion while it waits for the new one to
-        // come in.
-        const currentLine = document.lineAt(position)
-        const currentLinePrefix = document.getText(currentLine.range.with({ end: position }))
-        return new vscode.InlineCompletionItem(currentLinePrefix + completion.insertText, currentLine.range, {
-            title: 'Completion accepted',
-            command: 'cody.autocomplete.inline.accepted',
-            arguments: [{ codyLogId: logId, codyLines: completion.insertText.split(/\r\n|\r|\n/).length }],
+    /**
+     * Process completions items in VS Code-specific ways.
+     */
+    private processInlineCompletionsForVSCode(
+        logId: string,
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        items: InlineCompletionItem[]
+    ): vscode.InlineCompletionItem[] {
+        return items.map(completion => {
+            const currentLine = document.lineAt(position)
+            const currentLinePrefix = document.getText(currentLine.range.with({ end: position }))
+
+            // Return the completion from the start of the current line (instead of starting at the
+            // given position). This avoids UI jitter in VS Code; when typing or deleting individual
+            // characters, VS Code reuses the existing completion while it waits for the new one to
+            // come in.
+            const start = currentLine.range.start
+
+            // Limit the range to the current position if the model supports infilling and the
+            // response only has a single line.
+            // For non FIM models, the same line suffix will be repeated in the completion
+            const supportsInfilling = this.config.providerConfig.supportsInfilling
+            const isMultiline = completion.insertText.includes('\n')
+            const end = supportsInfilling && !isMultiline ? position : currentLine.range.end
+
+            return new vscode.InlineCompletionItem(
+                currentLinePrefix + completion.insertText,
+                new vscode.Range(start, end),
+                {
+                    title: 'Completion accepted',
+                    command: 'cody.autocomplete.inline.accepted',
+                    arguments: [{ codyLogId: logId, codyLines: completion.insertText.split(/\r\n|\r|\n/).length }],
+                }
+            )
         })
-    })
+    }
 }
 
 let globalInvocationSequenceForTracer = 0


### PR DESCRIPTION
When returning a completion to VS Code, we adjust range to replace the entire line. This works for anthropic, because the completion will repeat the suffix, but for an infilling model like StarCoder that's not the case.

## Test plan

<img width="1230" alt="Screenshot 2023-08-07 at 14 25 56" src="https://github.com/sourcegraph/cody/assets/458591/c22fa1df-cf4c-4fe6-8a28-32632e555142">
<img width="1256" alt="Screenshot 2023-08-07 at 14 25 12" src="https://github.com/sourcegraph/cody/assets/458591/2393c794-0751-49be-bfed-9e180078ce36">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
