### PR TITLE
fix: command filter regex

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Bug: Fixes an issue where the codebase context was not correctly inferred to load embeddings context for autocomplete. [pull/525](https://github.com/sourcegraph/cody/pull/525)
 - Inline Fixup: `/chat` will now redirect your question to the chat view correctly through the Non-Stop Fixup input box. [pull/386](https://github.com/sourcegraph/cody/pull/386)
+- Fix REGEX issue for existing `/reset`, `/search`, and `/fix` commands. [pull/594](https://github.com/sourcegraph/cody/pull/594)
 
 ### Changed
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -570,18 +570,18 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 return vscode.commands.executeCommand('cody.action.commands.menu')
             case text === '/commands-settings':
                 return vscode.commands.executeCommand('cody.settings.commands')
-            case /^\/o(pen)?/i.test(text) && this.editor.controllers.command !== undefined:
+            case /^\/o(pen)?\s.*$/.test(text) && this.editor.controllers.command !== undefined:
                 // open the user's ~/.vscode/cody.json file
                 await this.editor.controllers.command?.open(text.split(' ')[1])
                 return null
-            case /^\/r(eset)?/i.test(text):
+            case /^\/r(eset)?$/.test(text):
                 await this.clearAndRestartSession()
                 return null
-            case /^\/s(earch)?(\s)?/i.test(text):
+            case /^\/s(earch)?\s.*$/.test(text):
                 return { text, recipeId: 'context-search' }
-            case /^\/f(ix)?(\s)?/i.test(text):
+            case /^\/f(ix)?\s.*$/.test(text):
                 return { text, recipeId: 'fixup' }
-            case /^\/(explain|doc|test)$/i.test(text): {
+            case /^\/(explain|doc|test)$/.test(text): {
                 const promptText = this.editor.controllers.command?.find(text, true) || null
                 await this.editor.controllers.command?.get('command')
                 if (!promptText) {

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -570,14 +570,14 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 return vscode.commands.executeCommand('cody.action.commands.menu')
             case text === '/commands-settings':
                 return vscode.commands.executeCommand('cody.settings.commands')
-            case /^\/o(pen)?\s.*$/.test(text) && this.editor.controllers.command !== undefined:
+            case /^\/o(pen)?\s/.test(text) && this.editor.controllers.command !== undefined:
                 // open the user's ~/.vscode/cody.json file
                 await this.editor.controllers.command?.open(text.split(' ')[1])
                 return null
             case /^\/r(eset)?$/.test(text):
                 await this.clearAndRestartSession()
                 return null
-            case /^\/s(earch)?\s.*$/.test(text):
+            case /^\/s(earch)?\s/.test(text):
                 return { text, recipeId: 'context-search' }
             case /^\/f(ix)?\s.*$/.test(text):
                 return { text, recipeId: 'fixup' }


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1691422532897009

fix: command filter regex

Currently, typing /r or /reset would reset the chat as expected, but if you create a new slash command that starts with `r`, for example, `/release`, it would still perform the reset command because of the current REGEX we are using for the `/reset` command. 

This PR fixes that issue along with the same issue for `/search` and `/fix`

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

## After

submitting chat with `/read` should not perform `reset` 
submitting chat with `/stop` should not perform `search` 
submitting chat with `/fox` should not perform `fix.` 

## Before 
submitting chat with `/read` performs `reset` 
submitting chat with `/stop` performs `search` 
submitting chat with `/fox` performs `fix` 