### PR TITLE
Agent: Add clipboard to VS Code shim

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -299,6 +299,10 @@ const _env: Partial<typeof vscode.env> = {
     uriScheme: 'file',
     appRoot: process.cwd(),
     uiKind: UIKind.Web,
+    clipboard: {
+        readText: () => Promise.resolve(''),
+        writeText: () => Promise.resolve(),
+    },
 }
 export const env = _env as typeof vscode.env
 


### PR DESCRIPTION
I got an error previously, complaining about `env.clipboard.readText` miissing.

Added it in this PR.

## Test plan

Tested it with the JetBrains plugin. It builds and works with the new version of the shim, and the warning is gone.