### PR TITLE
Autocomplete: Fix suffix matching logic for FIM models

### DIFF
--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -445,9 +445,6 @@ function completionMatchesSuffix(
     }
 
     const suffix = docContext.currentLineSuffix
-    if (suffix.trim() === '') {
-        return true
-    }
 
     for (const completion of completions) {
         const insertion = completion.insertText

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -253,7 +253,7 @@ async function doGetInlineCompletions({
         tracer ? createCompletionProviderTracer(tracer) : undefined
     )
 
-    logCompletions(logId, completions, document, docContext, context, abortSignal)
+    logCompletions(logId, completions, document, docContext, context, providerConfig, abortSignal)
 
     return {
         logId,
@@ -385,6 +385,7 @@ function logCompletions(
     document: vscode.TextDocument,
     docContext: DocumentContext,
     context: vscode.InlineCompletionContext,
+    providerConfig: ProviderConfig,
     abortSignal: AbortSignal | undefined
 ): void {
     CompletionLogger.loaded(logId)
@@ -403,31 +404,9 @@ function logCompletions(
     //   completion with the suffix, we have to do a per-character diff to test
     //   this.
     const isAborted = abortSignal ? abortSignal.aborted : false
-    let isMatchingCompletionPopup = true
-    if (context.selectedCompletionInfo) {
-        const currentText = document.getText(context.selectedCompletionInfo.range)
-        const selectedText = context.selectedCompletionInfo.text
-        if (completions.length > 0 && !(currentText + completions[0].insertText).startsWith(selectedText)) {
-            isMatchingCompletionPopup = false
-        }
-    }
-    let containsCompletionThatMatchesSuffix = false
-    for (const completion of completions) {
-        const insertion = completion.insertText
-        const suffix = docContext.currentLineSuffix
-        let j = 0
-        // eslint-disable-next-line @typescript-eslint/prefer-for-of
-        for (let i = 0; i < insertion.length; i++) {
-            if (insertion[i] === suffix[j]) {
-                j++
-            }
-        }
-        if (j === suffix.length) {
-            containsCompletionThatMatchesSuffix = true
-        }
-    }
-
-    const isVisible = !isAborted && isMatchingCompletionPopup && containsCompletionThatMatchesSuffix
+    const isMatchingPopupItem = completionMatchesPopupItem(completions, document, context)
+    const isMatchingSuffix = completionMatchesSuffix(completions, docContext, providerConfig)
+    const isVisible = !isAborted && isMatchingPopupItem && isMatchingSuffix
 
     if (isVisible) {
         if (completions.length > 0) {
@@ -436,4 +415,53 @@ function logCompletions(
             CompletionLogger.noResponse(logId)
         }
     }
+}
+
+function completionMatchesPopupItem(
+    completions: InlineCompletionItem[],
+    document: vscode.TextDocument,
+    context: vscode.InlineCompletionContext
+): boolean {
+    if (context.selectedCompletionInfo) {
+        const currentText = document.getText(context.selectedCompletionInfo.range)
+        const selectedText = context.selectedCompletionInfo.text
+        if (completions.length > 0 && !(currentText + completions[0].insertText).startsWith(selectedText)) {
+            return false
+        }
+    }
+    return true
+}
+
+function completionMatchesSuffix(
+    completions: InlineCompletionItem[],
+    docContext: DocumentContext,
+    providerConfig: ProviderConfig
+): boolean {
+    // Models that support infilling do not replace an existing suffix but
+    // instead insert the completion only at the current cursor position. Thus,
+    // we do not need to compare the suffix
+    if (providerConfig.supportsInfilling) {
+        return true
+    }
+
+    const suffix = docContext.currentLineSuffix
+    if (suffix.trim() === '') {
+        return true
+    }
+
+    for (const completion of completions) {
+        const insertion = completion.insertText
+        let j = 0
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < insertion.length; i++) {
+            if (insertion[i] === suffix[j]) {
+                j++
+            }
+        }
+        if (j === suffix.length) {
+            return true
+        }
+    }
+
+    return false
 }


### PR DESCRIPTION
Models that support infilling do not replace an existing suffix but
instead insert the completion only at the current cursor position. Thus,
we do not need to compare the suffix

## Test plan

<img width="1177" alt="Screenshot 2023-08-08 at 15 40 18" src="https://github.com/sourcegraph/cody/assets/458591/9290aceb-9940-43f7-95cb-7dfad1440d3f">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
