### PR TITLE
Use CSS scroll anchoring for most chat scroll pinning

### DIFF
--- a/lib/ui/src/chat/Transcript.module.css
+++ b/lib/ui/src/chat/Transcript.module.css
@@ -4,3 +4,13 @@
     overflow-y: auto;
     overflow-x: hidden;
 }
+
+.scroll-anchored-container {
+    overflow-anchor: none;
+}
+
+.scroll-anchor {
+    overflow-anchor: auto;
+    height: 5px; /* this is the grippy region for autoscroll */
+    width: 100vw;
+}

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -62,92 +62,108 @@ export const Transcript: React.FunctionComponent<
     pluginsDevMode,
     isTranscriptError,
 }) {
+    // Scroll down whenever a new human message is received as input.
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
+    const scrollAnchoredContainerRef = useRef<HTMLDivElement>(null)
+    const humanMessageCount = transcript.filter(message => message.speaker === 'human').length
     useEffect(() => {
         if (transcriptContainerRef.current) {
-            // Only scroll if the user didn't scroll up manually more than the scrolling threshold.
-            // That is so that you can freely copy content or read up on older content while new
-            // content is being produced.
-            //
-            // We allow some small threshold for "what is considered not scrolled up" so that
-            // minimal scroll doesn't affect it (ie. if I'm not all the way scrolled down by like a
-            // pixel or two, I probably still want it to scroll).
-            const SCROLL_THRESHOLD = 50
-            const delta = Math.abs(
-                transcriptContainerRef.current.scrollHeight -
-                    transcriptContainerRef.current.offsetHeight -
-                    transcriptContainerRef.current.scrollTop
-            )
-            if (delta < SCROLL_THRESHOLD) {
-                transcriptContainerRef.current.scrollTo({
-                    top: transcriptContainerRef.current.scrollHeight,
-                })
-            }
+            transcriptContainerRef.current?.scrollTo({
+                top: transcriptContainerRef.current.scrollHeight,
+                behavior: 'smooth',
+            })
         }
-    }, [transcript, transcriptContainerRef])
+    }, [humanMessageCount, transcriptContainerRef])
 
-    // Scroll down whenever a new message is received.
-    const lastMessageSpeaker = transcript[transcript.length - 1]?.speaker
+    // When the content was not scrollable, then becomes scrollable, manually
+    // scroll the anchor into view. This overrides the browser's default
+    // behavior of initially anchoring to the top until a scroll occurs.
     useEffect(() => {
-        transcriptContainerRef.current?.scrollTo({
-            top: transcriptContainerRef.current.scrollHeight,
-        })
-    }, [lastMessageSpeaker])
+        const root = transcriptContainerRef.current
+        const container = scrollAnchoredContainerRef.current
+        if (!(root && container)) {
+            return undefined
+        }
+        const observer = new IntersectionObserver(
+            entries => {
+                for (const entry of entries) {
+                    if (!entry.isIntersecting) {
+                        root.scrollTo({
+                            top: root.scrollHeight,
+                            behavior: 'smooth',
+                        })
+                        break
+                    }
+                }
+            },
+            {
+                root,
+                threshold: 1,
+            }
+        )
+        observer.observe(container)
+        return () => {
+            observer.disconnect()
+        }
+    }, [transcriptContainerRef, scrollAnchoredContainerRef])
 
     return (
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
-            {transcript.map(
-                (message, index) =>
-                    message?.displayText && (
-                        <TranscriptItem
-                            // eslint-disable-next-line react/no-array-index-key
-                            key={index}
-                            message={message}
-                            inProgress={false}
-                            beingEdited={index > 0 && transcript.length - index === 2 && messageBeingEdited}
-                            setBeingEdited={setMessageBeingEdited}
-                            fileLinkComponent={fileLinkComponent}
-                            codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
-                            codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
-                            transcriptItemClassName={transcriptItemClassName}
-                            humanTranscriptItemClassName={humanTranscriptItemClassName}
-                            transcriptItemParticipantClassName={transcriptItemParticipantClassName}
-                            transcriptActionClassName={transcriptActionClassName}
-                            textAreaComponent={textAreaComponent}
-                            EditButtonContainer={EditButtonContainer}
-                            editButtonOnSubmit={editButtonOnSubmit}
-                            showEditButton={index > 0 && transcript.length - index === 2}
-                            FeedbackButtonsContainer={FeedbackButtonsContainer}
-                            feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                            copyButtonOnSubmit={copyButtonOnSubmit}
-                            showFeedbackButtons={index !== 0 && !isTranscriptError}
-                            submitButtonComponent={submitButtonComponent}
-                            chatInputClassName={chatInputClassName}
-                            ChatButtonComponent={ChatButtonComponent}
-                            pluginsDevMode={pluginsDevMode}
-                        />
-                    )
-            )}
-            {messageInProgress && messageInProgress.speaker === 'assistant' && (
-                <TranscriptItem
-                    message={messageInProgress}
-                    inProgress={true}
-                    beingEdited={false}
-                    setBeingEdited={setMessageBeingEdited}
-                    fileLinkComponent={fileLinkComponent}
-                    codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
-                    codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
-                    transcriptItemClassName={transcriptItemClassName}
-                    transcriptItemParticipantClassName={transcriptItemParticipantClassName}
-                    transcriptActionClassName={transcriptActionClassName}
-                    showEditButton={false}
-                    showFeedbackButtons={false}
-                    copyButtonOnSubmit={copyButtonOnSubmit}
-                    submitButtonComponent={submitButtonComponent}
-                    chatInputClassName={chatInputClassName}
-                    ChatButtonComponent={ChatButtonComponent}
-                />
-            )}
+            <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
+                {transcript.map(
+                    (message, index) =>
+                        message?.displayText && (
+                            <TranscriptItem
+                                // eslint-disable-next-line react/no-array-index-key
+                                key={index}
+                                message={message}
+                                inProgress={false}
+                                beingEdited={index > 0 && transcript.length - index === 2 && messageBeingEdited}
+                                setBeingEdited={setMessageBeingEdited}
+                                fileLinkComponent={fileLinkComponent}
+                                codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
+                                codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
+                                transcriptItemClassName={transcriptItemClassName}
+                                humanTranscriptItemClassName={humanTranscriptItemClassName}
+                                transcriptItemParticipantClassName={transcriptItemParticipantClassName}
+                                transcriptActionClassName={transcriptActionClassName}
+                                textAreaComponent={textAreaComponent}
+                                EditButtonContainer={EditButtonContainer}
+                                editButtonOnSubmit={editButtonOnSubmit}
+                                showEditButton={index > 0 && transcript.length - index === 2}
+                                FeedbackButtonsContainer={FeedbackButtonsContainer}
+                                feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                                copyButtonOnSubmit={copyButtonOnSubmit}
+                                showFeedbackButtons={index !== 0 && !isTranscriptError}
+                                submitButtonComponent={submitButtonComponent}
+                                chatInputClassName={chatInputClassName}
+                                ChatButtonComponent={ChatButtonComponent}
+                                pluginsDevMode={pluginsDevMode}
+                            />
+                        )
+                )}
+                {messageInProgress && messageInProgress.speaker === 'assistant' && (
+                    <TranscriptItem
+                        message={messageInProgress}
+                        inProgress={true}
+                        beingEdited={false}
+                        setBeingEdited={setMessageBeingEdited}
+                        fileLinkComponent={fileLinkComponent}
+                        codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
+                        codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
+                        transcriptItemClassName={transcriptItemClassName}
+                        transcriptItemParticipantClassName={transcriptItemParticipantClassName}
+                        transcriptActionClassName={transcriptActionClassName}
+                        showEditButton={false}
+                        showFeedbackButtons={false}
+                        copyButtonOnSubmit={copyButtonOnSubmit}
+                        submitButtonComponent={submitButtonComponent}
+                        chatInputClassName={chatInputClassName}
+                        ChatButtonComponent={ChatButtonComponent}
+                    />
+                )}
+            </div>
+            <div className={classNames(styles.scrollAnchor)}>&nbsp;</div>
         </div>
     )
 })

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -84,16 +84,22 @@ export const Transcript: React.FunctionComponent<
         if (!(root && container)) {
             return undefined
         }
