### PR TITLE
[Autocompletion]: Add initial tree-sitter post-processing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,24 @@ importers:
       stream-json:
         specifier: ^1.8.0
         version: 1.8.0
+      tree-sitter:
+        specifier: ^0.20.5
+        version: 0.20.5
+      tree-sitter-go:
+        specifier: ^0.20.0
+        version: 0.20.0
+      tree-sitter-java:
+        specifier: ^0.19.1
+        version: 0.19.1
+      tree-sitter-javascript:
+        specifier: ^0.19.0
+        version: 0.19.0
+      tree-sitter-python:
+        specifier: ^0.20.3
+        version: 0.20.3
+      tree-sitter-typescript:
+        specifier: ^0.20.1
+        version: 0.20.1
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -374,6 +392,9 @@ importers:
       vscode-uri:
         specifier: ^3.0.7
         version: 3.0.7
+      web-tree-sitter:
+        specifier: ^0.20.8
+        version: 0.20.8
       wink-eng-lite-web-model:
         specifier: ^1.5.0
         version: 1.5.0(wink-nlp@1.13.1)
@@ -408,6 +429,9 @@ importers:
       '@types/mock-require':
         specifier: ^2.0.1
         version: 2.0.1
+      '@types/progress':
+        specifier: ^2.0.5
+        version: 2.0.5
       '@types/semver':
         specifier: ^7.5.0
         version: 7.5.0
@@ -456,6 +480,9 @@ importers:
       playwright:
         specifier: ^1.33.0
         version: 1.33.0
+      progress:
+        specifier: ^2.0.3
+        version: 2.0.3
       semver:
         specifier: ^7.5.4
         version: 7.5.4
@@ -5691,6 +5718,12 @@ packages:
     resolution: {integrity: sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==}
     dev: true
 
+  /@types/progress@2.0.5:
+    resolution: {integrity: sha512-ZYYVc/kSMkhH9W/4dNK/sLNra3cnkfT2nJyOAIDY+C2u6w72wa0s1aXAezVtbTsnN8HID1uhXCrLwDE2ZXpplg==}
+    dependencies:
+      '@types/node': 20.4.0
+    dev: true
+
   /@types/promise.allsettled@1.0.3:
     resolution: {integrity: sha512-b/IFHHTkYkTqu41IH9UtpICwqrpKj2oNlb4KHPzFQDMiz+h1BgAeATeO0/XTph4+UkH9W2U0E4B4j64KWOovag==}
     dev: false
@@ -7903,7 +7936,6 @@ packages:
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
-    dev: true
 
   /deep-is@0.1.3:
     resolution: {integrity: sha512-GtxAN4HvBachZzm4OnWqc45ESpUCMwkYcsjnsPs23FwJbsO+k4t0k9bQCgOmzIlpHO28+WPK/KRbRk0DDHuuDw==}
@@ -8032,7 +8064,6 @@ packages:
   /detect-libc@2.0.1:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
-    dev: true
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -8990,7 +9021,6 @@ packages:
   /expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
-    dev: true
 
   /expr-eval@2.0.2:
     resolution: {integrity: sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==}
@@ -9579,7 +9609,6 @@ packages:
 
   /github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
-    dev: true
 
   /github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -10133,7 +10162,6 @@ packages:
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-    dev: true
 
   /inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
@@ -12570,7 +12598,6 @@ packages:
 
   /napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
-    dev: true
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
@@ -12601,7 +12628,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       semver: 7.5.4
-    dev: true
 
   /node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
@@ -13602,7 +13628,6 @@ packages:
       simple-get: 4.0.1
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
-    dev: true
 
   /prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -13865,7 +13890,6 @@ packages:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    dev: true
 
   /react-colorful@5.6.1(react-dom@18.1.0)(react@18.1.0):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
@@ -14685,7 +14709,6 @@ packages:
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-    dev: true
 
   /simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
@@ -14693,7 +14716,6 @@ packages:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    dev: true
 
   /simple-update-notifier@1.1.0:
     resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
@@ -15087,7 +15109,6 @@ packages:
   /strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -15508,6 +15529,49 @@ packages:
     hasBin: true
     dev: true
 
+  /tree-sitter-go@0.20.0:
+    resolution: {integrity: sha512-5OBBND9ykffXZnaKrVpk8RnSaZJ26Si8yCfJKPSkEypWrywqCmZOZ74NveqMY0ogmHK2X8mFFuIL5jUnxOKyYw==}
+    requiresBuild: true
+    dependencies:
+      nan: 2.17.0
+    dev: false
+
+  /tree-sitter-java@0.19.1:
+    resolution: {integrity: sha512-yVm+4q1D4niaHcEf2iqhOcIaiSp3wxHjeC4eoLAqSQNVxSrhThmT1FEfM4yDgHV4XaxH+62xpKHCwYG9NzRt6Q==}
+    requiresBuild: true
+    dependencies:
+      nan: 2.17.0
+    dev: false
+
+  /tree-sitter-javascript@0.19.0:
+    resolution: {integrity: sha512-SNykDdNgmlJZhX02ZIu0TQF9P7t847jV7769SxA9XrZ2QXjofQsVTMEi9+LpXZKsI0UoFYI25FnZm3fFm0z2yw==}
+    requiresBuild: true
+    dependencies:
+      nan: 2.17.0
+    dev: false
+
+  /tree-sitter-python@0.20.3:
+    resolution: {integrity: sha512-8R+00dCgTCBo2x9e53s3QnSoQhjrGJcxXHSfKSBcWwwZLTbiHqj/YKj7Ey6pYqPCgjCVPJ+bEIUCH3jTtTGzqA==}
+    requiresBuild: true
+    dependencies:
+      nan: 2.17.0
+    dev: false
+
+  /tree-sitter-typescript@0.20.1:
+    resolution: {integrity: sha512-wqpnhdVYX26ATNXeZtprib4+mF2GlYQB1cjRPibYGxDRiugx5OfjWwLE4qPPxEGdp2ZLSmZVesGUjLWzfKo6rA==}
+    requiresBuild: true
+    dependencies:
+      nan: 2.17.0
+    dev: false
+
+  /tree-sitter@0.20.5:
+    resolution: {integrity: sha512-xjxkKCKV7F2F5HWmyRE4bosoxkbxe9lYvFRc/nzmtHNqFNTwYwh0oWVVEt0VnbupZHMirEQW7vDx8ddJn72tjg==}
+    requiresBuild: true
+    dependencies:
+      nan: 2.17.0
+      prebuild-install: 7.1.1
+    dev: false
+
   /trim-newlines@4.1.1:
     resolution: {integrity: sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==}
     engines: {node: '>=12'}
@@ -15636,7 +15700,6 @@ packages:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
@@ -16304,6 +16367,10 @@ packages:
   /web-streams-polyfill@3.2.1:
     resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
     engines: {node: '>= 8'}
+    dev: false
+
+  /web-tree-sitter@0.20.8:
+    resolution: {integrity: sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==}
     dev: false
 
   /webidl-conversions@3.0.1:

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -3,3 +3,4 @@ out/
 .vscode-test/
 dist/
 .vscode-test-web/
+resources/wasm/

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -97,3 +97,14 @@ code --user-data-dir=/tmp/separate-vscode-instance --profile-temp
 To open the Cody sidebar, autocomplete trace view, etc., when debugging starts, you can set hidden
 VS Code user settings. See [`src/dev/helpers.ts`](src/dev/helpers.ts) for a list of available
 options.
