### PR TITLE
mockup adding codebase setting

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -109,15 +109,18 @@ export class Agent extends MessageHandler {
         })
 
         this.registerNotification('textDocument/didFocus', document => {
+            vscode_shim.setConfigCodebase(document.codebase)
             this.workspace.setActiveTextEditor(newTextEditor(this.workspace.agentTextDocument(document)))
         })
         this.registerNotification('textDocument/didOpen', document => {
+            vscode_shim.setConfigCodebase(document.codebase)
             this.workspace.setDocument(document)
             const textDocument = this.workspace.agentTextDocument(document)
             vscode_shim.onDidOpenTextDocument.fire(textDocument)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))
         })
         this.registerNotification('textDocument/didChange', document => {
+            vscode_shim.setConfigCodebase(document.codebase)
             const textDocument = this.workspace.agentTextDocument(document)
             this.workspace.setDocument(document)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -134,6 +134,7 @@ export interface ConnectionConfiguration {
     autocompleteAdvancedEmbeddings: boolean
     debug?: boolean
     verboseDebug?: boolean
+    codebase?: string
 }
 
 export interface Position {
@@ -152,6 +153,7 @@ export interface TextDocument {
     filePath: string
     content?: string
     selection?: Range
+    codebase?: string
 }
 
 export interface RecipeInfo {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -83,6 +83,12 @@ export function setConnectionConfig(newConfig: ConnectionConfiguration): void {
     connectionConfig = newConfig
 }
 
+export function setConfigCodebase(codebase?: string): void {
+    if (connectionConfig) {
+        connectionConfig.codebase = codebase
+    }
+}
+
 const configuration: vscode.WorkspaceConfiguration = {
     has(section) {
         return true
@@ -109,6 +115,8 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.debug ?? false
             case 'cody.debug.verbose':
                 return connectionConfig?.verboseDebug ?? false
+            case 'cody.codebase':
+                return connectionConfig?.codebase
             default:
                 return defaultValue
         }


### PR DESCRIPTION
I didn't test this all out but I think the change would look like this.  Doing this means the agent always acts like the vs code extension's codebase override is set which is what we would want to avoid it attempting to use the builtin git extension.

Current the vs code extension updates the context provider after each document change to make sure it's always looking at the correct repo. 