### PR TITLE
Agent: add codebase setting to configuration

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -112,14 +112,12 @@ export class Agent extends MessageHandler {
             this.workspace.setActiveTextEditor(newTextEditor(this.workspace.agentTextDocument(document)))
         })
         this.registerNotification('textDocument/didOpen', document => {
-            vscode_shim.setConfigCodebase(document.codebase)
             this.workspace.setDocument(document)
             const textDocument = this.workspace.agentTextDocument(document)
             vscode_shim.onDidOpenTextDocument.fire(textDocument)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))
         })
         this.registerNotification('textDocument/didChange', document => {
-            vscode_shim.setConfigCodebase(document.codebase)
             const textDocument = this.workspace.agentTextDocument(document)
             this.workspace.setDocument(document)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -13,7 +13,7 @@ import { newTextEditor } from './AgentTextEditor'
 import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
 import { AgentEditor } from './editor'
 import { MessageHandler } from './jsonrpc'
-import { AutocompleteItem, ConnectionConfiguration } from './protocol'
+import { AutocompleteItem, ExtensionConfiguration } from './protocol'
 import * as vscode_shim from './vscode-shim'
 
 const secretStorage = new Map<string, string>()
@@ -193,7 +193,7 @@ export class Agent extends MessageHandler {
         })
     }
 
