### PR TITLE
Agent: add requests for logging events and to find user ID

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -196,6 +196,24 @@ export class Agent extends MessageHandler {
                 return { items: [] }
             }
         })
+
+        this.registerRequest('graphql/currentUserId', async () => {
+            const client = await this.client
+            if (!client) {
+                throw new Error('Cody client not initialized')
+            }
+            const id = await client.graphqlClient.getCurrentUserId()
+            if (typeof id === 'string') {
+                return id
+            }
+
+            throw id
+        })
+        this.registerRequest('graphql/logEvent', async event => {
+            const client = await this.client
+            await client?.graphqlClient.logEvent(event)
+            return null
+        })
     }
 
     private setClient(config: ExtensionConfiguration): void {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { event } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 // This file documents the Cody Agent JSON-RPC protocol. Consult the JSON-RPC
 // specification to learn about how JSON-RPC works https://www.jsonrpc.org/specification
@@ -33,6 +34,9 @@ export type Requests = {
     'recipes/execute': [ExecuteRecipeParams, null]
 
     'autocomplete/execute': [AutocompleteParams, AutocompleteResult]
+
+    'graphql/currentUserId': [null, string]
+    'graphql/logEvent': [event, null]
 
     // ================
     // Server -> Client

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -51,6 +51,7 @@ export interface Client {
     codebaseContext: CodebaseContext
     sourcegraphStatus: { authenticated: boolean; version: string }
     codyStatus: { enabled: boolean; version: string }
+    graphqlClient: SourcegraphGraphQLAPIClient
 }
 
 export async function createClient({
@@ -191,6 +192,7 @@ export async function createClient({
             codebaseContext,
             sourcegraphStatus,
             codyStatus,
+            graphqlClient,
         }
     }
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -171,7 +171,7 @@ function extractDataOrError<T, R>(response: APIResponse<T> | Error, extract: (da
     return extract(response.data)
 }
 
-interface event {
+export interface event {
     event: string
     userCookieID: string
     url: string


### PR DESCRIPTION
Previously, the JetBrains plugin still sent direct network requests to the Sourcegraph instance. This was problematic because it meant that users behind proxies had to configure both proxy settings for the agent and for the Java plugin. This PR adds two endpoints to the Agent protocol allowing the JetBrains plugin to send requests to the Agent instead of sending network requests to Sourcegraph.

## Test plan

Tested alongside JetBrains PR
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
