### PR TITLE
Typewriter outputs larger chunks, up to short phrases

### DIFF
--- a/lib/shared/src/chat/typewriter.test.ts
+++ b/lib/shared/src/chat/typewriter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Typewriter } from './typewriter'
+
+describe('TypeWriter', () => {
+    it('closes the downstream consumer, no output', async () => {
+        const update = vi.fn(() => {})
+        const close = vi.fn(() => {})
+        const tw = new Typewriter({
+            update,
+            close,
+        })
+        tw.close()
+        await tw.finished
+        expect(update).toHaveBeenCalledTimes(0)
+        expect(close).toHaveBeenCalledTimes(1)
+    })
+    it('completes output before closing the downstream consumer', async () => {
+        let lastText = ''
+        const update = (s: string) => {
+            lastText = s
+        }
+        const close = vi.fn(() => {})
+        const tw = new Typewriter({
+            update,
+            close,
+        })
+        tw.update('hel')
+        tw.update('hello world')
+        tw.close()
+        await tw.finished
+        expect(lastText).toBe('hello world')
+        expect(close).toHaveBeenCalledTimes(1)
+    })
+    it('breaks the output into typed "chunks"', async () => {
+        let updateCallCount = 0
+        const update = () => {
+            updateCallCount++
+        }
+        const close = vi.fn(() => {})
+        const tw = new Typewriter({
+            update,
+            close,
+        })
+        const message = 'i am the very model of a modern major general, of information animal, mineral and vegetable'
+        tw.update(message)
+        tw.close()
+        await tw.finished
+        // This doesn't test the heuristic very precisely but should catch
+        // obvious issues like not breaking at all or very short chunks
+        expect(updateCallCount).toBeGreaterThan(message.length / 20)
+        expect(updateCallCount).toBeLessThan(message.length)
+        expect(close).toHaveBeenCalledTimes(1)
+    })
+    it('supplies the output as successively longer strings', async () => {
+        const lastUpdate = ''
+        const update = (s: string) => {
+            expect(s.slice(0, lastUpdate.length)).toEqual(lastUpdate)
+        }
+        const tw = new Typewriter({
+            update,
+            close: () => {},
+        })
+        const message = 'no matter how many white swans are found, it does not prove that there are no black swans'
+        tw.update(message)
+        tw.close()
+        await tw.finished
+    })
+})

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -17,6 +17,7 @@
     "webpack.config.js",
     "package.json",
     ".storybook/*.ts",
+    "../lib/shared/src/chat/typewriter.ts",
     "../lib/shared/src/telemetry/EventLogger.ts",
     "test/completions/completions-dataset.ts",
   ],


### PR DESCRIPTION
This simplifies the typewriter effect so that it doesn't change speed depending on the amount of pressure behind the typewriter. It also types in larger chunks. See #714.

## Test plan

```
pnpm test -- typewriter.test.ts
```

Manual test:

1. Open Cody-VScode and chat to it: "Explain Rust IterMut with examples." Typing should be incremental but be in chunks and generally hit word boundaries.
2. Cmd-Shift-P, Configure Display Language, 日本語 (ja), follow prompts to restart.
3. Chat to Cody: "RustのIterMutを例で説明して". Typing should be incremental—though monotonous—even in passages without spaces.