### PR TITLE
Autocomplete: Log errors

### DIFF
--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -15,7 +15,7 @@ import { RequestManager, RequestParams } from './request-manager'
 import { reuseLastCandidate } from './reuse-last-candidate'
 import { ProvideInlineCompletionsItemTraceData } from './tracer'
 import { InlineCompletionItem } from './types'
-import { isAbortError, isRateLimitError, SNIPPET_WINDOW_SIZE } from './utils'
+import { isAbortError, SNIPPET_WINDOW_SIZE } from './utils'
 
 export interface InlineCompletionsParams {
     // Context
@@ -122,13 +122,10 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
 
         params.tracer?.({ error: error.toString() })
         debug('getInlineCompletions:error', error.message, { verbose: error })
+        CompletionLogger.logError(error)
 
         if (isAbortError(error)) {
             return null
-        }
-
-        if (!isRateLimitError(error)) {
-            CompletionLogger.logCompletionEvent('error', { error: error.message })
         }
 
         throw error

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -36,6 +36,10 @@ export function isAbortError(error: Error): boolean {
     )
 }
 
+export function isRateLimitError(error: Error): boolean {
+    return error.message.includes('you exceeded the rate limit')
+}
+
 /**
  * Creates a new signal that forks a parent signal. When the parent signal is aborted, the forked
  * signal will be aborted as well. This allows propagating abort signals across asynchronous


### PR DESCRIPTION
Start to log unexpected errors during autocomplete (so everything that is not an abort error or a rate limiting error). To avoid overflowing the events log, errors are logged as cumulative counts grouped by the message with the first event logged immediately and every subsequent requests being debounced by a 5 minute timer.

## Test plan
- Open the VS Code extension in dev mode
- Open the outputs panel for Cody
- Disable your network connection
- Observe the following to only be logged once in the output console

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:completion:error {"message":"request to https://sourcegraph.com/.api/completions/code failed, reason: getaddrinfo ENOTFOUND sourcegraph.com","count":1}
``` 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
