### PR TITLE
Move typewriter so it does not throttle keyword expansion, reranker

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -3,8 +3,6 @@ import { Message } from '../sourcegraph-api'
 import type { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
 import type { CompletionCallbacks, CompletionParameters } from '../sourcegraph-api/completions/types'
 
-import { createTypewriter } from './typewriter'
-
 type ChatParameters = Omit<CompletionParameters, 'messages'>
 
 const DEFAULT_CHAT_COMPLETION_PARAMETERS: ChatParameters = {
@@ -20,9 +18,6 @@ export class ChatClient {
     public chat(messages: Message[], cb: CompletionCallbacks, params?: Partial<ChatParameters>): () => void {
         const isLastMessageFromHuman = messages.length > 0 && messages[messages.length - 1].speaker === 'human'
         const augmentedMessages = isLastMessageFromHuman ? messages.concat([{ speaker: 'assistant' }]) : messages
-        const typewriter = createTypewriter({
-            emit: cb.onChange,
-        })
 
         return this.completions.stream(
             {
@@ -30,14 +25,7 @@ export class ChatClient {
                 ...params,
                 messages: augmentedMessages,
             },
-            {
-                ...cb,
-                onChange: typewriter.write,
-                onComplete: () => {
-                    typewriter.stop()
-                    cb.onComplete()
-                },
-            }
+            cb
         )
     }
 }

--- a/lib/shared/src/chat/typewriter.ts
+++ b/lib/shared/src/chat/typewriter.ts
@@ -1,24 +1,14 @@
-interface Typewriter {
+export interface IncrementalTextConsumer {
     /**
-     * Push new text to the typewriter to emit over time.
+     * Push new text to the consumer.
      * Text should be incremental but still include the previous text. E.g. "Hel" -> "Hello" -> "Hello, world!"
      */
-    write: (incomingText: string) => void
-    /** Stop the typewriter, immediately emit any remaining text */
-    stop: () => void
-    /**
-     * Notify the typewriter that no more text will be written, but wait for the
-     * typewriter to finish emitting any remaining text. Returns a Promise with
-     * the completed text.
-     */
-    flush: () => Promise<string>
-}
+    update: (content: string) => void
 
-interface CreateTypewriterParams {
     /**
-     * Callback to call every time a new character is emitted
+     * Notify the consumer that the text is complete.
      */
-    emit: (text: string) => void
+    close: () => void
 }
 
 // Maximum/minimum amount of time to wait between character chunks
@@ -27,93 +17,115 @@ const MIN_DELAY_MS = 5
 
 const MIN_CHAR_CHUNK_SIZE = 1
 
-export const createTypewriter = ({ emit }: CreateTypewriterParams): Typewriter => {
-    let fullText = ''
-    let processedText = ''
-    let interval: ReturnType<typeof setInterval> | undefined
-    let done: undefined | ((s: string) => void)
+export class Typewriter implements IncrementalTextConsumer {
+    private upstreamClosed = false
+    private resolveFinished: (s: string) => void = () => {}
+    private rejectFinished: (err: any) => void = () => {}
 
-    function isComplete(): boolean {
-        return processedText.length === fullText.length
+    /**
+     * Promise indicating the typewriter is done "typing". Resolved with the
+     * complete text when available; rejects if the typewriter was stopped
+     * prematurely.
+     */
+    public readonly finished: Promise<string>
+
+    private text = ''
+    private i = 0
+    private interval: ReturnType<typeof setInterval> | undefined
+
+    /**
+     * Creates a Typewriter which will buffer incremental text and pass it
+     * through to `consumer` simulating a typing effect.
+     *
+     * @param consumer the consumer to pipe "typing" through to.
+     */
+    constructor(private readonly consumer: IncrementalTextConsumer) {
+        this.finished = new Promise((resolve, reject) => {
+            this.resolveFinished = resolve
+            this.rejectFinished = reject
+        })
     }
 
-    function writeAfterFlush(): void {
-        throw new Error('write after flush')
-    }
+    // IncrementalTextConsumer implementation. The "write" side of the pipe.
 
-    return {
-        flush: async (): Promise<string> => {
-            if (done) {
-                throw new Error('Typewriter already flushed')
-            }
-            if (isComplete()) {
-                done = writeAfterFlush
-                return Promise.resolve(processedText)
-            }
-            return new Promise(resolve => {
-                done = resolve
-            })
-        },
+    update(content: string): void {
+        if (this.upstreamClosed) {
+            throw new Error('Typewriter already closed')
+        }
+        if (this.text.length >= content.length) {
+            throw new Error('Content must be supplied incrementally')
+        }
+        this.text = content
 
-        write: (updatedText: string) => {
-            /** Keep text in sync with the latest update, so consumers can choose to `stop` early. */
-            fullText = updatedText
+        /**
+         * If we already have an interval running, stop it to avoid stacking
+         * multiple intervals on top of each other.
+         */
+        if (this.interval) {
+            clearInterval(this.interval)
+            this.interval = undefined
+        }
 
-            /**
-             * If we already have an interval running, stop it to avoid stacking
-             * multiple intervals on top of each other.
-             */
-            if (interval) {
-                clearInterval(interval)
-                interval = undefined
-            }
+        /**
+         * Calculate the delay from the remaining characters we know we have left to process
+         * This ensures that the typewriter effect will speed up if we start to fall behind.
+         */
+        const calculatedDelay = MAX_DELAY_MS / (this.text.length - this.i)
 
-            /**
-             * Calculate the delay from the remaining characters we know we have left to process
-             * This ensures that the typewriter effect will speed up if we start to fall behind.
-             */
-            const calculatedDelay = MAX_DELAY_MS / (updatedText.length - processedText.length)
+        /**
+         * We limit how small our delay can be to ensure we always have some form of typing effect.
+         */
+        const dynamicDelay = Math.max(calculatedDelay, MIN_DELAY_MS)
 
-            /**
-             * We limit how small our delay can be to ensure we always have some form of typing effect.
-             */
-            const dynamicDelay = Math.max(calculatedDelay, MIN_DELAY_MS)
+        /**
+         * To ensure we still can keep up with the updated text, we instead increase the character chunk size.
+         * We calculate this by working out how many characters we would need to maintain the same minimum delay.
+         * This ensures we always keep up with the text, no matter how large the incoming chunks are.
+         *
+         * Note: For particularly large chunks, this will result in a character chunk size that is far bigger than you would expect for a typing effect.
+         * This is an accepted trade-off in order to ensure we stay in sync with the incoming text.
+         */
+        const charChunkSize =
+            calculatedDelay < MIN_DELAY_MS ? Math.round(MIN_DELAY_MS / calculatedDelay) : MIN_CHAR_CHUNK_SIZE
 
-            /**
-             * To ensure we still can keep up with the updated text, we instead increase the character chunk size.
-             * We calculate this by working out how many characters we would need to maintain the same minimum delay.
-             * This ensures we always keep up with the text, no matter how large the incoming chunks are.
-             *
-             * Note: For particularly large chunks, this will result in a character chunk size that is far bigger than you would expect for a typing effect.
-             * This is an accepted trade-off in order to ensure we stay in sync with the incoming text.
-             */
-            const charChunkSize =
-                calculatedDelay < MIN_DELAY_MS ? Math.round(MIN_DELAY_MS / calculatedDelay) : MIN_CHAR_CHUNK_SIZE
+        this.interval = setInterval(() => {
+            this.i = Math.min(this.text.length, this.i + charChunkSize)
+            this.consumer.update(this.text.slice(0, this.i))
 
-            interval = setInterval(() => {
-                processedText += updatedText.slice(processedText.length, processedText.length + charChunkSize)
+            /** Clean up, notify when we have reached the end of the known remaining text. */
+            if (this.i === this.text.length) {
+                clearInterval(this.interval)
+                this.interval = undefined
 
-                /** Clean up, notify when we have reached the end of the known remaining text. */
-                if (isComplete()) {
-                    if (interval) {
-                        clearInterval(interval)
-                        interval = undefined
-                    }
-                    if (done) {
-                        done(processedText)
-                        done = writeAfterFlush
-                    }
+                if (this.upstreamClosed) {
+                    this.consumer.close()
+                    this.resolveFinished(this.text)
                 }
-
-                return emit(processedText)
-            }, dynamicDelay)
-        },
-        stop: () => {
-            if (interval) {
-                clearInterval(interval)
-                interval = undefined
             }
-            return emit(fullText)
-        },
+        }, dynamicDelay)
+    }
+
+    close(): void {
+        this.upstreamClosed = true
+    }
+
+    /** Stop the typewriter, immediately emit any remaining text */
+    stop(): void {
+        // Stop the animation
+        if (this.interval) {
+            clearInterval(this.interval)
+            this.interval = undefined
+        }
+        // Flush any pending content to the consumer.
+        if (this.i < this.text.length) {
+            this.consumer.update(this.text)
+        }
+        // Clean up the consumer, finished promise.
+        if (this.upstreamClosed) {
+            this.consumer.close()
+            this.resolveFinished(this.text)
+        } else {
+            this.rejectFinished(new Error('Typewriter stopped'))
+        }
     }
 }

--- a/lib/shared/src/chat/typewriter.ts
+++ b/lib/shared/src/chat/typewriter.ts
@@ -48,7 +48,7 @@ export class Typewriter implements IncrementalTextConsumer {
 
     // IncrementalTextConsumer implementation. The "write" side of the pipe.
 
-    update(content: string): void {
+    public update(content: string): void {
         if (this.upstreamClosed) {
             throw new Error('Typewriter already closed')
         }
@@ -105,12 +105,12 @@ export class Typewriter implements IncrementalTextConsumer {
         }, dynamicDelay)
     }
 
-    close(): void {
+    public close(): void {
         this.upstreamClosed = true
     }
 
     /** Stop the typewriter, immediately emit any remaining text */
-    stop(): void {
+    public stop(): void {
         // Stop the animation
         if (this.interval) {
             clearInterval(this.interval)

--- a/vscode/test/integration/chat.test.ts
+++ b/vscode/test/integration/chat.test.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode'
 
 import { MessageProvider } from '../../src/chat/MessageProvider'
 
-import { afterIntegrationTest, beforeIntegrationTest, getExtensionAPI, getTranscript } from './helpers'
+import { afterIntegrationTest, beforeIntegrationTest, getExtensionAPI, getTranscript, waitUntil } from './helpers'
 
 async function getChatViewProvider(): Promise<MessageProvider> {
     const chatViewProvider = await getExtensionAPI().exports.testing?.messageProvider.get()
@@ -22,6 +22,6 @@ suite('Chat', function () {
         await chatView.executeRecipe('chat-question', 'hello from the human')
 
         assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)
-        assert.match((await getTranscript(1)).displayText || '', /^hello from the assistant$/)
+        await waitUntil(async () => /^hello from the assistant$/.test((await getTranscript(1)).displayText || ''))
     })
 })

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -46,7 +46,7 @@ export async function ensureExecuteCommand<T>(command: string, ...args: any[]): 
     return result
 }
 
-async function waitUntil(predicate: () => Promise<boolean>): Promise<void> {
+export async function waitUntil(predicate: () => Promise<boolean>): Promise<void> {
     let delay = 10
     while (!(await predicate())) {
         await new Promise(resolve => setTimeout(resolve, delay))

--- a/vscode/test/integration/recipes.test.ts
+++ b/vscode/test/integration/recipes.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 
 import * as vscode from 'vscode'
 
-import { afterIntegrationTest, beforeIntegrationTest, getTranscript } from './helpers'
+import { afterIntegrationTest, beforeIntegrationTest, getTranscript, waitUntil } from './helpers'
 
 suite('Recipes', function () {
     this.beforeEach(() => beforeIntegrationTest())
@@ -24,6 +24,6 @@ suite('Recipes', function () {
         const humanMessage = await getTranscript(0)
         assert.match(humanMessage.displayText || '', /^\/explain/)
 
-        assert.match((await getTranscript(1)).displayText || '', /^hello from the assistant$/)
+        await waitUntil(async () => /^hello from the assistant$/.test((await getTranscript(1)).displayText || ''))
     })
 })


### PR DESCRIPTION
The Typewriter was integrated at a convenient point for other agents possibly, but it didn't work well for Cody-VScode. VScode's BotResponseMultiplexer buffers content to parse tags in the output, which chunks the incremental effect a bit. The typewriter also slowed down consumers like inline fixups which just want the complete code and don't care if it appears "typed."

Since then, Cody-VScode has added LLM turns for keyword expansion and context re-ranking. The typewriter effect also applied to these, needlessly slowing them down. For me these turns are about twice as fast now the typewriter is out of their path.

This moves the typewriter up to the MessageProvider, and only applies the typewriter effect to output destined for the chat sidebar. This makes all the code consumers faster because there's no animation delay. (The "typing" is very smooth now—maybe too smooth—because there's no coincidental chunking from the BotResponseMultiplexer.)

This adds a way for the consumer to drain the buffered content out of the typewriter while still "animating" it, `flush`. It indicates how much backpressure there was on the typewriter that we didn't really notice this "chunk at the end" behavior.

See #714.

## Test plan

```
pnpm test:unit && pnpm test:integration && pnpm test:e2e
```

Manual test:

1. Open Cody chat sidebar.
2. Ask it to enumerate the 50 states of the US in order of accession with their state flowers in a numbered list

The output should appear incrementally and completely.