### PR TITLE
overhaul autocomplete provider config

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -819,15 +819,15 @@
             "unstable-fireworks",
             "unstable-azure-openai"
           ],
-          "markdownDescription": "Overwrite the provider used for code autocomplete."
+          "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
         "cody.autocomplete.advanced.serverEndpoint": {
           "type": "string",
-          "markdownDescription": "Overwrite the server endpoint used for code autocomplete. This is only supported with a provider other than `anthropic`."
+          "markdownDescription": "The server endpoint used for code autocomplete. This is only supported with a provider other than `anthropic`."
         },
         "cody.autocomplete.advanced.accessToken": {
           "type": "string",
-          "markdownDescription": "Overwrite the access token used for code autocomplete. This is only supported with a provider other than `anthropic`."
+          "markdownDescription": "The access token used for code autocomplete. This is only supported with a provider other than `anthropic`."
         },
         "cody.autocomplete.advanced.embeddings": {
           "order": 99,

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -1,6 +1,8 @@
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
+import { debug } from '../../log'
+
 import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
 import { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableAzureOpenAiProviderConfig } from './unstable-azure-openai'
@@ -10,80 +12,80 @@ import { createProviderConfig as createUnstableHuggingFaceProviderConfig } from 
 
 export function createProviderConfig(
     config: Configuration,
-    onError: (error: string) => void,
     completionsClient: SourcegraphNodeCompletionsClient
-): ProviderConfig {
-    let providerConfig: null | ProviderConfig = null
+): ProviderConfig | null {
     switch (config.autocompleteAdvancedProvider) {
         case 'unstable-codegen': {
             if (config.autocompleteAdvancedServerEndpoint !== null) {
-                providerConfig = createUnstableCodeGenProviderConfig({
+                return createUnstableCodeGenProviderConfig({
                     serverEndpoint: config.autocompleteAdvancedServerEndpoint,
                 })
-                break
             }
 
-            onError(
-                'Provider `unstable-codegen` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`. Falling back to `anthropic`.'
+            debug(
+                'createProviderConfig',
+                'Provider `unstable-codegen` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
-            break
+            return null
         }
         case 'unstable-huggingface': {
             if (config.autocompleteAdvancedServerEndpoint !== null) {
-                providerConfig = createUnstableHuggingFaceProviderConfig({
+                return createUnstableHuggingFaceProviderConfig({
                     serverEndpoint: config.autocompleteAdvancedServerEndpoint,
                     accessToken: config.autocompleteAdvancedAccessToken,
                 })
-                break
             }
 
-            onError(
-                'Provider `unstable-huggingface` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`. Falling back to `anthropic`.'
+            debug(
+                'createProviderConfig',
+                'Provider `unstable-huggingface` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
-            break
+            return null
         }
         case 'unstable-azure-openai': {
             if (config.autocompleteAdvancedServerEndpoint === null) {
-                onError(
-                    'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`. Falling back to `anthropic`.'
+                debug(
+                    'createProviderConfig',
+                    'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
                 )
-                break
+                return null
             }
 
             if (config.autocompleteAdvancedAccessToken === null) {
-                onError(
-                    'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.accessToken`. Falling back to `anthropic`.'
+                debug(
+                    'createProviderConfig',
+                    'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.accessToken`.'
                 )
-                break
+                return null
             }
 
-            providerConfig = createUnstableAzureOpenAiProviderConfig({
+            return createUnstableAzureOpenAiProviderConfig({
                 serverEndpoint: config.autocompleteAdvancedServerEndpoint,
                 accessToken: config.autocompleteAdvancedAccessToken,
             })
-            break
         }
         case 'unstable-fireworks': {
             if (config.autocompleteAdvancedServerEndpoint !== null) {
-                providerConfig = createUnstableFireworksProviderConfig({
+                return createUnstableFireworksProviderConfig({
                     serverEndpoint: config.autocompleteAdvancedServerEndpoint,
                     accessToken: config.autocompleteAdvancedAccessToken,
                 })
-                break
             }
 
-            onError(
-                'Provider `unstable-fireworks` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`. Falling back to `anthropic`.'
+            debug(
+                'createProviderConfig',
+                'Provider `unstable-fireworks` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
-            break
+            return null
         }
+        case 'anthropic': {
+            return createAnthropicProviderConfig({
+                completionsClient,
+                contextWindowTokens: 2048,
+            })
+        }
+        default:
+            debug('createProviderConfig', `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`)
+            return null
     }
-    if (providerConfig) {
-        return providerConfig
-    }
-
-    return createAnthropicProviderConfig({
-        completionsClient,
-        contextWindowTokens: 2048,
-    })
 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -36,23 +36,6 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         debugRegex = new RegExp('.*')
     }
 
-    let autocompleteAdvancedProvider = config.get<
-        'anthropic' | 'unstable-codegen' | 'unstable-huggingface' | 'unstable-fireworks' | 'unstable-azure-openai'
-    >(CONFIG_KEY.autocompleteAdvancedProvider, 'anthropic')
-
-    if (
-        autocompleteAdvancedProvider !== 'anthropic' &&
-        autocompleteAdvancedProvider !== 'unstable-codegen' &&
-        autocompleteAdvancedProvider !== 'unstable-huggingface' &&
-        autocompleteAdvancedProvider !== 'unstable-fireworks' &&
-        autocompleteAdvancedProvider !== 'unstable-azure-openai'
-    ) {
-        autocompleteAdvancedProvider = 'anthropic'
-        void vscode.window.showInformationMessage(
-            `Unrecognized ${CONFIG_KEY.autocompleteAdvancedProvider}, defaulting to 'anthropic'`
-        )
-    }
-
     return {
         // NOTE: serverEndpoint is now stored in Local Storage instead but we will still keep supporting the one in confg
         // to use as fallback for users who do not have access to local storage
@@ -71,7 +54,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
         experimentalEditorTitleCommandIcon: config.get(CONFIG_KEY.experimentalEditorTitleCommandIcon, false),
-        autocompleteAdvancedProvider,
+        autocompleteAdvancedProvider: config.get(CONFIG_KEY.autocompleteAdvancedProvider, 'anthropic'),
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,
             null

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -52,7 +52,10 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
 
     const history = new VSCodeDocumentHistory()
 
-    const providerConfig = createProviderConfig(initialConfig, console.error, completionsClient)
+    const providerConfig = createProviderConfig(initialConfig, completionsClient)
+    if (!providerConfig) {
+        throw new Error('invalid completion config: no provider')
+    }
 
     const completionsProvider = new InlineCompletionItemProvider({
         providerConfig,


### PR DESCRIPTION
- Show error messages during provider creation in the output channel instead of (a) in a notification (which is annoying and shows up for each keystroke) or (b) in the webview, which is not somewhere the user would necessarily look for autocomplete-related issues.
- Do not default to the Anthropic provider if an invalid provider is specified. If the user is specifying a provider in `cody.autocomplete.advanced.provider`, their intent is likely to use a non-default provider, and falling back to Anthropic would not be desired.
- Remove the duplication in calls to `createCompletionsProvider`.
- Update settings docstrings.

(My initial motivation for this is that I got annoying VS Code notifications while hacking on a new unstable autocomplete provider based on Ollama.)

## Test plan

Set `cody.autocomplete.advanced.provider` to non-default and invalid values and ensure that the configuration is auto-applied and that the correct error messages are shown in the output channel.