### PR TITLE
command: add tab-to-complete

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -271,6 +271,12 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     setSelectedChatCommand(-1)
                     setFormInput('')
                 }
+                // tab to complete
+                if (event.key === 'Tab' && selectedChatCommand > -1) {
+                    event.preventDefault()
+                    const newInput = displayCommands?.[selectedChatCommand]?.[1]?.slashCommand
+                    setFormInput(newInput || formInput)
+                }
             }
 
             // Loop through input history on up arrow press

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Chat Commands: Add tab-to-complete behavior. [pull/606](https://github.com/sourcegraph/cody/pull/606)
+
 ### Fixed
 
 - Update file link color to match buttons. [pull/600](https://github.com/sourcegraph/cody/pull/600)

--- a/vscode/src/custom-prompts/utils/menu.ts
+++ b/vscode/src/custom-prompts/utils/menu.ts
@@ -16,7 +16,7 @@ const commandsSeparator: QuickPickItem = { kind: -1, label: 'commands' }
 const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'custom commands' }
 const configOption: QuickPickItem = { label: 'Configure Custom Commands...' }
 const settingsSeparator: QuickPickItem = { kind: -1, label: 'settings' }
-const addOption: QuickPickItem = { label: 'New Custom Command...', alwaysShow: true }
+const addOption: QuickPickItem = { label: 'New Custom User Command...', alwaysShow: true }
 const chatSubmitOption: QuickPickItem = { label: 'Submit Question', alwaysShow: true }
 const fixSubmitOption: QuickPickItem = { label: 'Submit Refactor Request', alwaysShow: true }
 
@@ -183,7 +183,7 @@ export async function showcommandTypeQuickPick(
 export const CustomCommandConfigMenuItems = [
     {
         kind: 0,
-        label: 'New Custom Command...',
+        label: 'New Custom User Command...',
         id: 'add',
         type: 'user',
         description: '',
@@ -191,7 +191,7 @@ export const CustomCommandConfigMenuItems = [
     { kind: -1, id: 'separator', label: '' },
     {
         kind: 0,
-        label: 'User Settings (JSON)',
+        label: 'Open User Settings (JSON)',
         id: 'open',
         type: 'user',
         description: '~/.vscode/cody.json',
@@ -199,7 +199,7 @@ export const CustomCommandConfigMenuItems = [
     },
     {
         kind: 0,
-        label: 'Workspace Settings (JSON)',
+        label: 'Open Workspace Settings (JSON)',
         id: 'open',
         type: 'workspace',
         description: '.vscode/cody.json',

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -15,7 +15,7 @@ test('open the Custom Commands in sidebar and add new user recipe', async ({ pag
     // Create Command via UI
     const recipeName = 'A Test Recipes'
     await page.getByText('Configure Custom Commands...').click()
-    await page.locator('a').filter({ hasText: 'New Custom Command...' }).click()
+    await page.locator('a').filter({ hasText: 'New Custom User Command...' }).click()
     await page.keyboard.type(recipeName)
     await page.keyboard.press('Enter')
     await page.keyboard.type('this is a test')

--- a/vscode/webviews/ChatCommands.tsx
+++ b/vscode/webviews/ChatCommands.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
@@ -14,14 +14,7 @@ export const ChatCommandsComponent: React.FunctionComponent<React.PropsWithChild
     setSelectedChatCommand,
     onSubmit,
 }) => {
-    const commandList = chatCommands?.filter(command => command[1]?.slashCommand)
     const selectionRef = useRef<HTMLButtonElement>(null)
-    useEffect(() => {
-        if (commandList && selectedChatCommand && selectedChatCommand >= 0 && selectionRef.current) {
-            selectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-            return
-        }
-    }, [commandList, selectedChatCommand])
 
     const onCommandClick = (slashCommand?: string): void => {
         if (!slashCommand) {
@@ -32,7 +25,7 @@ export const ChatCommandsComponent: React.FunctionComponent<React.PropsWithChild
         setSelectedChatCommand(-1)
     }
 
-    if (!commandList?.length || selectedChatCommand === undefined || selectedChatCommand < 0) {
+    if (!chatCommands?.length || selectedChatCommand === undefined || selectedChatCommand < 0) {
         return null
     }
 
@@ -52,18 +45,20 @@ export const ChatCommandsComponent: React.FunctionComponent<React.PropsWithChild
             <div className={classNames(styles.commandsContainer)}>
                 {chatCommands &&
                     selectedChatCommand >= 0 &&
-                    commandList?.map(([command, prompt], i) => (
-                        <button
-                            className={classNames(styles.commandItem, selectedChatCommand === i && styles.selected)}
-                            key={prompt.slashCommand}
-                            onClick={() => onCommandClick(prompt.slashCommand)}
-                            type="button"
-                            ref={i === selectedChatCommand ? selectionRef : null}
-                        >
-                            <p className={styles.commandTitle}>{prompt.slashCommand}</p>
-                            <p className={styles.commandDescription}>{command}</p>
-                        </button>
-                    ))}
+                    chatCommands
+                        ?.filter(command => command[1]?.slashCommand)
+                        ?.map(([command, prompt], i) => (
+                            <button
+                                className={classNames(styles.commandItem, selectedChatCommand === i && styles.selected)}
+                                key={prompt.slashCommand}
+                                onClick={() => onCommandClick(prompt.slashCommand)}
+                                type="button"
+                                ref={i === selectedChatCommand ? selectionRef : null}
+                            >
+                                <p className={styles.commandTitle}>{prompt.slashCommand}</p>
+                                <p className={styles.commandDescription}>{command}</p>
+                            </button>
+                        ))}
             </div>
         </div>
     )


### PR DESCRIPTION
separated from https://github.com/sourcegraph/cody/pull/602

- Add tab-to-complete && enter-to-complete behavior for matching commands in chat box
- Allow selecting a chat command by pressing enter in addition to tab

Hide Suggestions when the `/` command box is activated:

![image](https://github.com/sourcegraph/cody/assets/68532117/a2981b83-62af-4251-ad3b-a2b55b7c8224)


Additional clean up:

- Clear command selection when submitting input if no command selected
- Only show suggestions if no command list is open
- Use chatCommands prop directly instead of filtering to commands with slashCommand

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

tab to complete:

![tab](https://github.com/sourcegraph/cody/assets/68532117/5a75c7e6-e9b9-462b-8360-07df7441a490)
