### PR TITLE
Autocomplete: Aggregate completion started events

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -44,6 +44,8 @@ const displayedCompletions = new LRUCache<string, CompletionEvent>({
     max: 100, // Maximum number of completions that we are keeping track of
 })
 
+let completionsStartedSinceLastSuggestion = 0
+
 export function logCompletionEvent(name: string, params?: TelemetryEventProperties): void {
     logEvent(`CodyVSCodeExtension:completion:${name}`, params)
 }
@@ -76,7 +78,7 @@ export function start(id: string): void {
     const event = displayedCompletions.get(id)
     if (event && !event.startLoggedAt) {
         event.startLoggedAt = performance.now()
-        logCompletionEvent('started', event.params)
+        completionsStartedSinceLastSuggestion++
     }
 }
 
@@ -188,7 +190,9 @@ function logSuggestionEvents(): void {
             read: accepted || read,
             accepted,
             otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
+            completionsStartedSinceLastSuggestion,
         })
+        completionsStartedSinceLastSuggestion = 0
     })
 
     // Completions are kept in the LRU cache for longer. This is because they


### PR DESCRIPTION
Aggregate start events instead of firing so many of these

## Test plan

<img width="1241" alt="Screenshot 2023-08-16 at 12 31 25" src="https://github.com/sourcegraph/cody/assets/458591/34c8c53c-fe47-4b5f-9ccb-c03223a75410">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
