### PR TITLE
Agent: always build parent directory first

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -12,7 +12,7 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "node ./src/esbuild.mjs",
+    "build": "cd .. && pnpm build && cd agent && node ./src/esbuild.mjs",
     "agent": "pnpm run build && node dist/index.js",
     "build-ts": "tsc --build",
     "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t latest-linux-arm64,latest-linux-x64,latest-macos-arm64,latest-macos-x64,latest-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",


### PR DESCRIPTION
We have two cases of this fixing an error related to `Could not resolve "@sourcegraph/cody-shared"`


## Test plan

n/a
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
