### PR TITLE
Autocomplete: Use streaming to early-terminate Anthropic requests

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -237,7 +237,7 @@ export class Agent extends MessageHandler {
             setTranscript: () => {
                 // Not supported yet by agent.
             },
-            createCompletionsClient: config => new SourcegraphNodeCompletionsClient(config),
+            createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         })
     }
 }

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -8,6 +8,7 @@ export enum FeatureFlag {
     TestFlagDoNotUse = 'test-flag-do-not-use',
 
     CodyAutocompleteIncreasedDebounceTimeEnabled = 'cody-autocomplete-increased-debounce-time-enabled',
+    CodyAutocompleteStreamingResponse = 'cody-autocomplete-streaming-response',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/sourcegraph-api/completions/client.test.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.test.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/require-await */
+import { describe, expect, it } from 'vitest'
+
+import { createSSEIterator } from './client'
+
+describe('createSSEIterator', () => {
+    it('yields SSE messages from the iterator', async () => {
+        async function* createIterator(): AsyncIterableIterator<BufferSource> {
+            yield Buffer.from('event: completion\ndata: {"foo":"bar"}\n\n')
+            yield Buffer.from('event: completion\ndata: {"baz":"qux"}\n\n')
+        }
+
+        const messages = []
+        const iterator = createSSEIterator(createIterator())
+
+        for await (const message of iterator) {
+            messages.push(message)
+        }
+        expect(messages).toEqual([
+            { event: 'completion', data: '{"foo":"bar"}' },
+            { event: 'completion', data: '{"baz":"qux"}' },
+        ])
+    })
+
+    it('buffers partial responses', async () => {
+        async function* createIterator(): AsyncIterableIterator<BufferSource> {
+            yield Buffer.from('event: comple')
+            yield Buffer.from('tion\ndata: {"foo":"bar"}\n')
+            yield Buffer.from('\nevent: comple')
+            yield Buffer.from('tion\ndata: {"baz":"qux"}\n\n')
+        }
+
+        const messages = []
+        const iterator = createSSEIterator(createIterator())
+
+        for await (const message of iterator) {
+            messages.push(message)
+        }
+        expect(messages).toEqual([
+            { event: 'completion', data: '{"foo":"bar"}' },
+            { event: 'completion', data: '{"baz":"qux"}' },
+        ])
+    })
+
+    it('skips intermediate completion events', async () => {
+        async function* createIterator(): AsyncIterableIterator<BufferSource> {
+            yield Buffer.from('event: completion\ndata: {"foo":"bar"}\n\nevent: completion\ndata: {"baz":"qux"}\n\n')
+        }
+
+        const messages = []
+        const iterator = createSSEIterator(createIterator())
+
+        for await (const message of iterator) {
+            messages.push(message)
+        }
+        expect(messages).toEqual([{ event: 'completion', data: '{"baz":"qux"}' }])
+    })
+
+    it('handles `: ` in the event name', async () => {
+        async function* createIterator(): AsyncIterableIterator<BufferSource> {
+            yield Buffer.from('event: foo: bar\ndata: {"baz":"qux"}\n\n')
+        }
+
+        const messages = []
+        const iterator = createSSEIterator(createIterator())
+
+        for await (const message of iterator) {
+            messages.push(message)
+        }
+        expect(messages).toEqual([{ event: 'foo: bar', data: '{"baz":"qux"}' }])
+    })
+})

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -150,6 +150,7 @@ interface SSEMessage {
     data: string
 }
 
+const SSE_TERMINATOR = '\n\n'
 async function* createSSEDecoder(iterator: AsyncIterableIterator<BufferSource>): AsyncGenerator<SSEMessage> {
     let buffer = ''
     for await (const event of iterator) {
@@ -159,9 +160,9 @@ async function* createSSEDecoder(iterator: AsyncIterableIterator<BufferSource>):
         buffer += data
 
         let index: number
-        while ((index = buffer.indexOf('\n\n')) >= 0) {
+        while ((index = buffer.indexOf(SSE_TERMINATOR)) >= 0) {
             const message = buffer.slice(0, index)
-            buffer = buffer.slice(index + 2)
+            buffer = buffer.slice(index + SSE_TERMINATOR.length)
             messages.push(parseSSEEvent(message))
         }
 

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -1,3 +1,5 @@
+import fetch from 'isomorphic-fetch'
+
 import { ConfigurationWithAccessToken } from '../../configuration'
 
 import { CompletionCallbacks, CompletionParameters, CompletionResponse, Event } from './types'

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -165,9 +165,9 @@ async function* createSSEDecoder(iterator: AsyncIterableIterator<BufferSource>):
             messages.push(parseSSEEvent(message))
         }
 
-        // Here's a potential optimization because our current backend includes a repetition of the
+        // This is a potential optimization because our current backend includes a repetition of the
         // whole prior completion in each event. If more than one event is detected inside a chunk,
-        // we cam skip all but the last completion events.
+        // we can skip all but the last completion events.
         for (let i = 0; i < messages.length; i++) {
             if (
                 i + 1 < messages.length &&

--- a/lib/shared/src/test/mocks.ts
+++ b/lib/shared/src/test/mocks.ts
@@ -47,11 +47,15 @@ export class MockCompletionsClient extends SourcegraphCompletionsClient {
         throw new Error('mock stream is not implemented')
     }
 
-    public complete(params: CompletionParameters, abortSignal?: AbortSignal): Promise<CompletionResponse> {
+    public complete(
+        params: CompletionParameters,
+        onChunk?: (incompleteResponse: CompletionResponse) => void,
+        abortSignal?: AbortSignal
+    ): Promise<CompletionResponse> {
         if (!this.mocks.complete) {
             throw new Error('mock complete is not provided')
         }
-        return this.mocks.complete(params, abortSignal)
+        return this.mocks.complete(params, onChunk, abortSignal)
     }
 }
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Cody Commands: Display of clickable file path for current selection in chat view after executing a command. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Add a settings button to Cody pane header. [pull/701](https://github.com/sourcegraph/cody/pull/701)
 - Fixup: New `Discard` code lens to remove suggestions and decorations. [pull/711](https://github.com/sourcegraph/cody/pull/711)
+- Adds an experiment to stream autocomplete responses in order to improve latency. [pull/723](https://github.com/sourcegraph/cody/pull/723)
 
 ### Fixed
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -43,7 +43,7 @@ Support for Anthropic Claude, Claude 2, and OpenAI GPT-4/3.5, with more coming s
 
 ## Free Usage
 
-Cody is currently in beta, and includes free LLM usage for individual users on both personal and work code. While in beta, Cody is also available for free for all Sourcegraph Enterprise customers.
+Cody is currently in beta, and includes free LLM usage for individual users on both personal and work code. Fair use limits apply.
 
 ## Programming Languages
 
@@ -67,9 +67,7 @@ Embeddings for free Cody users are generated via the [Cody desktop app](https://
 
 ## Cody Enterprise
 
-Cody Enterprise requires the use of a Sourcegraph Enterprise instance, and gives you access to AI coding tools across your entire organization.
-
-If you’re a Sourcegraph Enterprise customer and would like to try Cody Enterprise, contact your technical advisor. If you’d like to set up a trial, [contact us](https://about.sourcegraph.com/contact/request-info) to discuss pricing and options.
+Cody Enterprise requires the use of a Sourcegraph Enterprise instance, and gives you access to AI coding tools across your entire organization. [Contact us](https://about.sourcegraph.com/contact/request-info) to set up a trial of Cody Enterprise. If you’re an existing Sourcegraph Enterprise customer, contact your technical advisor.
 
 ## Feedback
 

--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -180,7 +180,7 @@ describe('getInlineCompletions', () => {
             source: InlineCompletionsResultSource.Network,
         }))
 
-    test.only('preserves leading whitespace when prefix has no trailing whitespace', async () =>
+    test('preserves leading whitespace when prefix has no trailing whitespace', async () =>
         expect(
             await getInlineCompletions(
                 params('const isLocalHost = window.location.host█', [completion`├ === 'localhost'┤`])
@@ -1475,6 +1475,7 @@ describe('getInlineCompletions', () => {
                         async onNetworkRequest(_params, onPartialResponse) {
                             onPartialResponse?.(completion`├13┤`)
                             await nextTick()
+                            expect(abortController.signal.aborted).toBe(false)
                             onPartialResponse?.(completion`├1337\n┤`)
                             await nextTick()
                             expect(abortController.signal.aborted).toBe(true)

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -280,12 +280,11 @@ function getCompletionProviders({
     prefixPercentage,
     suffixPercentage,
     multiline,
-    docContext: { prefix, suffix },
+    docContext,
     toWorkspaceRelativePath,
 }: GetCompletionProvidersParams): Provider[] {
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
-        prefix,
-        suffix,
+        docContext,
         fileName: toWorkspaceRelativePath(document.uri),
         languageId: document.languageId,
         responsePercentage,

--- a/vscode/src/completions/processInlineCompletions.ts
+++ b/vscode/src/completions/processInlineCompletions.ts
@@ -68,6 +68,9 @@ export function processItem(
     item.insertText = trimUntilSuffix(item.insertText, prefix, suffix, document.languageId)
     item.insertText = collapseDuplicativeWhitespace(prefix, item.insertText)
 
+    // Trim start and end of the completion to remove all trailing whitespace.
+    item.insertText = item.insertText.trimEnd()
+
     return item
 }
 

--- a/vscode/src/completions/processInlineCompletions.ts
+++ b/vscode/src/completions/processInlineCompletions.ts
@@ -35,7 +35,7 @@ export function processInlineCompletions(
     return rankedResults
 }
 
-function processItem(
+export function processItem(
     item: InlineCompletionItem,
     {
         document,
@@ -56,6 +56,15 @@ function processItem(
         item.insertText = truncateMultilineCompletion(item.insertText, prefix, suffix, document.languageId)
         item.insertText = removeTrailingWhitespace(item.insertText)
     }
+
+    if (!multiline) {
+        // Only keep a single line in single-line completions mode
+        const indexOfNl = item.insertText.indexOf('\n')
+        if (indexOfNl !== -1) {
+            item.insertText = item.insertText.slice(0, indexOfNl + 1)
+        }
+    }
+
     item.insertText = trimUntilSuffix(item.insertText, prefix, suffix, document.languageId)
     item.insertText = collapseDuplicativeWhitespace(prefix, item.insertText)
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -2,8 +2,12 @@ import * as anthropic from '@anthropic-ai/sdk'
 
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
-import { CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import {
+    CompletionParameters,
+    CompletionResponse,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
+import { canUsePartialCompletion } from '../streaming'
 import {
     CLOSING_CODE_TAG,
     extractFromCodeBlock,
@@ -14,7 +18,7 @@ import {
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
 import { Completion, ContextSnippet } from '../types'
-import { batchCompletions, messagesToText } from '../utils'
+import { forkSignal, messagesToText } from '../utils'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
 
@@ -51,12 +55,12 @@ export class AnthropicProvider extends Provider {
 
     private createPromptPrefix(): { messages: Message[]; prefix: PrefixComponents } {
         // TODO(beyang): escape 'Human:' and 'Assistant:'
-        const prefixLines = this.options.prefix.split('\n')
+        const prefixLines = this.options.docContext.prefix.split('\n')
         if (prefixLines.length === 0) {
             throw new Error('no prefix lines')
         }
 
-        const { head, tail, overlap } = getHeadAndTail(this.options.prefix)
+        const { head, tail, overlap } = getHeadAndTail(this.options.docContext.prefix)
         const prefixMessages: Message[] = [
             {
                 speaker: 'human',
@@ -115,33 +119,6 @@ export class AnthropicProvider extends Provider {
         return { messages: [...referenceSnippetMessages, ...prefixMessages], prefix }
     }
 
-    private postProcess(rawResponse: string): string {
-        let completion = extractFromCodeBlock(rawResponse)
-
-        const trimmedPrefixContainNewline = this.options.prefix
-            .slice(this.options.prefix.trimEnd().length)
-            .includes('\n')
-        if (trimmedPrefixContainNewline) {
-            // The prefix already contains a `\n` that Claude was not aware of, so we remove any
-            // leading `\n` followed by whitespace that Claude might add.
-            completion = completion.replace(/^\s*\n\s*/, '')
-        } else {
-            completion = trimLeadingWhitespaceUntilNewline(completion)
-        }
-
-        // Remove bad symbols from the start of the completion string.
-        completion = fixBadCompletionStart(completion)
-
-        // Only keep a single line in single-line completions mode
-        if (!this.options.multiline) {
-            const lines = completion.split('\n')
-            completion = lines[0]
-        }
-
-        // Trim start and end of the completion to remove all trailing whitespace.
-        return completion.trimEnd()
-    }
-
     public async generateCompletions(
         abortSignal: AbortSignal,
         snippets: ContextSnippet[],
@@ -169,29 +146,95 @@ export class AnthropicProvider extends Provider {
         tracer?.params(args)
 
         // Issue request
-        const responses = await batchCompletions(this.completionsClient, args, this.options.n, abortSignal)
+        const responses = await this.batchAndProcessCompletions(
+            this.completionsClient,
+            args,
+            this.options.n,
+            abortSignal
+        )
 
         // Post-process
-        const ret = responses.map(resp => {
-            const content = this.postProcess(resp.completion)
-
-            if (content === null) {
-                return []
-            }
-
-            return [
-                {
-                    prefix: this.options.prefix,
-                    content,
-                    stopReason: resp.stopReason,
-                },
-            ]
-        })
+        const ret = responses.map(resp => [
+            {
+                prefix: this.options.docContext.prefix,
+                content: resp.completion,
+                stopReason: resp.stopReason,
+            },
+        ])
 
         const completions = ret.flat()
         tracer?.result({ rawResponses: responses, completions })
 
         return completions
+    }
+
+    private async batchAndProcessCompletions(
+        client: Pick<SourcegraphCompletionsClient, 'complete'>,
+        params: CompletionParameters,
+        n: number,
+        abortSignal: AbortSignal
+    ): Promise<CompletionResponse[]> {
+        const responses: Promise<CompletionResponse>[] = []
+        for (let i = 0; i < n; i++) {
+            responses.push(this.fetchAndProcessCompletions(client, params, abortSignal))
+        }
+        return Promise.all(responses)
+    }
+
+    private async fetchAndProcessCompletions(
+        client: Pick<SourcegraphCompletionsClient, 'complete'>,
+        params: CompletionParameters,
+        abortSignal: AbortSignal
+    ): Promise<CompletionResponse> {
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
+        return new Promise(async (resolve, reject) => {
+            try {
+                const abortController = forkSignal(abortSignal)
+
+                const result = await client.complete(
+                    params,
+                    (incompleteResponse: CompletionResponse) => {
+                        const processedCompletion = this.postProcess(incompleteResponse.completion)
+                        if (
+                            canUsePartialCompletion(processedCompletion, {
+                                document: { languageId: this.options.languageId },
+                                multiline: this.options.multiline,
+                                docContext: this.options.docContext,
+                            })
+                        ) {
+                            resolve({ ...incompleteResponse, completion: processedCompletion })
+                            abortController.abort()
+                        }
+                    },
+                    abortController.signal
+                )
+
+                resolve({ ...result, completion: this.postProcess(result.completion) })
+            } catch (error) {
+                reject(error)
+            }
+        })
+    }
+
+    private postProcess(rawResponse: string): string {
+        let completion = extractFromCodeBlock(rawResponse)
+
+        const trimmedPrefixContainNewline = this.options.docContext.prefix
+            .slice(this.options.docContext.prefix.trimEnd().length)
+            .includes('\n')
+        if (trimmedPrefixContainNewline) {
+            // The prefix already contains a `\n` that Claude was not aware of, so we remove any
+            // leading `\n` followed by whitespace that Claude might add.
+            completion = completion.replace(/^\s*\n\s*/, '')
+        } else {
+            completion = trimLeadingWhitespaceUntilNewline(completion)
+        }
+
+        // Remove bad symbols from the start of the completion string.
+        completion = fixBadCompletionStart(completion)
+
+        // Trim start and end of the completion to remove all trailing whitespace.
+        return completion.trimEnd()
     }
 }
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -233,8 +233,7 @@ export class AnthropicProvider extends Provider {
         // Remove bad symbols from the start of the completion string.
         completion = fixBadCompletionStart(completion)
 
-        // Trim start and end of the completion to remove all trailing whitespace.
-        return completion.trimEnd()
+        return completion
     }
 }
 

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -1,5 +1,6 @@
 import { CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
+import { DocumentContext } from '../document'
 import { Completion, ContextSnippet } from '../types'
 
 export interface ProviderConfig {
@@ -37,11 +38,10 @@ export interface ProviderConfig {
 }
 
 export interface ProviderOptions {
-    /** A unique and descriptive identifier for the provider. */
+    // A unique and descriptive identifier for the provider.
     id: string
 
-    prefix: string
-    suffix: string
+    docContext: DocumentContext
     fileName: string
     languageId: string
     multiline: boolean

--- a/vscode/src/completions/providers/unstable-azure-openai.ts
+++ b/vscode/src/completions/providers/unstable-azure-openai.ts
@@ -43,7 +43,7 @@ export class UnstableAzureOpenAIProvider extends Provider {
     }
 
     public async generateCompletions(abortSignal: AbortSignal, snippets: ContextSnippet[]): Promise<Completion[]> {
-        const { head, tail } = getHeadAndTail(this.options.prefix)
+        const { head, tail } = getHeadAndTail(this.options.docContext.prefix)
 
         // Create prompt
         // Although we are using gpt-35-turbo in text completion
@@ -94,7 +94,7 @@ export class UnstableAzureOpenAIProvider extends Provider {
         const results = json.choices
             .map(choice => ({
                 messages: prompt,
-                prefix: this.options.prefix,
+                prefix: this.options.docContext.prefix,
                 content: postProcess(choice.text),
             }))
             // Omit any empty completion

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -21,7 +21,7 @@ export class UnstableCodeGenProvider extends Provider {
     }
 
     public async generateCompletions(abortSignal: AbortSignal, snippets: ContextSnippet[]): Promise<Completion[]> {
-        const { prefix, suffix } = this.options
+        const { prefix, suffix } = this.options.docContext
         const suffixAfterFirstNewline = suffix.slice(suffix.indexOf('\n'))
 
         const params = {
@@ -60,10 +60,7 @@ export class UnstableCodeGenProvider extends Provider {
             const completions: string[] = data.completions.map(c => postProcess(c.completion, this.options.multiline))
             log?.onComplete(completions)
 
-            return completions.map(content => ({
-                prefix: this.options.prefix,
-                content,
-            }))
+            return completions.map(content => ({ content }))
         } catch (error: any) {
             if (!isAbortError(error)) {
                 log?.onError(error)

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -28,7 +28,7 @@ export class UnstableFireworksProvider extends Provider {
 
     private createPrompt(snippets: ContextSnippet[]): string {
         const maxPromptChars = CONTEXT_WINDOW_CHARS - CONTEXT_WINDOW_CHARS * this.options.responsePercentage
-        const { prefix, suffix } = this.options
+        const { prefix, suffix } = this.options.docContext
 
         const intro: string[] = []
         let prompt = ''
@@ -113,7 +113,6 @@ export class UnstableFireworksProvider extends Provider {
             log?.onComplete(completions.map(c => c.content))
 
             return completions.map(c => ({
-                prefix: this.options.prefix,
                 content: c.content,
                 stopReason: c.stopReason,
             }))

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -28,7 +28,7 @@ export class UnstableHuggingFaceProvider extends Provider {
 
     private createPrompt(snippets: ContextSnippet[]): string {
         const maxPromptChars = CONTEXT_WINDOW_CHARS - CONTEXT_WINDOW_CHARS * this.options.responsePercentage
-        const { prefix, suffix } = this.options
+        const { prefix, suffix } = this.options.docContext
 
         const intro: string[] = []
         let prompt = ''
@@ -109,7 +109,6 @@ export class UnstableHuggingFaceProvider extends Provider {
             log?.onComplete(completions)
 
             return completions.map(content => ({
-                prefix: this.options.prefix,
                 content,
             }))
         } catch (error: any) {

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -25,8 +25,7 @@ class MockProvider extends Provider {
 function createProvider(prefix: string) {
     return new MockProvider({
         id: 'mock-provider',
-        prefix,
-        suffix: '',
+        docContext: docState(prefix).docContext,
         fileName: '',
         languageId: 'typescript',
         multiline: false,

--- a/vscode/src/completions/streaming.ts
+++ b/vscode/src/completions/streaming.ts
@@ -1,5 +1,6 @@
 import { truncateMultilineCompletion } from './multiline'
 import { ProcessInlineCompletionsParams } from './processInlineCompletions'
+import { trimUntilSuffix } from './text-processing'
 
 /**
  * Evaluates a partial completion response and returns true when we can already use it. This is used
@@ -10,7 +11,7 @@ import { ProcessInlineCompletionsParams } from './processInlineCompletions'
  *  1. When a single line completion is requested, it terminates after the first full line was
  *     received.
  *  2. For a multi-line completion, it terminates when the completion will be truncated based on the
- *     multi-line indentation logic.
+ *     multi-line indentation logic or an eventual match with a line already in the editor.
  */
 export function canUsePartialCompletion(
     partialResponse: string,
@@ -31,7 +32,9 @@ export function canUsePartialCompletion(
     const completion = partialResponse.slice(0, lastNlIndex)
 
     if (multiline) {
-        const truncated = truncateMultilineCompletion(completion, prefix, suffix, document.languageId)
+        let truncated = truncateMultilineCompletion(completion, prefix, suffix, document.languageId)
+        truncated = trimUntilSuffix(truncated, prefix, suffix, document.languageId)
+
         return truncated.split('\n').length < completion.split('\n').length
     }
 

--- a/vscode/src/completions/streaming.ts
+++ b/vscode/src/completions/streaming.ts
@@ -1,0 +1,40 @@
+import { truncateMultilineCompletion } from './multiline'
+import { ProcessInlineCompletionsParams } from './processInlineCompletions'
+
+/**
+ * Evaluates a partial completion response and returns true when we can already use it. This is used
+ * to terminate any streaming responses where we can get a token-by-token access to the result and
+ * want to terminate as soon as stop conditions are triggered.
+ *
+ * Right now this handles two cases:
+ *  1. When a single line completion is requested, it terminates after the first full line was
+ *     received.
+ *  2. For a multi-line completion, it terminates when the completion will be truncated based on the
+ *     multi-line indentation logic.
+ */
+export function canUsePartialCompletion(
+    partialResponse: string,
+    {
+        document,
+        multiline,
+        docContext: { prefix, suffix },
+    }: Pick<ProcessInlineCompletionsParams, 'document' | 'multiline' | 'docContext'>
+): boolean {
+    const lastNlIndex = partialResponse.lastIndexOf('\n')
+
+    // If there is no `\n` in the completion, we have not received a single full line yet
+    if (lastNlIndex === -1) {
+        return false
+    }
+
+    // The last line might not be complete yet, so we discard it
+    const completion = partialResponse.slice(0, lastNlIndex)
+
+    if (multiline) {
+        const truncated = truncateMultilineCompletion(completion, prefix, suffix, document.languageId)
+        return truncated.split('\n').length < completion.split('\n').length
+    }
+
+    const isNonEmptyLine = completion.trim() !== ''
+    return isNonEmptyLine
+}

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -86,7 +86,7 @@ function renderWebviewHtml(data: ProvideInlineCompletionsItemTraceData | undefin
 ## Completers
 
 ${data.completers?.map(
-    ({ id, prefix, suffix, ...otherOptions }) =>
+    ({ id, docContext: { prefix, suffix }, ...otherOptions }) =>
         `
 ### ${id}
 
@@ -270,6 +270,6 @@ function jsonForDataset(data: ProvideInlineCompletionsItemTraceData | undefined)
         context: ${JSON.stringify(data?.context?.context.map(c => ({ fileName: c.fileName, content: c.content })))},
         fileName: ${JSON.stringify(completer.fileName)},
         languageId: ${JSON.stringify(completer.languageId)},
-        content: \`${completer.prefix}$\{CURSOR}${completer.suffix}\`,
+        content: \`${completer.docContext.prefix}$\{CURSOR}${completer.docContext.suffix}\`,
     }`
 }

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -1,11 +1,6 @@
 import * as anthropic from '@anthropic-ai/sdk'
 
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
-import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
-import {
-    CompletionParameters,
-    CompletionResponse,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
 export function messagesToText(messages: Message[]): string {
     return messages
@@ -31,19 +26,6 @@ export function lastNLines(text: string, n: number): string {
     return lines.slice(Math.max(0, lines.length - n)).join('\n')
 }
 
-export async function batchCompletions(
-    client: Pick<SourcegraphCompletionsClient, 'complete'>,
-    params: CompletionParameters,
-    n: number,
-    abortSignal: AbortSignal
-): Promise<CompletionResponse[]> {
-    const responses: Promise<CompletionResponse>[] = []
-    for (let i = 0; i < n; i++) {
-        responses.push(client.complete(params, abortSignal))
-    }
-    return Promise.all(responses)
-}
-
 export function isAbortError(error: Error): boolean {
     return (
         // http module
@@ -52,4 +34,20 @@ export function isAbortError(error: Error): boolean {
         error.message.includes('The operation was aborted') ||
         error.message.includes('The user aborted a request')
     )
+}
+
+/**
+ * Creates a new signal that forks a parent signal. When the parent signal is aborted, the forked
+ * signal will be aborted as well. This allows propagating abort signals across asynchronous
+ * operations.
+ *
+ * Aborting the forked controller however does not affect the parent.
+ */
+export function forkSignal(signal: AbortSignal): AbortController {
+    const controller = new AbortController()
+    if (signal.aborted) {
+        controller.abort()
+    }
+    signal.addEventListener('abort', () => controller.abort())
+    return controller
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -113,7 +113,7 @@ const register = async (
     const config = getConfiguration(workspaceConfig)
 
     const {
-        sourcegraphGraphQLAPIClient,
+        featureFlagProvider,
         intentDetector,
         codebaseContext: initialCodebaseContext,
         chatClient,
@@ -124,8 +124,6 @@ const register = async (
 
     const authProvider = new AuthProvider(initialConfig, secretStorage, localStorage, telemetryService)
     await authProvider.init()
-
-    const featureFlagProvider = new FeatureFlagProvider(sourcegraphGraphQLAPIClient)
 
     const contextProvider = new ContextProvider(
         initialConfig,

--- a/vscode/test/completions/mock-vscode.ts
+++ b/vscode/test/completions/mock-vscode.ts
@@ -25,7 +25,9 @@ const vscodeMock = {
                         case 'cody.autocomplete.enabled':
                             return true
                         case 'cody.serverEndpoint':
-                            return 'https://sourcegraph.com'
+                            return 'http://sourcegraph.test:3080/'
+                        case 'cody.autocomplete.advanced.provider':
+                            return 'anthropic'
                         default:
                             return undefined
                     }


### PR DESCRIPTION
This adds a backward-compatible support for using the new streaming backend added in https://github.com/sourcegraph/sourcegraph/pull/55967.

It currently only works in Node.js because the node-fetch polyfill we use returns native Node streams and not unified browser streams. However given that browser support is not official right now, I decided that for now (especially until we know this experiment is giving us wins) it's not worth to add a separate implementation.

This all works by the new `stream` bool option on the server. When set and the server has the changes in https://github.com/sourcegraph/sourcegraph/pull/55967, we return an SSE event stream. On the client, we can check the header values for wether we got a streaming response and use that.

Architecture wise this is not super nice yet and duplicates some code of post-processing to find out if the request is already finished. There are three econditions to detect wether a streaming response is "fullfilled" right now:

1. A single-line completion can be terminated if we have one non-empty full line of response
2. A multi-line completion can be terminated if the multi-line truncation logic (which currently uses indentation but might later use tree sitter) starts to truncate the answer
3. 2. A multi-line completion can be terminated if a line inside the new completion matches one that is already inside the document

## Test plan

Tested in combination with https://github.com/sourcegraph/sourcegraph/pull/55967 and sourcegraph.com (which is behind this change)

 - Run [sourcegraph/sourcegraph#55967](https://github.com/sourcegraph/sourcegraph/pull/55967) as a local SG server
 - Set up Cody VS Code to connect to localhost
 - Check out https://github.com/sourcegraph/cody/pull/723
 - Start a dev instance and see that completions will work and might be faster
   - I've tested this with our completion testing tool but since we only have a handful of examples and don't do a bazillion test runs, there's a log of variance in the early results. 
   - We can roll this out as an A/B test very easily (cc @taras-yemets)

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
