### PR TITLE
Unblock VS Code release by removing the web build

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -16,7 +16,7 @@
     "dev:web": "pnpm run -s build:dev:web && pnpm run -s _dev:vscode-test-web --browserType none",
     "watch:dev:web": "concurrently \"pnpm run -s watch:build:dev:web\" \"pnpm run -s _dev:vscode-test-web --browserType none\"",
     "_dev:vscode-test-web": "vscode-test-web --extensionDevelopmentPath=. ${WORKSPACE-test/fixtures/workspace}",
-    "build": "tsc --build && pnpm run -s _build:esbuild:desktop && pnpm run -s _build:esbuild:web && pnpm run -s _build:webviews --mode production",
+    "build": "tsc --build && pnpm run -s _build:esbuild:desktop && pnpm run -s _build:webviews --mode production",
     "_build:desktop": "pnpm run -s _build:esbuild:desktop && pnpm run -s _build:webviews --mode production",
     "_build:web": "pnpm run -s _build:esbuild:web && pnpm run -s _build:webviews --mode production",
     "build:dev:desktop": "concurrently \"pnpm run -s _build:esbuild:desktop\" \"pnpm run -s _build:webviews --mode development\"",


### PR DESCRIPTION
Unblocking the VS Code release by removing the web build temporarily 

## Test plan

```
α vscode (ps/rm-web-build)
pnpm run build

> cody-ai@0.8.0 build /Users/philipp/dev/cody/vscode
> tsc --build && pnpm run -s _build:esbuild:desktop && pnpm run -s _build:webviews --mode production


  dist/extension.node.js      6.0mb ⚠️
  dist/extension.node.js.map  9.6mb

⚡ Done in 144ms
vite v4.4.3 building for production...
✓ 438 modules transformed.
../dist/webviews/index.html                0.78 kB
../dist/webviews/codicon-2d58c995.ttf     70.78 kB
../dist/webviews/index-024934e3.css       57.90 kB
../dist/webviews/index.js              1,759.42 kB │ map: 12,839.48 kB
✓ built in 2.20s
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
