### PR TITLE
update dotcomUrl

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -342,7 +342,7 @@ export class SourcegraphGraphQLAPIClient {
             return {}
         }
         if (new URL(this.config.serverEndpoint).hostname === new URL (this.dotcomUrl).hostname) {
-            return this.sendEventLogRequestToDotComAPI(event)
+            return this.sendEventLogRequestToAPI(event)
         }
         const responses = await Promise.all([
             this.sendEventLogRequestToAPI(event),

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -169,7 +169,8 @@ interface event {
 }
 
 export class SourcegraphGraphQLAPIClient {
-    private dotcomUrl = 'https://sourcegraph.com/'
+    private dotcomUrl = 'https://sourcegraph.com'
+    private dotcomHostname = 'sourcegraph.com'
 
     constructor(
         private config: Pick<
@@ -341,7 +342,7 @@ export class SourcegraphGraphQLAPIClient {
         if (this.config.isRunningInsideAgent) {
             return {}
         }
-        if (this.config.serverEndpoint === this.dotcomUrl) {
+        if (new URL(this.config.serverEndpoint).hostname === this.dotcomHostname) {
             return this.sendEventLogRequestToDotComAPI(event)
         }
         const responses = await Promise.all([

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -170,7 +170,6 @@ interface event {
 
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = 'https://sourcegraph.com'
-    private dotcomHostname = 'sourcegraph.com'
 
     constructor(
         private config: Pick<
@@ -342,7 +341,7 @@ export class SourcegraphGraphQLAPIClient {
         if (this.config.isRunningInsideAgent) {
             return {}
         }
-        if (new URL(this.config.serverEndpoint).hostname === this.dotcomHostname) {
+        if (new URL(this.config.serverEndpoint).hostname === new URL (this.dotcomUrl).hostname) {
             return this.sendEventLogRequestToDotComAPI(event)
         }
         const responses = await Promise.all([

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -169,7 +169,7 @@ interface event {
 }
 
 export class SourcegraphGraphQLAPIClient {
-    private dotcomUrl = 'https://sourcegraph.com'
+    private dotcomUrl = 'https://sourcegraph.com/'
 
     constructor(
         private config: Pick<

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -341,7 +341,7 @@ export class SourcegraphGraphQLAPIClient {
         if (this.config.isRunningInsideAgent) {
             return {}
         }
-        if (new URL(this.config.serverEndpoint).hostname === new URL (this.dotcomUrl).hostname) {
+        if (new URL(this.config.serverEndpoint).hostname === new URL(this.dotcomUrl).hostname) {
             return this.sendEventLogRequestToAPI(event)
         }
         const responses = await Promise.all([


### PR DESCRIPTION
This PR does two things:
- update the if statement that sends events to dotcom to do a match on hostname (avoids issue with serverEndpoint and dotcomUrl not matching because `"sourcegraph.com" != "sourcegraph.com/"`
- sends to sendEventLogRequestToAPI to have proper user_ids.


## Test plan
tested locally

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
