### PR TITLE
Fixed typo in context-search.ts

### DIFF
--- a/lib/shared/src/chat/recipes/context-search.ts
+++ b/lib/shared/src/chat/recipes/context-search.ts
@@ -18,7 +18,7 @@ Parameters:
 Functionality:
 - Gets a search query from the human input or a prompt.
 - Truncates the query to MAX_HUMAN_INPUT_TOKENS.
-- Searches the vactor database for code and text results matching the query.
+- Searches the vector database for code and text results matching the query.
 - If codebase is not embedded or if keyword context is selected, get local keyword context instead
 - Returns up to 12 code results and 3 text results.
 - Generates a markdown string displaying the results with file names linking to the search page for that file.


### PR DESCRIPTION
Fixed typo in context-search.ts comment


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

n/a