### PR TITLE
Autocomplete: Tweak StarCoder options

### DIFF
--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -14,7 +14,7 @@ interface UnstableFireworksOptions {
 
 const PROVIDER_IDENTIFIER = 'fireworks'
 const STOP_WORD = '<|endoftext|>'
-const CONTEXT_WINDOW_CHARS = 3500 // ~ 1280 token limit
+const CONTEXT_WINDOW_CHARS = 5000 // ~ 2000 token limit
 
 export class UnstableFireworksProvider extends Provider {
     private serverEndpoint: string
@@ -73,7 +73,6 @@ export class UnstableFireworksProvider extends Provider {
             max_tokens: this.options.multiline ? 256 : 30,
             temperature: 0.4,
             top_p: 0.95,
-            min_tokens: 1,
             n: this.options.n,
             echo: false,
             model: 'accounts/fireworks/models/fireworks-starcoder-7b-w8a16-1gpu',


### PR DESCRIPTION
- Removes the minimum tokens to sample, the model can now yield nothing if nothing is probably. This feels nicer than always forcing a completion and still seems to always provide tokens when it makes sense
- Increases the context window length to be more equivalent to our Anthropic prompt 

## Test plan

Played with it locally, this is not stable anyways.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
