### PR TITLE
commands: match commands on description

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,7 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - `Explain Code` command now includes visible content of the current file when no code is selected. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Show errors in chat view instead of notification windows. [pull/602](https://github.com/sourcegraph/cody/pull/602)
-- Cody Commands: Match commands on description in menu []()
+- Cody Commands: Match commands on description in menu [pull/702](https://github.com/sourcegraph/cody/pull/702)
 
 ## [0.6.7]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - `Explain Code` command now includes visible content of the current file when no code is selected. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Show errors in chat view instead of notification windows. [pull/602](https://github.com/sourcegraph/cody/pull/602)
+- Cody Commands: Match commands on description in menu []()
 
 ## [0.6.7]
 

--- a/vscode/src/custom-prompts/menus/index.ts
+++ b/vscode/src/custom-prompts/menus/index.ts
@@ -25,6 +25,7 @@ export async function showCommandMenu(items: QuickPickItem[]): Promise<CommandMe
         quickPick.items = items
         quickPick.title = options.title
         quickPick.placeholder = options.placeHolder
+        quickPick.matchOnDescription = true
         quickPick.ignoreFocusOut = options.ignoreFocusOut
 
         quickPick.buttons = [menu_buttons.gear]

--- a/vscode/src/custom-prompts/menus/index.ts
+++ b/vscode/src/custom-prompts/menus/index.ts
@@ -33,7 +33,7 @@ export async function showCommandMenu(items: QuickPickItem[]): Promise<CommandMe
         const labels = new Set(items.map(item => item.label))
         quickPick.onDidChangeValue(() => {
             if (quickPick.value && !labels.has(quickPick.value)) {
-                quickPick.items = [menu_options.submitChat, menu_options.submitFix, ...items]
+                quickPick.items = [...items, menu_options.submitChat, menu_options.submitFix]
                 input = quickPick.value
                 return
             }


### PR DESCRIPTION
 This change makes the VS Code command menu match on the command description, not just the title. 

This enables searching `/`commands in the menu.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Demo:

<img width="745" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/9c916ca5-a954-4c81-900a-8029d3189528">
<img width="755" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/3e35fe4c-33c9-4019-9190-a7c10c91ee40">



