### PR TITLE
log charCount and lineCount for suggested text

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -136,7 +136,6 @@ export function accept(id: string, lineCount: number, charCount: number): void {
 
     completionEvent.acceptedAt = performance.now()
 
-    logSuggestionEvents()
     logCompletionEvent('accepted', {
         ...completionEvent.params,
         lineCount,

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -136,6 +136,8 @@ export function accept(id: string, lineCount: number, charCount: number): void {
 
     completionEvent.acceptedAt = performance.now()
 
+    logSuggestionEvents()
+    clear()
     logCompletionEvent('accepted', {
         ...completionEvent.params,
         lineCount,

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -15,6 +15,7 @@ import {
     LastInlineCompletionCandidate,
 } from './getInlineCompletions'
 import * as CompletionLogger from './logger'
+import { logCompletionEvent } from './logger'
 import { ProviderConfig } from './providers/provider'
 import { RequestManager } from './request-manager'
 import { ProvideInlineCompletionItemsTracer, ProvideInlineCompletionsItemTraceData } from './tracer'
@@ -241,20 +242,22 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             // current same line suffix and reach to the end of the line.
             const end = currentLine.range.end
 
-            return new vscode.InlineCompletionItem(
-                currentLinePrefix + completion.insertText,
-                new vscode.Range(start, end),
-                {
-                    title: 'Completion accepted',
-                    command: 'cody.autocomplete.inline.accepted',
-                    arguments: [
-                        {
-                            codyLogId: logId,
-                            codyCompletion: completion,
-                        },
-                    ],
-                }
-            )
+            // Log suggested text token count
+            const suggestedText = currentLinePrefix + completion.insertText
+            const lineCount = suggestedText.split(/\r\n|\r|\n/).length
+            const charCount = suggestedText.length
+            logCompletionEvent('suggested', { lineCount, charCount })
+
+            return new vscode.InlineCompletionItem(suggestedText, new vscode.Range(start, end), {
+                title: 'Completion accepted',
+                command: 'cody.autocomplete.inline.accepted',
+                arguments: [
+                    {
+                        codyLogId: logId,
+                        codyCompletion: completion,
+                    },
+                ],
+            })
         })
     }
 }


### PR DESCRIPTION
Currently, we are logging suggestion only when a suggestion is accepted.

This PR makes an update to logs lineCount and charCount of each suggested text even if it is not accepted.

Since I am not familiar with the code on autocomplete, @vovakulikov can you confirm if this change would not cause performance issue with autocomplete or if this is the right place to add?


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Check output channel and look for the `CodyVSCodeExtension:completion:suggested` event.