### PR TITLE
Autocomplete: Check next non-empty line for last candidate test and network cache

### DIFF
--- a/vscode/src/completions/document.ts
+++ b/vscode/src/completions/document.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { getNextNonEmptyLine, getPrevNonEmptyLine } from './utils/text-utils'
+
 export interface DocumentContext {
     prefix: string
     suffix: string
@@ -50,25 +52,6 @@ export function getCurrentDocContext(
         .getText(new vscode.Range(position, document.positionAt(document.getText().length)))
         .split('\n')
 
-    let nextNonEmptyLine = ''
-    if (suffixLines.length > 0) {
-        for (const line of suffixLines) {
-            if (line.trim().length > 0) {
-                nextNonEmptyLine = line
-                break
-            }
-        }
-    }
-
-    let prevNonEmptyLine = ''
-    for (let i = prefixLines.length - 1; i >= 0; i--) {
-        const line = prefixLines[i]
-        if (line.trim().length > 0) {
-            prevNonEmptyLine = line
-            break
-        }
-    }
-
     const currentLinePrefix = prefixLines[prefixLines.length - 1]
 
     let prefix: string
@@ -86,6 +69,7 @@ export function getCurrentDocContext(
     } else {
         prefix = document.getText(new vscode.Range(new vscode.Position(0, 0), position))
     }
+    const prevNonEmptyLine = getPrevNonEmptyLine(prefix)
 
     let totalSuffix = 0
     let endLine = 0
@@ -97,6 +81,7 @@ export function getCurrentDocContext(
         totalSuffix += suffixLines[i].length
     }
     const suffix = suffixLines.slice(0, endLine).join('\n')
+    const nextNonEmptyLine = getNextNonEmptyLine(suffix)
 
     const currentLineSuffix = suffixLines[0]
 

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -67,6 +67,9 @@ export interface LastInlineCompletionCandidate {
     /** The prefix of the line (before the cursor position) where this candidate was generated. */
     lastTriggerCurrentLinePrefix: string
 
+    /** The next non-empty line in the suffix */
+    lastTriggerNextNonEmptyLine: string
+
     /** The previously suggested result. */
     result: Pick<InlineCompletionsResult, 'logId' | 'items'>
 }
@@ -147,7 +150,7 @@ async function doGetInlineCompletions({
     getCodebaseContext,
     documentHistory,
     requestManager,
-    lastCandidate: lastCandidate,
+    lastCandidate,
     debounceInterval,
     setIsLoading,
     abortSignal,

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -4,6 +4,7 @@ import { Provider } from './providers/provider'
 import { RequestManager, RequestManagerResult, RequestParams } from './request-manager'
 import { documentAndPosition } from './testHelpers'
 import { Completion } from './types'
+import { getNextNonEmptyLine, getPrevNonEmptyLine } from './utils/text-utils'
 
 class MockProvider extends Provider {
     public didFinishNetworkRequest = false
@@ -48,8 +49,8 @@ function docState(prefix: string): RequestParams {
             currentLinePrefix:
                 prefix.lastIndexOf('\n') === -1 ? prefix : prefix.slice(Math.max(0, prefix.lastIndexOf('\n') + 1)),
             currentLineSuffix: suffix,
-            prevNonEmptyLine: '',
-            nextNonEmptyLine: '',
+            prevNonEmptyLine: getPrevNonEmptyLine(prefix),
+            nextNonEmptyLine: getNextNonEmptyLine(suffix),
         },
         multiline: false,
     }

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -37,8 +37,7 @@ function createProvider(prefix: string) {
     })
 }
 
-function docState(prefix: string): RequestParams {
-    const suffix = ';'
+function docState(prefix: string, suffix: string = ';'): RequestParams {
     const { document, position } = documentAndPosition(`${prefix}█${suffix}`)
     return {
         document,
@@ -57,11 +56,12 @@ function docState(prefix: string): RequestParams {
 }
 
 describe('RequestManager', () => {
-    let createRequest: (prefix: string, provider: Provider) => Promise<RequestManagerResult>
+    let createRequest: (prefix: string, provider: Provider, suffix?: string) => Promise<RequestManagerResult>
     beforeEach(() => {
         const requestManager = new RequestManager()
 
-        createRequest = (prefix: string, provider: Provider) => requestManager.request(docState(prefix), [provider], [])
+        createRequest = (prefix: string, provider: Provider, suffix?: string) =>
+            requestManager.request(docState(prefix, suffix), [provider], [])
     })
 
     it('resolves a single request', async () => {
@@ -88,6 +88,23 @@ describe('RequestManager', () => {
 
         expect(cacheHit).toBe('hit')
         expect(completions[0].insertText).toBe("'hello')")
+    })
+
+    it('does not resolve from cache if the suffix has changed', async () => {
+        const prefix = 'console.log('
+        const suffix1 = ')\nconsole.log(1)'
+        const provider1 = createProvider(prefix)
+        setTimeout(() => provider1.resolveRequest(["'hello')"]), 0)
+        await createRequest(prefix, provider1, suffix1)
+
+        const suffix2 = ')\nconsole.log(2)'
+        const provider2 = createProvider(prefix)
+        setTimeout(() => provider2.resolveRequest(["'world')"]), 0)
+
+        const { completions, cacheHit } = await createRequest(prefix, provider2, suffix2)
+
+        expect(cacheHit).toBeNull()
+        expect(completions[0].insertText).toBe("'world')")
     })
 
     it('keeps requests running when a new request comes in', async () => {

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -110,6 +110,7 @@ export class RequestManager {
             uri: document.uri,
             lastTriggerPosition: position,
             lastTriggerCurrentLinePrefix: docContext.currentLinePrefix,
+            lastTriggerNextNonEmptyLine: docContext.nextNonEmptyLine,
             result: {
                 logId: '',
                 items,

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -169,7 +169,7 @@ class RequestCache {
     private cache = new LRUCache<string, InlineCompletionItem[]>({ max: 50 })
 
     private toCacheKey(key: RequestParams): string {
-        return key.docContext.prefix
+        return `${key.docContext.prefix}█${key.docContext.nextNonEmptyLine}`
     }
 
     public get(key: RequestParams): InlineCompletionItem[] | undefined {

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -10,15 +10,16 @@ import { InlineCompletionItem } from './types'
 export function reuseLastCandidate({
     document,
     position,
-    lastCandidate: { lastTriggerPosition, lastTriggerCurrentLinePrefix, ...lastCandidate },
-    docContext: { currentLinePrefix, currentLineSuffix },
+    lastCandidate: { lastTriggerPosition, lastTriggerCurrentLinePrefix, lastTriggerNextNonEmptyLine, ...lastCandidate },
+    docContext: { currentLinePrefix, currentLineSuffix, nextNonEmptyLine },
 }: Required<Pick<InlineCompletionsParams, 'document' | 'position' | 'lastCandidate'>> & {
     docContext: DocumentContext
 }): InlineCompletionsResult | null {
     const isSameDocument = lastCandidate.uri.toString() === document.uri.toString()
     const isSameLine = lastTriggerPosition.line === position.line
+    const isSameNextNonEmptyLine = lastTriggerNextNonEmptyLine === nextNonEmptyLine
 
-    if (!isSameDocument || !isSameLine) {
+    if (!isSameDocument || !isSameLine || !isSameNextNonEmptyLine) {
         return null
     }
 

--- a/vscode/src/completions/utils/text-utils.test.ts
+++ b/vscode/src/completions/utils/text-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { getNextNonEmptyLine, getPrevNonEmptyLine } from './text-utils'
+
+describe('getNextNonEmptyLine', () => {
+    it.each([
+        ['foo\nbar', 'bar'],
+        ['foo\nbar\nbaz', 'bar'],
+        ['foo\n\nbar', 'bar'],
+        ['foo\n  \nbar', 'bar'],
+        ['\nbar', 'bar'],
+        ['foo', ''],
+        ['foo\n', ''],
+        ['', ''],
+    ])('should work for %s', (suffix, expected) => {
+        expect(getNextNonEmptyLine(suffix)).toBe(expected)
+    })
+})
+
+describe('getPrevNonEmptyLine', () => {
+    it.each([
+        ['foo\nbar', 'foo'],
+        ['foo\nbar\nbaz', 'foo'],
+        ['foo\n\nbar', 'foo'],
+        ['foo\n  \nbar', 'foo'],
+        ['bar', ''],
+        ['bar\n', 'bar'],
+        ['\nbar', ''],
+        ['', ''],
+    ])('should work for %s', (suffix, expected) => {
+        expect(getPrevNonEmptyLine(suffix)).toBe(expected)
+    })
+})

--- a/vscode/src/completions/utils/text-utils.ts
+++ b/vscode/src/completions/utils/text-utils.ts
@@ -68,12 +68,35 @@ export function shouldIncludeClosingLine(prefixIndentationWithFirstCompletionLin
 
     const startIndent = indentation(prefixIndentationWithFirstCompletionLine)
 
-    const firstNewLineIndex = suffix.indexOf('\n') + 1
-    const nextNonEmptyLine =
-        suffix
-            .slice(firstNewLineIndex)
-            .split('\n')
-            .find(line => line.trim().length > 0) ?? ''
+    const nextNonEmptyLine = getNextNonEmptyLine(suffix)
 
     return indentation(nextNonEmptyLine) < startIndent || includeClosingLineBasedOnBrackets
+}
+
+export function getNextNonEmptyLine(suffix: string): string {
+    const nextNewline = suffix.indexOf('\n')
+    // There is no next line
+    if (nextNewline === -1) {
+        return ''
+    }
+    return (
+        suffix
+            .slice(nextNewline + 1)
+            .split('\n')
+            .find(line => line.trim().length > 0) ?? ''
+    )
+}
+
+export function getPrevNonEmptyLine(prefix: string): string {
+    const prevNewline = prefix.lastIndexOf('\n')
+    // There is no prev line
+    if (prevNewline === -1) {
+        return ''
+    }
+    return (
+        prefix
+            .slice(0, prevNewline)
+            .split('\n')
+            .find(line => line.trim().length > 0) ?? ''
+    )
 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -17,6 +17,7 @@ import { ProviderConfig } from './providers/provider'
 import { RequestManager } from './request-manager'
 import { ProvideInlineCompletionItemsTracer, ProvideInlineCompletionsItemTraceData } from './tracer'
 import { InlineCompletionItem } from './types'
+import { getNextNonEmptyLine } from './utils/text-utils'
 
 interface CodyCompletionItemProviderConfig {
     providerConfig: ProviderConfig
@@ -161,6 +162,11 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                           uri: document.uri,
                           lastTriggerPosition: position,
                           lastTriggerCurrentLinePrefix: document.lineAt(position).text.slice(0, position.character),
+                          lastTriggerNextNonEmptyLine: getNextNonEmptyLine(
+                              document.getText(
+                                  new vscode.Range(position, document.lineAt(document.lineCount - 1).range.end)
+                              )
+                          ),
                           result: {
                               logId: result.logId,
                               items: result.items,


### PR DESCRIPTION
Add the next non-empty line to the "last candidate" logic. This way we can detect wether a multi-line completion was already inserted. If the suffix has changed this dramatically, the last candidate is no longer relevant and we should instead issue a new request.

## Test plan

### Before

<img width="873" alt="Screenshot 2023-08-07 at 15 28 42" src="https://github.com/sourcegraph/cody/assets/458591/a06d96d5-ea74-4125-85be-ef94f41b7f8b">

### After

https://github.com/sourcegraph/cody/assets/458591/329c9bb5-5c4b-4467-95ca-b9a6b4769dd9


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
