### PR TITLE
Autocomplete: Remove suffix matching bail for FIM models

### DIFF
--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -183,16 +183,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
 
         // A completion that won't be visible in VS Code will not be returned and not be logged.
-        if (
-            !isCompletionVisible(
-                result?.items,
-                document,
-                docContext,
-                context,
-                this.config.providerConfig,
-                abortController.signal
-            )
-        ) {
+        if (!isCompletionVisible(result?.items, document, docContext, context, abortController.signal)) {
             return null
         }
 
@@ -271,7 +262,6 @@ function isCompletionVisible(
     document: vscode.TextDocument,
     docContext: DocumentContext,
     context: vscode.InlineCompletionContext,
-    providerConfig: ProviderConfig,
     abortSignal: AbortSignal | undefined
 ): boolean {
     // There are these cases when a completion is being returned here but won't
@@ -289,7 +279,7 @@ function isCompletionVisible(
     //   this.
     const isAborted = abortSignal ? abortSignal.aborted : false
     const isMatchingPopupItem = completionMatchesPopupItem(completions, document, context)
-    const isMatchingSuffix = completionMatchesSuffix(completions, docContext, providerConfig)
+    const isMatchingSuffix = completionMatchesSuffix(completions, docContext)
     const isVisible = !isAborted && isMatchingPopupItem && isMatchingSuffix
 
     return isVisible
@@ -310,18 +300,7 @@ function completionMatchesPopupItem(
     return true
 }
 
-function completionMatchesSuffix(
-    completions: InlineCompletionItem[],
-    docContext: DocumentContext,
-    providerConfig: ProviderConfig
-): boolean {
-    // Models that support infilling do not replace an existing suffix but
-    // instead insert the completion only at the current cursor position. Thus,
-    // we do not need to compare the suffix
-    if (providerConfig.supportsInfilling) {
-        return true
-    }
-
+function completionMatchesSuffix(completions: InlineCompletionItem[], docContext: DocumentContext): boolean {
     const suffix = docContext.currentLineSuffix
 
     for (const completion of completions) {


### PR DESCRIPTION
This is a leftover from #655 that removed the different branching and makes sure the same line suffix is truncated for FIM models too. 

## Test plan

- Configure the StarCoder model (c.f. [sourcegraph.slack.com/archives/C05AGQYD528/p1690551781096999](https://sourcegraph.slack.com/archives/C05AGQYD528/p1690551781096999))
- Get a completion returned that has a different same line suffix 
- Observe the event will no longer be logged as displayed after the fix

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
