### PR TITLE
Agent: add debug notifications for clients to receive debug messages

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -69,7 +69,7 @@ export class Agent extends MessageHandler {
     constructor() {
         super()
         vscode_shim.setWorkspaceDocuments(this.workspace)
-
+        vscode_shim.setAgent(this)
         this.registerRequest('initialize', async client => {
             process.stderr.write(
                 `Cody Agent: handshake with client '${client.name}' (version '${client.version}') at workspace root path '${client.workspaceRootUri}'\n`

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -19,7 +19,7 @@ export class TestClient extends MessageHandler {
                 accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
                 serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
                 customHeaders: {},
-                autocompleteAdvancedProvider: '',
+                autocompleteAdvancedProvider: 'anthropic',
                 autocompleteAdvancedAccessToken: '',
                 autocompleteAdvancedServerEndpoint: '',
                 autocompleteAdvancedEmbeddings: true,

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -23,6 +23,8 @@ export class TestClient extends MessageHandler {
                 autocompleteAdvancedAccessToken: '',
                 autocompleteAdvancedServerEndpoint: '',
                 autocompleteAdvancedEmbeddings: true,
+                debug: false,
+                verboseDebug: false,
             },
         })
         this.notify('initialized', null)

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -79,6 +79,8 @@ export type Notifications = {
     // request. The server should never send this notification outside of a
     // 'chat/executeRecipe' request.
     'chat/updateMessageInProgress': [ChatMessage | null]
+
+    'debug/message': [DebugMessage]
 }
 
 export interface AutocompleteParams {
@@ -130,6 +132,8 @@ export interface ConnectionConfiguration {
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedAccessToken: string | null
     autocompleteAdvancedEmbeddings: boolean
+    debug: boolean
+    verboseDebug: boolean
 }
 
 export interface Position {
@@ -159,4 +163,9 @@ export interface ExecuteRecipeParams {
     id: RecipeID
     humanChatInput: string
     data?: any
+}
+
+export interface DebugMessage {
+    channel: string
+    message: string
 }

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -132,8 +132,8 @@ export interface ConnectionConfiguration {
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedAccessToken: string | null
     autocompleteAdvancedEmbeddings: boolean
-    debug: boolean
-    verboseDebug: boolean
+    debug?: boolean
+    verboseDebug?: boolean
 }
 
 export interface Position {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -106,9 +106,9 @@ const configuration: vscode.WorkspaceConfiguration = {
             case 'cody.advanced.agent.running':
                 return true
             case 'cody.debug.enable':
-                return connectionConfig?.debug
+                return connectionConfig?.debug ?? false
             case 'cody.debug.verbose':
-                return connectionConfig?.verboseDebug
+                return connectionConfig?.verboseDebug ?? false
             default:
                 return defaultValue
         }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -26,7 +26,7 @@ import {
     Uri,
 } from '../../vscode/src/testutils/mocks'
 
-import { Agent } from './agent'
+import type { Agent } from './agent'
 import { AgentTabGroups } from './AgentTabGroups'
 import type { ConnectionConfiguration } from './protocol'
 

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -26,6 +26,7 @@ import {
     Uri,
 } from '../../vscode/src/testutils/mocks'
 
+import { Agent } from './agent'
 import { AgentTabGroups } from './AgentTabGroups'
 import type { ConnectionConfiguration } from './protocol'
 
@@ -104,6 +105,10 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.autocompleteAdvancedEmbeddings
             case 'cody.advanced.agent.running':
                 return true
+            case 'cody.debug.enable':
+                return connectionConfig?.debug
+            case 'cody.debug.verbose':
+                return connectionConfig?.verboseDebug
             default:
                 return defaultValue
         }
@@ -161,6 +166,10 @@ const statusBarItem: Partial<vscode.StatusBarItem> = {
 export const visibleTextEditors: vscode.TextEditor[] = []
 
 export const tabGroups = new AgentTabGroups()
+let agent: Agent | undefined
+export function setAgent(newAgent: Agent): void {
+    agent = newAgent
+}
 
 const _window: Partial<typeof vscode.window> = {
     tabGroups,
@@ -196,9 +205,21 @@ const _window: Partial<typeof vscode.window> = {
     createOutputChannel: ((name: string) =>
         ({
             name,
-            append: () => {},
-            appendLine: () => {},
-            replace: () => {},
+            append: message => {
+                if (agent) {
+                    agent.notify('debug/message', { channel: name, message })
+                }
+            },
+            appendLine: message => {
+                if (agent) {
+                    agent.notify('debug/message', { channel: name, message })
+                }
+            },
+            replace: message => {
+                if (agent) {
+                    agent.notify('debug/message', { channel: name, message })
+                }
+            },
             clear: () => {},
             show: () => {},
             hide: () => {},

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -478,7 +478,9 @@ function createCompletionsProvider(
     } else if (config.isRunningInsideAgent) {
         throw new Error(
             "Can't register completion provider because `providerConfig` evaluated to `null`. " +
-                'To fix this problem, debug why createProviderConfig returned null instead of ProviderConfig.'
+                'To fix this problem, debug why createProviderConfig returned null instead of ProviderConfig. ' +
+                'To further debug this problem, here is the configuration:\n' +
+                JSON.stringify(config, null, 2)
         )
     }
 


### PR DESCRIPTION
Adds a debug notification to Agent, extensions can list to this notification to receive the debugging information that is generated in Agent during commands like autocomplete. 
## Test plan
Run extension with debug enabled verify debug messages received.
Run extension with debug disabled verify no debug messages received.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