+        let wasIntersecting = true
         const observer = new IntersectionObserver(
             entries => {
                 for (const entry of entries) {
-                    if (!entry.isIntersecting) {
+                    if (entry.rootBounds?.width === 0 || entries[0].rootBounds?.height === 0) {
+                        // After restoring a pane the root element hasn't been sized yet, and we
+                        // trivially overflow it. Ignore this.
+                        continue
+                    }
+                    if (wasIntersecting && !entry.isIntersecting) {
                         root.scrollTo({
                             top: root.scrollHeight,
                             behavior: 'smooth',
                         })
-                        break
                     }
+                    wasIntersecting = entry.isIntersecting
                 }
             },
             {


### PR DESCRIPTION
Chat scroll pinning was broken for `/search` because that adds messages in quick succession and the React effect was only looking at the change in message author.

The general approach was also iffy because we were basically polling the scroll position on updates, but in practice scrolling works best when it is managed asynchronously by the browser.

This takes a different approach:
- Use CSS scroll anchoring. This takes care of 90% of what we want with pinning the scroll position to the bottom: If you scroll away from the anchor, the scroll position doesn't change, the browser manages all of this for us. We also get better behavior when you resize the panel; the scroll position will stick to the bottom pretty intelligently.
- Because browsers anchor the scroll position to the top until there's any scrolling, this uses an intersection observer to detect when the content becomes scrollable and force it to scroll. I actually like the behavior without that, but have implemented this for consistency with what we had.
- When there's a new human message, scroll to the bottom. This means when you commit input in the chat box, we scroll to it.

I've made some subtle UX changes like animating some of the scrolls.

The scroll anchor adds a 5px gutter at the bottom of the content which is the "grippy" region for the scroll. We can avoid that extra space if we want, I took a look at it, it requires a couple of stacking contexts and I thought it wasn't worth it. But we can do it if we want.

## Test plan

1. New Cody chat, ask it to enumerate 50 states in order of accession in a numbered list. The scroll should follow the content as it streams in.
2. Scroll up, chat to ask it to enumerate the 50 states and their state vegetables. The scroll should jump to the new question when you hit enter; then follow the content.
3. Scroll up, switch to the files panel, switch back. The scroll position should be where you left it.
4. While content is streaming in, scroll away from it. As new content appears the scroll should not jump back to the bottom.
5. Scroll to the bottom, ask to enumerate 50 states etc., while content is streaming in switch to the files panel, wait, then switch back. The scroll position should be where it was when you switched away. That is, *not* pinned any more.
6. Do `/search foo` and the scroll position should keep up with the bottom of the content. (This comes in very *fast* and I think we should add a heuristic to maybe not do that. But it is better than the behavior today, which quietly drops the new content below the fold.)
7. Reload the webviews/restart the extension with a long transcript. The restored transcript should be scrolled to the bottom.