### PR TITLE
Agent: Log arguments need to be strings 

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -211,6 +211,13 @@ export class Agent extends MessageHandler {
         })
         this.registerRequest('graphql/logEvent', async event => {
             const client = await this.client
+            if (typeof event.argument === 'object') {
+                event.argument = JSON.stringify(event.argument)
+            }
+            if (typeof event.publicArgument === 'object') {
+                event.publicArgument = JSON.stringify(event.publicArgument)
+            }
+            console.error(JSON.stringify(event))
             await client?.graphqlClient.logEvent(event)
             return null
         })


### PR DESCRIPTION
GraphQL mutations to record log events were failing from agent because arguments and public arguments are required to be strings. 


## Test plan
./gradlew -PforceAgentBuild=true :runIde
Added logging in agent to ensure log mutation requests were successful. 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
