### PR TITLE
Use primary button theme on hover for insert, copy.

### DIFF
--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -65,7 +65,13 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 
 .code-blocks-copy-button:hover,
 .code-blocks-insert-button:hover {
-    background-color: var(--vscode-button-secondaryHoverBackground);
+    /* Flip to the primary button hover styles because the secondary button
+     * hover background is transparent in many themes. The transparent
+     * background which doesn't work with the layered design.
+     */
+    background-color: var(--vscode-button-hoverBackground);
+    color: var(--vscode-button-foreground);
+    border-color: var(--vscode-button-border);
 }
 
 .input-row {


### PR DESCRIPTION
Fixes #614.

Secondary button backgrounds are transparent in many themes. This doesn't work with the kind of overlapping design we have, so on hover I'm flipping to the primary button hover theme.

![Screenshot 2023-08-17 at 15 14 08](https://github.com/sourcegraph/cody/assets/55120/1fac78be-e0a6-4ebb-9d39-9351256135d1)

## Test plan

1. Open Cody chat, `show me hello world in Rust`
2. Hover over the code, confirm the insert, copy buttons appear.
3. Hover over each button, confirm the button is legible and has a background.