### PR TITLE
Autocomplete: More analytics tweaks

### DIFF
--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -109,11 +109,6 @@ export enum InlineCompletionsResultSource {
 export async function getInlineCompletions(params: InlineCompletionsParams): Promise<InlineCompletionsResult | null> {
     try {
         const result = await doGetInlineCompletions(params)
-        if (result) {
-            debug('getInlineCompletions:result', InlineCompletionsResultSource[result.source])
-        } else {
-            debug('getInlineCompletions:noResult', '')
-        }
         params.tracer?.({ result })
         return result
     } catch (unknownError: unknown) {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -52,7 +52,7 @@ export function logCompletionEvent(name: string, params?: TelemetryEventProperti
     logEvent(`CodyVSCodeExtension:completion:${name}`, params)
 }
 
-export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMode' | 'type'>): string {
+export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMode' | 'type' | 'id'>): string {
     const id = createId()
     const params: CompletionEvent['params'] = {
         ...inputParams,

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -53,7 +53,7 @@ export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMo
     const params: CompletionEvent['params'] = {
         ...inputParams,
         type: 'inline',
-        // Keep the legacy name for backward compatibility in analytics
+        // @deprecated: We only keep the legacy name for backward compatibility in analytics
         multilineMode: inputParams.multiline ? 'block' : null,
         id,
     }
@@ -99,9 +99,9 @@ export function loaded(id: string): void {
     }
 }
 
-// Suggested completions will not be logged immediately. Instead, we log them when
-// we either hide them again (they are NOT accepted) or when they ARE accepted.
-// This way, we can calculate the duration they were actually visible for.
+// Suggested completions will not be logged immediately. Instead, we log them when we either hide
+// them again (they are NOT accepted) or when they ARE accepted. This way, we can calculate the
+// duration they were actually visible for.
 export function suggested(id: string, source: string): void {
     const event = displayedCompletions.get(id)
     if (!event) {
@@ -138,8 +138,7 @@ export function noResponse(id: string): void {
 }
 
 /**
- * This callback should be triggered whenever VS Code tries to highlight a new
- * completion and it's
+ * This callback should be triggered whenever VS Code tries to highlight a new completion and it's
  * used to measure how long previous completions were visible.
  */
 export function clear(): void {

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -1,8 +1,6 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
-import { debug } from '../log'
-
 import { DocumentContext } from './document'
 import { LastInlineCompletionCandidate } from './getInlineCompletions'
 import { logCompletionEvent } from './logger'
@@ -52,10 +50,8 @@ export class RequestManager {
     ): Promise<RequestManagerResult> {
         const cachedCompletions = this.cache.get(params)
         if (cachedCompletions) {
-            debug('RequestManager', 'cache hit', { verbose: { params, cachedCompletions } })
             return { completions: cachedCompletions, cacheHit: 'hit' }
         }
-        debug('RequestManager', 'cache miss', { verbose: { params } })
 
         const request = new InflightRequest(params)
         this.inflightRequests.add(request)
@@ -136,9 +132,6 @@ export class RequestManager {
                 const synthesizedItems = synthesizedCandidate.items
 
                 logCompletionEvent('synthesizedFromParallelRequest')
-                debug('RequestManager', 'cache hit after request started', {
-                    verbose: { params: request.params, cachedCompletions: synthesizedItems },
-                })
                 request.resolve({ completions: synthesizedItems, cacheHit: 'hit-after-request-started' })
                 this.inflightRequests.delete(request)
             }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -13,6 +13,7 @@ import {
     InlineCompletionsResultSource,
     LastInlineCompletionCandidate,
 } from './getInlineCompletions'
+import * as CompletionsLogger from './logger'
 import { ProviderConfig } from './providers/provider'
 import { RequestManager } from './request-manager'
 import { ProvideInlineCompletionItemsTracer, ProvideInlineCompletionsItemTraceData } from './tracer'
@@ -178,6 +179,14 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         return {
             items: result ? this.processInlineCompletionsForVSCode(result.logId, document, position, result.items) : [],
         }
+    }
+
+    public handleDidAcceptCompletionItem(logId: string, lines: number): void {
+        // When a completion is accepted, the lastCandidate should be cleared. This makes sure the
+        // log id is never reused if the completion is accepted.
+        this.lastCandidate = undefined
+
+        CompletionsLogger.accept(logId, lines)
     }
 
     /**

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -12,7 +12,6 @@ import { InlineChatViewManager } from './chat/InlineChatViewProvider'
 import { MessageProviderOptions } from './chat/MessageProvider'
 import { CODY_FEEDBACK_URL } from './chat/protocol'
 import { VSCodeDocumentHistory } from './completions/context/history'
-import * as CompletionsLogger from './completions/logger'
 import { createProviderConfig } from './completions/providers/createProvider'
 import { registerAutocompleteTraceView } from './completions/tracer/traceView'
 import { InlineCompletionItemProvider } from './completions/vscodeInlineCompletionItemProvider'
@@ -498,7 +497,7 @@ function createCompletionsProvider(
 
     disposables.push(
         vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyLines }) => {
-            CompletionsLogger.accept(codyLogId, codyLines)
+            completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyLines)
         }),
         vscode.languages.registerInlineCompletionItemProvider('*', completionsProvider),
         registerAutocompleteTraceView(completionsProvider)


### PR DESCRIPTION
These are a few tweaks that hopefully makes us understand why in some niche situations with low `n`, we see so many accepted events. 

I have not found anything in the logging that would explain it so far so I’m also going to include the log IDs (which are 100% anonymous) so we can cross match exactly what accepted event belongs to what completion.

- We now include the log `id` with all completion events
- The output console was cleaned up. The deleted logger calls were redundant information
- Completion suggestion events now have an additional `accepted` field
  - This field will be set in the same run loop as we also log the `completion:accepted` events and the idea here is that might not need two different event types but can instead simplify the logging to only one event per autocomplete request. This might also help us find out why we currently have more `accepted` events then desired.
- Unset the last candidate when the current candidate was accepted. 
	- This is aimed to fix the "completion accepted without being suggested" events where we have <100 per day (very very low compared to the rest): https://sourcegraph.looker.com/x/9kGPrMNsHSqwhmow3F8wKf

## Test plan

I removed a bunch of things from the output log and made sure the logging works as expected locally: 

https://github.com/sourcegraph/cody/assets/458591/10bedc81-ff23-42ea-83e7-0bc97f4e0786



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
