### PR TITLE
Agent: recipes/execute - handle empty selection

### DIFF
--- a/agent/src/editor.ts
+++ b/agent/src/editor.ts
@@ -55,6 +55,14 @@ export class AgentEditor implements Editor {
             return null
         }
         const offsets = new DocumentOffsets(document)
+        if (!document.selection) {
+            return {
+                fileName: document.filePath ?? '',
+                precedingText: document.content ?? '',
+                selectedText: '',
+                followingText: '',
+            }
+        }
         const from = offsets.offset(document.selection.start)
         const to = offsets.offset(document.selection.end)
         return {


### PR DESCRIPTION
Previously, the agent crashed when executing a recipe when the client hadn't provided any text document selection.


## Test plan

- Start IntelliJ with an open file but no selection
- Send a chat message. Nothing happened, it was stuck in processing mode and the "Stop generating" button is just there.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
