### PR TITLE
log custom command only

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -574,9 +574,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             case /^\/f(ix)?\s.*$/.test(text):
                 return { text, recipeId: 'fixup' }
             case /^\/(explain|doc|test|smell)$/.test(text):
-                this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:called`, {
-                    source: 'chat',
-                })
             default: {
                 if (!this.editor.getActiveTextEditor()?.filePath) {
                     await this.addCustomInteraction('Command failed. Please open a file and try again.', text)

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -574,6 +574,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             case /^\/f(ix)?\s.*$/.test(text):
                 return { text, recipeId: 'fixup' }
             case /^\/(explain|doc|test|smell)$/.test(text):
+                this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:called`, {
+                    source: 'chat',
+                })
             default: {
                 if (!this.editor.getActiveTextEditor()?.filePath) {
                     await this.addCustomInteraction('Command failed. Please open a file and try again.', text)

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -118,8 +118,11 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             this.lastUsedCommands.add(id)
         }
 
-        const commandName = myPrompt?.type === 'default' ? myPrompt.slashCommand?.replace('/', '') : 'custom'
-        this.telemetryService.log(`CodyVSCodeExtension:command:${commandName}:called`)
+        // Log custom command usage
+        if (myPrompt?.type !== 'default') {
+            this.telemetryService.log('CodyVSCodeExtension:command:custom:called')
+        }
+
         return myPrompt?.prompt || ''
     }
 


### PR DESCRIPTION
Since we are already logging default command being called in MessageProvider, we should only log custom command in the command controller.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

check output channel to confirm default commands are not being logged twice.