### PR TITLE
Autocomplete: Fix fireworks model name

### DIFF
--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -75,7 +75,7 @@ export class UnstableFireworksProvider extends Provider {
             top_p: 0.95,
             n: this.options.n,
             echo: false,
-            model: 'accounts/fireworks/models/fireworks-starcoder-7b-w8a16-1gpu',
+            model: 'accounts/fireworks/models/starcoder-7b-w8a16-1gpu',
         }
 
         const log = logger.startCompletion({


### PR DESCRIPTION
Fireworks renamed the starcoder 7b model.

## Test plan

Tested locally:

- Enable the fireworks provider (refer to https://sourcegraph.slack.com/archives/C05AGQYD528/p1690551781096999 for the API secrets)
- Trigger an autocomplete request
- Verify that a response comes back

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
