### PR TITLE
Autocomplete: Abort network requests when a completion request is resolved with a previously started request's response

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -31,6 +31,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Cody Commands: Match commands on description in Cody menu [pull/702](https://github.com/sourcegraph/cody/pull/702)
 - Cody Commands: Don't require Esc to dismiss Cody menu. [pull/700](https://github.com/sourcegraph/cody/pull/700)
 - Updated welcome chat words. [pull/748](https://github.com/sourcegraph/cody/pull/748)
+- Autocomplete: Reduce network bandwidth with requests are resolved by previous responses. [pull/762](https://github.com/sourcegraph/cody/pull/762)
 
 ## [0.6.7]
 

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -10,6 +10,7 @@ import { getNextNonEmptyLine, getPrevNonEmptyLine } from './utils/text-utils'
 
 class MockProvider extends Provider {
     public didFinishNetworkRequest = false
+    public didAbort = false
     protected resolve: (completion: Completion[]) => void = () => {}
 
     public resolveRequest(completions: string[]): void {
@@ -17,7 +18,10 @@ class MockProvider extends Provider {
         this.resolve(completions.map(content => ({ content })))
     }
 
-    public generateCompletions(): Promise<Completion[]> {
+    public generateCompletions(abortSignal: AbortSignal): Promise<Completion[]> {
+        abortSignal.addEventListener('abort', () => {
+            this.didAbort = true
+        })
         return new Promise(resolve => {
             this.resolve = resolve
         })
@@ -160,5 +164,23 @@ describe('RequestManager', () => {
 
         // Ensure that the completed network request does not cause issues
         provider2.resolveRequest(["'world')"])
+    })
+
+    it('aborts a newer request if a prior request resolves it', async () => {
+        const prefix1 = 'console.'
+        const provider1 = createProvider(prefix1)
+        const promise1 = createRequest(prefix1, provider1)
+
+        const prefix2 = 'console.log('
+        const provider2 = createProvider(prefix2)
+        const promise2 = createRequest(prefix2, provider2)
+
+        provider1.resolveRequest(["log('hello')"])
+
+        expect((await promise1).completions[0].insertText).toBe("log('hello')")
+        const { completions } = await promise2
+        expect(completions[0].insertText).toBe("'hello')")
+
+        expect(provider2.didAbort).toBe(true)
     })
 })


### PR DESCRIPTION
Right now, a completion can be resolved while the network request is still being in progress if a previous completion request matches the new editor text. This happens in ~10% of situations and was responsible for a small increase in latency.

I noticed that we did not abort the request if that is the case though and we still used the second response to the seed the cache. I think in this case, this is not necessary since we already have a completion that matches and that we consider a "match" for the given prefix. I think that we should rather preserve the costs and network bandwidth in this case.

To think through this:

- 👉 User starts by typing `console.l` and waits a few MS
- ➡️ We start request 1 with the prefix `console.`
- 👉 User continues to type until it reaches `console.log`
- ➡️ We start request 2 with the prefix `console.log`
- ⬅️ Request 1 resolves with `console.log('hello world')`
   - We detect this can also apply to request 2 so we resolve request number 1 and 2 with this value
- ⬅️ (later) Request 2 resolves with something else (e.g. `console.log('foobar')`). Since 2 was already resolved, we only put this into the network request for the exact  `console.log` prefix that we already resolved before.

## Test plan

Added a test case to ensure the abort signal is being propagated in that case

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
