### PR TITLE
Unblock the VS Code build #2 - Remove the web build from package.json

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -92,7 +92,6 @@
     "vscode": "^1.79.0"
   },
   "main": "./dist/extension.node.js",
-  "browser": "./dist/extension.web.js",
   "activationEvents": [
     "onStartupFinished"
   ],


### PR DESCRIPTION
## Test plan

This builds now for real 😓 

```
α vscode (main)✗
pnpm vsce package --no-dependencies
Executing prepublish script 'npm run vscode:prepublish'...

> cody-ai@0.8.0 vscode:prepublish
> pnpm -s run build


  dist/extension.node.js      6.0mb ⚠️
  dist/extension.node.js.map  9.6mb

⚡ Done in 149ms
vite v4.4.3 building for production...
✓ 438 modules transformed.
../dist/webviews/index.html                0.78 kB
../dist/webviews/codicon-2d58c995.ttf     70.78 kB
../dist/webviews/index-024934e3.css       57.90 kB
../dist/webviews/index.js              1,759.42 kB │ map: 12,839.48 kB
✓ built in 2.18s
 DONE  Packaged: /Users/philipp/dev/cody/vscode/cody-ai-0.8.0.vsix (196 files, 27.05MB)
 INFO
The latest version of @vscode/vsce is 2.20.1 and you have 2.19.0.
Update it now: npm install -g @vscode/vsce
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
