### PR TITLE
Don't trigger multiline completion in case of function or method invocation

### DIFF
--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -583,6 +583,30 @@ describe('getInlineCompletions', () => {
             expect(requests[0].stopSequences).not.toContain('\n')
         })
 
+        test('does not trigger a multi-line completion at a function call', async () => {
+            const requests: CompletionParameters[] = []
+            await getInlineCompletions(
+                params('bar(█)', [], {
+                    onNetworkRequest(request) {
+                        requests.push(request)
+                    },
+                })
+            )
+            expect(requests).toHaveLength(1)
+        })
+
+        test('does not trigger a multi-line completion at a method call', async () => {
+            const requests: CompletionParameters[] = []
+            await getInlineCompletions(
+                params('foo.bar(█)', [], {
+                    onNetworkRequest(request) {
+                        requests.push(request)
+                    },
+                })
+            )
+            expect(requests).toHaveLength(1)
+        })
+
         test('uses an indentation based approach to cut-off completions', async () => {
             const items = await getInlineCompletionsInsertText(
                 params(

--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -607,6 +607,18 @@ describe('getInlineCompletions', () => {
             expect(requests).toHaveLength(1)
         })
 
+        test('trigger a multi-line completion at a method declarations', async () => {
+            const requests: CompletionParameters[] = []
+            await getInlineCompletions(
+                params('method.hello () { █', [], {
+                    onNetworkRequest(request) {
+                        requests.push(request)
+                    },
+                })
+            )
+            expect(requests).toHaveLength(1)
+        })
+
         test('uses an indentation based approach to cut-off completions', async () => {
             const items = await getInlineCompletionsInsertText(
                 params(

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -3,7 +3,12 @@ import detectIndent from 'detect-indent'
 import { DocumentContext } from './document'
 import { getLanguageConfig } from './language'
 import { indentation } from './text-processing'
-import { getEditorTabSize, OPENING_BRACKET_REGEX, shouldIncludeClosingLine } from './utils/text-utils'
+import {
+    FUNCTION_OR_METHOD_INVOCATION_REGEX,
+    getEditorTabSize,
+    OPENING_BRACKET_REGEX,
+    shouldIncludeClosingLine,
+} from './utils/text-utils'
 
 export function detectMultiline(
     {
@@ -17,6 +22,12 @@ export function detectMultiline(
 ): boolean {
     const config = getLanguageConfig(languageId)
     if (!config) {
+        return false
+    }
+
+    // Don't fire multiline completion for method or function invocations
+    // see https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606
+    if ((currentLinePrefix + currentLineSuffix).match(FUNCTION_OR_METHOD_INVOCATION_REGEX)) {
         return false
     }
 

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -4,6 +4,7 @@ import { DocumentContext } from './document'
 import { getLanguageConfig } from './language'
 import { indentation } from './text-processing'
 import {
+    FUNCTION_KEYWORDS,
     FUNCTION_OR_METHOD_INVOCATION_REGEX,
     getEditorTabSize,
     OPENING_BRACKET_REGEX,
@@ -27,7 +28,10 @@ export function detectMultiline(
 
     // Don't fire multiline completion for method or function invocations
     // see https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606
-    if ((currentLinePrefix + currentLineSuffix).match(FUNCTION_OR_METHOD_INVOCATION_REGEX)) {
+    if (
+        !currentLinePrefix.trim().match(FUNCTION_KEYWORDS) &&
+        (currentLinePrefix + currentLineSuffix).match(FUNCTION_OR_METHOD_INVOCATION_REGEX)
+    ) {
         return false
     }
 

--- a/vscode/src/completions/multiline.ts
+++ b/vscode/src/completions/multiline.ts
@@ -26,11 +26,14 @@ export function detectMultiline(
         return false
     }
 
+    const checkInvocation =
+        currentLineSuffix.trim().length > 0 ? currentLinePrefix + currentLineSuffix : currentLinePrefix
+
     // Don't fire multiline completion for method or function invocations
     // see https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606
     if (
         !currentLinePrefix.trim().match(FUNCTION_KEYWORDS) &&
-        (currentLinePrefix + currentLineSuffix).match(FUNCTION_OR_METHOD_INVOCATION_REGEX)
+        checkInvocation.match(FUNCTION_OR_METHOD_INVOCATION_REGEX)
     ) {
         return false
     }

--- a/vscode/src/completions/utils/text-utils.ts
+++ b/vscode/src/completions/utils/text-utils.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 export const INDENTATION_REGEX = /^[\t ]*/
 export const OPENING_BRACKET_REGEX = /([([{])$/
+export const FUNCTION_OR_METHOD_INVOCATION_REGEX = /\b[^()]+\((.*)\)$/g
 
 export const BRACKET_PAIR = {
     '(': ')',

--- a/vscode/src/completions/utils/text-utils.ts
+++ b/vscode/src/completions/utils/text-utils.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 export const INDENTATION_REGEX = /^[\t ]*/
 export const OPENING_BRACKET_REGEX = /([([{])$/
 export const FUNCTION_OR_METHOD_INVOCATION_REGEX = /\b[^()]+\((.*)\)$/g
+export const FUNCTION_KEYWORDS = /^(function|def|fn)/g
 
 export const BRACKET_PAIR = {
     '(': ')',


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606

As it is described in GH discussion, we shouldn't make multiline completion for cases like function or method 
invocation (but we should do this in case of method or function declaration). 

So this PR gates multiline completion behind this regexp check (regexp isn't ideal, but this is what we have to
work with until we get parsers working) You can check this regexp [here](https://regex101.com/r/k85odc/1)

## Test plan
- Check that completion doesn't try to do multiline complete if your cursor is within arguments
position of function or method invocation/call statement 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
