### PR TITLE
Agent: make advanced autocomplete configuration optional 

### DIFF
--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -139,10 +139,10 @@ export interface ExtensionConfiguration {
     serverEndpoint: string
     accessToken: string
     customHeaders: Record<string, string>
-    autocompleteAdvancedProvider: string
-    autocompleteAdvancedServerEndpoint: string | null
-    autocompleteAdvancedAccessToken: string | null
-    autocompleteAdvancedEmbeddings: boolean
+    autocompleteAdvancedProvider?: string
+    autocompleteAdvancedServerEndpoint?: string | null
+    autocompleteAdvancedAccessToken?: string | null
+    autocompleteAdvancedEmbeddings?: boolean
     debug?: boolean
     verboseDebug?: boolean
     codebase?: string

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -96,13 +96,17 @@ const configuration: vscode.WorkspaceConfiguration = {
             case 'cody.autocomplete.enabled':
                 return true
             case 'cody.autocomplete.advanced.provider':
-                return connectionConfig?.autocompleteAdvancedProvider
+                return connectionConfig?.autocompleteAdvancedProvider ?? 'anthropic'
             case 'cody.autocomplete.advanced.serverEndpoint':
                 return connectionConfig?.autocompleteAdvancedServerEndpoint
+                    ? connectionConfig?.autocompleteAdvancedServerEndpoint
+                    : null
             case 'cody.autocomplete.advanced.accessToken':
                 return connectionConfig?.autocompleteAdvancedAccessToken
+                    ? connectionConfig?.autocompleteAdvancedAccessToken
+                    : null
             case 'cody.autocomplete.advanced.embeddings':
-                return connectionConfig?.autocompleteAdvancedEmbeddings
+                return connectionConfig?.autocompleteAdvancedEmbeddings ?? true
             case 'cody.advanced.agent.running':
                 return true
             case 'cody.debug.enable':


### PR DESCRIPTION
New agent configuration values were added to support additional autocomplete providers, this updates them to be optional and sets the defaults the same as the vs code extension

## Test plan
test add to confirm working agent with minimal configuration.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
