### PR TITLE
add walkthrough for commands, update commands menu

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -6,9 +6,10 @@ import { registerHighlightContributions, renderMarkdown as renderMarkdownCommon 
  * Supported URIs to render as links in outputted markdown.
  * - https?: Web
  * - vscode: VS Code URL scheme (open in editor)
- * - command:cody.welcome: VS Code command scheme exception we add to support directly linking to the welcome guide from within the chat.
+ * - command:cody. VS Code command scheme for cody (run command)
+ *  - e.g. command:cody.welcome: VS Code command scheme exception we add to support directly linking to the welcome guide from within the chat.
  */
-const ALLOWED_URI_REGEXP = /^((https?|vscode):\/\/[^\s#$./?].\S*|command:cody.welcome)$/i
+const ALLOWED_URI_REGEXP = /^((https?|vscode):\/\/[^\s#$./?].\S*|command:cody.*)$/i
 
 const DOMPURIFY_CONFIG = {
     ALLOWED_TAGS: [

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Chat Commands: Add tab-to-complete behavior. [pull/606](https://github.com/sourcegraph/cody/pull/606)
 - Option to toggle `cody.experimental.editorTitleCommandIcon` setting through status bar. [pull/611](https://github.com/sourcegraph/cody/pull/611)
+- New walkthrough for Cody Commands. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ### Fixed
 
@@ -20,6 +21,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Changed
 
 - Removed beta labels from autocorrect and inine chat features. [pull/605](https://github.com/sourcegraph/cody/pull/605)
+- Update shortcut for Cody Commands Menu to `alt` + `c` due to conflict with existing keybinding for `fixup`. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ## [0.6.5]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -110,9 +110,17 @@
             }
           },
           {
+            "id": "commands",
+            "title": "Cody Commands",
+            "description": "You can use Cody commands to streamline your development process (e.g. generate unit tests, documentation, and more) with just a few clicks.\n[Open Commands Menu](command:cody.action.commands.menu)",
+            "media": {
+              "markdown": "walkthroughs/commands.md"
+            }
+          },
+          {
             "id": "explain",
             "title": "Explain Code",
-            "description": "Ask Cody to explain some code. Select some lines and use the \"Explain selected code\" recipe.\n[Open Commands](command:cody.action.commands.menu)",
+            "description": "Ask Cody to explain some code. Select some lines and use the \"Explain Code\" command.\n[Open Commands Menu](command:cody.action.commands.menu)",
             "media": {
               "markdown": "walkthroughs/explain.md"
             }
@@ -415,7 +423,7 @@
       {
         "command": "cody.action.commands.menu",
         "category": "Cody",
-        "title": "Commands Menu",
+        "title": "Commands",
         "when": "cody.activated",
         "icon": "$(cody-logo)"
       },
@@ -452,9 +460,9 @@
       },
       {
         "command": "cody.action.commands.menu",
-        "key": "ctrl+shift+v",
-        "mac": "cmd+shift+v",
-        "when": "cody.activated && editorFocus"
+        "key": "alt+c",
+        "mac": "alt+c",
+        "when": "cody.activated"
       },
       {
         "command": "-github.copilot.generate",

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -538,7 +538,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (!text?.startsWith('/')) {
             return { text, recipeId }
         }
-        this.telemetryService.log(`CodyVSCodeExtension:slashCommand:${text}:submitted`)
+        const commandKey = text.split(' ')[0].replace('/', '')
+        this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:filtering`)
         switch (true) {
             case text === '/':
                 return vscode.commands.executeCommand('cody.action.commands.menu')
@@ -560,7 +561,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 const promptText = this.editor.controllers.command?.find(text, true)
                 await this.editor.controllers.command?.get('command')
                 if (promptText) {
-                    this.telemetryService.log(`CodyVSCodeExtension:command:${text}:executing`)
+                    this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:executing`)
                     return { text: promptText, recipeId: 'custom-prompt' }
                 }
                 return { text, recipeId }

--- a/vscode/src/custom-prompts/menus/CustomCommandBuilderMenu.ts
+++ b/vscode/src/custom-prompts/menus/CustomCommandBuilderMenu.ts
@@ -31,6 +31,7 @@ export class CustomCommandsBuilderMenu {
             ...NewCustomCommandConfigMenuOptions,
             prompt: 'Enter an unique name for the new command.',
             placeHolder: 'e,g. Vulnerability Scanner',
+            ignoreFocusOut: true,
             validateInput: (input: string) => {
                 if (!input) {
                     return 'Command name cannot be empty. Please enter a unique name.'
@@ -54,6 +55,7 @@ export class CustomCommandsBuilderMenu {
             ...NewCustomCommandConfigMenuOptions,
             prompt: 'Enter a prompt—a set of instructions/questions for Cody to follow and answer.',
             placeHolder: "e.g. 'Create five different test cases for the selected code'",
+            ignoreFocusOut: true,
             validateInput: (input: string) => {
                 if (!input || input.split(' ').length < minPromptLength) {
                     return `Please enter a prompt with a minimum of ${minPromptLength} words`

--- a/vscode/src/custom-prompts/menus/index.ts
+++ b/vscode/src/custom-prompts/menus/index.ts
@@ -14,8 +14,8 @@ interface CommandMenuResponse {
 
 export async function showCommandMenu(items: QuickPickItem[]): Promise<CommandMenuResponse> {
     const options = {
-        title: 'Cody Commands',
-        placeHolder: 'Search for a command',
+        title: 'Cody (Shortcut: ⌥C)',
+        placeHolder: 'Search for a command or enter your question here',
         ignoreFocusOut: true,
     }
 

--- a/vscode/src/custom-prompts/utils/menu.ts
+++ b/vscode/src/custom-prompts/utils/menu.ts
@@ -192,6 +192,7 @@ export const CustomCommandConfigMenuItems = [
     {
         kind: 0,
         label: 'Open User Settings (JSON)',
+        detail: 'Stored on your machine and usable across all your workspaces',
         id: 'open',
         type: 'user',
         description: '~/.vscode/cody.json',
@@ -200,6 +201,7 @@ export const CustomCommandConfigMenuItems = [
     {
         kind: 0,
         label: 'Open Workspace Settings (JSON)',
+        detail: 'Project-specific and shared with anyone using this workspace',
         id: 'open',
         type: 'workspace',
         description: '.vscode/cody.json',

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -339,18 +339,18 @@ const register = async (
             }
             await sidebarChatProvider.executeCustomCommand(title)
         }),
-        vscode.commands.registerCommand('cody.command.explain-code', () =>
-            executeRecipeInSidebar('custom-prompt', true, '/explain')
-        ),
-        vscode.commands.registerCommand('cody.recipe.explain-code', () =>
-            executeRecipeInSidebar('explain-code-detailed')
-        ),
-        vscode.commands.registerCommand('cody.command.generate-unit-test', () =>
-            executeRecipeInSidebar('custom-prompt', true, '/tests')
-        ),
-        vscode.commands.registerCommand('cody.command.generate-docstring', () =>
-            executeRecipeInSidebar('custom-prompt', true, '/docstring')
-        ),
+        vscode.commands.registerCommand('cody.command.explain-code', async () => {
+            await executeRecipeInSidebar('custom-prompt', true, '/explain')
+            telemetryService.log('CodyVSCodeExtension:recipe:explain-code-high-level:executed')
+        }),
+        vscode.commands.registerCommand('cody.command.generate-unit-test', async () => {
+            await executeRecipeInSidebar('custom-prompt', true, '/test')
+            telemetryService.log('CodyVSCodeExtension:recipe:generate-unit-test:executed')
+        }),
+        vscode.commands.registerCommand('cody.command.generate-docstring', async () => {
+            await executeRecipeInSidebar('custom-prompt', true, '/doc')
+            telemetryService.log('CodyVSCodeExtension:recipe:generate-docstring:executed')
+        }),
         vscode.commands.registerCommand('cody.command.inline-touch', () =>
             executeRecipeInSidebar('inline-touch', false)
         ),

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -104,7 +104,7 @@ export function createStatusBar(): CodyStatusBar {
                     },
                 },
                 {
-                    label: '$(terminal) Custom Commands Settings',
+                    label: '$(symbol-namespace) Custom Commands Settings',
                     async onSelect(): Promise<void> {
                         await vscode.commands.executeCommand('cody.settings.commands')
                     },

--- a/vscode/walkthroughs/commands.md
+++ b/vscode/walkthroughs/commands.md
@@ -1,0 +1,5 @@
+## Cody Commands
+
+Cody can generate unit tests, documentation, and more, leveraging its full awareness of your codebase. You can access and create various helpful commands to streamline your development process with just a few clicks.
+
+To get started, select a command from the [Cody: Commands Menu](command:cody.action.commands.menu), or right click on a code section.

--- a/vscode/walkthroughs/explain.md
+++ b/vscode/walkthroughs/explain.md
@@ -3,8 +3,10 @@
 <video autoPlay muted loop playsInline>
     <source
         type="video/mp4"
-        src="https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/cody-explain-may2023.mp4"
+        src="https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/cody-explain-code-aug2023.mp4"
     />
 </video>
 
-Cody can explain what code is doing—at a high level or in detail. Highlight any code block or an entire file and Cody will explain what’s happening in conversational language.
+Cody can explain code in an easy-to-understand manner. Highlight any code block and execute the `Explain Code` command from your right-click menu, and Cody will explain it to you in conversational language.
+
+You can also execute a command from the [Cody: Commands Menu (Shortcut: ⌥C)](command:cody.action.commands.menu).

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -90,7 +90,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         setEnabledPlugins(message.plugins)
                         break
                     case 'custom-prompts':
-                        setMyPrompts(message.prompts || null)
+                        setMyPrompts(message.prompts?.filter(command => command[1]?.slashCommand) || null)
                         break
                     case 'transcript-errors':
                         setIsTranscriptError(message.isTranscriptError)

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -154,11 +154,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             isCodyEnabled={true}
             codyNotEnabledNotice={undefined}
             afterMarkdown={
-                showOnboardingButtons
-                    ? 'To get started, select some code and right click to select a Cody command to run.'
-                    : ''
+                '🔔 Recipes are now [Cody Commands](command:cody.action.commands.menu)! You can start using them with the [⌥C](command:cody.action.commands.menu) shortcut on highlighted code. \n\nSee [Getting Started](command:cody.welcome) to learn more about [Cody Commands](command:cody.action.commands.menu).'
             }
-            helpMarkdown="See [Getting Started](command:cody.welcome) for help and tips."
+            helpMarkdown=""
             ChatButtonComponent={ChatButton}
             pluginsDevMode={pluginsDevMode}
             chatCommands={chatCommands}


### PR DESCRIPTION
feat: add walkthrough for cody commands and update commands menu

- Add new walkthrough for `Cody Commands`.
- Update welcome message suggested by chris here before we have the new design added https://github.com/sourcegraph/cody/issues/633#issuecomment-1671714738
- Update shortcut for Cody Commands Menu to `alt` + `c` due to conflict. 
- Update description for "Explain Code" command.
- Update the title for Commands Menu to just "Commands".
- Update telemetry to log command as recipe on right clicks before we have implemented the correct logs for commands

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

UI change to communicate UI change in last patch:

![image](https://github.com/sourcegraph/cody/assets/68532117/37baa4a1-e225-4b0d-88c1-2afaefb51025)
