### PR TITLE
Autocomplete: Fix previous non-empty line

### DIFF
--- a/vscode/src/completions/utils/text-utils.test.ts
+++ b/vscode/src/completions/utils/text-utils.test.ts
@@ -20,7 +20,7 @@ describe('getNextNonEmptyLine', () => {
 describe('getPrevNonEmptyLine', () => {
     it.each([
         ['foo\nbar', 'foo'],
-        ['foo\nbar\nbaz', 'foo'],
+        ['foo\nbar\nbaz', 'bar'],
         ['foo\n\nbar', 'foo'],
         ['foo\n  \nbar', 'foo'],
         ['bar', ''],

--- a/vscode/src/completions/utils/text-utils.ts
+++ b/vscode/src/completions/utils/text-utils.ts
@@ -97,6 +97,6 @@ export function getPrevNonEmptyLine(prefix: string): string {
         prefix
             .slice(0, prevNewline)
             .split('\n')
-            .find(line => line.trim().length > 0) ?? ''
+            .findLast(line => line.trim().length > 0) ?? ''
     )
 }


### PR DESCRIPTION
😱 this is a huge oversight from my side. Thankfully this is only used for a very niche case in the multiline detection logic that isn't used much so there's no big impact.

## Test plan

- Fixed the test case

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
