### PR TITLE
Agent: implement more `vscode` APIs

### DIFF
--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type * as vscode from 'vscode'
-import { URI } from 'vscode-uri'
 
 import { AgentTextDocument } from './AgentTextDocument'
 import { newTextEditor } from './AgentTextEditor'
@@ -10,7 +9,7 @@ import * as vscode_shim from './vscode-shim'
 
 export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
     private readonly documents: Map<string, TextDocument> = new Map()
-    public workspaceRootUri: URI | null = null
+    public workspaceRootUri: vscode_shim.Uri | undefined
     public activeDocumentFilePath: string | null = null
     public loadedDocument(document: TextDocument): TextDocument {
         const fromCache = this.documents.get(document.filePath)
@@ -22,6 +21,13 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         }
         return document
     }
+
+    public setActiveTextEditor(textEditor: vscode.TextEditor): void {
+        this.activeDocumentFilePath = textEditor.document.fileName
+        vscode_shim.onDidChangeActiveTextEditor.fire(textEditor)
+        vscode_shim.window.activeTextEditor = textEditor
+    }
+
     public agentTextDocument(document: TextDocument): AgentTextDocument {
         return new AgentTextDocument(this.loadedDocument(document))
     }

--- a/agent/src/editor.ts
+++ b/agent/src/editor.ts
@@ -1,5 +1,3 @@
-import { URI } from 'vscode-uri'
-
 import {
     ActiveTextEditor,
     ActiveTextEditorDiagnostic,
@@ -12,6 +10,7 @@ import {
 import { Agent } from './agent'
 import { DocumentOffsets } from './offsets'
 import { TextDocument } from './protocol'
+import * as vscode_shim from './vscode-shim'
 
 export class AgentEditor implements Editor {
     public controllers?: ActiveTextEditorViewControllers | undefined
@@ -28,8 +27,8 @@ export class AgentEditor implements Editor {
         return uri?.scheme === 'file' ? uri.fsPath : null
     }
 
-    public getWorkspaceRootUri(): URI | null {
-        return this.agent.workspace.workspaceRootUri
+    public getWorkspaceRootUri(): vscode_shim.Uri | null {
+        return this.agent.workspace.workspaceRootUri ?? null
     }
 
     private activeDocument(): TextDocument | undefined {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -103,7 +103,7 @@ export interface ClientInfo {
     workspaceRootUri: string
 
     /** @deprecated Use `workspaceRootUri` instead. */
-    workspaceRootPath: string
+    workspaceRootPath?: string
 
     connectionConfiguration?: ConnectionConfiguration
     capabilities?: ClientCapabilities

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -130,6 +130,7 @@ export const onDidRenameFiles = new EventEmitter<vscode.FileRenameEvent>()
 export const onDidDeleteFiles = new EventEmitter<vscode.FileDeleteEvent>()
 
 export interface WorkspaceDocuments {
+    workspaceRootUri?: Uri
     openTextDocument: (filePath: string) => Promise<vscode.TextDocument>
 }
 let workspaceDocuments: WorkspaceDocuments | undefined
@@ -144,6 +145,18 @@ const _workspace: Partial<typeof vscode.workspace> = {
         // properly pass around URIs once the agent protocol supports URIs
         const filePath = uri instanceof Uri ? uri.path : uri?.toString() ?? ''
         return workspaceDocuments ? workspaceDocuments.openTextDocument(filePath) : ('missingWorkspaceDocuments' as any)
+    },
+    getWorkspaceFolder: () => {
+        if (workspaceDocuments?.workspaceRootUri === undefined) {
+            throw new Error(
+                'workspaceDocuments is undefined. To fix this problem, make sure that the agent has been initialized.'
+            )
+        }
+        return {
+            uri: workspaceDocuments.workspaceRootUri,
+            index: 0,
+            name: workspaceDocuments.workspaceRootUri?.path,
+        }
     },
     onDidChangeWorkspaceFolders: (() => ({})) as any,
     onDidOpenTextDocument: onDidOpenTextDocument.event,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -15,7 +15,7 @@ import type * as vscode_types from 'vscode'
 import { URI } from 'vscode-uri'
 
 export class Uri {
-    public static parse(value: string, strict?: boolean): URI {
+    public static parse(value: string, strict?: boolean): Uri {
         return Uri.from(URI.parse(value, strict).toJSON())
     }
     public static file(path: string): URI {


### PR DESCRIPTION
Previously, `VSCodeEditor` was not working correctly because the agent shim for `vscode` was not implementing the following APIs

- `window.activeTextEditor`
- `workspace.getWorkspaceFolder`

This PR fixes the issue so that `VSCodeEditor` works even when running inside the agent.

## Test plan

@chwarwick tested this change manually and confirmed it works as expected.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