-    private setClient(config: ConnectionConfiguration): void {
+    private setClient(config: ExtensionConfiguration): void {
         vscode_shim.setConnectionConfig(config)
         vscode_shim.onDidChangeConfiguration.fire({
             affectsConfiguration: () =>

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -112,12 +112,14 @@ export class Agent extends MessageHandler {
             this.workspace.setActiveTextEditor(newTextEditor(this.workspace.agentTextDocument(document)))
         })
         this.registerNotification('textDocument/didOpen', document => {
+            vscode_shim.setConfigCodebase(document.codebase)
             this.workspace.setDocument(document)
             const textDocument = this.workspace.agentTextDocument(document)
             vscode_shim.onDidOpenTextDocument.fire(textDocument)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))
         })
         this.registerNotification('textDocument/didChange', document => {
+            vscode_shim.setConfigCodebase(document.codebase)
             const textDocument = this.workspace.agentTextDocument(document)
             this.workspace.setDocument(document)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -134,7 +134,7 @@ export class Agent extends MessageHandler {
             vscode_shim.onDidCloseTextDocument.fire(this.workspace.agentTextDocument(document))
         })
 
-        const configurationDidChange = (config: ExtensionConfiguration) => {
+        const configurationDidChange = (config: ExtensionConfiguration): void => {
             this.setClient(config)
         }
 

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -55,7 +55,7 @@ export type Notifications = {
     // The server should use the provided connection configuration for all
     // subsequent requests/notications. The previous connection configuration
     // should no longer be used.
-    'connectionConfiguration/didChange': [ConnectionConfiguration]
+    'connectionConfiguration/didChange': [ExtensionConfiguration]
 
     // Lifecycle notifications for the client to notify the server about text
     // contents of documents and to notify which document is currently focused.
@@ -105,7 +105,7 @@ export interface ClientInfo {
     /** @deprecated Use `workspaceRootUri` instead. */
     workspaceRootPath?: string
 
-    connectionConfiguration?: ConnectionConfiguration
+    connectionConfiguration?: ExtensionConfiguration
     capabilities?: ClientCapabilities
 }
 
@@ -124,7 +124,7 @@ export interface ServerInfo {
 }
 export interface ServerCapabilities {}
 
-export interface ConnectionConfiguration {
+export interface ExtensionConfiguration {
     serverEndpoint: string
     accessToken: string
     customHeaders: Record<string, string>

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -153,7 +153,6 @@ export interface TextDocument {
     filePath: string
     content?: string
     selection?: Range
-    codebase?: string
 }
 
 export interface RecipeInfo {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -52,10 +52,19 @@ export type Notifications = {
     // The 'exit' notification must be sent after the client receives the 'shutdown' response.
     exit: [null]
 
-    // The server should use the provided connection configuration for all
-    // subsequent requests/notications. The previous connection configuration
+    // The server should use the provided extension configuration for all
+    // subsequent requests/notifications. The previous extension configuration
     // should no longer be used.
+    // This notification is functionally equivalent to extensionConfiguration/didChange
+    // and exists to match the previous naming of configuration
     'connectionConfiguration/didChange': [ExtensionConfiguration]
+
+    // The server should use the provided connection configuration for all
+    // subsequent requests/notifications. The previous extension configuration
+    // should no longer be used.
+    // This notification is functionally equivalent to connectionConfiguration/didChange
+    // and provided to match the updated configuration naming
+    'extensionConfiguration/didChange': [ExtensionConfiguration]
 
     // Lifecycle notifications for the client to notify the server about text
     // contents of documents and to notify which document is currently focused.
@@ -105,7 +114,9 @@ export interface ClientInfo {
     /** @deprecated Use `workspaceRootUri` instead. */
     workspaceRootPath?: string
 
+    /** @deprecated Use `extensionConfiguration` instead. */
     connectionConfiguration?: ExtensionConfiguration
+    extensionConfiguration?: ExtensionConfiguration
     capabilities?: ClientCapabilities
 }
 

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -134,6 +134,7 @@ export interface ConnectionConfiguration {
     autocompleteAdvancedEmbeddings: boolean
     debug?: boolean
     verboseDebug?: boolean
+    codebase?: string
 }
 
 export interface Position {
@@ -152,6 +153,7 @@ export interface TextDocument {
     filePath: string
     content?: string
     selection?: Range
+    codebase?: string
 }
 
 export interface RecipeInfo {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -83,6 +83,12 @@ export function setConnectionConfig(newConfig: ConnectionConfiguration): void {
     connectionConfig = newConfig
 }
 
+export function setConfigCodebase(codebase?: string): void {
+    if (connectionConfig && codebase) {
+        connectionConfig.codebase = codebase
+    }
+}
+
 const configuration: vscode.WorkspaceConfiguration = {
     has(section) {
         return true
@@ -109,6 +115,8 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.debug ?? false
             case 'cody.debug.verbose':
                 return connectionConfig?.verboseDebug ?? false
+            case 'cody.codebase':
+                return connectionConfig?.codebase
             default:
                 return defaultValue
         }

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -28,7 +28,7 @@ import {
 
 import type { Agent } from './agent'
 import { AgentTabGroups } from './AgentTabGroups'
-import type { ConnectionConfiguration } from './protocol'
+import type { ExtensionConfiguration } from './protocol'
 
 export {
     emptyEvent,
@@ -78,15 +78,9 @@ const emptyFileWatcher: vscode.FileSystemWatcher = {
     dispose(): void {},
 }
 
-export let connectionConfig: ConnectionConfiguration | undefined
-export function setConnectionConfig(newConfig: ConnectionConfiguration): void {
+export let connectionConfig: ExtensionConfiguration | undefined
+export function setConnectionConfig(newConfig: ExtensionConfiguration): void {
     connectionConfig = newConfig
-}
-
-export function setConfigCodebase(codebase?: string): void {
-    if (connectionConfig && codebase) {
-        connectionConfig.codebase = codebase
-    }
 }
 
 const configuration: vscode.WorkspaceConfiguration = {


### PR DESCRIPTION
Add a codebase setting to the ExtensionConfiguration (renamed from ConnectionConfiguration).  This allows the agent's internal version of the vs code extension to operate in the mode where the codebase is manually set instead of inferred from  the git remote of the current file.  

## Test plan

Tested by using the JetBrains extension to set the codebase in the configuration and verified that the contextProvider used the codebase to fetch embeddings for autocomplete context.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
