### PR TITLE
fix: handle aborted messages correctly

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Handle `socket hung up` errors that are not caused by the `stop generating` button. [pull/598](https://github.com/sourcegraph/cody/pull/598)
+
 ### Changed
 
 ## [0.6.5]

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -212,6 +212,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 debug('ChatViewProvider:onError', err)
 
                 if (isAbortError(err)) {
+                    void this.onCompletionEnd()
                     return
                 }
                 // Log users out on unauth error
@@ -259,7 +260,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     protected async abortCompletion(): Promise<void> {
         this.cancelCompletion()
         await this.multiplexer.notifyTurnComplete()
-        await this.onCompletionEnd()
     }
 
     private async getPluginsContext(

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -210,9 +210,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             onError: (err, statusCode) => {
                 // TODO notify the multiplexer of the error
                 debug('ChatViewProvider:onError', err)
-
-                if (isAbortError(err)) {
-                    void this.onCompletionEnd()
+                // When the user has initiated the abortion of the message, isMessageInProgress would have set to false by abortCompletion() and we can safely ignore this error.
+                // If isMessageInProgeress is true, then user did not abort the message and we will treat it as an error.
+                if (isAbortError(err) && !this.isMessageInProgress) {
                     return
                 }
                 // Log users out on unauth error
@@ -260,6 +260,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     protected async abortCompletion(): Promise<void> {
         this.cancelCompletion()
         await this.multiplexer.notifyTurnComplete()
+        await this.onCompletionEnd()
     }
 
     private async getPluginsContext(


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1691104523645779

fix: handle aborted messages correctly

This PR proposed to check `isMessageInProgress` before treating abort errors as real errors. This avoids chat being hung indefinitely on the `socket hang up` error, which is the same error that returns for aborted messages.

Issue: the onCompletionEnd method was being called after aborting completion that produces the `socket hang up` error, but it does not cover cases where `socket hang up` is returned for errors that were not caused by calling `abort`, leaving the chat to be stuck with `stop generating` indefinitely until the user clicks on the `stop generating` button to mark it as completed manually. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

See Demo:

After: the `stop generating` button still works accordingly in sidebar chat and inline chat

https://github.com/sourcegraph/cody/assets/68532117/4a6c04d2-296e-4fc2-b28f-a5f7c7e8588e

Before:

![image](https://github.com/sourcegraph/cody/assets/68532117/86dc5146-415b-4413-922b-4c087dd2be68)


https://github.com/sourcegraph/cody/assets/68532117/46a29100-64be-456d-af56-fdf02fc8de76

