### PR TITLE
Add increased autocomplete debounce time feature flag support

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Compute suggestions based on the currently selected option in the suggest widget when `cody.autocomplete.experimental.completeSuggestWidgetSelection` is enabled. [pull/636](https://github.com/sourcegraph/cody/pull/636)
 - Fixup: New `Discard` code lens to remove suggestions and decorations. [pull/711](https://github.com/sourcegraph/cody/pull/711)
 - New chat message input, with auto-resizing and a command button. [pull/718](https://github.com/sourcegraph/cody/pull/718)
+- Increased autocomplete debounce time feature flag support [pull/733](https://github.com/sourcegraph/cody/pull/733)
 
 ### Fixed
 

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
@@ -66,7 +66,7 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
                 completionsClient: null as any,
                 contextWindowTokens: 2048,
             }),
-            featureFlagProvider: dummyFeatureFlagProvider
+            featureFlagProvider: dummyFeatureFlagProvider,
 
             ...superArgs,
         })

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
@@ -2,6 +2,9 @@ import dedent from 'dedent'
 import { describe, expect, test, vi } from 'vitest'
 import type * as vscode from 'vscode'
 
+import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+
+import { FeatureFlagProvider } from '../services/FeatureFlagProvider'
 import { vsCodeMocks } from '../testutils/mocks'
 
 import { getInlineCompletions, InlineCompletionsResultSource } from './getInlineCompletions'
@@ -34,6 +37,14 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
     triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
 }
 
+const dummyFeatureFlagProvider = new FeatureFlagProvider(
+    new SourcegraphGraphQLAPIClient({
+        accessToken: 'access-token',
+        serverEndpoint: 'https://sourcegraph.com',
+        customHeaders: {},
+    })
+)
+
 class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider {
     constructor(
         mockGetInlineCompletions: typeof getInlineCompletions,
@@ -55,6 +66,7 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
                 completionsClient: null as any,
                 contextWindowTokens: 2048,
             }),
+            featureFlagProvider: dummyFeatureFlagProvider
 
             ...superArgs,
         })

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -466,7 +466,8 @@ function createCompletionsProvider(
     config: Configuration,
     completionsClient: SourcegraphCompletionsClient,
     statusBar: CodyStatusBar,
-    contextProvider: ContextProvider
+    contextProvider: ContextProvider,
+    featureFlagProvider: FeatureFlagProvider
 ): vscode.Disposable {
     const disposables: vscode.Disposable[] = []
 
@@ -480,6 +481,7 @@ function createCompletionsProvider(
             getCodebaseContext: () => contextProvider.context,
             isEmbeddingsContextEnabled: config.autocompleteAdvancedEmbeddings,
             completeSuggestWidgetSelection: config.autocompleteExperimentalCompleteSuggestWidgetSelection,
+            featureFlagProvider,
         })
 
         disposables.push(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -421,7 +421,13 @@ const register = async (
             completionsProvider.dispose()
         }
 
-        completionsProvider = createCompletionsProvider(config, completionsClient, statusBar, contextProvider)
+        completionsProvider = createCompletionsProvider(
+            config,
+            completionsClient,
+            statusBar,
+            contextProvider,
+            featureFlagProvider
+        )
     }
     vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration('cody.autocomplete')) {

--- a/vscode/src/services/FeatureFlagProvider.ts
+++ b/vscode/src/services/FeatureFlagProvider.ts
@@ -2,7 +2,7 @@ import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/source
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 export enum FeatureFlag {
-    EmbeddingsContextEnabled = 'cody-embeddings-context-enabled',
+    CodyAutocompleteIncreasedDebounceTimeEnabled = 'cody-autocomplete-increased-debounce-time-enabled',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -9,6 +9,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { NoopEditor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
+import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { GetContextResult } from '../../src/completions/context/context'
@@ -17,6 +18,7 @@ import { createProviderConfig } from '../../src/completions/providers/createProv
 import { InlineCompletionItemProvider } from '../../src/completions/vscodeInlineCompletionItemProvider'
 import { getFullConfig } from '../../src/configuration'
 import { configureExternalServices } from '../../src/external-services'
+import { FeatureFlagProvider } from '../../src/services/FeatureFlagProvider'
 import { InMemorySecretStorage } from '../../src/services/SecretStorageProvider'
 import { wrapVSCodeTextDocument } from '../../src/testutils/textDocument'
 
@@ -26,6 +28,14 @@ import { findSubstringPosition } from './utils'
 
 let didLogConfig = false
 let providerName: string
+
+const dummyFeatureFlagProvider = new FeatureFlagProvider(
+    new SourcegraphGraphQLAPIClient({
+        accessToken: 'access-token',
+        serverEndpoint: 'https://sourcegraph.com',
+        customHeaders: {},
+    })
+)
 
 async function initCompletionsProvider(context: GetContextResult): Promise<InlineCompletionItemProvider> {
     const secretStorage = new InMemorySecretStorage()
@@ -67,6 +77,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
         getCodebaseContext: () => codebaseContext,
         isEmbeddingsContextEnabled: true,
         contextFetcher: () => Promise.resolve(context),
+        featureFlagProvider: dummyFeatureFlagProvider,
     })
 
     return completionsProvider


### PR DESCRIPTION
Tweak single-line autocomplete debounce time depending on `'cody-autocomplete-increased-debounce-time-enabled'` feature flag value. 

## Test plan
As we restrict feature flags evaluation only to dotcom users, the actual events data should be checked on dotcom instance `event_logs` table ([docs](https://docs.sourcegraph.com/dev/how-to/use_feature_flags#measure-the-effect-of-a-feature-flag)). 
During the development I tested the functionality in the following way:
- remove (comment out) `isDotCom` condition in `FeatureFlagProvider` methods
- run local Sourcegraph instance (`sg start`)
- log in to the local instance as admin and add `'cody-autocomplete-increased-debounce-time-enabled'` feature flag
- sign it to the local Sourcegraph instance in Cody VSCode extension
- launch the VSCode extension from the VSCode Run&Debug menu
- perform a Cody completion action and check whether the correct timeout is used depending on the feature flag value
- double-check feature flag value using the GraphQL API
```
query Name {
  evaluateFeatureFlag(flagName: "cody-autocomplete-increased-debounce-time-enabled")
} 
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
