### PR TITLE
Autocomplete: Truncate same line suffix from prompt

### DIFF
--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -21,11 +21,14 @@ export class UnstableCodeGenProvider extends Provider {
     }
 
     public async generateCompletions(abortSignal: AbortSignal, snippets: ContextSnippet[]): Promise<Completion[]> {
+        const { prefix, suffix } = this.options
+        const suffixAfterFirstNewline = suffix.slice(suffix.indexOf('\n'))
+
         const params = {
             debug_ext_path: 'cody',
             lang_prefix: `<|${mapVSCodeLanguageIdToModelId(this.options.languageId)}|>`,
-            prefix: this.options.prefix,
-            suffix: this.options.suffix,
+            prefix,
+            suffix: suffixAfterFirstNewline,
             top_p: 0.95,
             temperature: 0.2,
             max_tokens: this.options.multiline ? 128 : 40,

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -28,6 +28,7 @@ export class UnstableFireworksProvider extends Provider {
 
     private createPrompt(snippets: ContextSnippet[]): string {
         const maxPromptChars = CONTEXT_WINDOW_CHARS - CONTEXT_WINDOW_CHARS * this.options.responsePercentage
+        const { prefix, suffix } = this.options
 
         const intro: string[] = []
         let prompt = ''
@@ -50,8 +51,10 @@ export class UnstableFireworksProvider extends Provider {
                     .map(line => (languageConfig ? languageConfig.commentStart + line : ''))
                     .join('\n') + '\n'
 
+            const suffixAfterFirstNewline = suffix.slice(suffix.indexOf('\n'))
+
             // Prompt format is taken form https://starcoder.co/bigcode/starcoder#fill-in-the-middle
-            const nextPrompt = `<fim_prefix>${introString}${this.options.prefix}<fim_suffix>${this.options.suffix}<fim_middle>`
+            const nextPrompt = `<fim_prefix>${introString}${prefix}<fim_suffix>${suffixAfterFirstNewline}<fim_middle>`
 
             if (nextPrompt.length >= maxPromptChars) {
                 return prompt

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -28,6 +28,7 @@ export class UnstableHuggingFaceProvider extends Provider {
 
     private createPrompt(snippets: ContextSnippet[]): string {
         const maxPromptChars = CONTEXT_WINDOW_CHARS - CONTEXT_WINDOW_CHARS * this.options.responsePercentage
+        const { prefix, suffix } = this.options
 
         const intro: string[] = []
         let prompt = ''
@@ -50,8 +51,10 @@ export class UnstableHuggingFaceProvider extends Provider {
                     .map(line => (languageConfig ? languageConfig.commentStart + line : ''))
                     .join('\n') + '\n'
 
+            const suffixAfterFirstNewline = suffix.slice(suffix.indexOf('\n'))
+
             // Prompt format is taken form https://huggingface.co/bigcode/starcoder#fill-in-the-middle
-            const nextPrompt = `<fim_prefix>${introString}${this.options.prefix}<fim_suffix>${this.options.suffix}<fim_middle>`
+            const nextPrompt = `<fim_prefix>${introString}${prefix}<fim_suffix>${suffixAfterFirstNewline}<fim_middle>`
 
             if (nextPrompt.length >= maxPromptChars) {
                 return prompt

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -235,7 +235,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             const start = currentLine.range.start
 
             // The completion will always exclude the same line suffix, so it has to overwrite the
-            // current range.
+            // current same line suffix and reach to the end of the line.
             const end = currentLine.range.end
 
             return new vscode.InlineCompletionItem(

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -234,12 +234,9 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             // come in.
             const start = currentLine.range.start
 
-            // Limit the range to the current position if the model supports infilling and the
-            // response only has a single line.
-            // For non FIM models, the same line suffix will be repeated in the completion
-            const supportsInfilling = this.config.providerConfig.supportsInfilling
-            const isMultiline = completion.insertText.includes('\n')
-            const end = supportsInfilling && !isMultiline ? position : currentLine.range.end
+            // The completion will always exclude the same line suffix, so it has to overwrite the
+            // current range.
+            const end = currentLine.range.end
 
             return new vscode.InlineCompletionItem(
                 currentLinePrefix + completion.insertText,


### PR DESCRIPTION
This PR removes the same line suffix from all fill-in-middle providers. There are multiple reasons for this:

- For single line completions, we don't want to match the same line suffix in some cases. consider this file:
  ```
  for (let i = 0; i < array.length; █)
  ``` 
  
  We actually want this to complete with `i++) {` (notice the added opening brace) and replace the existing `)`.
- Some models like StarCoder doesn't seem to be too happy with same line suffixes resulting in responses that _sometimes have the same line suffix repeated and sometimes not_.

Some recent change to try to deal with this better resulted in a pretty big regression with the FIM models (I think this is what @olafurpg experienced today too, so I think it's better to just remove it all-together.

This _can_ result in completions with a suffix that won't match the same line suffix but we already handle this case anyways so it's not worse than what we already have.

## Test plan

- Configure the StarCoder model (c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1690551781096999)
- Trigger some inline completion and observe that the same line suffix is no longer repeated in the insertion
- You can check the updated prompt in the logs too 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
