### PR TITLE
Add autoresizing and command button to chat input

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -429,7 +429,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                         disabled={needsEmailVerification || !isCodyEnabled}
                         onInput={onChatInput}
                         onKeyDown={onChatKeyDown}
-                        setValue={value => inputHandler(value)}
+                        setValue={inputHandler}
                     />
                     <SubmitButton
                         className={styles.submitButton}

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -74,6 +74,7 @@ export interface ChatUITextAreaProps {
     required: boolean
     disabled?: boolean
     onInput: React.FormEventHandler<HTMLElement>
+    setValue?: (value: string) => void
     onKeyDown?: (event: React.KeyboardEvent<HTMLElement>, caretPosition: number | null) => void
 }
 
@@ -428,6 +429,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                         disabled={needsEmailVerification || !isCodyEnabled}
                         onInput={onChatInput}
                         onKeyDown={onChatKeyDown}
+                        setValue={value => inputHandler(value)}
                     />
                     <SubmitButton
                         className={styles.submitButton}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Cody Commands: Display of clickable file path for current selection in chat view after executing a command. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Add a settings button to Cody pane header. [pull/701](https://github.com/sourcegraph/cody/pull/701)
 - Fixup: New `Discard` code lens to remove suggestions and decorations. [pull/711](https://github.com/sourcegraph/cody/pull/711)
+- New chat message input, with auto-resizing and a command button. [pull/718](https://github.com/sourcegraph/cody/pull/718)
 
 ### Fixed
 

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -9,7 +9,7 @@ test('open the Custom Commands in sidebar and add new user recipe', async ({ pag
 
     await expect(sidebar.getByText("Hello! I'm Cody.")).toBeVisible()
 
-    await sidebar.getByRole('textbox', { name: 'Text area' }).fill('/')
+    await sidebar.getByRole('textbox', { name: 'Chat message' }).fill('/')
     await sidebar.locator('vscode-button').getByRole('img').click()
 
     // Create Command via UI

--- a/vscode/test/e2e/history.test.ts
+++ b/vscode/test/e2e/history.test.ts
@@ -15,7 +15,7 @@ test.skip('checks for the chat history and new session', async ({ page, sidebar 
     await page.click('[aria-label="Start a New Chat Session"]')
     await expect(sidebar.getByText("Hello! I'm Cody. I can write code and answer questions for you.")).toBeVisible()
 
-    await sidebar.getByRole('textbox', { name: 'Text area' }).fill('Hello')
+    await sidebar.getByRole('textbox', { name: 'Chat message' }).fill('Hello')
     await sidebar.locator('vscode-button').getByRole('img').click()
     await expect(sidebar.getByText('Hello')).toBeVisible()
     await page.getByRole('button', { name: 'Chat History' }).click()

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -74,28 +74,60 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     padding: 0.75rem 0.75rem 1rem 0.75rem;
 }
 
-.chat-input-context {
-    opacity: 0.85;
+/* Container used for autogrowing, based on https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */
+.chat-input-container {
+    display: grid;
 }
 
-.chat-input {
-    border: 1px solid var(--vscode-input-border, transparent);
-    border-radius: 2px;
-    --corner-radius: 2; /* Make sure the inner <textarea> gets the right border-radius */
+.chat-input-container::after {
+    content: attr(data-value) " ";
+    white-space: pre-wrap;
+    visibility: hidden;
+}
+
+/* Both elements need the same styling so the height matches */
+.chat-input, .chat-input-container::after {
     box-sizing: border-box;
-    height: 35px; /* Gross hack to remove the space below the input */
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: none;
+    border-radius: 2px;
+    padding: 8px 8px 32px 8px;
+    font: inherit;
+    width: 100%;
+    overflow: hidden;
+
+    min-height: 3.5rem;
+
+    /* Place on top of each other */
+    grid-area: 1 / 1 / 2 / 2;
 }
 
 .chat-input:focus,
 .chat-input:focus-visible,
 .chat-input:focus-within {
-    outline: 1px solid var(--vscode-inputOption-activeBorder);
+    outline: 1px solid var(--vscode-focusBorder);
     outline-offset: -1px;
+}
+
+.chat-input-actions {
+    position: absolute;
+    bottom: 4px;
+    left: 4px;
+    /* We default to no events, but then switch it back below if there's a not-disabled child */
+    pointer-events: none;
+}
+.chat-input-actions:not(:has([disabled])) {
+    pointer-events: auto;
 }
 
 .chat-button {
     margin-top: 0.5rem;
     padding: 0.25rem;
+}
+
+.chat-input-context {
+    opacity: 0.85;
 }
 
 .feedback-buttons {
@@ -134,13 +166,12 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     color: var(--foreground);
 }
 
-.submit-button-disabled,
-.submit-button-disabled:hover {
-    cursor: default;
-    --button-icon-hover-background: none;
-    color: var(--vscode-icon-foreground);
-    opacity: 0.4;
-    pointer-events: none; /* Lets you focus the text area by clicking the disabled button */
+.submit-button, .submit-button-disabled {
+    margin-bottom: 0;
+}
+
+.submit-button[disabled] {
+    pointer-events: none;
 }
 
 .stop-generating-button {

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -99,6 +99,7 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     padding: 8px 8px 32px 8px;
     font: inherit;
     width: 100%;
+    overflow: hidden;
 
     min-height: 3.5rem;
 

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -121,16 +121,17 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     position: absolute;
     bottom: 6px;
     left: 4px;
-
-    /* We default to no events, but then switch it back below if there's a not-disabled child */
-    /* We need this on the container as well as the individual buttons */
+    /* This is a small detail, but we always want clicks to fall through the textarea if buttons are disabled */
     pointer-events: none;
 }
-.chat-input-actions:not(:has([disabled])) {
+
+.chat-input-actions > * {
+    /* We have to set this explicitly, otherwise it will use the parent's value */
     pointer-events: auto;
 }
 
 .chat-input-actions [disabled] {
+    /* Disabled buttons just send their clicks to the textarea, similar to Slack’s implementation */
     pointer-events: none;
 }
 

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -76,12 +76,16 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 
 /* Container used for autogrowing, based on https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */
 .chat-input-container {
+    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
     display: grid;
 }
 
 .chat-input-container::after {
+    /* Note the weird space! Needed to preventy jumpy behavior */
     content: attr(data-value) " ";
+    /* This is how textarea text behaves */
     white-space: pre-wrap;
+    /* Hidden from view, clicks, and screen readers */
     visibility: hidden;
 }
 
@@ -95,7 +99,6 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     padding: 8px 8px 32px 8px;
     font: inherit;
     width: 100%;
-    overflow: hidden;
 
     min-height: 3.5rem;
 

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -112,13 +112,19 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 
 .chat-input-actions {
     position: absolute;
-    bottom: 4px;
+    bottom: 6px;
     left: 4px;
+
     /* We default to no events, but then switch it back below if there's a not-disabled child */
+    /* We need this on the container as well as the individual buttons */
     pointer-events: none;
 }
 .chat-input-actions:not(:has([disabled])) {
     pointer-events: auto;
+}
+
+.chat-input-actions [disabled] {
+    pointer-events: none;
 }
 
 .chat-button {

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -90,7 +90,7 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     box-sizing: border-box;
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
-    border: none;
+    border: 1px solid transparent;
     border-radius: 2px;
     padding: 8px 8px 32px 8px;
     font: inherit;
@@ -101,6 +101,10 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 
     /* Place on top of each other */
     grid-area: 1 / 1 / 2 / 2;
+}
+
+.chat-input {
+    border-color: var(--vscode-input-border, transparent);
 }
 
 .chat-input:focus,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -238,6 +238,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                 onInput={onInput}
                 onKeyDown={onTextAreaKeyDown}
                 placeholder={placeholder}
+                aria-label="Chat message"
                 title="" // Set to blank to avoid HTML5 error tooltip "Please fill in this field"
             />
             <div className={styles.chatInputActions}>

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -225,7 +225,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
             setValue('/')
             inputRef.current?.focus()
         }
-    }, [setValue])
+    }, [inputRef, setValue])
 
     return (
         <div className={classNames(styles.chatInputContainer)} data-value={value || placeholder}>
@@ -237,7 +237,6 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                 required={required}
                 onInput={onInput}
                 onKeyDown={onTextAreaKeyDown}
-                autoFocus={autoFocus}
                 placeholder={placeholder}
                 title="" // Set to blank to avoid HTML5 error tooltip "Please fill in this field"
             />

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -213,9 +213,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
 
     const onTextAreaKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLElement>): void => {
-            if (onKeyDown) {
-                onKeyDown(event, inputRef.current?.selectionStart ?? null)
-            }
+            onKeyDown?.(event, inputRef.current?.selectionStart ?? null)
         },
         [inputRef, onKeyDown]
     )

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { VSCodeButton, VSCodeLink, VSCodeTextArea } from '@vscode/webview-ui-toolkit/react'
+import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
@@ -188,15 +188,17 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     className,
     autoFocus,
     value,
+    setValue,
     required,
     onInput,
     onKeyDown,
-    rows,
 }) => {
+    const inputRef = useRef<HTMLTextAreaElement>(null)
+    const placeholder = "Ask a question or type '/' for commands"
+
     // Focus the textarea when the webview gains focus (unless there is text selected). This makes
     // it so that the user can immediately start typing to Cody after invoking `Cody: Focus on Chat
     // View` with the keyboard.
-    const inputRef = useRef<HTMLTextAreaElement>(null)
     useEffect(() => {
         const handleFocus = (): void => {
             if (document.getSelection()?.isCollapsed) {
@@ -209,43 +211,54 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
         }
     }, [])
 
-    // <VSCodeTextArea autofocus> does not work, so implement autofocus ourselves.
-    useEffect(() => {
-        if (autoFocus) {
+    const onTextAreaKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLElement>): void => {
+            if (onKeyDown) {
+                onKeyDown(event, inputRef.current?.selectionStart ?? null)
+            }
+        },
+        [inputRef, onKeyDown]
+    )
+
+    const onTextAreaCommandButtonClick = useCallback((): void => {
+        if (setValue && inputRef?.current?.value === '') {
+            setValue('/')
             inputRef.current?.focus()
         }
-    }, [autoFocus])
-
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>): void => {
-        if (onKeyDown) {
-            onKeyDown(event, (inputRef.current as any)?.control.selectionStart)
-        }
-    }
+    }, [setValue])
 
     return (
-        <VSCodeTextArea
-            className={classNames(styles.chatInput, className)}
-            rows={rows}
-            ref={
-                // VSCodeTextArea has a very complex type.
-                //
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                inputRef as any
-            }
-            value={value}
-            autofocus={autoFocus}
-            required={required}
-            onInput={e => onInput(e as React.FormEvent<HTMLTextAreaElement>)}
-            placeholder="Ask a question or type '/' for commands"
-            onKeyDown={handleKeyDown}
-            title="" // Set to blank to avoid HTML5 error tooltip "Please fill in this field"
-        />
+        <div className={classNames(styles.chatInputContainer)} data-value={value || placeholder}>
+            <textarea
+                className={classNames(styles.chatInput, className)}
+                rows={1}
+                ref={inputRef}
+                value={value}
+                required={required}
+                onInput={onInput}
+                onKeyDown={onTextAreaKeyDown}
+                autoFocus={autoFocus}
+                placeholder={placeholder}
+                title="" // Set to blank to avoid HTML5 error tooltip "Please fill in this field"
+            />
+            <div className={styles.chatInputActions}>
+                <VSCodeButton
+                    appearance="icon"
+                    type="button"
+                    className={styles.chatInputCommandButton}
+                    onClick={onTextAreaCommandButtonClick}
+                    disabled={!!value}
+                >
+                    <i className="codicon codicon-terminal" />
+                </VSCodeButton>
+            </div>
+        </div>
     )
 }
 
 const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({ className, disabled, onClick }) => (
     <VSCodeButton
-        className={classNames(disabled ? styles.submitButtonDisabled : styles.submitButton, className)}
+        className={classNames(styles.submitButton, className)}
         appearance="icon"
         type="button"
         disabled={disabled}


### PR DESCRIPTION
This revamps the chat input with better styling (high contrast outline support, proper border radius, etc), autoresizing support for long lines and narrow screens, and a command button.

https://github.com/sourcegraph/cody/assets/153/07d8e3c0-d9a4-4591-bf22-87d2cfc55a2b

| Before | After |
| - | - |
| <img width="884" alt="Screenshot 2023-08-18 at 12 24 50 am" src="https://github.com/sourcegraph/cody/assets/153/381152a7-8fe5-413d-9f70-ee0f6dcd2957"> | <img width="884" alt="Screenshot 2023-08-18 at 12 23 56 am" src="https://github.com/sourcegraph/cody/assets/153/41598e31-88c6-491b-b039-39724dec57df"> |
| <img width="884" alt="Screenshot 2023-08-18 at 12 25 00 am" src="https://github.com/sourcegraph/cody/assets/153/185de523-49d8-4c43-8f5c-1d7024abf407"> | <img width="884" alt="Screenshot 2023-08-18 at 12 23 37 am" src="https://github.com/sourcegraph/cody/assets/153/06bfc3a7-7daa-4561-b474-1ca43328a2a0"> |

Fixes #613 

## Test plan

- Interact with it
- Verify it works
- Test different color schemes