+
+### Wasm tree sitter modules
+
+We use tree-sitter parser for a better code analysis in post completion process. In order to be able
+to run these modules in VSCode runtime we have to use their wasm version. Wasm modules are not common
+modules, you can't just inline them into the bundle by default, you have to load them separately and
+connect them with special `load` wasm API.
+
+We don't keep these modules in .git tree, but instead we load them manually from our google cloud bucket.
+In order to do it you can run `./scripts/download-wasm-modules.ts` or just `pnpm download-wasm` before
+running you vscode locally.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -27,7 +27,8 @@
     "lint": "pnpm run lint:js",
     "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
     "release": "ts-node ./scripts/release.ts",
-    "release:dry-run": "CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
+    "download-wasm": "ts-node ./scripts/download-wasm-modules.ts && cp ./resources/wasm/* ./dist",
+    "release:dry-run": "pnpm run download-wasm && CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
     "storybook": "storybook dev -p 6007 --no-open --no-version-updates --no-release-notes",
     "test:e2e": "pnpm exec playwright install && tsc --build && pnpm run -s build:dev:desktop && playwright test",
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
@@ -1001,9 +1002,16 @@
     "mock-require": "^3.0.3",
     "openai": "^3.2.1",
     "stream-json": "^1.8.0",
+    "tree-sitter": "^0.20.5",
+    "tree-sitter-go": "^0.20.0",
+    "tree-sitter-java": "^0.19.1",
+    "tree-sitter-javascript": "^0.19.0",
+    "tree-sitter-python": "^0.20.3",
+    "tree-sitter-typescript": "^0.20.1",
     "uuid": "^9.0.0",
     "vscode-languageserver-textdocument": "^1.0.8",
     "vscode-uri": "^3.0.7",
+    "web-tree-sitter": "^0.20.8",
     "wink-eng-lite-web-model": "^1.5.0",
     "wink-nlp": "^1.13.1",
     "wink-nlp-utils": "^2.1.0"
@@ -1017,6 +1025,7 @@
     "@types/lodash": "^4.14.195",
     "@types/mocha": "^10.0.1",
     "@types/mock-require": "^2.0.1",
+    "@types/progress": "^2.0.5",
     "@types/semver": "^7.5.0",
     "@types/uuid": "^9.0.2",
     "@types/vscode": "^1.79.0",
@@ -1033,6 +1042,7 @@
     "ovsx": "^0.8.2",
     "path-browserify": "^1.0.1",
     "playwright": "^1.33.0",
+    "progress": "^2.0.3",
     "semver": "^7.5.4"
   }
 }

