### PR TITLE
support signing in on VS Code Web

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -60,7 +60,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                     break
                 }
                 if (message.type === 'callback' && message.endpoint) {
-                    await this.authProvider.redirectToEndpointLogin(message.endpoint)
+                    this.authProvider.redirectToEndpointLogin(message.endpoint)
                     break
                 }
                 // cody.auth.signin or cody.auth.signout

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -139,6 +139,9 @@ export interface LocalEnv {
     appName: string
     extensionVersion: string
 
+    /** Whether the extension is running in VS Code Web (as opposed to VS Code Desktop). */
+    uiKindIsWeb: boolean
+
     // App Local State
     hasAppJson: boolean
     isAppInstalled: boolean

--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -48,24 +48,30 @@ export const AuthMenu = async (type: AuthMenuType, historyItems: string[]): Prom
     return option
 }
 
-// step 1 is to get the endpoint, step 2 is to get the token
-export async function LoginStepInputBox(title: string, step: number, needToken: boolean): Promise<LoginInput | null> {
-    // Get endpoint
-    const options = LoginStepOptions[step - 1]
-    options.title = title
-    const endpoint = await vscode.window.showInputBox(options)
-    if (!needToken || !endpoint) {
-        return { endpoint, token: null }
-    }
-    return TokenInputBox(endpoint)
+/**
+ * Show a VS Code input box to ask the user to enter a Sourcegraph instance URL.
+ */
+export async function showInstanceURLInputBox(title: string): Promise<string | undefined> {
+    return vscode.window.showInputBox({
+        title,
+        prompt: 'Enter the URL of the Sourcegraph instance',
+        placeHolder: 'https://sourcegraph.example.com',
+        password: false,
+        ignoreFocusOut: true,
+    })
 }
 
-export async function TokenInputBox(endpoint: string): Promise<LoginInput | null> {
-    // Get endpoint
-    const options = LoginStepOptions[1]
-    options.title = endpoint
-    const token = await vscode.window.showInputBox(LoginStepOptions[1])
-    return { endpoint, token }
+/**
+ * Show a VS Code input box to ask the user to enter an access token.
+ */
+export async function showAccessTokenInputBox(endpoint: string): Promise<string | undefined> {
+    return vscode.window.showInputBox({
+        title: endpoint,
+        prompt: 'Paste your access token. To create an access token, go to "Settings" and then "Access tokens" on the Sourcegraph instance.',
+        placeHolder: 'Access Token',
+        password: true,
+        ignoreFocusOut: true,
+    })
 }
 
 export const AuthMenuOptions = {
@@ -106,26 +112,5 @@ export const LoginMenuOptionItems = [
         id: 'token',
         label: 'Sign in with URL and Access Token',
         totalSteps: 2,
-    },
-]
-
-const LoginStepOptions = [
-    {
-        prompt: 'Enter the URL of the Sourcegraph instance',
-        placeholder: 'https://sourcegraph.mycompany.com/',
-        password: false,
-        ignoreFocusOut: true,
-        totalSteps: 2,
-        title: '',
-        step: 1,
-    },
-    {
-        prompt: 'Paste your access token. To create an access token, go to "Settings" and then "Access tokens" on the Sourcegraph instance.',
-        placeholder: 'Access Token',
-        password: true,
-        ignoreFocusOut: true,
-        totalSteps: 2,
-        title: 'Sign in with URL and Access Token',
-        step: 2,
     },
 ]

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -174,13 +174,14 @@ async function loadAppJson(uri: vscode.Uri): Promise<AppJson | null> {
     }
 }
 
-const envInit = {
+const envInit: LocalEnv = {
     os: process.platform,
     arch: process.arch,
     homeDir: process.env.HOME,
     uriScheme: vscode.env.uriScheme,
     appName: vscode.env.appName,
     extensionVersion: version,
+    uiKindIsWeb: vscode.env.uiKind === vscode.UIKind.Web,
     isAppInstalled: false,
     isAppRunning: false,
     hasAppJson: false,

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -39,6 +39,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 isAppInstalled: false,
                 isAppRunning: false,
                 hasAppJson: false,
+                uiKindIsWeb: false,
                 extensionVersion: '0.0.0',
             },
             authStatus: {

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -149,6 +149,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     telemetryService={telemetryService}
                     appOS={config?.os}
                     appArch={config?.arch}
+                    uiKindIsWeb={config?.uiKindIsWeb}
                     callbackScheme={config?.uriScheme}
                     onLoginRedirect={onLoginRedirect}
                 />

--- a/vscode/webviews/Login.tsx
+++ b/vscode/webviews/Login.tsx
@@ -21,6 +21,7 @@ interface LoginProps {
     callbackScheme?: string
     appOS?: string
     appArch?: string
+    uiKindIsWeb?: boolean
     onLoginRedirect: (uri: string) => void
 }
 
@@ -47,6 +48,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     callbackScheme,
     appOS,
     appArch,
+    uiKindIsWeb,
     isAppInstalled = false,
     isAppRunning = false,
     onLoginRedirect,
@@ -80,8 +82,12 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     const NoAppConnect: React.FunctionComponent = () => (
         <section className={classNames(styles.section, styles.codyGradient)}>
-            <h2 className={styles.sectionHeader}>Cody App for {appOS} coming soon</h2>
-            <p className={styles.openMessage}>{APP_DESC.comingSoon}</p>
+            {!uiKindIsWeb && (
+                <>
+                    <h2 className={styles.sectionHeader}>Cody App for {appOS} coming soon</h2>
+                    <p className={styles.openMessage}>{APP_DESC.comingSoon}</p>
+                </>
+            )}
             <VSCodeButton
                 className={styles.button}
                 type="button"
@@ -104,7 +110,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
             {authStatus && <ErrorContainer authStatus={authStatus} isApp={isApp} endpoint={endpoint} />}
             {/* Signin Sections */}
             <div className={styles.sectionsContainer}>
-                <AppConnect />
+                {!uiKindIsWeb && <AppConnect />}
                 {!isOSSupported && <NoAppConnect />}
                 <div className={styles.otherSignInOptions}>
                     <VSCodeButton


### PR DESCRIPTION
Refactor vscode input boxes for instance URL and access token.

Refactor the code to make it possible to just show an access token input box.

Do not show Cody app login when running in VS Code Web

Support VS Code Web in login flow: VS Code Web does not support callbacks like vscode:// from our access token creation flow because it is running on the web and does not have a system protocol handler registered. There is a solution to this, but it requires changes on the Sourcegraph.com backend. So, for now, just open up the new access token creation page and ask the user for the token.


## Test plan

Start with a fresh VS Code instance and try signing in via Sourcegraph.com or via a token.