### PR TITLE
VS Code: Release 0.6.6

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,14 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.6.6]
+
+### Added
+
 - Chat Commands: Add tab-to-complete behavior. [pull/606](https://github.com/sourcegraph/cody/pull/606)
 - Option to toggle `cody.experimental.editorTitleCommandIcon` setting through status bar. [pull/611](https://github.com/sourcegraph/cody/pull/611)
 - New walkthrough for Cody Commands. [pull/648](https://github.com/sourcegraph/cody/pull/648)
@@ -18,11 +26,13 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Handle `socket hung up` errors that are not caused by the `stop generating` button. [pull/598](https://github.com/sourcegraph/cody/pull/598)
 - Fix "Reload Window" appearing in all VS Code views. [pull/603](https://github.com/sourcegraph/cody/pull/603)
 - Fixes issues where in some instances, suggested autocomplete events were under counted. [pull/649](https://github.com/sourcegraph/cody/pull/649)
+- Various smaller tweaks to autocomplete analytics. [pull/644](https://github.com/sourcegraph/cody/pull/644)
 
 ### Changed
 
 - Removed beta labels from autocorrect and inine chat features. [pull/605](https://github.com/sourcegraph/cody/pull/605)
 - Update shortcut for Cody Commands to `alt` + `c` due to conflict with existing keybinding for `fixup`. [pull/648](https://github.com/sourcegraph/cody/pull/648)
+- Removed beta labels from autocorrect and inline chat features. [pull/605](https://github.com/sourcegraph/cody/pull/605)
 
 ## [0.6.5]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -27,6 +27,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Fix "Reload Window" appearing in all VS Code views. [pull/603](https://github.com/sourcegraph/cody/pull/603)
 - Fixes issues where in some instances, suggested autocomplete events were under counted. [pull/649](https://github.com/sourcegraph/cody/pull/649)
 - Various smaller tweaks to autocomplete analytics. [pull/644](https://github.com/sourcegraph/cody/pull/644)
+- Includes the correct pre-release version in analytics events. [pull/641](https://github.com/sourcegraph/cody/pull/641)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
This PR is preparing for a patch release (we need to at least bump the version on `main` so I can cherry-pick this onto a release branch).

I think all of the changes referenced in the change log so far small enough to be part of the patch release but I would like someone else to weigh in here too (cc @toolmantim @dominiccooney @abeatrix @beyang @kalanchan @vovakulikov).

I went over [all individual commits since the 0.6.5 release](https://github.com/sourcegraph/cody/compare/vscode-v0.6.5...main) to make sure we have not forgotten anything and so I think we can cherry-pick everything from `main` for this patch.

**Note:**

@abeatrix wants to get another bug fix in.

## Test plan

This is just a version bump.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
