### PR TITLE
Autocomplete: Fix starcoder model name again

### DIFF
--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -78,7 +78,7 @@ export class UnstableFireworksProvider extends Provider {
             top_p: 0.95,
             n: this.options.n,
             echo: false,
-            model: 'accounts/fireworks/models/starcoder-7b-w8a16-1gpu',
+            model: 'accounts/fireworks/models/starcoder-7b-w8a16',
         }
 
         const log = logger.startCompletion({


### PR DESCRIPTION
This just updates the model name after a conversation with Fireworks. 

## Test plan

- Configure the StarCoder model (c.f. [sourcegraph.slack.com/archives/C05AGQYD528/p1690551781096999](https://sourcegraph.slack.com/archives/C05AGQYD528/p1690551781096999))
- See that completions work again

<img width="875" alt="Screenshot 2023-08-16 at 15 52 03" src="https://github.com/sourcegraph/cody/assets/458591/5af2444f-73ea-4e66-9808-200507e18b6f">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
