### PR TITLE
always log error from getInlineCompletions

### DIFF
--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -116,8 +116,8 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
 
         params.tracer?.({ error: error.toString() })
 
+        debug('getInlineCompletions:error', error.message, { verbose: error })
         if (isAbortError(error)) {
-            debug('getInlineCompletions:error', error.message, { verbose: error })
             return null
         }
 


### PR DESCRIPTION
The behavior of only logging when it *was* an abort error was mistaken. It might be useful to only log when it is *not* an abort error, but for now, let's log in all cases.



## Test plan

n/a