### PR TITLE
fix: change file link color to match buttons

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Update file link color to match buttons. [pull/600](https://github.com/sourcegraph/cody/pull/600)
+
 ### Changed
 
 ## [0.6.5]

--- a/vscode/webviews/FileLink.module.css
+++ b/vscode/webviews/FileLink.module.css
@@ -1,7 +1,7 @@
 .link-button {
     background: none;
     border: none;
-    color: var(--vscode-textLink-foreground);
+    color: var(--vscode-button-secondaryForeground);
     cursor: pointer;
     font-size: inherit;
     text-decoration: underline;


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1691431852119019


The file link color was changed from `--vscode-textLink-foreground` to `--vscode-button-secondaryForeground` for the `link-button`

This makes the file links match the styling of the secondary buttons we currently use for the[ file links component](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/webviews/Chat.module.css?L45), providing a more consistent user experience.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Before:

[Shades of Purple](https://marketplace.visualstudio.com/items?itemName=ahmadawais.shades-of-purple)
![image](https://github.com/sourcegraph/cody/assets/68532117/4171f2a2-ba22-4f8d-ac0e-29090ad05f52)

Material theme palenight HC
![image](https://github.com/sourcegraph/cody/assets/68532117/3a74fbe0-5c6f-4198-8ff5-87be057b092f)

Light+ theme
![image](https://github.com/sourcegraph/cody/assets/68532117/0648ed8a-4aa5-4184-b74a-353f76f48aff)

Dark+
![image](https://github.com/sourcegraph/cody/assets/68532117/00d40497-f072-45b6-b233-24ab4a3a793f)

After:

[Shades of Purple](https://marketplace.visualstudio.com/items?itemName=ahmadawais.shades-of-purple)
![image](https://github.com/sourcegraph/cody/assets/68532117/fd07f292-465a-466c-8737-706ef16fe639)

Material theme palenight HC
![image](https://github.com/sourcegraph/cody/assets/68532117/42367aa8-f9ad-4903-bebd-0e8cc108ab23)

Light+ theme
![image](https://github.com/sourcegraph/cody/assets/68532117/0e39fc24-1044-4f6c-9fe5-076151866aec)

Dark +
![image](https://github.com/sourcegraph/cody/assets/68532117/aedbd84c-12fb-4759-b445-c81b807f7482)
