### PR TITLE
add experimentalEditorTitleCommandIcon > statusbar

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -14,6 +14,7 @@ export interface Configuration {
     experimentalChatPredictions: boolean
     inlineChat: boolean
     experimentalCommandLenses: boolean
+    experimentalEditorTitleCommandIcon: boolean
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
     autocompleteAdvancedProvider:

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Added
 
 - Chat Commands: Add tab-to-complete behavior. [pull/606](https://github.com/sourcegraph/cody/pull/606)
+- Option to toggle `cody.experimental.editorTitleCommandIcon` setting through status bar. [pull/TBA](https://github.com/sourcegraph/cody/pull/TBA)
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,7 +9,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Added
 
 - Chat Commands: Add tab-to-complete behavior. [pull/606](https://github.com/sourcegraph/cody/pull/606)
-- Option to toggle `cody.experimental.editorTitleCommandIcon` setting through status bar. [pull/TBA](https://github.com/sourcegraph/cody/pull/TBA)
+- Option to toggle `cody.experimental.editorTitleCommandIcon` setting through status bar. [pull/611](https://github.com/sourcegraph/cody/pull/611)
 
 ### Fixed
 

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -36,6 +36,7 @@ export type Config = Pick<
     | 'experimentalChatPredictions'
     | 'experimentalGuardrails'
     | 'experimentalCommandLenses'
+    | 'experimentalEditorTitleCommandIcon'
     | 'pluginsEnabled'
     | 'pluginsConfig'
     | 'pluginsDebugEnabled'

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -18,6 +18,7 @@ describe('getConfiguration', () => {
             useContext: 'embeddings',
             autocomplete: true,
             experimentalCommandLenses: false,
+            experimentalEditorTitleCommandIcon: false,
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
             inlineChat: true,
@@ -55,6 +56,8 @@ describe('getConfiguration', () => {
                     case 'cody.experimental.chatPredictions':
                         return true
                     case 'cody.experimental.commandLenses':
+                        return true
+                    case 'cody.experimental.editorTitleCommandIcon':
                         return true
                     case 'cody.experimental.guardrails':
                         return true
@@ -107,6 +110,7 @@ describe('getConfiguration', () => {
             autocomplete: false,
             experimentalChatPredictions: true,
             experimentalCommandLenses: true,
+            experimentalEditorTitleCommandIcon: true,
             experimentalGuardrails: true,
             inlineChat: true,
             experimentalNonStop: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -70,6 +70,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
         experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
+        experimentalEditorTitleCommandIcon: config.get(CONFIG_KEY.experimentalEditorTitleCommandIcon, false),
         autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -89,6 +89,13 @@ export function createStatusBar(): CodyStatusBar {
                     'cody.experimental.commandLenses',
                     c => c.experimentalCommandLenses
                 ),
+                createFeatureToggle(
+                    'Editor Title Icon',
+                    'Experimental',
+                    'Enable Cody to appear in editor title menu for quick access to Cody commands',
+                    'cody.experimental.editorTitleCommandIcon',
+                    c => c.experimentalEditorTitleCommandIcon
+                ),
                 { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
                 {
                     label: '$(gear) Cody Extension Settings',


### PR DESCRIPTION
This adds the existing configuration setting called experimentalEditorTitleCommandIcon that adds cody icon that can be used to toggle showing the chat `command menu` in the editor title bar:
![image](https://github.com/sourcegraph/cody/assets/68532117/3f01159b-65aa-40b4-9631-8d936418ed3d)

The setting is defaulted to false. When enabled, it will show the icon that can be clicked to open the command menu.

This also updates the status bar service to respect this new setting when determining whether to show the icon as enabled or not.

Related components updated:
- configuration.ts
- StatusBar.ts
- ContextProvider.ts
- configuration.test.ts

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Cody icon only shows up in the title bar when the setting is set to true:

![image](https://github.com/sourcegraph/cody/assets/68532117/7da2bba9-21d4-4959-b9a2-cb59a3a097c2)

![image](https://github.com/sourcegraph/cody/assets/68532117/38b05b7a-560a-491b-a95c-dbf2c792c8d0)
