### PR TITLE
VSCode: Don't add "Reload Window" actions to all views

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -619,11 +619,6 @@
           "command": "cody.fixup.apply-all",
           "when": "cody.nonstop.fixups.enabled && view == cody.fixup.tree.view && cody.activated",
           "group": "navigation"
-        },
-        {
-          "command": "workbench.action.reloadWindow",
-          "title": "Reload",
-          "group": "8_cody@0"
         }
       ],
       "editor/title": [


### PR DESCRIPTION
#53908 introduced a stray system-wide "Reload Window" action. This reverts that change and fixes #601.

| Before | After |
| - | - |
| <img width="556" alt="Screenshot 2023-08-08 at 11 52 25 am" src="https://github.com/sourcegraph/cody/assets/153/77c354f3-e0b9-43c2-8b7d-4f7e4ab6934c"> | <img width="556" alt="Screenshot 2023-08-08 at 11 53 09 am" src="https://github.com/sourcegraph/cody/assets/153/d3d5f518-08aa-4d27-a913-d4357e23e37d"> |

## Test plan

- Opened views, checked reload option doesn't exist
- Used the Cody Settings palette to enable/disable features, click "Reload Window" in notification and verified still works
