### PR TITLE
Agent: code cleanup and get autocomplete working again

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -15,7 +15,7 @@
     "build": "node ./src/esbuild.mjs",
     "agent": "pnpm run build && node dist/index.js",
     "build-ts": "tsc --build",
-    "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t node16-linux-arm64,node16-linux-x64,node16-macos-arm64,node16-macos-x64,node16-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
+    "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t latest-linux-arm64,latest-linux-x64,latest-macos-arm64,latest-macos-x64,latest-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "lint": "pnpm run lint:js",
     "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
     "test": "pnpm run build && vitest"

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -41,15 +41,11 @@ function initializeVscodeExtension(): void {
             onDidChange: vscode_shim.emptyEvent(),
             get(key) {
                 if (key === 'cody.access-token' && vscode_shim.connectionConfig) {
-                    // console.log('MATCH')
                     return Promise.resolve(vscode_shim.connectionConfig.accessToken)
                 }
-                // console.log({ key })
-
                 return Promise.resolve(secretStorage.get(key))
             },
             store(key, value) {
-                // console.log({ key, value })
                 secretStorage.set(key, value)
                 return Promise.resolve()
             },
@@ -181,7 +177,7 @@ export class Agent extends MessageHandler {
 
             try {
                 const result = await provider.provideInlineCompletionItems(
-                    textDocument as any,
+                    textDocument,
                     new vscode.Position(params.position.line, params.position.character),
                     { triggerKind: vscode.InlineCompletionTriggerKind.Automatic, selectedCompletionInfo: undefined },
                     token

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -75,7 +75,7 @@ describe('StandardAgent', () => {
 
     it('lists recipes correctly', async () => {
         const recipes = await client.listRecipes()
-        assert(recipes.length === 8)
+        assert.equal(9, recipes.length)
     })
 
     it('returns non-empty autocomplete', async () => {

--- a/agent/src/jsonrpc.ts
+++ b/agent/src/jsonrpc.ts
@@ -220,13 +220,14 @@ export class MessageHandler {
                     },
                     error => {
                         const message = error instanceof Error ? error.message : `${error}`
+                        const stack = error instanceof Error ? `\n${error.stack}` : ''
                         const data: ResponseMessage<any> = {
                             jsonrpc: '2.0',
                             id: msg.id,
                             error: {
                                 code: ErrorCode.InternalError,
                                 message,
-                                data: JSON.stringify(error),
+                                data: JSON.stringify({ error, stack }),
                             },
                         }
                         this.messageEncoder.send(data)

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -102,8 +102,9 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.autocompleteAdvancedAccessToken
             case 'cody.autocomplete.advanced.embeddings':
                 return connectionConfig?.autocompleteAdvancedEmbeddings
+            case 'cody.advanced.agent.running':
+                return true
             default:
-                // console.log({ section })
                 return defaultValue
         }
     },
@@ -231,20 +232,25 @@ const _commands: Partial<typeof vscode.commands> = {
             }
         })
     },
-    executeCommand: (command, args) => {
+    executeCommand: async (command, args) => {
         const registered = registeredCommands.get(command)
         if (registered) {
             try {
                 if (args) {
-                    return registered.callback(...args)
+                    return await wrapIntoPromise(registered.callback(...args))
                 }
-                return registered.callback()
+                return await wrapIntoPromise(registered.callback())
             } catch (error) {
                 console.error(error)
             }
         }
     },
 }
+
+function wrapIntoPromise(value: any): Promise<any> {
+    return value instanceof Promise ? value : Promise.resolve(value)
+}
+
 export const commands = _commands as typeof vscode.commands
 
 const _env: Partial<typeof vscode.env> = {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -232,22 +232,24 @@ const _commands: Partial<typeof vscode.commands> = {
             }
         })
     },
-    executeCommand: async (command, args) => {
+    executeCommand: (command, args) => {
         const registered = registeredCommands.get(command)
         if (registered) {
             try {
                 if (args) {
-                    return await wrapIntoPromise(registered.callback(...args))
+                    return promisify(registered.callback(...args))
                 }
-                return await wrapIntoPromise(registered.callback())
+                return promisify(registered.callback())
             } catch (error) {
                 console.error(error)
             }
         }
+
+        return Promise.resolve(undefined)
     },
 }
 
-function wrapIntoPromise(value: any): Promise<any> {
+function promisify(value: any): Promise<any> {
     return value instanceof Promise ? value : Promise.resolve(value)
 }
 

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -6,9 +6,6 @@
     "outDir": "dist",
     "target": "es2019",
     "allowJs": true,
-    // "paths": {
-    //   "vscode": ["./src/vscode-shim.ts"],
-    // },
   },
   "include": ["**/*", ".*", "package.json"],
   "exclude": ["dist"],

--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -12,7 +12,6 @@ const shimFromRootDirectory = path.resolve(process.cwd(), 'agent', 'src', 'vscod
 // we're running tests from the root directory of the cody repo or from the
 // agent/ subdirectory.
 function shimDirectory(): string {
-    console.log({ shimFromRootDirectory })
     try {
         if (statSync(shimFromRootDirectory + '.ts').isFile()) {
             return shimFromRootDirectory

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -29,6 +29,7 @@ export interface Configuration {
     autocompleteExperimentalCompleteSuggestWidgetSelection?: boolean
     pluginsEnabled?: boolean
     pluginsDebugEnabled?: boolean
+    isRunningInsideAgent?: boolean
     pluginsConfig?: {
         confluence?: {
             baseUrl: string

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -22,6 +22,7 @@ describe('getConfiguration', () => {
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
             inlineChat: true,
+            isRunningInsideAgent: false,
             experimentalNonStop: false,
             customHeaders: {},
             debugEnable: false,
@@ -91,6 +92,8 @@ describe('getConfiguration', () => {
                         }
                     case 'cody.plugins.debug.enabled':
                         return false
+                    case 'cody.advanced.agent.running':
+                        return false
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -113,6 +116,7 @@ describe('getConfiguration', () => {
             experimentalEditorTitleCommandIcon: true,
             experimentalGuardrails: true,
             inlineChat: true,
+            isRunningInsideAgent: false,
             experimentalNonStop: true,
             debugEnable: true,
             debugVerbose: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -68,6 +68,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         pluginsEnabled: config.get<boolean>(CONFIG_KEY.pluginsEnabled, false),
         pluginsDebugEnabled: config.get<boolean>(CONFIG_KEY.pluginsDebugEnabled, true),
         pluginsConfig: config.get(CONFIG_KEY.pluginsConfig, {}),
+        isRunningInsideAgent: config.get('cody.advanced.agent.running' as any, false),
     }
 }
 

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -68,6 +68,14 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         pluginsEnabled: config.get<boolean>(CONFIG_KEY.pluginsEnabled, false),
         pluginsDebugEnabled: config.get<boolean>(CONFIG_KEY.pluginsDebugEnabled, true),
         pluginsConfig: config.get(CONFIG_KEY.pluginsConfig, {}),
+
+        // Note: the setting below only exists for the agent to provide more
+        // helpful error messages when something goes wrong. In spirit, we try
+        // to minimize agent-specific code paths in the VSC extension but we
+        // make an exception for improved debug logging because it makes a huge
+        // difference when troubleshooting an issue like "the completion
+        // provider never got registered", which manifests by default with a
+        // silent timeout.
         isRunningInsideAgent: config.get('cody.advanced.agent.running' as any, false),
     }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -394,8 +394,8 @@ const register = async (
             completionsProvider = null
             if (config.isRunningInsideAgent) {
                 throw new Error(
-                    'config.autocomplete evaluated to false, it must be true when running inside the agent. ' +
-                        'To fix this problem, make sure that the settin cody.autocomplete.enabled has the value true.'
+                    'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
+                        'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
                 )
             }
             return
@@ -477,7 +477,7 @@ function createCompletionsProvider(
         )
     } else if (config.isRunningInsideAgent) {
         throw new Error(
-            "Can't register completion provider because providerConfig evaluated to null. " +
+            "Can't register completion provider because `providerConfig` evaluated to `null`. " +
                 'To fix this problem, debug why createProviderConfig returned null instead of ProviderConfig.'
         )
     }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -392,6 +392,12 @@ const register = async (
         if (!config.autocomplete) {
             completionsProvider?.dispose()
             completionsProvider = null
+            if (config.isRunningInsideAgent) {
+                throw new Error(
+                    'config.autocomplete evaluated to false, it must be true when running inside the agent. ' +
+                        'To fix this problem, make sure that the settin cody.autocomplete.enabled has the value true.'
+                )
+            }
             return
         }
 
@@ -468,6 +474,11 @@ function createCompletionsProvider(
             }),
             vscode.languages.registerInlineCompletionItemProvider('*', completionsProvider),
             registerAutocompleteTraceView(completionsProvider)
+        )
+    } else if (config.isRunningInsideAgent) {
+        throw new Error(
+            "Can't register completion provider because providerConfig evaluated to null. " +
+                'To fix this problem, debug why createProviderConfig returned null instead of ProviderConfig.'
         )
     }
 


### PR DESCRIPTION
Previously, autocomplete via agent wasn't working because of regressions that got introduced in the last PR to fix ESLint errors. We have integration tests that caught this regression but we don't run that test in CI because it currently requires SRC_ACCESS_TOKEN.

This PR fixes the regression above along with other improvements:

- Use latest Node.js for agent binaries because the VSC extension is using APIs that are not present in Node.js v16 (version we previously used for the agent) causing the agent to crash.
- Remove leftover `console.log`
- Fix failing integration test after we added a new agent recipe
- Fail fast when running the extension via the agent and we don't register the completion provider. We currently await on the completion provider, which silently times out if we don't register the completion.


## Test plan

Manually tested with https://github.com/sourcegraph/sourcegraph/pull/55826

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
