### PR TITLE
Autocomplete: Do not trigger a multi-line request for a method invocation

### DIFF
--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -583,6 +583,18 @@ describe('getInlineCompletions', () => {
             expect(requests[0].stopSequences).not.toContain('\n')
         })
 
+        test('does not trigger a multi-line completion at a method call', async () => {
+            const requests: CompletionParameters[] = []
+            await getInlineCompletions(
+                params('foo.bar(█', [], {
+                    onNetworkRequest(request) {
+                        requests.push(request)
+                    },
+                })
+            )
+            expect(requests).toHaveLength(1)
+        })
+
         test('uses an indentation based approach to cut-off completions', async () => {
             const items = await getInlineCompletionsInsertText(
                 params(

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -21,6 +21,11 @@ export function detectMultiline(
     }
 
     if (enableExtendedTriggers && currentLinePrefix.match(OPENING_BRACKET_REGEX)) {
+        // @TODO: Use tree sitter to detect a method call instead of this
+        if (currentLinePrefix.match(/\..*\($/)) {
+            return false
+        }
+
         return true
     }
 


### PR DESCRIPTION
A quick workaround for https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606 that just doesn't trigger a multi-line completion if the prefix matches `/\..*\($/)` (so a `.` and ends with `(`).

The idea is to use tree sitter and language analysis to detect this case but that's a quick fix that should cover a large range of languages without causing too much harm. WDYT @vovakulikov @valerybugakov?

## Test plan

- Added a test case

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
