### PR TITLE
Add a settings button to Cody pane header

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Cody Commands: New `/smell` command, an improved version of the old `Find Code Smell` recipe. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Display of clickable file path for current selection in chat view after executing a command. [pull/602](https://github.com/sourcegraph/cody/pull/602)
+- Add a settings button to Cody pane header. [pull/701](https://github.com/sourcegraph/cody/pull/701)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -320,6 +320,14 @@
         "icon": "$(history)"
       },
       {
+        "command": "cody.status-bar.interacted",
+        "category": "Cody",
+        "title": "Chat Settings",
+        "group": "Cody",
+        "icon": "$(settings-gear)",
+        "when": "cody.activated"
+      },
+      {
         "command": "cody.comment.add",
         "title": "Ask Cody",
         "category": "Cody Inline Chat",
@@ -612,6 +620,11 @@
           "command": "cody.history",
           "when": "view == cody.chat && cody.activated",
           "group": "navigation@2"
+        },
+        {
+          "command": "cody.status-bar.interacted",
+          "when": "view == cody.chat && cody.activated",
+          "group": "navigation@4"
         },
         {
           "command": "cody.feedback",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -322,7 +322,7 @@
       {
         "command": "cody.status-bar.interacted",
         "category": "Cody",
-        "title": "Chat Settings",
+        "title": "Cody Settings",
         "group": "Cody",
         "icon": "$(settings-gear)",
         "when": "cody.activated"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -647,11 +647,6 @@
           "group": "9_cody@0"
         },
         {
-          "command": "cody.settings.extension",
-          "when": "view == cody.chat",
-          "group": "8_cody@1"
-        },
-        {
           "command": "cody.fixup.apply-all",
           "when": "cody.nonstop.fixups.enabled && view == cody.fixup.tree.view && cody.activated",
           "group": "navigation"

--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -77,15 +77,15 @@ export async function showAccessTokenInputBox(endpoint: string): Promise<string 
 export const AuthMenuOptions = {
     signin: {
         title: 'Other Sign in Options',
-        placeholder: 'Select a sign in option',
+        placeholder: 'Choose a sign in option',
     },
     signout: {
         title: 'Sign Out',
-        placeHolder: 'Select instance to sign out',
+        placeHolder: 'Choose instance to sign out',
     },
     switch: {
         title: 'Switch Account',
-        placeHolder: 'Press Esc to cancel',
+        placeHolder: 'Choose an account',
     },
 }
 

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -113,8 +113,8 @@ export function createStatusBar(): CodyStatusBar {
                 ...FeedbackOptionItems,
             ],
             {
-                title: 'Cody Settings Menu',
-                placeHolder: 'Select an option',
+                title: 'Cody Settings',
+                placeHolder: 'Choose an option',
                 matchOnDescription: true,
             }
         )


### PR DESCRIPTION
There's lots of goodies hidden away in our settings menu that you can only access via the statusbar. This adds a settings icon to the main title bar to help people discover these more easily. You can also now access it via the VS Code command palette.

![image](https://github.com/sourcegraph/cody/assets/153/b345c60a-6fa5-4b06-85ad-94f749735726)

![image](https://github.com/sourcegraph/cody/assets/153/e8627658-af96-4dbf-8301-6219b2eb5151)

## Test plan

- Opened Cody
- Clicked the button