### PR TITLE
Don't require Esc to dismiss Cody menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - `Explain Code` command now includes visible content of the current file when no code is selected. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Show errors in chat view instead of notification windows. [pull/602](https://github.com/sourcegraph/cody/pull/602)
+- Don't require Esc to dismiss Cody menu. [pull/700](https://github.com/sourcegraph/cody/pull/700)
 
 ## [0.6.7]
 

--- a/vscode/src/custom-prompts/menus/CustomCommandBuilderMenu.ts
+++ b/vscode/src/custom-prompts/menus/CustomCommandBuilderMenu.ts
@@ -83,6 +83,7 @@ export class CustomCommandsBuilderMenu {
             title: 'Select the context to include with the prompt for the new command',
             placeHolder: 'Tip: Providing limited but precise context helps Cody provide more relevant answers',
             canPickMany: true,
+            ignoreFocusOut: true,
             onDidSelectItem: (item: QuickPickItem) => {
                 item.picked = !item.picked
             },

--- a/vscode/src/custom-prompts/menus/CustomCommandBuilderMenu.ts
+++ b/vscode/src/custom-prompts/menus/CustomCommandBuilderMenu.ts
@@ -83,7 +83,6 @@ export class CustomCommandsBuilderMenu {
             title: 'Select the context to include with the prompt for the new command',
             placeHolder: 'Tip: Providing limited but precise context helps Cody provide more relevant answers',
             canPickMany: true,
-            ignoreFocusOut: false,
             onDidSelectItem: (item: QuickPickItem) => {
                 item.picked = !item.picked
             },

--- a/vscode/src/custom-prompts/menus/index.ts
+++ b/vscode/src/custom-prompts/menus/index.ts
@@ -16,7 +16,6 @@ export async function showCommandMenu(items: QuickPickItem[]): Promise<CommandMe
     const options = {
         title: 'Cody (Shortcut: ⌥C)',
         placeHolder: 'Search for a command or enter your question here...',
-        ignoreFocusOut: true,
     }
 
     return new Promise(resolve => {
@@ -25,7 +24,6 @@ export async function showCommandMenu(items: QuickPickItem[]): Promise<CommandMe
         quickPick.items = items
         quickPick.title = options.title
         quickPick.placeholder = options.placeHolder
-        quickPick.ignoreFocusOut = options.ignoreFocusOut
 
         quickPick.buttons = [menu_buttons.gear]
 

--- a/vscode/src/custom-prompts/menus/index.ts
+++ b/vscode/src/custom-prompts/menus/index.ts
@@ -55,7 +55,6 @@ export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<Qui
     const CustomCommandsMenuOptions: QuickPickOptions = {
         title: 'Cody Custom Commands (Experimental)',
         placeHolder: 'Search command to run...',
-        ignoreFocusOut: true,
     }
 
     return new Promise(resolve => {


### PR DESCRIPTION
This removes the `ignoreFocusOut: true` settings on our command quickpick, removing the need for you use to press `esc` in the input to dismiss it. This makes it feel just as quick and light as the standard `cmd-shift-p` command palette.

The one downside to removing it is if you need to change your code selection mid-quickpick-item-selection, but given the standard command palette has commands that depend on code selection too (e.g. "Transform to Kebab Case") I think we should follow their suit and not introduce the extra bit of friction that requiring `esc` adds.

## Test plan

- Opened command palette
- Clicked outside it and verified it dismisses