### PR TITLE
Adding support for downward scrolling when a search operation is performed on Cody

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -385,6 +385,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         // Ex: performing fuzzy / context-search does not require responses from LLM backend
         switch (recipeId) {
             case 'context-search':
+                this.sendTranscript()
                 await this.onCompletionEnd()
                 break
             default: {


### PR DESCRIPTION
**NOTE: The core functionality of this PR has been replaced by https://github.com/sourcegraph/cody/pull/704**



Solves https://github.com/sourcegraph/cody/issues/699 
Currently the search doesn't scroll down because when the context search result is be sent to transcript `onCompletionEnd` is being called(This is an edge case recipe because it involves no LLM calls or streaming).   
https://github.com/sourcegraph/cody/blob/23ce972044869cbfca2cd31b20dd85293d4b1771/vscode/src/chat/MessageProvider.ts#L387-L388
 
If you look at `onCompletionEnd` function you can see that it has `isMessageInProgress` is set to false "before" the transcript is sent to the webview. The problem with having the `isMessageInProgress` is that it doesn't push the window down when it gets the result. So I am calling `this.sendTranscript()` upstream at a point where `this.isMessageInProgress` is truthy and when you do that the window scrolls downwards(Just like it does in the case when we are streaming LLM responses in other recipes). Also an important thing to note is that because we get the response all at once and not as a stream we start seeing the results jump to the bottom which is slightly different from how it "feels" on the streaming case.  


https://github.com/sourcegraph/cody/blob/23ce972044869cbfca2cd31b20dd85293d4b1771/vscode/src/chat/MessageProvider.ts#L257-L268 




## Test plan

Tested Locally
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
