### PR TITLE
Autocomplete: Fix suggestion event over counting

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Update file link color to match buttons. [pull/600](https://github.com/sourcegraph/cody/pull/600)
 - Handle `socket hung up` errors that are not caused by the `stop generating` button. [pull/598](https://github.com/sourcegraph/cody/pull/598)
 - Fix "Reload Window" appearing in all VS Code views. [pull/603](https://github.com/sourcegraph/cody/pull/603)
+- Fixes issues where in some instances, suggested autocomplete events were under counted. [pull/649](https://github.com/sourcegraph/cody/pull/649)
 
 ### Changed
 

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -7,7 +7,7 @@ import { debug } from '../log'
 
 import { GetContextOptions, GetContextResult } from './context/context'
 import { DocumentHistory } from './context/history'
-import { DocumentContext, getCurrentDocContext } from './document'
+import { DocumentContext } from './document'
 import * as CompletionLogger from './logger'
 import { detectMultiline } from './multiline'
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './providers/provider'
@@ -22,11 +22,10 @@ export interface InlineCompletionsParams {
     document: vscode.TextDocument
     position: vscode.Position
     context: vscode.InlineCompletionContext
+    docContext: DocumentContext
 
     // Prompt parameters
     promptChars: number
-    maxPrefixChars: number
-    maxSuffixChars: number
     providerConfig: ProviderConfig
     responsePercentage: number
     prefixPercentage: number
@@ -132,9 +131,8 @@ async function doGetInlineCompletions({
     document,
     position,
     context,
+    docContext,
     promptChars,
-    maxPrefixChars,
-    maxSuffixChars,
     providerConfig,
     responsePercentage,
     prefixPercentage,
@@ -152,11 +150,6 @@ async function doGetInlineCompletions({
     tracer,
 }: InlineCompletionsParams): Promise<InlineCompletionsResult | null> {
     tracer?.({ params: { document, position, context } })
-
-    const docContext = getCurrentDocContext(document, position, maxPrefixChars, maxSuffixChars)
-    if (!docContext) {
-        return null
-    }
 
     // If we have a suffix in the same line as the cursor and the suffix contains any word
     // characters, do not attempt to make a completion. This means we only make completions if
@@ -255,7 +248,7 @@ async function doGetInlineCompletions({
             ? InlineCompletionsResultSource.CacheAfterRequestStart
             : InlineCompletionsResultSource.Network
 
-    logCompletions(logId, completions, document, docContext, context, providerConfig, source, abortSignal)
+    CompletionLogger.loaded(logId)
 
     return {
         logId,
@@ -374,89 +367,4 @@ function createCompletionProviderTracer(
             result: data => tracer({ completionProviderCallResult: data }),
         }
     )
-}
-
-function logCompletions(
-    logId: string,
-    completions: InlineCompletionItem[],
-    document: vscode.TextDocument,
-    docContext: DocumentContext,
-    context: vscode.InlineCompletionContext,
-    providerConfig: ProviderConfig,
-    source: InlineCompletionsResultSource,
-    abortSignal: AbortSignal | undefined
-): void {
-    CompletionLogger.loaded(logId)
-
-    // There are these cases when a completion is being returned here but won't
-    // be displayed by VS Code.
-    //
-    // - When the abort signal was already triggered and a new completion
-    //   request was stared.
-    // - When the VS Code completion popup is open and we suggest a completion
-    //   that does not match the currently selected completion. For now we make
-    //   sure to not log these completions as displayed.
-    //   TODO: Take this into account when creating the completion prefix.
-    // - When no completions contains characters in the current line that are
-    //   not in the current line suffix. Since VS Code will try to merge
-    //   completion with the suffix, we have to do a per-character diff to test
-    //   this.
-    const isAborted = abortSignal ? abortSignal.aborted : false
-    const isMatchingPopupItem = completionMatchesPopupItem(completions, document, context)
-    const isMatchingSuffix = completionMatchesSuffix(completions, docContext, providerConfig)
-    const isVisible = !isAborted && isMatchingPopupItem && isMatchingSuffix
-
-    if (isVisible) {
-        if (completions.length > 0) {
-            CompletionLogger.suggested(logId, InlineCompletionsResultSource[source])
-        } else {
-            CompletionLogger.noResponse(logId)
-        }
-    }
-}
-
-function completionMatchesPopupItem(
-    completions: InlineCompletionItem[],
-    document: vscode.TextDocument,
-    context: vscode.InlineCompletionContext
-): boolean {
-    if (context.selectedCompletionInfo) {
-        const currentText = document.getText(context.selectedCompletionInfo.range)
-        const selectedText = context.selectedCompletionInfo.text
-        if (completions.length > 0 && !(currentText + completions[0].insertText).startsWith(selectedText)) {
-            return false
-        }
-    }
-    return true
-}
-
-function completionMatchesSuffix(
-    completions: InlineCompletionItem[],
-    docContext: DocumentContext,
-    providerConfig: ProviderConfig
-): boolean {
-    // Models that support infilling do not replace an existing suffix but
-    // instead insert the completion only at the current cursor position. Thus,
-    // we do not need to compare the suffix
-    if (providerConfig.supportsInfilling) {
-        return true
-    }
-
-    const suffix = docContext.currentLineSuffix
-
-    for (const completion of completions) {
-        const insertion = completion.insertText
-        let j = 0
-        // eslint-disable-next-line @typescript-eslint/prefer-for-of
-        for (let i = 0; i < insertion.length; i++) {
-            if (insertion[i] === suffix[j]) {
-                j++
-            }
-        }
-        if (j === suffix.length) {
-            return true
-        }
-    }
-
-    return false
 }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -122,6 +122,18 @@ export function accept(id: string, lines: number): void {
         return
     }
 
+    // Some additional logging to ensure the invariant is correct. I expect these branches to never
+    // hit but if they do, they might explain undercount issues
+    if (!completionEvent.loadedAt) {
+        logCompletionEvent('unexpectedNotLoaded')
+    }
+    if (!completionEvent.startLoggedAt) {
+        logCompletionEvent('unexpectedNotStarted')
+    }
+    if (!completionEvent.suggestedAt) {
+        logCompletionEvent('unexpectedNotSuggested')
+    }
+
     completionEvent.acceptedAt = performance.now()
 
     logSuggestionEvents()

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -123,7 +123,7 @@ export function accept(id: string, lines: number): void {
     }
 
     // Some additional logging to ensure the invariant is correct. I expect these branches to never
-    // hit but if they do, they might explain undercount issues
+    // hit but if they do, they might help debug analytics issues
     if (!completionEvent.loadedAt) {
         logCompletionEvent('unexpectedNotLoaded')
     }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -7,6 +7,7 @@ import { CodyStatusBar } from '../services/StatusBar'
 
 import { getContext, GetContextOptions, GetContextResult } from './context/context'
 import { DocumentHistory } from './context/history'
+import { DocumentContext, getCurrentDocContext } from './document'
 import {
     getInlineCompletions,
     InlineCompletionsParams,
@@ -38,7 +39,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     private promptChars: number
     private maxPrefixChars: number
     private maxSuffixChars: number
-    private abortOpenCompletions: () => void = () => {}
 
     private readonly config: Required<CodyCompletionItemProviderConfig>
 
@@ -107,7 +107,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         context: vscode.InlineCompletionContext,
         // Making it optional here to execute multiple suggestion in parallel from the CLI script.
         token?: vscode.CancellationToken
-    ): Promise<vscode.InlineCompletionList> {
+    ): Promise<vscode.InlineCompletionList | null> {
         const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
 
         let stopLoading: () => void | undefined
@@ -120,22 +120,24 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
 
         const abortController = new AbortController()
-        this.abortOpenCompletions()
         if (token) {
             if (token.isCancellationRequested) {
                 abortController.abort()
             }
             token.onCancellationRequested(() => abortController.abort())
-            this.abortOpenCompletions = () => abortController.abort()
+        }
+
+        const docContext = getCurrentDocContext(document, position, this.maxPrefixChars, this.maxSuffixChars)
+        if (!docContext) {
+            return null
         }
 
         const result = await this.getInlineCompletions({
             document,
             position,
             context,
+            docContext,
             promptChars: this.promptChars,
-            maxPrefixChars: this.maxPrefixChars,
-            maxSuffixChars: this.maxSuffixChars,
             providerConfig: this.config.providerConfig,
             responsePercentage: this.config.responsePercentage,
             prefixPercentage: this.config.prefixPercentage,
@@ -153,12 +155,16 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             tracer,
         })
 
+        if (!result) {
+            return null
+        }
+
         // Track the last candidate completion (that is shown as ghost text in the editor) so that
         // we can reuse it if the user types in such a way that it is still valid (such as by typing
         // `ab` if the ghost text suggests `abcd`).
-        if (result && result.source !== InlineCompletionsResultSource.LastCandidate) {
+        if (result.source !== InlineCompletionsResultSource.LastCandidate) {
             this.lastCandidate =
-                result?.items.length > 0
+                result.items.length > 0
                     ? {
                           uri: document.uri,
                           lastTriggerPosition: position,
@@ -174,6 +180,26 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                           },
                       }
                     : undefined
+        }
+
+        // A completion that won't be visible in VS Code will not be returned and not be logged.
+        if (
+            !isCompletionVisible(
+                result?.items,
+                document,
+                docContext,
+                context,
+                this.config.providerConfig,
+                abortController.signal
+            )
+        ) {
+            return null
+        }
+
+        if (result.items.length > 0) {
+            CompletionsLogger.suggested(result.logId, InlineCompletionsResultSource[result.source])
+        } else {
+            CompletionsLogger.noResponse(result.logId)
         }
 
         return {
@@ -241,4 +267,79 @@ function createTracerForInvocation(tracer: ProvideInlineCompletionItemsTracer): 
         data = { ...data, ...update }
         tracer(data)
     }
+}
+
+function isCompletionVisible(
+    completions: InlineCompletionItem[],
+    document: vscode.TextDocument,
+    docContext: DocumentContext,
+    context: vscode.InlineCompletionContext,
+    providerConfig: ProviderConfig,
+    abortSignal: AbortSignal | undefined
+): boolean {
+    // There are these cases when a completion is being returned here but won't
+    // be displayed by VS Code.
+    //
+    // - When the abort signal was already triggered and a new completion
+    //   request was stared.
+    // - When the VS Code completion popup is open and we suggest a completion
+    //   that does not match the currently selected completion. For now we make
+    //   sure to not log these completions as displayed.
+    //   TODO: Take this into account when creating the completion prefix.
+    // - When no completions contains characters in the current line that are
+    //   not in the current line suffix. Since VS Code will try to merge
+    //   completion with the suffix, we have to do a per-character diff to test
+    //   this.
+    const isAborted = abortSignal ? abortSignal.aborted : false
+    const isMatchingPopupItem = completionMatchesPopupItem(completions, document, context)
+    const isMatchingSuffix = completionMatchesSuffix(completions, docContext, providerConfig)
+    const isVisible = !isAborted && isMatchingPopupItem && isMatchingSuffix
+
+    return isVisible
+}
+
+function completionMatchesPopupItem(
+    completions: InlineCompletionItem[],
+    document: vscode.TextDocument,
+    context: vscode.InlineCompletionContext
+): boolean {
+    if (context.selectedCompletionInfo) {
+        const currentText = document.getText(context.selectedCompletionInfo.range)
+        const selectedText = context.selectedCompletionInfo.text
+        if (completions.length > 0 && !(currentText + completions[0].insertText).startsWith(selectedText)) {
+            return false
+        }
+    }
+    return true
+}
+
+function completionMatchesSuffix(
+    completions: InlineCompletionItem[],
+    docContext: DocumentContext,
+    providerConfig: ProviderConfig
+): boolean {
+    // Models that support infilling do not replace an existing suffix but
+    // instead insert the completion only at the current cursor position. Thus,
+    // we do not need to compare the suffix
+    if (providerConfig.supportsInfilling) {
+        return true
+    }
+
+    const suffix = docContext.currentLineSuffix
+
+    for (const completion of completions) {
+        const insertion = completion.insertText
+        let j = 0
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < insertion.length; i++) {
+            if (insertion[i] === suffix[j]) {
+                j++
+            }
+        }
+        if (j === suffix.length) {
+            return true
+        }
+    }
+
+    return false
 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -14,7 +14,7 @@ import {
     InlineCompletionsResultSource,
     LastInlineCompletionCandidate,
 } from './getInlineCompletions'
-import * as CompletionsLogger from './logger'
+import * as CompletionLogger from './logger'
 import { ProviderConfig } from './providers/provider'
 import { RequestManager } from './request-manager'
 import { ProvideInlineCompletionItemsTracer, ProvideInlineCompletionsItemTraceData } from './tracer'
@@ -197,9 +197,9 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
 
         if (result.items.length > 0) {
-            CompletionsLogger.suggested(result.logId, InlineCompletionsResultSource[result.source])
+            CompletionLogger.suggested(result.logId, InlineCompletionsResultSource[result.source])
         } else {
-            CompletionsLogger.noResponse(result.logId)
+            CompletionLogger.noResponse(result.logId)
         }
 
         return {
@@ -212,7 +212,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         // log id is never reused if the completion is accepted.
         this.lastCandidate = undefined
 
-        CompletionsLogger.accept(logId, lines)
+        CompletionLogger.accept(logId, lines)
     }
 
     /**

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -135,9 +135,11 @@ async function generateCompletionsForDataset(codeSamples: Sample[]): Promise<voi
                 undefined
             )
 
-            const completions = ('items' in completionItems ? completionItems.items : completionItems).map(item =>
-                typeof item.insertText === 'string' ? item.insertText : ''
-            )
+            const completions = completionItems
+                ? ('items' in completionItems ? completionItems.items : completionItems).map(item =>
+                      typeof item.insertText === 'string' ? item.insertText : ''
+                  )
+                : []
             console.error(`#${index}@i=${i}`, completions)
             codeSampleResults.push({
                 completions,


### PR DESCRIPTION
This PR fixes an issue that sometimes caused completion suggestion events to not fire correctly. The issue here was that we decided wether or not a completion is visible in the `getInlineCompletions` code that was now change to _still yield completions_.

The yielding is fine, we have relied on these results to be used for the last candidate cache. However, this would also mean that we would store a log id that was _deemed as not visible_ but that never reconsidered this condition. This meant that such a completion could become visible later and we would be able to accept it, even though it was never logged as suggested.

To fix this, we move this logic into the VS Code specific part (which conceptually makes more sense anyways since it's full of VS Code specific logic) and also test the visibility after every cache retrieval. 

## Test plan

I've added three conditions to test invariants that should not be possible. To test locally, I've added debugger break points into either of them and repeatedly triggered a bazillion of completions. After these changes, I don't seem to be able to trigger them anymore. I’m leaving some logs in there, though, so we can see if they happen on production.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
