### PR TITLE
throttle updates of context to chat sidebar

### DIFF
--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash'
 import * as vscode from 'vscode'
 
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
@@ -194,10 +195,12 @@ export class ContextProvider implements vscode.Disposable {
                 },
             })
         }
-        this.disposables.push(this.configurationChangeEvent.event(() => send()))
-        this.disposables.push(vscode.window.onDidChangeActiveTextEditor(() => send()))
-        this.disposables.push(vscode.window.onDidChangeTextEditorSelection(() => send()))
-        return send()
+        const throttledSend = throttle(send, 250, { leading: true, trailing: true })
+
+        this.disposables.push(this.configurationChangeEvent.event(() => throttledSend()))
+        this.disposables.push(vscode.window.onDidChangeActiveTextEditor(() => throttledSend()))
+        this.disposables.push(vscode.window.onDidChangeTextEditorSelection(() => throttledSend()))
+        return throttledSend()
     }
 
     /**


### PR DESCRIPTION
This should reduce the amount of needless work done when the user (for example) holds down the arrow key in a document to change the cursor position.



## Test plan

Switch files while the sidebar is open and confirm the new filename is shown at the bottom.