### PR TITLE
Autocomplete: Include up to a single new line in the Anthropic prompt

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Inline Chat: Fix issue where state was not being set correctly, causing Cody Commands to use the selection range from the last created Inline Chat instead of the current selection. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Commands that use the current file as context now correctly generate context message for the current file instead of using codebase context generated from current selection. [pull/683](https://github.com/sourcegraph/cody/pull/683)
+- Improves the autocomplete responses on a new line after a comment [pull/]()
 
 ### Changed
 

--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -1426,6 +1426,30 @@ describe('getInlineCompletions', () => {
         expect(requests[0].stopSequences).toEqual(['\n\nHuman:', '</CODE5711>', '\n\n'])
     })
 
+    test('trims whitespace in the prefix but keeps one \n', async () => {
+        const requests: CompletionParameters[] = []
+        await getInlineCompletions(
+            params(
+                dedent`
+            class Range {
+
+
+                █
+            }
+        `,
+                [],
+                {
+                    onNetworkRequest(request) {
+                        requests.push(request)
+                    },
+                }
+            )
+        )
+        expect(requests).toHaveLength(3)
+        const messages = requests[0].messages
+        expect(messages[messages.length - 1].text).toBe('Here is the code: <CODE5711>class Range {\n')
+    })
+
     test('synthesizes a completion from a prior request', async () => {
         // Reuse the same request manager for both requests in this test
         const requestManager = new RequestManager()


### PR DESCRIPTION
 We learned that Anthropic is giving us worse results with trailing whitespace in the prompt.
 To fix this, we started to trim the prompt.

 However, when the prefix includes a line break, the LLM needs to know that we do not want the
 current line to complete and instead start a new one. For this specific case, we're injecting
 a line break in the trimmed prefix.

 This will only be added if the existing line is otherwise empty and will help especially with
 cases like users typing a comment and asking the LLM to provide a suggestion for the next
 line of code:

     // Write some code
     █


## Test plan

- Added a test case

### Before

<img width="947" alt="Screenshot 2023-08-17 at 17 53 06" src="https://github.com/sourcegraph/cody/assets/458591/33c4158c-23f4-4035-a0b8-b2e67b82efa5">


### After

<img width="522" alt="Screenshot 2023-08-17 at 18 04 44" src="https://github.com/sourcegraph/cody/assets/458591/5581c075-513a-42d8-aced-8c56bf106273">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
