### PR TITLE
VS Code: Remove beta labels from features

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -119,7 +119,7 @@
           },
           {
             "id": "inline-assist",
-            "title": "Inline Chat (Beta)",
+            "title": "Inline Chat",
             "description": "Chat with Cody without leaving your file. Click the + button next to any line number in a file to bring up Inline Chat.\n[Enable in Settings](command:cody.walkthrough.enableInlineChat)",
             "media": {
               "markdown": "walkthroughs/inline-assist.md"
@@ -127,7 +127,7 @@
           },
           {
             "id": "autocomplete",
-            "title": "Code Autocomplete (Beta)",
+            "title": "Code Autocomplete",
             "description": "Let Cody automatically write code for you. Start writing a comment or a line of code and Cody will suggest the next few lines.",
             "media": {
               "markdown": "walkthroughs/autocomplete.md"

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -30,7 +30,7 @@ export function createStatusBar(): CodyStatusBar {
 
         function createFeatureToggle(
             name: string,
-            description: string,
+            description: string | undefined,
             detail: string,
             setting: string,
             getValue: (config: Configuration) => boolean,
@@ -62,14 +62,14 @@ export function createStatusBar(): CodyStatusBar {
                 { label: 'enable/disable features', kind: vscode.QuickPickItemKind.Separator },
                 createFeatureToggle(
                     'Code Autocomplete',
-                    'Beta',
+                    undefined,
                     'Enable Cody-powered code autocompletions',
                     'cody.autocomplete.enabled',
                     c => c.autocomplete
                 ),
                 createFeatureToggle(
                     'Inline Chat',
-                    'Beta',
+                    undefined,
                     'Enable chatting and editing with Cody, directly in your code',
                     'cody.inlineChat.enabled',
                     c => c.inlineChat

--- a/vscode/walkthroughs/autocomplete.md
+++ b/vscode/walkthroughs/autocomplete.md
@@ -1,4 +1,4 @@
-## Code Autocomplete (Beta)
+## Code Autocomplete
 
 <video autoPlay muted loop playsInline>
     <source


### PR DESCRIPTION
Given the whole extension is in beta we don't need to label these two features as individually in beta.

| Before | After |
| - | - |
| <img width="1147" alt="Screenshot 2023-08-08 at 8 03 52 pm" src="https://github.com/sourcegraph/cody/assets/153/ca714706-3b66-4441-847e-fc6ad9bb3159"> | <img width="1147" alt="Screenshot 2023-08-08 at 8 03 06 pm" src="https://github.com/sourcegraph/cody/assets/153/ef8e7c9e-cf53-46a9-b1fb-1303137d9f06"> |

## Test plan

- Opened Cody settings, verified renders