### PR TITLE
Cody: Always expand inline on chat

### DIFF
--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -174,7 +174,7 @@ export class InlineController implements VsCodeInlineController {
         // disable reply until the task is completed
         thread.canReply = false
         thread.label = this.threadLabel
-        thread.collapsibleState = vscode.CommentThreadCollapsibleState.Collapsed
+        thread.collapsibleState = vscode.CommentThreadCollapsibleState.Expanded
 
         const comment = new Comment(reply, 'Me', this.userIcon, thread)
         thread.comments = [...thread.comments, comment]


### PR DESCRIPTION
## Description

This should be `Expanded`. I don't know exactly why this wasn't causing issues before (maybe it's impossible to do this when a user has focus?), but we want this to be `Expanded` so we can programmatically create inline chats (like through code actions

## Test plan

Tested inline chat and inline fix
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
