### PR TITLE
Agent: disable telemetry only via the shim

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -93,6 +93,12 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.serverEndpoint
             case 'cody.customHeaders':
                 return connectionConfig?.customHeaders
+            case 'cody.telemetry.level':
+                // Use the dedicated `graphql/logEvent` to send telemetry from
+                // agent clients.  The reason we disable telemetry via config is
+                // that we don't want to submit vscode-specific events when
+                // running inside the agent.
+                return 'off'
             case 'cody.autocomplete.enabled':
                 return true
             case 'cody.autocomplete.advanced.provider':

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -183,19 +183,15 @@ export interface event {
     hashedLicenseKey?: string
 }
 
+type GraphQLAPIClientConfig = Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'> &
+    Pick<Partial<ConfigurationWithAccessToken>, 'telemetryLevel'>
+
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = 'https://sourcegraph.com'
 
-    constructor(
-        private config: Pick<
-            ConfigurationWithAccessToken,
-            'serverEndpoint' | 'accessToken' | 'customHeaders' | 'isRunningInsideAgent'
-        >
-    ) {}
+    constructor(private config: GraphQLAPIClientConfig) {}
 
-    public onConfigurationChange(
-        newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>
-    ): void {
+    public onConfigurationChange(newConfig: GraphQLAPIClientConfig): void {
         this.config = newConfig
     }
 
@@ -353,7 +349,7 @@ export class SourcegraphGraphQLAPIClient {
             console.log(`not logging ${event.event} in test mode`)
             return {}
         }
-        if (this.config.isRunningInsideAgent) {
+        if (this.config?.telemetryLevel === 'off') {
             return {}
         }
         if (this.isDotCom()) {


### PR DESCRIPTION
Previously, we used the `isRunningInsideAgent` config to determine whether telemetry should be disable or not. This solution had the problem that we actually want to send telemetry from the agent when the client sends the recently added `graphql/logEvent` request. We just want to disable telemetry for vscode-specific events.

This PR fixes the problem by reverting the previous `isRunningInsideAgent` check and adds a check based on the `cody.telemetry.level` configuration setting. The shim hardcodes the value to `'off'` making telemetry disabled when running inside the agent, while the telmetry level defaults to `'all'` when we manually construct the GraphQL client.


## Test plan

Manually tested the following steps with @chwarwick 

- Added `console.log({event: event.name, telemetry: this.config.telemetryLevel})` to the `logEvent` handler in the GQL client
- Started latest JB plugin with current build
- Triggered autocomplete, verified that all the events are JetBrains specific. Verified that no VSCode events are submitted.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
