### PR TITLE
fix duplicate paste events for telemetry log

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -5,7 +5,6 @@ import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat
 
 import { View } from '../../webviews/NavBar'
 import { debug } from '../log'
-import { countCode, matchCodeSnippets } from '../services/InlineAssist'
 
 import { MessageProvider, MessageProviderOptions } from './MessageProvider'
 import { ExtensionMessage, WebviewMessage } from './protocol'
@@ -182,17 +181,11 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     }
 
     /**
-     * Prevent logging insert events as paste events on doc change
-     */
-    private isInsertEvent = false
-
-    /**
      * Handles insert event to insert text from code block at cursor position
      * Replace selection if there is one and then log insert event
      * Note: Using workspaceEdit instead of 'editor.action.insertSnippet' as the later reformats the text incorrectly
      */
     private async handleInsertAtCursor(text: string): Promise<void> {
-        this.isInsertEvent = true
         const selectionRange = vscode.window.activeTextEditor?.selection
         const editor = vscode.window.activeTextEditor
         if (!editor || !selectionRange) {
@@ -206,11 +199,8 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
 
         // Log insert event
         const op = 'insert'
-        const { lineCount, charCount } = countCode(text)
         const eventName = op + 'Button'
-        const args = { op, charCount, lineCount }
-        this.telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
-        this.isInsertEvent = false
+        this.editor.controllers.inline?.setLastCopiedCode(text, eventName)
     }
 
     /**
@@ -222,27 +212,10 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     private async handleCopiedCode(text: string, eventType: 'Button' | 'Keydown'): Promise<void> {
         // If it's a Button event, then the text is already passed in from the whole code block
         const copiedCode = eventType === 'Button' ? text : await vscode.env.clipboard.readText()
-
-        // Log Copy event
-        const op = 'copy'
-        const { lineCount, charCount } = countCode(copiedCode)
-        const eventName = op + eventType
-        const args = { op, charCount, lineCount }
-        this.telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
-
-        // Create listener for changes to the active text editor for paste event
-        vscode.workspace.onDidChangeTextDocument(e => {
-            const changedText = e.contentChanges[0]?.text
-            // check if the copied code is the same as the changed text without spaces
-            const isMatched = matchCodeSnippets(copiedCode, changedText)
-            // Log paste event when the copied code is pasted
-            if (!this.isInsertEvent && isMatched) {
-                this.telemetryService.log('CodyVSCodeExtension:pasteKeydown:clicked', {
-                    ...args,
-                    op: 'paste',
-                })
-            }
-        })
+        // Send to Inline Controller for tracking
+        if (copiedCode) {
+            this.editor.controllers.inline?.setLastCopiedCode(copiedCode, 'copyButton')
+        }
     }
 
     protected handleEnabledPlugins(plugins: string[]): void {

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -212,9 +212,10 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     private async handleCopiedCode(text: string, eventType: 'Button' | 'Keydown'): Promise<void> {
         // If it's a Button event, then the text is already passed in from the whole code block
         const copiedCode = eventType === 'Button' ? text : await vscode.env.clipboard.readText()
+        const eventName = eventType === 'Button' ? 'copyButton' : 'keyDown:Copy'
         // Send to Inline Controller for tracking
         if (copiedCode) {
-            this.editor.controllers.inline?.setLastCopiedCode(copiedCode, 'copyButton')
+            this.editor.controllers.inline?.setLastCopiedCode(copiedCode, eventName)
         }
     }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -313,8 +313,7 @@ const register = async (
             'cody.action.fixup',
             (instruction: string, range: vscode.Range): Promise<void> => executeFixup({ instruction, range })
         ),
-        vscode.commands.registerCommand('cody.action.commands.menu', async caller => {
-            console.log(caller)
+        vscode.commands.registerCommand('cody.action.commands.menu', async () => {
             await editor.controllers.command?.menu('default')
         }),
         vscode.commands.registerCommand(
@@ -330,19 +329,15 @@ const register = async (
         }),
         vscode.commands.registerCommand('cody.command.explain-code', async () => {
             await executeRecipeInSidebar('custom-prompt', true, '/explain')
-            telemetryService.log('CodyVSCodeExtension:recipe:explain-code-high-level:executed')
         }),
         vscode.commands.registerCommand('cody.command.generate-tests', async () => {
             await executeRecipeInSidebar('custom-prompt', true, '/test')
-            telemetryService.log('CodyVSCodeExtension:recipe:generate-unit-test:executed')
         }),
         vscode.commands.registerCommand('cody.command.document-code', async () => {
             await executeRecipeInSidebar('custom-prompt', true, '/doc')
-            telemetryService.log('CodyVSCodeExtension:recipe:generate-docstring:executed')
         }),
         vscode.commands.registerCommand('cody.command.smell-code', async () => {
             await executeRecipeInSidebar('custom-prompt', true, '/smell')
-            telemetryService.log('CodyVSCodeExtension:recipe:find-code-smells:executed')
         }),
         vscode.commands.registerCommand('cody.command.inline-touch', () =>
             executeRecipeInSidebar('inline-touch', false)

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -149,7 +149,7 @@ export class InlineController implements VsCodeInlineController {
             // the copied code should be the same as the clipboard text
             if (matchCodeSnippets(code, clipboardText) && matchCodeSnippets(code, changedText)) {
                 const op = 'paste'
-                const eventType = eventName === 'inlineChat' ? 'inlineChat' : 'keyDown'
+                const eventType = eventName.startsWith('inlineChat') ? 'inlineChat' : 'keyDown'
                 // 'CodyVSCodeExtension:inlineChat:Paste:clicked' or 'CodyVSCodeExtension:keyDown:Paste:clicked'
                 this.telemetryService.log(`CodyVSCodeExtension:${eventType}:Paste:clicked`, {
                     op,
@@ -302,22 +302,15 @@ export class InlineController implements VsCodeInlineController {
             const lastClipboardText = this.lastClipboardText
             if (e && documentUri?.fsPath === this.thread?.uri.fsPath) {
                 // check if the current range is within the selection range of the thread
-                const selectionRange = this.getSelectionRange()
                 const clipboardText = await vscode.env.clipboard.readText()
-                if (!selectionRange.contains(e.selections[0]) || clipboardText === lastClipboardText) {
+                if (clipboardText === this.lastCopiedCode.code || clipboardText === lastClipboardText) {
                     return
                 }
                 // check if the clipboard text is part of the text string
                 if (groupedText.includes(clipboardText)) {
                     this.lastClipboardText = clipboardText
-                    const eventName = 'inlineChat'
-                    const op = 'copy'
-                    const { lineCount, charCount } = this.setLastCopiedCode(clipboardText, eventName)
-                    this.telemetryService.log('CodyVSCodeExtension:inlineChat:Copy:clicked', {
-                        op,
-                        lineCount,
-                        charCount,
-                    })
+                    const eventName = 'inlineChat:Copy'
+                    this.setLastCopiedCode(clipboardText, eventName)
                 }
             }
         })


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1692117220217969?thread_ts=1692054351.708989&cid=C05AGQYD528

Moved tracker for copy and paste event to inline controller

█ logEvent (telemetry disabled): CodyVSCodeExtension:inlineChat:Copy:clicked {"op":"copy","charCount":73,"lineCount":4}
█ logEvent (telemetry disabled): CodyVSCodeExtension:inlineChat:Paste:clicked {"op":"paste","lineCount":4,"charCount":73}
█ logEvent (telemetry disabled): CodyVSCodeExtension:inlineChat:Copy:clicked {"op":"copy","charCount":20,"lineCount":1}
█ logEvent (telemetry disabled): CodyVSCodeExtension:inlineChat:Paste:clicked {"op":"paste","lineCount":1,"charCount":20}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"op":"insert","charCount":228,"lineCount":8}
█ logEvent (telemetry disabled): CodyVSCodeExtension:copyButton:clicked {"op":"copy","charCount":228,"lineCount":8}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"op":"insert","charCount":228,"lineCount":8}
█ logEvent (telemetry disabled): CodyVSCodeExtension:keyDown:Paste:clicked {"op":"paste","lineCount":8,"charCount":228}
█ logEvent (telemetry disabled): CodyVSCodeExtension:copyButton:clicked {"op":"copy","charCount":39,"lineCount":2}
█ logEvent (telemetry disabled): CodyVSCodeExtension:keyDown:Paste:clicked {"op":"paste","lineCount":2,"charCount":39}

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

perform copy-and-paste actions and check the output channel

See demo https://www.loom.com/share/c3c5c11ee7bc418a914f6058602f6dd3?sid=043e4ef1-2a63-4919-81e7-cc443aafbec4