### PR TITLE
Bump cody-shared package version

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-shared",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Cody shared library",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Release `cody-shared` v0.0.5 ([version list on npm](https://www.npmjs.com/package/@sourcegraph/cody-shared?activeTab=versions)).

## Test plan
N/A

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