--- a/vscode/scripts/download-wasm-modules.ts
+++ b/vscode/scripts/download-wasm-modules.ts
@@ -9,6 +9,7 @@ const WASM_DIRECTORY = path.join(path.resolve(__dirname), '..', 'resources', 'wa
 const urls = [
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-javascript.wasm',
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-typescript.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-tsx.wasm',
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-c_sharp.wasm',
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-cpp.wasm',
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-go.wasm',

--- a/vscode/scripts/download-wasm-modules.ts
+++ b/vscode/scripts/download-wasm-modules.ts
@@ -1,0 +1,97 @@
+import fs, { existsSync, mkdirSync, WriteStream } from 'fs'
+import http from 'https'
+import path from 'path'
+
+import ProgressBar from 'progress'
+
+const WASM_DIRECTORY = path.join(path.resolve(__dirname), '..', 'resources', 'wasm')
+
+const urls = [
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-javascript.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-typescript.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-c_sharp.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-cpp.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-go.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-python.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-ruby.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-rust.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-java.wasm',
+]
+
+export async function main(): Promise<void> {
+    const hasStoreDir = existsSync(WASM_DIRECTORY)
+
+    if (!hasStoreDir) {
+        mkdirSync(WASM_DIRECTORY)
+    }
+
+    const filesToDownload = getMissingFiles(urls)
+
+    if (filesToDownload.length === 0) {
+        console.log('All wasm modules are in place, have a good day!')
+        return
+    }
+
+    console.log(`We miss ${filesToDownload.length} files.`)
+
+    try {
+        await Promise.all(filesToDownload.map(downloadFile))
+        console.log('All files were successful downloaded, check resources/wasm directory')
+    } catch (error) {
+        console.error('Some error occurred', error)
+    }
+}
+
+void main()
+
+function getMissingFiles(urls: string[]): string[] {
+    const missingFiles = []
+
+    for (const url of urls) {
+        const filePath = getFilePathFromURL(url)
+        if (!existsSync(path.resolve(WASM_DIRECTORY, filePath))) {
+            missingFiles.push(url)
+        }
+    }
+
+    return missingFiles
+}
+
+function getFilePathFromURL(url: string): string {
+    const parts = url.split('/')
+    return parts[parts.length - 1]
+}
+
+function downloadFile(url: string): Promise<WriteStream> {
+    const fileName = getFilePathFromURL(url)
+
+    const downloadDirectory = path.resolve(__dirname, '..', 'resources', 'wasm')
+    const file = fs.createWriteStream(path.join(downloadDirectory, fileName))
+
+    return new Promise((resolve, reject) => {
+        http.get(url).on('response', res => {
+            const contentLength = res.headers?.['content-length'] ?? '0'
+            const totalLength = parseInt(contentLength, 10)
+
+            const progress = new ProgressBar('-> downloading [:bar] :rate/bps :percent :etas', {
+                width: 40,
+                complete: '=',
+                incomplete: ' ',
+                renderThrottle: 1,
+                total: totalLength,
+            })
+
+            res.on('data', (chunk): void => {
+                file.write(chunk)
+                progress.tick(chunk.length)
+            })
+                .on('end', () => {
+                    resolve(file.end())
+                })
+                .on('error', err => {
+                    console.log('\n')
+                    reject(err)
+                })
+        })
+    })
+}

--- a/vscode/scripts/download-wasm-modules.ts
+++ b/vscode/scripts/download-wasm-modules.ts
@@ -17,6 +17,8 @@ const urls = [
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-ruby.wasm',
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-rust.wasm',
     'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-java.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-dart.wasm',
+    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-php.wasm',
 ]
 
 export async function main(): Promise<void> {
@@ -74,7 +76,7 @@ function downloadFile(url: string): Promise<WriteStream> {
             const contentLength = res.headers?.['content-length'] ?? '0'
             const totalLength = parseInt(contentLength, 10)
 
-            const progress = new ProgressBar('-> downloading [:bar] :rate/bps :percent :etas', {
+            const progress = new ProgressBar(`-> ${fileName} [:bar] :rate/bps :percent :etas`, {
                 width: 40,
                 complete: '=',
                 incomplete: ' ',

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -3,6 +3,7 @@ import detectIndent from 'detect-indent'
 import { DocumentContext } from './document'
 import { getLanguageConfig } from './language'
 import { indentation } from './text-processing'
+import { PostProcessCompletionContext } from './types'
 import { getEditorTabSize, OPENING_BRACKET_REGEX, shouldIncludeClosingLine } from './utils/text-utils'
 
 export function detectMultiline(
@@ -79,13 +80,10 @@ function ensureSameOrLargerIndentation(completion: string): string {
     return completion
 }
 
-export function truncateMultilineCompletion(
-    completion: string,
-    prefix: string,
-    suffix: string,
-    languageId: string
-): string {
+export function truncateMultilineCompletion(completion: string, context: PostProcessCompletionContext): string {
+    const { prefix, suffix, languageId } = context
     const config = getLanguageConfig(languageId)
+
     if (!config) {
         return completion
     }

--- a/vscode/src/completions/shared-post-process.ts
+++ b/vscode/src/completions/shared-post-process.ts
@@ -1,34 +1,120 @@
 import { truncateMultilineCompletion } from './multiline'
 import { collapseDuplicativeWhitespace, trimUntilSuffix } from './text-processing'
-import { Completion } from './types'
+import { Completion, PostProcessCompletionContext } from './types'
+import { GenericLexem, parseLanguage, SupportedLanguage } from './utils/grammars'
+import { createParser, ParserApi, Point, Tree } from './utils/lexical-analysis'
 
-/**
- * This function implements post-processing logic that is applied regardless of
- * which provider is chosen.
- */
-export function sharedPostProcess({
-    prefix,
-    suffix,
-    languageId,
-    multiline,
-    completion,
-}: {
+interface CompletionContext {
     prefix: string
     suffix: string
     languageId: string
     multiline: boolean
     completion: Completion
-}): Completion {
-    let content = completion.content
+    withLexemeAnalysis?: boolean
+}
 
-    if (multiline) {
-        content = truncateMultilineCompletion(content, prefix, suffix, languageId)
-    }
-    content = trimUntilSuffix(content, prefix, suffix, languageId)
-    content = collapseDuplicativeWhitespace(prefix, content)
+/**
+ * This function implements post-processing logic that is applied regardless of
+ * which provider is chosen.
+ */
+export async function sharedPostProcess(context: CompletionContext): Promise<Completion> {
+    const language = parseLanguage(context.languageId)
+    const hasLexemAnalysisSupport = language !== null && context.withLexemeAnalysis
+
+    const processor = combineProcessors([
+        runIf(context.multiline, truncateMultilineCompletion),
+
+        // Language specific post-processing, if we do completion
+        // for language that we support in tree-sitter parsers we process them with
+        // parsers specific flow
+        runIf(hasLexemAnalysisSupport, runParserProcessors(language)),
+        trimUntilSuffix,
+        collapseDuplicativeWhitespace,
+    ])
+
+    const content = await processor(context.completion.content, {
+        prefix: context.prefix,
+        suffix: context.suffix,
+        languageId: context.languageId,
+    })
 
     return {
-        ...completion,
+        ...context.completion,
         content: content.trimEnd(),
     }
+}
+
+type SyncProcessor<Context> = (completionContent: string, context: Context) => string
+type AsyncProcessor<Context> = (completionContent: string, context: Context) => Promise<string>
+
+type Processor<Context> = SyncProcessor<Context> | AsyncProcessor<Context>
+
+function combineProcessors<Context>(processors: Processor<Context>[]): AsyncProcessor<Context> {
+    return async (completionContent: string, context: Context) =>
+        processors.reduce<Promise<string> | string>((content, processor) => {
+            if (typeof content === 'string') {
+                return processor(content, context)
+            }
+
+            return content.then(completion => processor(completion, context))
+        }, completionContent)
+}
+
+function runIf<Context>(condition: boolean | undefined | null, processor: Processor<Context>): Processor<Context> {
+    if (!condition) {
+        return (completionContent: string) => completionContent
+    }
+
+    return processor
+}
+
+interface ParserProcessorContext {
+    ast: Tree
+    parser: ParserApi
+    prefix: string
+    suffix: string
+    cursorPosition: Point
+}
+
+function runParserProcessors(language: SupportedLanguage | null): Processor<PostProcessCompletionContext> {
+    return async (completion, context) => {
+        const cursorPosition = positionFromPrefix(context.prefix)
+        const parser = createParser({ language: language as SupportedLanguage })
+        const parsedAST = await parser.parse(context.prefix + context.suffix)
+
+        const processor = combineProcessors([trimByFunctionInvocation])
+
+        return processor(completion, { ...context, cursorPosition, ast: parsedAST, parser })
+    }
+}
+
+function trimByFunctionInvocation(completion: string, context: ParserProcessorContext): string {
+    const cursorNode = context.ast.rootNode.descendantForPosition(context.cursorPosition)
+    const closestArgumentNode = context.parser.findParentLexem(cursorNode, GenericLexem.Arguments)
+
+    // Safe pass in case if we couldn't parse the snippet correctly
+    if (closestArgumentNode === null || closestArgumentNode.hasError()) {
+        return completion
+    }
+
+    const linesInArguments = Math.min(closestArgumentNode.endPosition.row - closestArgumentNode.startPosition.row, 1)
+
+    return getFirstNLines(completion, linesInArguments)
+}
+
+function positionFromPrefix(prefix: string): Point {
+    if (prefix.length === 0) {
+        return { row: 0, column: 0 }
+    }
+
+    const lines = prefix.split('\n')
+    const lastLine = lines[lines.length - 1]
+
+    return { row: lines.length - 1, column: lastLine.length - 1 }
+}
+
+function getFirstNLines(string: string, n: number): string {
+    const lines = string.split('\n')
+
+    return lines.splice(0, n).join('\n')
 }

--- a/vscode/src/completions/text-processing.ts
+++ b/vscode/src/completions/text-processing.ts
@@ -1,4 +1,5 @@
 import { getLanguageConfig } from './language'
+import { PostProcessCompletionContext } from './types'
 import { isAlmostTheSameString } from './utils/string-comparator'
 import { getEditorTabSize } from './utils/text-utils'
 
@@ -129,7 +130,8 @@ function trimSpace(s: string): TrimmedString {
  * Oftentimes, the last couple of lines of the completion may match against the suffix
  * (the code following the cursor).
  */
-export function trimUntilSuffix(insertion: string, prefix: string, suffix: string, languageId: string): string {
+export function trimUntilSuffix(insertion: string, context: PostProcessCompletionContext): string {
+    const { suffix, prefix, languageId } = context
     const config = getLanguageConfig(languageId)
 
     insertion = insertion.trimEnd()
@@ -210,10 +212,13 @@ export function trimLeadingWhitespaceUntilNewline(str: string): string {
  *
  * Language-specific customizations are needed here to get greater accuracy.
  */
-export function collapseDuplicativeWhitespace(prefix: string, completion: string): string {
+export function collapseDuplicativeWhitespace(completion: string, context: PostProcessCompletionContext): string {
+    const { prefix } = context
+
     if (prefix.endsWith(' ') || prefix.endsWith('\t')) {
         completion = completion.replace(/^[\t ]+/, '')
     }
+
     return completion
 }
 

--- a/vscode/src/completions/types.ts
+++ b/vscode/src/completions/types.ts
@@ -3,3 +3,9 @@ export interface Completion {
     content: string
     stopReason?: string
 }
+
+export interface PostProcessCompletionContext {
+    prefix: string
+    suffix: string
+    languageId: string
+}

--- a/vscode/src/completions/utils/grammars.ts
+++ b/vscode/src/completions/utils/grammars.ts
@@ -21,12 +21,20 @@ export enum SupportedLanguage {
     Php = 'php',
 }
 
+/**
+ * Different languages have different names for lexem we want to work
+ * with in our parser logic, this enum is supposed to be an abstraction
+ * layer to parser and query code snippets with generic language agnostic
+ * lexems, see map function below to see how generic lexems relate to
+ * specific language lexem tokens.
+ */
 export enum GenericLexem {
     IfStatement,
     ElseClause,
     StatementBlock,
     CallExpression,
     Comment,
+    MethodCall,
 }
 
 enum StandardLexem {
@@ -50,6 +58,7 @@ enum GoLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'call_expression',
+    MethodCall = 'call_expression',
     Comment = 'comment',
 }
 
@@ -58,15 +67,17 @@ enum PythonLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'call',
+    MethodCall = 'call',
     Comment = 'comment',
 }
 
 enum DartLexemType {
+    Comment = 'comment',
     IfStatement = 'if_statement',
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'expression_statement',
-    Comment = 'comment',
+    MethodCall = 'call_expression',
 }
 
 enum CLexemType {
@@ -78,30 +89,33 @@ enum CLexemType {
 }
 
 enum CppLexemType {
+    Comment = 'comment',
     IfStatement = 'if_statement',
     ElseClause = 'else_clause',
     StatementBlock = 'compound_statement',
     CallExpression = 'call_expression',
-    Comment = 'comment',
+    MethodCall = 'call_expression',
 }
 
 enum CSharpLexemType {
+    Comment = 'comment',
     IfStatement = 'if_statement',
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'invocation_expression',
-    Comment = 'comment',
+    MethodCall = 'invocation_expression',
 }
 
 enum PhpLexemType {
+    Comment = 'comment',
     IfStatement = 'if_statement',
     ElseClause = 'else_clause',
     StatementBlock = 'compound_statement',
-    CallExpression = 'expression_statement',
-    Comment = 'comment',
+    CallExpression = 'function_call_expression',
+    MethodCall = 'member_call_expression',
 }
 
-export type LEXEME_DICTIONARY = Record<GenericLexem, string>
+export type LEXEME_DICTIONARY = Record<GenericLexem, string | null>
 
 export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONARY | null {
     switch (language) {
@@ -115,6 +129,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: StandardLexem.StatementBlock,
                 [GenericLexem.CallExpression]: StandardLexem.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: StandardLexem.CallExpression,
             }
 
         case SupportedLanguage.Java:
@@ -124,6 +139,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: JavaLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: JavaLexemType.MethodInvocation,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: JavaLexemType.MethodInvocation,
             }
 
         case SupportedLanguage.Go:
@@ -133,6 +149,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: GoLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: GoLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: GoLexemType.MethodCall,
             }
 
         case SupportedLanguage.Python:
@@ -142,6 +159,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: PythonLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: PythonLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: PythonLexemType.MethodCall,
             }
 
         case SupportedLanguage.Dart:
@@ -151,6 +169,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: DartLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: DartLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: DartLexemType.MethodCall,
             }
 
         case SupportedLanguage.C:
@@ -160,6 +179,8 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: CLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: CLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                // C doesn't support class or methods
+                [GenericLexem.MethodCall]: null,
             }
 
         case SupportedLanguage.Cpp:
@@ -169,6 +190,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: CppLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: CppLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: CppLexemType.MethodCall,
             }
 
         case SupportedLanguage.CSharp:
@@ -178,6 +200,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: CSharpLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: CSharpLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: CSharpLexemType.MethodCall,
             }
 
         case SupportedLanguage.Php:
@@ -187,6 +210,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: PhpLexemType.StatementBlock,
                 [GenericLexem.CallExpression]: PhpLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: PhpLexemType.MethodCall,
             }
 
         default:
@@ -196,6 +220,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.StatementBlock]: StandardLexem.StatementBlock,
                 [GenericLexem.CallExpression]: StandardLexem.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
+                [GenericLexem.MethodCall]: null,
             }
     }
 }

--- a/vscode/src/completions/utils/grammars.ts
+++ b/vscode/src/completions/utils/grammars.ts
@@ -1,0 +1,200 @@
+/**
+ * List of all supported languages that we have grammars and
+ * lexems for. Note that enum values are copied from VSCode API,
+ * if we want to make it work with different editors we should
+ * enhance language detection.
+ *
+ * TODO: Decouple language detect to make it editor agnostic
+ */
+export enum SupportedLanguage {
+    JavaScript = 'javascript',
+    JSX = 'javascriptreact',
+    TypeScript = 'typescript',
+    TSX = 'typescriptreact',
+    Java = 'java',
+    Go = 'go',
+    Python = 'python',
+    Dart = 'dart',
+    C = 'c',
+    Cpp = 'cpp',
+    CSharp = 'csharp',
+    Php = 'php'
+}
+
+export enum GenericLexem {
+    IfStatement,
+    ElseClause,
+    StatementBlock,
+    CallExpression,
+    Comment
+}
+
+enum StandardLexem {
+    IfStatement = 'if_statement',
+    ElseClause = 'else_clause',
+    StatementBlock = 'statement_block',
+    CallExpression = 'call_expression',
+    Comment = 'comment'
+}
+
+enum JavaLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    MethodInvocation = 'method_invocation',
+    Comment = 'comment'
+}
+
+enum GoLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    CallExpression = 'call_expression',
+    Comment = 'comment'
+}
+
+enum PythonLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    CallExpression = 'call',
+    Comment = 'comment'
+}
+
+enum DartLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    CallExpression = 'expression_statement',
+    Comment = 'comment'
+}
+
+enum CLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else_clause',
+    StatementBlock = 'compound_statement',
+    CallExpression = 'call_expression',
+    Comment = 'comment'
+}
+
+enum CppLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else_clause',
+    StatementBlock = 'compound_statement',
+    CallExpression = 'call_expression',
+    Comment = 'comment'
+}
+
+enum CSharpLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    CallExpression = 'invocation_expression',
+    Comment = 'comment'
+}
+
+enum PhpLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else_clause',
+    StatementBlock = 'compound_statement',
+    CallExpression = 'expression_statement',
+    Comment = 'comment'
+}
+
+export type LEXEME_DICTIONARY = Record<GenericLexem, string>
+
+export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONARY | null {
+    switch (language) {
+        case SupportedLanguage.JSX:
+        case SupportedLanguage.JavaScript:
+        case SupportedLanguage.TSX:
+        case SupportedLanguage.TypeScript:
+            return {
+                [GenericLexem.IfStatement]: StandardLexem.IfStatement,
+                [GenericLexem.ElseClause]: StandardLexem.ElseClause,
+                [GenericLexem.StatementBlock]: StandardLexem.StatementBlock,
+                [GenericLexem.CallExpression]: StandardLexem.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.Java:
+            return {
+                [GenericLexem.IfStatement]: JavaLexemType.IfStatement,
+                [GenericLexem.ElseClause]: JavaLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: JavaLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: JavaLexemType.MethodInvocation,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.Go:
+            return {
+                [GenericLexem.IfStatement]: GoLexemType.IfStatement,
+                [GenericLexem.ElseClause]: GoLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: GoLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: GoLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.Python:
+            return {
+                [GenericLexem.IfStatement]: PythonLexemType.IfStatement,
+                [GenericLexem.ElseClause]: PythonLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: PythonLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: PythonLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.Dart:
+            return {
+                [GenericLexem.IfStatement]: DartLexemType.IfStatement,
+                [GenericLexem.ElseClause]: DartLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: DartLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: DartLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.C:
+            return {
+                [GenericLexem.IfStatement]: CLexemType.IfStatement,
+                [GenericLexem.ElseClause]: CLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: CLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: CLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.Cpp:
+            return {
+                [GenericLexem.IfStatement]: CppLexemType.IfStatement,
+                [GenericLexem.ElseClause]: CppLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: CppLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: CppLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.CSharp:
+            return {
+                [GenericLexem.IfStatement]: CSharpLexemType.IfStatement,
+                [GenericLexem.ElseClause]: CSharpLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: CSharpLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: CSharpLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        case SupportedLanguage.Php:
+            return {
+                [GenericLexem.IfStatement]: PhpLexemType.IfStatement,
+                [GenericLexem.ElseClause]: PhpLexemType.ElseClause,
+                [GenericLexem.StatementBlock]: PhpLexemType.StatementBlock,
+                [GenericLexem.CallExpression]: PhpLexemType.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+            }
+
+        default: return {
+            [GenericLexem.IfStatement]: StandardLexem.IfStatement,
+                [GenericLexem.ElseClause]: StandardLexem.ElseClause,
+                [GenericLexem.StatementBlock]: StandardLexem.StatementBlock,
+                [GenericLexem.CallExpression]: StandardLexem.CallExpression,
+                [GenericLexem.Comment]: StandardLexem.Comment,
+        }
+    }
+}

--- a/vscode/src/completions/utils/grammars.ts
+++ b/vscode/src/completions/utils/grammars.ts
@@ -21,6 +21,12 @@ export enum SupportedLanguage {
     Php = 'php',
 }
 
+export const parseLanguage = (langId: string): SupportedLanguage | null => {
+    const matchedLang = Object.entries(SupportedLanguage).find(([key, value]) => value === langId)
+
+    return matchedLang ? (langId as SupportedLanguage) : null
+}
+
 /**
  * Different languages have different names for lexem we want to work
  * with in our parser logic, this enum is supposed to be an abstraction
@@ -35,14 +41,16 @@ export enum GenericLexem {
     CallExpression,
     Comment,
     MethodCall,
+    Arguments,
 }
 
-enum StandardLexem {
+export enum StandardLexem {
     IfStatement = 'if_statement',
     ElseClause = 'else_clause',
     StatementBlock = 'statement_block',
     CallExpression = 'call_expression',
     Comment = 'comment',
+    Arguments = 'arguments',
 }
 
 enum JavaLexemType {
@@ -130,6 +138,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: StandardLexem.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: StandardLexem.CallExpression,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.Java:
@@ -140,6 +149,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: JavaLexemType.MethodInvocation,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: JavaLexemType.MethodInvocation,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.Go:
@@ -150,6 +160,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: GoLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: GoLexemType.MethodCall,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.Python:
@@ -160,6 +171,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: PythonLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: PythonLexemType.MethodCall,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.Dart:
@@ -170,6 +182,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: DartLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: DartLexemType.MethodCall,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.C:
@@ -181,6 +194,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 // C doesn't support class or methods
                 [GenericLexem.MethodCall]: null,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.Cpp:
@@ -191,6 +205,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: CppLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: CppLexemType.MethodCall,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.CSharp:
@@ -201,6 +216,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: CSharpLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: CSharpLexemType.MethodCall,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         case SupportedLanguage.Php:
@@ -211,6 +227,7 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: PhpLexemType.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: PhpLexemType.MethodCall,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
 
         default:
@@ -221,6 +238,26 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.CallExpression]: StandardLexem.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
                 [GenericLexem.MethodCall]: null,
+                [GenericLexem.Arguments]: StandardLexem.Arguments,
             }
+    }
+}
+
+export function getInlineCommentToken(language: SupportedLanguage): string {
+    switch (language) {
+        case SupportedLanguage.JavaScript:
+        case SupportedLanguage.JSX:
+        case SupportedLanguage.TypeScript:
+        case SupportedLanguage.TSX:
+        case SupportedLanguage.Java:
+        case SupportedLanguage.Go:
+        case SupportedLanguage.Dart:
+        case SupportedLanguage.C:
+        case SupportedLanguage.Cpp:
+        case SupportedLanguage.CSharp:
+        case SupportedLanguage.Php:
+            return '//'
+        case SupportedLanguage.Python:
+            return '#'
     }
 }

--- a/vscode/src/completions/utils/grammars.ts
+++ b/vscode/src/completions/utils/grammars.ts
@@ -18,7 +18,7 @@ export enum SupportedLanguage {
     C = 'c',
     Cpp = 'cpp',
     CSharp = 'csharp',
-    Php = 'php'
+    Php = 'php',
 }
 
 export enum GenericLexem {
@@ -26,7 +26,7 @@ export enum GenericLexem {
     ElseClause,
     StatementBlock,
     CallExpression,
-    Comment
+    Comment,
 }
 
 enum StandardLexem {
@@ -34,7 +34,7 @@ enum StandardLexem {
     ElseClause = 'else_clause',
     StatementBlock = 'statement_block',
     CallExpression = 'call_expression',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum JavaLexemType {
@@ -42,7 +42,7 @@ enum JavaLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     MethodInvocation = 'method_invocation',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum GoLexemType {
@@ -50,7 +50,7 @@ enum GoLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'call_expression',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum PythonLexemType {
@@ -58,7 +58,7 @@ enum PythonLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'call',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum DartLexemType {
@@ -66,7 +66,7 @@ enum DartLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'expression_statement',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum CLexemType {
@@ -74,7 +74,7 @@ enum CLexemType {
     ElseClause = 'else_clause',
     StatementBlock = 'compound_statement',
     CallExpression = 'call_expression',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum CppLexemType {
@@ -82,7 +82,7 @@ enum CppLexemType {
     ElseClause = 'else_clause',
     StatementBlock = 'compound_statement',
     CallExpression = 'call_expression',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum CSharpLexemType {
@@ -90,7 +90,7 @@ enum CSharpLexemType {
     ElseClause = 'else',
     StatementBlock = 'block',
     CallExpression = 'invocation_expression',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 enum PhpLexemType {
@@ -98,7 +98,7 @@ enum PhpLexemType {
     ElseClause = 'else_clause',
     StatementBlock = 'compound_statement',
     CallExpression = 'expression_statement',
-    Comment = 'comment'
+    Comment = 'comment',
 }
 
 export type LEXEME_DICTIONARY = Record<GenericLexem, string>
@@ -189,12 +189,13 @@ export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONAR
                 [GenericLexem.Comment]: StandardLexem.Comment,
             }
 
-        default: return {
-            [GenericLexem.IfStatement]: StandardLexem.IfStatement,
+        default:
+            return {
+                [GenericLexem.IfStatement]: StandardLexem.IfStatement,
                 [GenericLexem.ElseClause]: StandardLexem.ElseClause,
                 [GenericLexem.StatementBlock]: StandardLexem.StatementBlock,
                 [GenericLexem.CallExpression]: StandardLexem.CallExpression,
                 [GenericLexem.Comment]: StandardLexem.Comment,
-        }
+            }
     }
 }

--- a/vscode/src/completions/utils/lexical-analysis.test.ts
+++ b/vscode/src/completions/utils/lexical-analysis.test.ts
@@ -7,7 +7,6 @@ import { createParser, GenericLexem, SupportedLanguage } from './lexical-analysi
 const CUSTOM_WASM_LANGUAGE_DIR = path.resolve(__dirname, '..', '..', '..', 'resources', 'wasm')
 
 describe('lexical analysis', () => {
-
     describe('JavaScript', () => {
         it('finds statement declaration correctly', async () => {
             const parser = createParser({
@@ -30,7 +29,11 @@ describe('lexical analysis', () => {
                 console.log('hello d')
             `)
 
-            const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
+            const declaration = parser.findClosestLexem(
+                tree!.rootNode,
+                { row: 7, column: 25 },
+                GenericLexem.StatementBlock
+            )
             expect(declaration?.text).toBe(`{
                     // hello
                     console.log('hello from else statement')
@@ -59,7 +62,11 @@ describe('lexical analysis', () => {
                 console.log('end of program')
             `)
 
-            const declaration = parser.findClosestLexem(tree!.rootNode, { row: 5, column: 25 }, GenericLexem.StatementBlock)
+            const declaration = parser.findClosestLexem(
+                tree!.rootNode,
+                { row: 5, column: 25 },
+                GenericLexem.StatementBlock
+            )
             expect(declaration?.text).toBe(`{
                   if (d > 5) {
                     console.log('d is greater than 5')
@@ -84,7 +91,11 @@ describe('lexical analysis', () => {
                 }
             `)
 
-            const declaration = parser.findClosestLexem(tree.rootNode, { row: 3, column: 25 }, GenericLexem.StatementBlock)
+            const declaration = parser.findClosestLexem(
+                tree.rootNode,
+                { row: 3, column: 25 },
+                GenericLexem.StatementBlock
+            )
             expect(declaration?.text).toBe(`{
                     return (
                         <HelloWorld/>
@@ -115,7 +126,11 @@ describe('lexical analysis', () => {
                 console.log('hello d')
             `)
 
-            const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
+            const declaration = parser.findClosestLexem(
+                tree!.rootNode,
+                { row: 7, column: 25 },
+                GenericLexem.StatementBlock
+            )
             expect(declaration?.text).toBe(`{
                     // hello
                     console.log('hello from else statement')
@@ -136,7 +151,11 @@ describe('lexical analysis', () => {
                 }
             `)
 
-            const declaration = parser.findClosestLexem(tree.rootNode, { row: 3, column: 25 }, GenericLexem.StatementBlock)
+            const declaration = parser.findClosestLexem(
+                tree.rootNode,
+                { row: 3, column: 25 },
+                GenericLexem.StatementBlock
+            )
             expect(declaration?.text).toBe(`{
                     return (
                         <HelloWorld/>

--- a/vscode/src/completions/utils/lexical-analysis.test.ts
+++ b/vscode/src/completions/utils/lexical-analysis.test.ts
@@ -1,0 +1,76 @@
+import path from 'path'
+
+import { describe, expect, it } from 'vitest'
+
+import { createParser, GenericLexem, SupportedLanguage } from './lexical-analysis'
+
+const CUSTOM_WASM_LANGUAGE_DIR = path.resolve(__dirname, '..', '..', '..', 'resources', 'wasm')
+
+describe('lexical analysis', () => {
+    it('finds statement declaration correctly', async () => {
+        const parser = createParser({
+            language: SupportedLanguage.JavaScript,
+            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+        })
+
+        const tree = await parser.parse(`
+                const d = 5;
+
+                function helloWorld() {
+                  if (d > 5) {
+                    console.log('d is greater than 5')
+                  } else {
+                    // hello
+                    console.log('hello from else statement')
+                  }
+                }
+
+                console.log('hello d')
+            `)
+
+        expect(tree).toBeTruthy()
+
+        const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
+
+        expect(declaration?.text).toBe(`{
+                    // hello
+                    console.log('hello from else statement')
+                  }`)
+    })
+
+    it('finds statement declaration within function correctly', async () => {
+        const parser = createParser({
+            language: SupportedLanguage.JavaScript,
+            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+        })
+
+        const tree = await parser.parse(`
+                const var1 = 5;
+                const var2 = 6;
+
+                function greatComparator() {
+                  if (d > 5) {
+                    console.log('d is greater than 5')
+                  } else {
+                    // hello
+                    console.log('hello from else statement')
+                  }
+                }
+
+                console.log('end of program')
+            `)
+
+        expect(tree).toBeTruthy()
+
+        const declaration = parser.findClosestLexem(tree!.rootNode, { row: 5, column: 25 }, GenericLexem.StatementBlock)
+
+        expect(declaration?.text).toBe(`{
+                  if (d > 5) {
+                    console.log('d is greater than 5')
+                  } else {
+                    // hello
+                    console.log('hello from else statement')
+                  }
+                }`)
+    })
+})

--- a/vscode/src/completions/utils/lexical-analysis.test.ts
+++ b/vscode/src/completions/utils/lexical-analysis.test.ts
@@ -2,18 +2,20 @@ import path from 'path'
 
 import { describe, expect, it } from 'vitest'
 
-import { createParser, GenericLexem, SupportedLanguage, traverseTree } from './lexical-analysis'
+import { createParser, GenericLexem, SupportedLanguage } from './lexical-analysis'
 
 const CUSTOM_WASM_LANGUAGE_DIR = path.resolve(__dirname, '..', '..', '..', 'resources', 'wasm')
 
 describe('lexical analysis', () => {
-    it('finds statement declaration correctly', async () => {
-        const parser = createParser({
-            language: SupportedLanguage.JavaScript,
-            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
-        })
 
-        const tree = await parser.parse(`
+    describe('JavaScript', () => {
+        it('finds statement declaration correctly', async () => {
+            const parser = createParser({
+                language: SupportedLanguage.JavaScript,
+                grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+            })
+
+            const tree = await parser.parse(`
                 const d = 5;
 
                 function helloWorld() {
@@ -28,23 +30,20 @@ describe('lexical analysis', () => {
                 console.log('hello d')
             `)
 
-        expect(tree).toBeTruthy()
-
-        const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
-
-        expect(declaration?.text).toBe(`{
+            const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
+            expect(declaration?.text).toBe(`{
                     // hello
                     console.log('hello from else statement')
                   }`)
-    })
-
-    it('finds statement declaration within function correctly', async () => {
-        const parser = createParser({
-            language: SupportedLanguage.JavaScript,
-            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
         })
 
-        const tree = await parser.parse(`
+        it('finds statement declaration within function correctly', async () => {
+            const parser = createParser({
+                language: SupportedLanguage.JavaScript,
+                grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+            })
+
+            const tree = await parser.parse(`
                 const var1 = 5;
                 const var2 = 6;
 
@@ -60,11 +59,8 @@ describe('lexical analysis', () => {
                 console.log('end of program')
             `)
 
-        expect(tree).toBeTruthy()
-
-        const declaration = parser.findClosestLexem(tree!.rootNode, { row: 5, column: 25 }, GenericLexem.StatementBlock)
-
-        expect(declaration?.text).toBe(`{
+            const declaration = parser.findClosestLexem(tree!.rootNode, { row: 5, column: 25 }, GenericLexem.StatementBlock)
+            expect(declaration?.text).toBe(`{
                   if (d > 5) {
                     console.log('d is greater than 5')
                   } else {
@@ -72,15 +68,39 @@ describe('lexical analysis', () => {
                     console.log('hello from else statement')
                   }
                 }`)
-    })
-
-    it('parses common TypeScript function', async () => {
-        const parser = createParser({
-            language: SupportedLanguage.TypeScript,
-            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
         })
 
-        const tree = await parser.parse(`
+        it('parses common JSX function', async () => {
+            const parser = createParser({
+                language: SupportedLanguage.JavaScript,
+                grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+            })
+
+            const tree = await parser.parse(`
+                function Component() {
+                    return (
+                        <HelloWorld/>
+                    )
+                }
+            `)
+
+            const declaration = parser.findClosestLexem(tree.rootNode, { row: 3, column: 25 }, GenericLexem.StatementBlock)
+            expect(declaration?.text).toBe(`{
+                    return (
+                        <HelloWorld/>
+                    )
+                }`)
+        })
+    })
+
+    describe('TypeScript', () => {
+        it('parses common TypeScript function', async () => {
+            const parser = createParser({
+                language: SupportedLanguage.TypeScript,
+                grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+            })
+
+            const tree = await parser.parse(`
                 const d: number = 5;
 
                 function helloWorld() {
@@ -95,49 +115,20 @@ describe('lexical analysis', () => {
                 console.log('hello d')
             `)
 
-        expect(tree).toBeTruthy()
-
-        const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
-
-        expect(declaration?.text).toBe(`{
+            const declaration = parser.findClosestLexem(tree!.rootNode, { row: 7, column: 25 }, GenericLexem.StatementBlock)
+            expect(declaration?.text).toBe(`{
                     // hello
                     console.log('hello from else statement')
                   }`)
-    })
-
-    it('parses common JSX function', async () => {
-        const parser = createParser({
-            language: SupportedLanguage.JavaScript,
-            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
         })
 
-        const tree = await parser.parse(`
-                function Component() {
-                    return (
-                        <HelloWorld/>
-                    )
-                }
-            `)
+        it('parses common TSX function', async () => {
+            const parser = createParser({
+                language: SupportedLanguage.TSX,
+                grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
+            })
 
-        expect(tree).toBeTruthy()
-
-        traverseTree(tree.rootNode)
-        const declaration = parser.findClosestLexem(tree.rootNode, { row: 3, column: 25 }, GenericLexem.StatementBlock)
-
-        expect(declaration?.text).toBe(`{
-                    return (
-                        <HelloWorld/>
-                    )
-                }`)
-    })
-
-    it('parses common TSX function', async () => {
-        const parser = createParser({
-            language: SupportedLanguage.TSX,
-            grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
-        })
-
-        const tree = await parser.parse(`
+            const tree = await parser.parse(`
                 function Component(props: Props): ReactNode {
                     return (
                         <HelloWorld/>
@@ -145,15 +136,12 @@ describe('lexical analysis', () => {
                 }
             `)
 
-        expect(tree).toBeTruthy()
-
-        traverseTree(tree.rootNode)
-        const declaration = parser.findClosestLexem(tree.rootNode, { row: 3, column: 25 }, GenericLexem.StatementBlock)
-
-        expect(declaration?.text).toBe(`{
+            const declaration = parser.findClosestLexem(tree.rootNode, { row: 3, column: 25 }, GenericLexem.StatementBlock)
+            expect(declaration?.text).toBe(`{
                     return (
                         <HelloWorld/>
                     )
                 }`)
+        })
     })
 })

--- a/vscode/src/completions/utils/lexical-analysis.ts
+++ b/vscode/src/completions/utils/lexical-analysis.ts
@@ -2,7 +2,7 @@ import path from 'path'
 
 import Parser, { Point, SyntaxNode, Tree } from 'web-tree-sitter'
 
-import { getLanguageLexems, SupportedLanguage, GenericLexem } from './grammars'
+import { GenericLexem, getLanguageLexems, SupportedLanguage } from './grammars'
 
 export { SupportedLanguage, GenericLexem }
 

--- a/vscode/src/completions/utils/lexical-analysis.ts
+++ b/vscode/src/completions/utils/lexical-analysis.ts
@@ -10,6 +10,14 @@ export { SupportedLanguage, GenericLexem }
 // see https://github.com/asgerf/dts-tree-sitter
 type GrammarPath = string
 
+/**
+ * Map language to wasm grammar path modules, usually we would have
+ * used node bindings for grammar packages, but since VSCode editor
+ * runtime doesn't support this we have to work with wasm modules.
+ *
+ * Note: make sure that dist folder contains these modules when you
+ * run VSCode extension.
+ */
 const SUPPORTED_LANGUAGES: Record<SupportedLanguage, GrammarPath> = {
     [SupportedLanguage.JavaScript]: 'tree-sitter-javascript.wasm',
     [SupportedLanguage.JSX]: 'tree-sitter-javascript.wasm',
@@ -25,6 +33,12 @@ const SUPPORTED_LANGUAGES: Record<SupportedLanguage, GrammarPath> = {
     [SupportedLanguage.Php]: 'tree-sitter-php.wasm',
 }
 
+/*
+ * Loading wasm grammar and creation parser instance everytime we trigger
+ * pre- and post-process might be a performance problem, so we create instance
+ * and load language grammar only once, first time we need parser for a specific
+ * language, next time we read it from this cache.
+ * */
 const PARSERS_LOCAL_CACHE: Partial<Record<SupportedLanguage, Parser>> = {}
 
 interface ParserSettings {
@@ -87,6 +101,10 @@ export function createParser(settings: ParserSettings): ParserApi {
     }
 }
 
+/*
+ * Walk the whole syntax tree recursively and log each node text
+ * and its lexem type. It's used mostly for debug purpose.
+ */
 export function logTree(node: SyntaxNode): void {
     console.group(node.type)
     console.log(node.text)

--- a/vscode/src/completions/utils/lexical-analysis.ts
+++ b/vscode/src/completions/utils/lexical-analysis.ts
@@ -12,13 +12,14 @@ import Parser, { Point, SyntaxNode, Tree } from 'web-tree-sitter'
  */
 export enum SupportedLanguage {
     JavaScript = 'javascript',
+    JSX = 'javascriptreact',
     TypeScript = 'typescript',
+    TSX = 'typescriptreact',
     Java = 'java',
-    Go = 'go',
     // The problem with these two is that we have to use typescript
     // wasm module grammar, the problem that exports in wasm works differently
     // we probably have to compile custom wasm module for tsx grammar.
-    // JSX = 'javascriptreact',
+    Go = 'go',
     // TSX = 'typescriptreact',
 }
 
@@ -28,9 +29,12 @@ type GrammarPath = string
 
 const SUPPORTED_LANGUAGES: Record<SupportedLanguage, GrammarPath> = {
     [SupportedLanguage.JavaScript]: 'tree-sitter-javascript.wasm',
+    [SupportedLanguage.JSX]: 'tree-sitter-javascript.wasm',
     [SupportedLanguage.Java]: 'tree-sitter-java.wasm',
     [SupportedLanguage.Go]: 'tree-sitter-go.wasm',
     [SupportedLanguage.TypeScript]: 'tree-sitter-typescript.wasm',
+    [SupportedLanguage.TSX]: 'tree-sitter-tsx.wasm',
+
     // Since TypeScript is a subset over javascript grammar we
     // use typescript grammar here in order to support jsx parsing
     // [SupportedLanguage.JSX]: TypeScript.tsx,
@@ -78,6 +82,12 @@ export const LANGUAGE_TO_LEXEM: Partial<Record<SupportedLanguage, LEXEME_DICTION
     // We reuse JavaScript lexemes for typescript since TS grammar extends
     // JavaScript grammar
     [SupportedLanguage.TypeScript]: {
+        [GenericLexem.IfStatement]: JavaScriptLexemType.IfStatement,
+        [GenericLexem.ElseClause]: JavaScriptLexemType.ElseClause,
+        [GenericLexem.StatementBlock]: JavaScriptLexemType.StatementBlock,
+        [GenericLexem.CallExpression]: JavaScriptLexemType.CallExpression,
+    },
+    [SupportedLanguage.TSX]: {
         [GenericLexem.IfStatement]: JavaScriptLexemType.IfStatement,
         [GenericLexem.ElseClause]: JavaScriptLexemType.ElseClause,
         [GenericLexem.StatementBlock]: JavaScriptLexemType.StatementBlock,
@@ -158,4 +168,15 @@ export function createParser(settings: ParserSettings): ParserApi {
             return null
         },
     }
+}
+
+export function traverseTree(node: SyntaxNode): void {
+    console.group(node.type)
+    console.log(node.text)
+
+    node.children.forEach(child => {
+        traverseTree(child)
+    })
+
+    console.groupEnd()
 }

--- a/vscode/src/completions/utils/lexical-analysis.ts
+++ b/vscode/src/completions/utils/lexical-analysis.ts
@@ -1,0 +1,161 @@
+import path from 'path'
+
+import Parser, { Point, SyntaxNode, Tree } from 'web-tree-sitter'
+
+/**
+ * List of all supported languages that we have grammars and
+ * lexems for. Note that enum values are copied from VSCode API,
+ * if we want to make it work with different editors we should
+ * enhance language detection.
+ *
+ * TODO: Decouple language detect to make it editor agnostic
+ */
+export enum SupportedLanguage {
+    JavaScript = 'javascript',
+    TypeScript = 'typescript',
+    Java = 'java',
+    Go = 'go',
+    // The problem with these two is that we have to use typescript
+    // wasm module grammar, the problem that exports in wasm works differently
+    // we probably have to compile custom wasm module for tsx grammar.
+    // JSX = 'javascriptreact',
+    // TSX = 'typescriptreact',
+}
+
+// TODO: Add grammar type autogenerate script
+// see https://github.com/asgerf/dts-tree-sitter
+type GrammarPath = string
+
+const SUPPORTED_LANGUAGES: Record<SupportedLanguage, GrammarPath> = {
+    [SupportedLanguage.JavaScript]: 'tree-sitter-javascript.wasm',
+    [SupportedLanguage.Java]: 'tree-sitter-java.wasm',
+    [SupportedLanguage.Go]: 'tree-sitter-go.wasm',
+    [SupportedLanguage.TypeScript]: 'tree-sitter-typescript.wasm',
+    // Since TypeScript is a subset over javascript grammar we
+    // use typescript grammar here in order to support jsx parsing
+    // [SupportedLanguage.JSX]: TypeScript.tsx,
+    // [SupportedLanguage.TypeScript]: TypeScript.typescript,
+    // [SupportedLanguage.TSX]: TypeScript.tsx,
+}
+
+export enum GenericLexem {
+    IfStatement,
+    ElseClause,
+    StatementBlock,
+    CallExpression,
+}
+
+enum JavaScriptLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else_clause',
+    StatementBlock = 'statement_block',
+    CallExpression = ' call_expression',
+}
+
+enum JavaLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    MethodInvocation = 'method_invocation',
+}
+
+enum GoLexemType {
+    IfStatement = 'if_statement',
+    ElseClause = 'else',
+    StatementBlock = 'block',
+    CallExpression = 'call_expression',
+}
+
+type LEXEME_DICTIONARY = Record<GenericLexem, string>
+
+export const LANGUAGE_TO_LEXEM: Partial<Record<SupportedLanguage, LEXEME_DICTIONARY>> = {
+    [SupportedLanguage.JavaScript]: {
+        [GenericLexem.IfStatement]: JavaScriptLexemType.IfStatement,
+        [GenericLexem.ElseClause]: JavaScriptLexemType.ElseClause,
+        [GenericLexem.StatementBlock]: JavaScriptLexemType.StatementBlock,
+        [GenericLexem.CallExpression]: JavaScriptLexemType.CallExpression,
+    },
+    // We reuse JavaScript lexemes for typescript since TS grammar extends
+    // JavaScript grammar
+    [SupportedLanguage.TypeScript]: {
+        [GenericLexem.IfStatement]: JavaScriptLexemType.IfStatement,
+        [GenericLexem.ElseClause]: JavaScriptLexemType.ElseClause,
+        [GenericLexem.StatementBlock]: JavaScriptLexemType.StatementBlock,
+        [GenericLexem.CallExpression]: JavaScriptLexemType.CallExpression,
+    },
+    [SupportedLanguage.Java]: {
+        [GenericLexem.IfStatement]: JavaLexemType.IfStatement,
+        [GenericLexem.ElseClause]: JavaLexemType.ElseClause,
+        [GenericLexem.StatementBlock]: JavaLexemType.StatementBlock,
+        [GenericLexem.CallExpression]: JavaLexemType.MethodInvocation,
+    },
+    [SupportedLanguage.Go]: {
+        [GenericLexem.IfStatement]: GoLexemType.IfStatement,
+        [GenericLexem.ElseClause]: GoLexemType.ElseClause,
+        [GenericLexem.StatementBlock]: GoLexemType.StatementBlock,
+        [GenericLexem.CallExpression]: GoLexemType.CallExpression,
+    },
+}
+
+export function getLanguageLexems(language: SupportedLanguage): LEXEME_DICTIONARY | null {
+    return LANGUAGE_TO_LEXEM[language] ?? null
+}
+
+interface ParserSettings {
+    language: SupportedLanguage
+
+    /*
+     * A custom path to the directory where we store wasm grammar modules
+     * primary reasons for this is to provide a custom path for testing
+     */
+    grammarDirectory?: string
+}
+
+interface ParserApi {
+    parse: (sourceCode: string) => Promise<Tree>
+    findClosestLexem: (rootNode: SyntaxNode, cursor: Point, lexemType: GenericLexem) => SyntaxNode | null
+}
+
+export function createParser(settings: ParserSettings): ParserApi {
+    const { language, grammarDirectory } = settings
+
+    let parser: Parser
+    const lexems = getLanguageLexems(language)
+
+    return {
+        parse: async (sourceCode: string): Promise<Tree> => {
+            if (!parser) {
+                await Parser.init()
+                parser = new Parser()
+            }
+
+            const rootDir = grammarDirectory ?? __dirname
+            const wasmPath = path.resolve(rootDir, SUPPORTED_LANGUAGES[language])
+            const languageGrammar = await Parser.Language.load(wasmPath)
+
+            parser.setLanguage(languageGrammar)
+
+            return parser.parse(sourceCode)
+        },
+
+        findClosestLexem: (rootNode: SyntaxNode, cursor: Point, lexemType: GenericLexem): SyntaxNode | null => {
+            const currentLexem = lexems?.[lexemType]
+
+            if (!currentLexem) {
+                throw new Error(`Support current lexem ${lexemType} for ${language} language`)
+            }
+
+            let nodeAtCursor: SyntaxNode | null = rootNode.descendantForPosition(cursor)
+
+            while (nodeAtCursor) {
+                nodeAtCursor = nodeAtCursor.parent
+
+                if (nodeAtCursor?.type === currentLexem) {
+                    return nodeAtCursor
+                }
+            }
+
+            return null
+        },
+    }
+}

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -365,7 +365,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         isCacheHit: boolean,
         abortSignal: AbortSignal
     ): Promise<vscode.InlineCompletionList> {
-        const results = processCompletions(completions, prefix, suffix, multiline, languageId)
+        const results = await processCompletions(completions, prefix, suffix, multiline, languageId)
 
         // We usually resolve cached results instantly. However, if the inserted completion would
         // include more than one line, this can create a lot of visible UI churn. To avoid this, we
@@ -420,16 +420,18 @@ export interface Completion {
     stopReason?: string
 }
 
-function processCompletions(
+async function processCompletions(
     completions: Completion[],
     prefix: string,
     suffix: string,
     multiline: boolean,
     languageId: string
-): Completion[] {
+): Promise<Completion[]> {
     // Shared post-processing logic
-    const processedCompletions = completions.map(completion =>
-        sharedPostProcess({ prefix, suffix, multiline, languageId, completion })
+    // TODO: Move more control over to shared post process so we could run
+    // prefix + suffix parsing only once for all completions parts
+    const processedCompletions = await Promise.all(
+        completions.map(completion => sharedPostProcess({ prefix, suffix, multiline, languageId, completion }))
     )
 
     // Filter results


### PR DESCRIPTION
Based on https://github.com/sourcegraph/cody/pull/538

This PR introduces some minimal changes in the shared post-process logic to fit new tree-sitter-based rules (completion adjust runners). As an example, this PR tries to solve this problem with the method and function invocation https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606

## Test plan
- No test play yet, WIP draft
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
