### PR TITLE
fix: handle message abort errors gracefully

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Do not display error messages after clicking on the "stop-generating" button. [pull/776](https://github.com/sourcegraph/cody/pull/776)
+
 ### Changed
 
 ## [0.8.0]

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -230,11 +230,13 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             onError: (err, statusCode) => {
                 // TODO notify the multiplexer of the error
                 debug('ChatViewProvider:onError', err)
-                // When the user has initiated the abortion of the message, isMessageInProgress would have set to false by abortCompletion() and we can safely ignore this error.
-                // If isMessageInProgeress is true, then user did not abort the message and we will treat it as an error.
-                if (isAbortError(err) && !this.isMessageInProgress) {
+
+                if (isAbortError(err)) {
+                    this.isMessageInProgress = false
+                    this.sendTranscript()
                     return
                 }
+
                 // Log users out on unauth error
                 if (statusCode && statusCode >= 400 && statusCode <= 410) {
                     this.authProvider


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/cody/issues/757

Currently the stop-generating button returns an error in UI:

![image](https://github.com/sourcegraph/cody/assets/68532117/b87b9c3b-62e1-450f-abf8-8c677c3dec3b)

![image](https://github.com/sourcegraph/cody/assets/68532117/8eb95b16-9a55-4567-b6a5-c7fea8aca05d)

fix: handle message abort errors gracefully

Included in this PR:
- Set isMessageInProgress to false for abort error
- Send transcript after handling abort error to let webview know there is no message in progress so that the `stop-generating` button will be removed from UI

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Run a command and then click on the `stop-generating` button, you should not see any error:

![image](https://github.com/sourcegraph/cody/assets/68532117/5b27cd64-7a8e-4cf8-a8fe-3ae81a956975)

We should also look into adding a test for the stop-generating button 
