### PR TITLE
fixup: add code lens to discard fixup suggestion

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Cody Commands: New `/smell` command, an improved version of the old `Find Code Smell` recipe. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Display of clickable file path for current selection in chat view after executing a command. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Add a settings button to Cody pane header. [pull/701](https://github.com/sourcegraph/cody/pull/701)
+- Fixup: New `Discard` code lens to remove suggestions and decorations. [pull/711](https://github.com/sourcegraph/cody/pull/711)
 
 ### Fixed
 

--- a/vscode/src/non-stop/FixupCodeLenses.ts
+++ b/vscode/src/non-stop/FixupCodeLenses.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { debug } from '../log'
+
 import { getLensesForTask } from './codelenses'
 import { FixupTask } from './FixupTask'
 import { FixupFileCollection } from './roles'
@@ -35,7 +37,9 @@ export class FixupCodeLenses implements vscode.CodeLensProvider {
         for (const task of this.files.tasksForFile(file)) {
             lenses.push(...(this.taskLenses.get(task) || []))
         }
-        console.log(`lenses for: ${document.uri} (${lenses.length})`)
+        debug('FixupCodeLenses:provideCodeLenses', 'CodeLenses', {
+            verbose: { lens: `${document.uri} (${lenses.length})` },
+        })
         return lenses
     }
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { VsCodeFixupController, VsCodeFixupTaskRecipeData } from '@sourcegraph/cody-shared/src/editor'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
+import { debug } from '../log'
 import { countCode } from '../services/InlineAssist'
 
 import { computeDiff, Diff } from './diff'
@@ -122,7 +123,7 @@ export class FixupController
     // Apply single fixup from task ID. Public for testing.
     public async apply(id: taskID): Promise<void> {
         this.telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', { op: 'apply' })
-        console.log(id + ' applying')
+        debug('FixupController:apply', 'applying', { verbose: { id } })
         const task = this.tasks.get(id)
         if (!task) {
             console.error('cannot find task')
@@ -494,7 +495,8 @@ export class FixupController
             // Not a transition--nothing to do.
             return
         }
-        console.log(task.id, 'changing state from', oldState, 'to', state)
+
+        debug('FixupController:setTaskState: ', 'changing state', { verbose: { task } })
         task.state = state
 
         // TODO: These state transition actions were moved from FixupTask, but

--- a/vscode/src/non-stop/codelenses.ts
+++ b/vscode/src/non-stop/codelenses.ts
@@ -18,7 +18,8 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
             const title = getReadyLens(codeLensRange, task.id)
             const apply = getApplyLens(codeLensRange, task.id)
             const diff = getDiffLens(codeLensRange, task.id)
-            return [title, apply, diff]
+            const discard = getDiscardLens(codeLensRange, task.id)
+            return [title, apply, diff, discard]
         }
         case CodyTaskState.applying: {
             const title = getApplyingLens(codeLensRange)


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1692000660788579

Add a new Code Lens for discarding Fixup suggestions.

Currently user MUST accept the change and undo the change to get rid the code lens. This button will remove all that on click.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Added Discard lens:

<img width="1252" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/0db66fb2-44a5-42af-a96a-7cb777eb09b9">
