### PR TITLE
fix: replace {languageName} in custom prompt

### DIFF
--- a/lib/shared/src/chat/prompts/utils.ts
+++ b/lib/shared/src/chat/prompts/utils.ts
@@ -64,10 +64,10 @@ export function promptTextWithCodeSelection(
     // Use the whole context window for the prompt because we're attaching no files
     const maxTokenCount = MAX_AVAILABLE_PROMPT_LENGTH - (codePrefix.length + prompt.length) / CHARS_PER_TOKEN
     const truncatedCode = truncateText(selection.selectedText, Math.min(maxTokenCount, MAX_RECIPE_INPUT_TOKENS))
-    const promptText = `${codePrefix}\n\n<selected>\n${truncatedCode}\n</selected>\n\n${prompt.replace(
+    const promptText = `${codePrefix}\n\n<selected>\n${truncatedCode}\n</selected>\n\n${prompt}`.replaceAll(
         '{languageName}',
         languageName
-    )}`
+    )
     return promptText
 }
 

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -29,7 +29,7 @@ import {
 } from '../prompts/vscode-context'
 import { Interaction } from '../transcript/interaction'
 
-import { getContextMessagesFromSelection, numResults } from './helpers'
+import { getContextMessagesFromSelection, getFileExtension, getNormalizedLanguageName, numResults } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 /** ======================================================
@@ -78,8 +78,11 @@ export class CustomPrompt implements Recipe {
         const displayText = selection?.fileName
             ? getHumanDisplayTextWithFileName(slashCommand, selection, context.editor.getWorkspaceRootUri())
             : slashCommand
+        const languageName = selection?.fileName ? getNormalizedLanguageName(getFileExtension(selection?.fileName)) : ''
         // Prompt text to share with Cody but not display to human
-        const codyPromptText = prompts.instruction.replace('{humanInput}', promptText)
+        const codyPromptText = prompts.instruction
+            .replace('{humanInput}', promptText)
+            .replaceAll('{languageName}', languageName)
 
         // Attach code selection to prompt text if only selection is needed as context
         if (selection && isOnlySelectionRequired(isContextNeeded)) {


### PR DESCRIPTION
This PR updates to correctly replace the `{languageName}` string in prompt text. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Check the output channel after running the /smell command

### Before

<img width="1430" alt="Screenshot 2023-08-14 at 6 16 28 PM" src="https://github.com/sourcegraph/cody/assets/68532117/92395758-8f9e-4a31-9b20-a511c802efe2">


### After

<img width="1442" alt="Screenshot 2023-08-14 at 6 15 28 PM" src="https://github.com/sourcegraph/cody/assets/68532117/cf6f9671-88a8-46ef-a081-e3023a559638">

