### PR TITLE
New welcome chat words

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -30,6 +30,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Cody Commands: Show errors in chat view instead of notification windows. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Match commands on description in Cody menu [pull/702](https://github.com/sourcegraph/cody/pull/702)
 - Cody Commands: Don't require Esc to dismiss Cody menu. [pull/700](https://github.com/sourcegraph/cody/pull/700)
+- Updated welcome chat words. [pull/748](https://github.com/sourcegraph/cody/pull/748)
 
 ## [0.6.7]
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -150,9 +150,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             // down here to render cody is disabled on the instance nicely.
             isCodyEnabled={true}
             codyNotEnabledNotice={undefined}
-            afterMarkdown={
-                '🔔 Recipes are now [Cody Commands](command:cody.action.commands.menu)! You can start using them with the [⌥C](command:cody.action.commands.menu) shortcut on highlighted code. \n\nSee [Getting Started](command:cody.welcome) to learn more about [Cody Commands](command:cody.action.commands.menu).'
-            }
+            afterMarkdown={welcomeMessageMarkdown}
             helpMarkdown=""
             ChatButtonComponent={ChatButton}
             pluginsDevMode={pluginsDevMode}
@@ -358,3 +356,10 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({ classN
         </div>
     )
 }
+
+const welcomeMessageMarkdown = `Start writing code and I’ll autocomplete lines and entire functions for you.
+
+You can ask me to explain, document and refactor code using the [Cody Commands](command:cody.action.commands.menu) action (⌥C), or by right-clicking on code and using the “Cody” menu.
+
+See the [Getting Started](command:cody.welcome) guide for more tips and tricks.
+`


### PR DESCRIPTION
Partially implements #633 with new welcome message text:

<img width="1008" alt="Screenshot 2023-08-21 at 7 53 34 pm" src="https://github.com/sourcegraph/cody/assets/153/a1dcee1e-8f0f-4c39-b41a-312bae6d7da0">

Reason for the partial implementation is that there's currently no way to embed images or a component in the welcome markdown, so we couldn't include the illustrations as per the Figma.

Closes #633

## Test plan

- Started a new chat, verified welcome text