### PR TITLE
Agent: Suppress telemetry if agent is running and update docs

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -172,7 +172,7 @@ export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = 'https://sourcegraph.com'
 
     constructor(
-        private config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>
+        private config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders' | 'isRunningInsideAgent'>
     ) {}
 
     public onConfigurationChange(
@@ -333,6 +333,9 @@ export class SourcegraphGraphQLAPIClient {
     public async logEvent(event: event): Promise<LogEventResponse | Error> {
         if (process.env.CODY_TESTING === 'true') {
             console.log(`not logging ${event.event} in test mode`)
+            return {}
+        }
+        if (this.config.isRunningInsideAgent) {
             return {}
         }
         if (this.config.serverEndpoint === this.dotcomUrl) {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -172,7 +172,10 @@ export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = 'https://sourcegraph.com'
 
     constructor(
-        private config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders' | 'isRunningInsideAgent'>
+        private config: Pick<
+            ConfigurationWithAccessToken,
+            'serverEndpoint' | 'accessToken' | 'customHeaders' | 'isRunningInsideAgent'
+        >
     ) {}
 
     public onConfigurationChange(

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -69,13 +69,10 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         pluginsDebugEnabled: config.get<boolean>(CONFIG_KEY.pluginsDebugEnabled, true),
         pluginsConfig: config.get(CONFIG_KEY.pluginsConfig, {}),
 
-        // Note: the setting below only exists for the agent to provide more
-        // helpful error messages when something goes wrong. In spirit, we try
-        // to minimize agent-specific code paths in the VSC extension but we
-        // make an exception for improved debug logging because it makes a huge
-        // difference when troubleshooting an issue like "the completion
-        // provider never got registered", which manifests by default with a
-        // silent timeout.
+        // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
+        // We currently use this flag for the agent to provide more helpful error messages
+        // when something goes wrong, and to suppress event logging in the agent.
+        // Rely on this flag sparingly.
         isRunningInsideAgent: config.get('cody.advanced.agent.running' as any, false),
     }
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/cody/issues/686

It's currently only the JetBrains plugin that relies on the `isAgentEnabled` flag, and the JetBrains plugin is logging events for itself. To avoid double logging, this PR disables logging in the agent in this case.

I also updated the docs for the flag to convey the sentiment of using the flag, and document the exceptions.

## Test plan

I couldn't get any logs, so couldn't really test this. I've tried to spy on the traffic with [Fiddler Everywhere](https://www.telerik.com/fiddler/fiddler-everywhere), but it couldn't see anything.