### PR TITLE
Improve "explain code" with research and summarization steps

### DIFF
--- a/lib/shared/src/chat/recipes/explain-code-high-level.ts
+++ b/lib/shared/src/chat/recipes/explain-code-high-level.ts
@@ -1,9 +1,24 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
-import { Interaction } from '../transcript/interaction'
+import { Interaction, ResponseHandling } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
+
+class ExplainFirstInteraction extends Interaction {
+    public override getNextInteraction(): Interaction | undefined {
+        return new Interaction(
+            {
+                speaker: 'human',
+                text: `Write a summary explaining the code to our colleague. Start with the purpose of this code. Then give the most interesting supporting details grounded in the facts from your earlier research. ${MARKDOWN_FORMAT_PROMPT}`,
+                displayText: 'Explaining it.',
+            },
+            { speaker: 'assistant' },
+            Promise.resolve([]),
+            []
+        )
+    }
+}
 
 export class ExplainCodeHighLevel implements Recipe {
     public id: RecipeID = 'explain-code-high-level'
@@ -20,10 +35,40 @@ export class ExplainCodeHighLevel implements Recipe {
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
 
         const languageName = getNormalizedLanguageName(selection.fileName)
-        const promptMessage = `Explain the following ${languageName} code at a high level. Only include details that are essential to an overall understanding of what's happening in the code.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`
-        const displayText = `Explain the following code at a high level:\n\`\`\`\n${selection.selectedText}\n\`\`\``
+        const promptMessage = `We need to read and understand this ${languageName} code to explain to our colleague
+what it does and how it works. Our colleague is an busy, experienced
+software developer. Answer the following questions:
 
-        return new Interaction(
+1. What is the purpose of this code? Does this code realize its
+intended purpose? Is the complexity of the code commensurate with the
+complexity of the problem?
+
+2. How would someone use this code correctly? What would they need to
+be careful to do?
+
+3. What are the notable implementation details of this code--data
+structures, algorithms, concurrency/reentrancy, resource management,
+etc.?
+
+4. What are the notable "engineering" details of this code--system
+integration, error handling, secure coding, dependencies, etc.
+
+When you reply, find exact code relevant and write them down
+word-for-word inside <thinking></thinking> XML tags. This is space for
+you to write down relevant content and will not be show to the
+user. Once you are done extracting relevant code, respond with
+detailed observations related to each topic area.
+
+Here is the code from ${selection.fileName}:
+
+\`\`\`
+${truncatedSelectedText}
+\`\`\`
+${MARKDOWN_FORMAT_PROMPT}`
+
+        const displayText = `Reading ${selection.fileName} and related code.`
+
+        return new ExplainFirstInteraction(
             { speaker: 'human', text: promptMessage, displayText },
             { speaker: 'assistant' },
             getContextMessagesFromSelection(
@@ -33,7 +78,10 @@ export class ExplainCodeHighLevel implements Recipe {
                 selection,
                 context.codebaseContext
             ),
-            []
+            [],
+            undefined,
+            undefined,
+            ResponseHandling.HIDE
         )
     }
 }

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -15,6 +15,11 @@ export interface InteractionJSON {
     context?: ContextMessage[]
 }
 
+export enum ResponseHandling {
+    DISPLAY = 1,
+    HIDE = 2,
+}
+
 export class Interaction {
     constructor(
         private readonly humanMessage: InteractionMessage,
@@ -22,7 +27,8 @@ export class Interaction {
         private fullContext: Promise<ContextMessage[]>,
         private usedContextFiles: ContextFile[],
         public readonly timestamp: string = new Date().toISOString(),
-        private pluginExecutionInfos: PluginFunctionExecutionInfo[] = []
+        private pluginExecutionInfos: PluginFunctionExecutionInfo[] = [],
+        public readonly responseHandling: ResponseHandling = ResponseHandling.DISPLAY
     ) {}
 
     public getAssistantMessage(): InteractionMessage {
@@ -80,5 +86,13 @@ export class Interaction {
             pluginExecutionInfos: this.pluginExecutionInfos,
             timestamp: this.timestamp,
         }
+    }
+
+    /**
+     * When the interaction is complete, asks whether another LLM turn is
+     * needed.
+     */
+    public getNextInteraction(): Interaction | undefined {
+        return undefined
     }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -329,7 +329,7 @@ const register = async (
             await sidebarChatProvider.executeCustomCommand(title)
         }),
         vscode.commands.registerCommand('cody.command.explain-code', async () => {
-            await executeRecipeInSidebar('custom-prompt', true, '/explain')
+            await executeRecipeInSidebar('explain-code-high-level', true, '/explain')
             telemetryService.log('CodyVSCodeExtension:recipe:explain-code-high-level:executed')
         }),
         vscode.commands.registerCommand('cody.command.generate-tests', async () => {

--- a/vscode/test/integration/recipes.test.ts
+++ b/vscode/test/integration/recipes.test.ts
@@ -20,10 +20,13 @@ suite('Recipes', function () {
         // Run the "explain" command
         await vscode.commands.executeCommand('cody.command.explain-code')
 
-        // Check the chat transcript contains markdown
-        const humanMessage = await getTranscript(0)
-        assert.match(humanMessage.displayText || '', /^\/explain/)
+        // Check the transcript contains messages from two steps.
+        let humanMessage = await getTranscript(0)
+        assert.match(humanMessage.displayText || '', /^Reading Main\.java and related code\./)
 
-        assert.match((await getTranscript(1)).displayText || '', /^hello from the assistant$/)
+        humanMessage = await getTranscript(2)
+        assert.match(humanMessage.displayText || '', /^Explaining it\./)
+
+        assert.match((await getTranscript(3)).displayText || '', /^hello from the assistant$/)
     })
 })


### PR DESCRIPTION
This is a first step to making the "explain code high level" recipe more useful. It works by first prompting Cody to think and research, then summarize. This produces more organized explanations, usually with coherent explanations of the code's purpose.

## Test plan

```
pnpm test:integration
```

Manual test:

- Open some code.
- Cmd-Shift-P, Ask Cody: Explain Code
- Should see successive messages that Cody is reading, then explaining the code.
- In the chat box, `/explain` should trigger the same behavior.