### PR TITLE
improve 2 Cody text labels

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -105,7 +105,7 @@ export class FixupController
         const fixupFile = this.files.forUri(documentUri)
         const task = new FixupTask(fixupFile, instruction, selectionRange)
         this.tasks.set(task.id, task)
-        this.setTaskState(task, CodyTaskState.asking)
+        this.setTaskState(task, CodyTaskState.working)
         return task
     }
 
@@ -167,7 +167,7 @@ export class FixupController
             return
         }
         void vscode.window.showInformationMessage('Cody will rewrite to include your changes')
-        this.setTaskState(task, CodyTaskState.asking)
+        this.setTaskState(task, CodyTaskState.working)
         return undefined
     }
 
@@ -310,7 +310,7 @@ export class FixupController
         if (!task) {
             return Promise.resolve()
         }
-        if (task.state !== CodyTaskState.asking) {
+        if (task.state !== CodyTaskState.working) {
             // TODO: Update this when we re-spin tasks with conflicts so that
             // we store the new text but can also display something reasonably
             // stable in the editor
@@ -502,10 +502,10 @@ export class FixupController
         // TODO: These state transition actions were moved from FixupTask, but
         // it is wrong for a single task to toggle the cody.fixup.running state.
         // There's more than one task.
-        if (oldState !== CodyTaskState.asking && task.state === CodyTaskState.asking) {
+        if (oldState !== CodyTaskState.working && task.state === CodyTaskState.working) {
             task.spinCount++
             void vscode.commands.executeCommand('setContext', 'cody.fixup.running', true)
-        } else if (oldState === CodyTaskState.asking && task.state !== CodyTaskState.asking) {
+        } else if (oldState === CodyTaskState.working && task.state !== CodyTaskState.working) {
             void vscode.commands.executeCommand('setContext', 'cody.fixup.running', false)
         }
 

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -48,7 +48,7 @@ export class FixupTypingUI {
 
     private async getInstructionFromQuickPick({
         title = 'Cody',
-        placeholder = "Tell Cody what to do, or type ' / ' for commands",
+        placeholder = "Tell Cody what to do, or type '/' for commands",
         value = '',
         prefix = '',
     } = {}): Promise<string> {

--- a/vscode/src/non-stop/TaskViewProvider.ts
+++ b/vscode/src/non-stop/TaskViewProvider.ts
@@ -117,7 +117,7 @@ export class TaskViewProvider implements vscode.TreeDataProvider<FixupTaskTreeIt
 
 export class FixupTaskTreeItem extends vscode.TreeItem {
     // TODO: Don't duplicate the task state here; use the FixupTask directly.
-    private state: CodyTaskState = CodyTaskState.asking
+    private state: CodyTaskState = CodyTaskState.working
     public fsPath: string
 
     // state for parent node
@@ -169,7 +169,7 @@ export class FixupTaskTreeItem extends vscode.TreeItem {
         let ready = tasksSize - failedSize
 
         switch (state) {
-            case CodyTaskState.asking:
+            case CodyTaskState.working:
                 text += ', 1 running'
                 ready--
                 break

--- a/vscode/src/non-stop/codelenses.ts
+++ b/vscode/src/non-stop/codelenses.ts
@@ -9,8 +9,8 @@ import { CodyTaskState } from './utils'
 export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
     const codeLensRange = getSingleLineRange(task.selectionRange.start.line)
     switch (task.state) {
-        case CodyTaskState.asking: {
-            const title = getAskingLens(codeLensRange)
+        case CodyTaskState.working: {
+            const title = getWorkingLens(codeLensRange)
             const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
@@ -47,10 +47,10 @@ function getErrorLens(codeLensRange: vscode.Range): vscode.CodeLens {
     return lens
 }
 
-function getAskingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+function getWorkingLens(codeLensRange: vscode.Range): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
-        title: '$(sync~spin) Asking Cody...',
+        title: '$(sync~spin) Cody is working...',
         command: 'cody.focus',
     }
     return lens

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -1,6 +1,6 @@
 export enum CodyTaskState {
     'idle' = 1,
-    'asking' = 2,
+    'working' = 2,
     'ready' = 3,
     'applying' = 4,
     'fixed' = 5,
@@ -24,8 +24,8 @@ export const fixupTaskList: CodyTaskList = {
         icon: 'clock',
         description: 'Initial state',
     },
-    [CodyTaskState.asking]: {
-        id: 'asking',
+    [CodyTaskState.working]: {
+        id: 'working',
         icon: 'sync~spin',
         description: 'Cody is preparing a response',
     },

--- a/vscode/src/services/CodeLensProvider.ts
+++ b/vscode/src/services/CodeLensProvider.ts
@@ -46,7 +46,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
         vscode.workspace.onDidCloseTextDocument(e => this.removeOnFSPath(e.uri))
         vscode.workspace.onDidSaveTextDocument(e => this.removeOnFSPath(e.uri))
 
-        this.updateState(CodyTaskState.asking, thread.range)
+        this.updateState(CodyTaskState.working, thread.range)
     }
 
     /**
@@ -115,7 +115,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
      * Check if the file path is the same
      */
     private removeOnFSPath(uri: vscode.Uri): void {
-        if (this.status === CodyTaskState.asking) {
+        if (this.status === CodyTaskState.working) {
             return
         }
         if (uri.fsPath === this.thread.uri.fsPath) {
@@ -126,7 +126,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
      * Check if it is in pending state
      */
     public isPending(): boolean {
-        return this.status === CodyTaskState.asking
+        return this.status === CodyTaskState.working
     }
     /**
      * Dispose the disposables
@@ -143,7 +143,7 @@ function getLenses(id: string, codeLensRange: vscode.Range, isPending: boolean):
     const title = new vscode.CodeLens(codeLensRange)
     // Open Chat View
     title.command = {
-        title: isPending ? '$(sync~spin) Asking Cody...' : '✨ Edited by Cody',
+        title: isPending ? '$(sync~spin) Cody is working...' : '✨ Edited by Cody',
         tooltip: 'Open Cody chat view',
         command: 'cody.focus',
     }

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -404,7 +404,7 @@ export class InlineController implements VsCodeInlineController {
      */
     private async runFixMode(comment: Comment, thread: vscode.CommentThread): Promise<void> {
         const lens = await this.makeCodeLenses(comment.id, this.extensionPath, thread)
-        lens.updateState(CodyTaskState.asking, thread.range)
+        lens.updateState(CodyTaskState.working, thread.range)
         this.codeLenses.set(comment.id, lens)
         this.currentTaskId = comment.id
         void vscode.commands.executeCommand('workbench.action.collapseAllComments')

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -35,7 +35,7 @@ test('decorations from un-applied Cody changes appear', async ({ page, sidebar }
     await page.getByRole('option', { name: 'Refactor This Code' }).click()
 
     // Wait for the input box to appear
-    await page.getByPlaceholder("Tell Cody what to do, or type ' / ' for commands").click()
+    await page.getByPlaceholder("Tell Cody what to do, or type '/' for commands").click()
     // Type in the instruction for fixup
     await page.keyboard.type('replace hello with goodbye')
     // Press enter to submit the fixup

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -32,7 +32,7 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     await page.getByRole('option', { name: 'Refactor This Code' }).click()
 
     // Wait for the input box to appear
-    await page.getByPlaceholder("Tell Cody what to do, or type ' / ' for commands").click()
+    await page.getByPlaceholder("Tell Cody what to do, or type '/' for commands").click()
     // Type in the instruction for fixup
     await page.keyboard.type('replace hello with goodbye')
     // Press enter to submit the fixup


### PR DESCRIPTION
- Use "Cody is working" label instead of "Asking Cody". "Working" makes sense for inline refactors *and* questions. "Asking" makes less sense for inline refactors.
- Eliminate weird-looking spaces in `' / '`.

## Test plan

n/a