### PR TITLE
Autocomplete: Log chars with suggestion event

### DIFF
--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -197,7 +197,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
 
         if (result.items.length > 0) {
-            CompletionLogger.suggested(result.logId, InlineCompletionsResultSource[result.source])
+            CompletionLogger.suggested(result.logId, InlineCompletionsResultSource[result.source], result.items[0])
         } else {
             CompletionLogger.noResponse(result.logId)
         }
@@ -212,10 +212,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         // log id is never reused if the completion is accepted.
         this.lastCandidate = undefined
 
-        const lines = completion.insertText.split(/\r\n|\r|\n/).length
-        const chars = completion.insertText.length
-
-        CompletionLogger.accept(logId, lines, chars)
+        CompletionLogger.accept(logId, completion)
     }
 
     /**


### PR DESCRIPTION
## Test plan

- Get a completion to display
- Accept it or make another change to the doc (anything to flush the completion)
- Inspect the logs:
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:completion:suggested {"multiline":false,"providerIdentifier":"fireworks","languageId":"typescriptreact","type":"inline","multilineMode":null,"id":"p2oipy5zu","contextSummary":{"duration":0.2133750021457672},"source":"CacheAfterRequestStart","lines":1,"chars":22,"latency":125.26608400046825,"displayDuration":9680.995083000511,"read":true,"accepted":true,"otherCompletionProviderEnabled":true,"completionsStartedSinceLastSuggestion":5}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
