### PR TITLE
Autocomplete: Log number of accepted chars per suggestion

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+- Include the number of accepted characters per autocomplete suggestion. []()
+
 ## [0.6.6]
 
 ### Added

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,7 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
-- Include the number of accepted characters per autocomplete suggestion. []()
+- Include the number of accepted characters per autocomplete suggestion. [pull/674](https://github.com/sourcegraph/cody/pull/674)
 
 ## [0.6.6]
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -114,7 +114,7 @@ export function suggested(id: string, source: string): void {
     }
 }
 
-export function accept(id: string, lines: number): void {
+export function accept(id: string, lines: number, chars: number): void {
     const completionEvent = displayedCompletions.get(id)
     if (!completionEvent || completionEvent.acceptedAt) {
         // Log a debug event, this case should not happen in production
@@ -140,6 +140,7 @@ export function accept(id: string, lines: number): void {
     logCompletionEvent('accepted', {
         ...completionEvent.params,
         lines,
+        chars,
         otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
     })
 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -207,12 +207,15 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
     }
 
-    public handleDidAcceptCompletionItem(logId: string, lines: number): void {
+    public handleDidAcceptCompletionItem(logId: string, completion: InlineCompletionItem): void {
         // When a completion is accepted, the lastCandidate should be cleared. This makes sure the
         // log id is never reused if the completion is accepted.
         this.lastCandidate = undefined
 
-        CompletionLogger.accept(logId, lines)
+        const lines = completion.insertText.split(/\r\n|\r|\n/).length
+        const chars = completion.insertText.length
+
+        CompletionLogger.accept(logId, lines, chars)
     }
 
     /**
@@ -244,7 +247,12 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 {
                     title: 'Completion accepted',
                     command: 'cody.autocomplete.inline.accepted',
-                    arguments: [{ codyLogId: logId, codyLines: completion.insertText.split(/\r\n|\r|\n/).length }],
+                    arguments: [
+                        {
+                            codyLogId: logId,
+                            codyCompletion: completion,
+                        },
+                    ],
                 }
             )
         })

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -469,8 +469,8 @@ function createCompletionsProvider(
         })
 
         disposables.push(
-            vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyLines }) => {
-                completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyLines)
+            vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyCompletion }) => {
+                completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyCompletion)
             }),
             vscode.languages.registerInlineCompletionItemProvider('*', completionsProvider),
             registerAutocompleteTraceView(completionsProvider)


### PR DESCRIPTION
Part of #672

Adds tracking for number of inserted characters per completion request.

## Test plan

<img width="1280" alt="Screenshot 2023-08-14 at 16 27 18" src="https://github.com/sourcegraph/cody/assets/458591/146e7ee0-e221-4400-a757-2fdb078c48f5">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
