### PR TITLE
Do not init inline controller on startup when disabled

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -23,6 +23,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Inline Chat: Fix issue where state was not being set correctly, causing Cody Commands to use the selection range from the last created Inline Chat instead of the current selection. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Commands that use the current file as context now correctly generate context message for the current file instead of using codebase context generated from current selection. [pull/683](https://github.com/sourcegraph/cody/pull/683)
 - Improves the autocomplete responses on a new line after a comment [pull/]()
+- Fixes an issue where the inline chat UI would render briefly when starting VS Code even when the feature is disabled. [pull/]()
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -23,7 +23,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Inline Chat: Fix issue where state was not being set correctly, causing Cody Commands to use the selection range from the last created Inline Chat instead of the current selection. [pull/602](https://github.com/sourcegraph/cody/pull/602)
 - Cody Commands: Commands that use the current file as context now correctly generate context message for the current file instead of using codebase context generated from current selection. [pull/683](https://github.com/sourcegraph/cody/pull/683)
 - Improves the autocomplete responses on a new line after a comment [pull/]()
-- Fixes an issue where the inline chat UI would render briefly when starting VS Code even when the feature is disabled. [pull/]()
+- Fixes an issue where the inline chat UI would render briefly when starting VS Code even when the feature is disabled. [pull/764](https://github.com/sourcegraph/cody/pull/764)
 
 ### Changed
 

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -67,8 +67,15 @@ export class InlineController implements VsCodeInlineController {
     ) {
         this.codyIcon = getIconPath('cody', this.extensionPath)
         this.userIcon = getIconPath('user', this.extensionPath)
-        this.commentController = this.init()
-        this._disposables.push(this.commentController)
+
+        const config = vscode.workspace.getConfiguration('cody')
+        const enableInlineChat = config.get('inlineChat.enabled') as boolean
+
+        if (enableInlineChat) {
+            this.commentController = this.init()
+            this._disposables.push(this.commentController)
+        }
+
         // Toggle Inline Chat on Config Change
         vscode.workspace.onDidChangeConfiguration(e => {
             const config = vscode.workspace.getConfiguration('cody')


### PR DESCRIPTION
When the inline chat is disabled, we'd still show the comment thread UI during extension startup before we "fix" it by removing it again. This is causing unnecessary visual churn so we now check the settings right away.

## Test plan


https://github.com/sourcegraph/cody/assets/458591/51f9e2a7-91d1-4fbc-9555-49cb68fd211f



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
