### PR TITLE
lib/shared: add arg to optionally initialize chat with a specific scope

### DIFF
--- a/lib/shared/src/chat/useClient.ts
+++ b/lib/shared/src/chat/useClient.ts
@@ -56,7 +56,7 @@ export interface CodyClient {
         messageId?: string | undefined,
         scope?: CodyClientScope
     ) => Promise<Transcript | null>
-    initializeNewChat: () => Transcript | null
+    initializeNewChat: (newScope?: Partial<CodyClientScope>) => Transcript | null
     executeRecipe: (
         recipeId: RecipeID,
         options?: {
@@ -225,25 +225,28 @@ export const useClient = ({
         [graphqlClient]
     )
 
-    const initializeNewChat = useCallback((): Transcript | null => {
-        if (config.needsEmailVerification) {
-            return transcript
-        }
-        const newTranscript = new Transcript()
-        setIsMessageInProgressState(false)
-        setTranscriptState(newTranscript)
-        setChatMessagesState(newTranscript.toChat())
-        setScopeState(scope => ({
-            includeInferredRepository: true,
-            includeInferredFile: true,
-            repositories: [],
-            editor: scope.editor,
-        }))
+    const initializeNewChat = useCallback(
+        (initialScope?: Partial<CodyClientScope>): Transcript | null => {
+            if (config.needsEmailVerification) {
+                return transcript
+            }
+            const newTranscript = new Transcript()
+            setIsMessageInProgressState(false)
+            setTranscriptState(newTranscript)
+            setChatMessagesState(newTranscript.toChat())
+            setScopeState(scope => ({
+                includeInferredRepository: initialScope?.includeInferredFile ?? true,
+                includeInferredFile: initialScope?.includeInferredFile ?? true,
+                repositories: initialScope?.repositories ?? [],
+                editor: initialScope?.editor ?? scope.editor,
+            }))
 
-        onEvent?.('initializedNewChat')
+            onEvent?.('initializedNewChat')
 
-        return newTranscript
-    }, [onEvent, config.needsEmailVerification, transcript])
+            return newTranscript
+        },
+        [onEvent, config.needsEmailVerification, transcript]
+    )
 
     const executeRecipe = useCallback(
         async (


### PR DESCRIPTION
Pre-req for https://github.com/sourcegraph/sourcegraph/issues/55363. Updates the signature of `CodyClient.initializeNewChat()` to accept an optional arg `newScope` which, if provided, will be used to set the new transcript's scope state. Retains the same defaults if arg is omitted. 

## Test plan

Manual testing with/without arg provided. Ensure unit tests still pass.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
