### PR TITLE
WIP - Agent: experiment with proxy settings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
       glob:
         specifier: ^7.2.3
         version: 7.2.3
+      https-proxy-agent:
+        specifier: ^7.0.1
+        version: 7.0.1
       isomorphic-fetch:
         specifier: ^3.0.0
         version: 3.0.0
@@ -6647,7 +6650,6 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /agentkeepalive@4.3.0:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
@@ -10353,7 +10355,6 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -939,6 +939,7 @@
     }
   },
   "dependencies": {
+    "https-proxy-agent": "^7.0.1",
     "@anthropic-ai/sdk": "^0.4.2",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/cody-ui": "workspace:*",

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -5,6 +5,7 @@ import { Completion, ContextSnippet } from '../types'
 import { isAbortError } from '../utils'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
+import { HttpsProxyAgent } from 'https-proxy-agent'
 
 interface UnstableCodeGenOptions {
     serverEndpoint: string
@@ -45,14 +46,17 @@ export class UnstableCodeGenProvider extends Provider {
             provider: PROVIDER_IDENTIFIER,
             serverEndpoint: this.serverEndpoint,
         })
-        const response = await fetch(this.serverEndpoint, {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const options = {
             method: 'POST',
             body: JSON.stringify(params),
             headers: {
                 'Content-Type': 'application/json',
             },
             signal: abortSignal,
-        })
+            agent: new HttpsProxyAgent('socks5://127.0.0.1:9999')
+        }
+        const response = await fetch(this.serverEndpoint, options as any)
 
         try {
             const data = (await response.json()) as { completions: { completion: string }[] }


### PR DESCRIPTION
WIP - trying to implement the equivalent of `http.proxy` setting for VS Code. Not working yet.

## Test plan
n/a
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
