### PR TITLE
lib/shared: bump package version

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-shared",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Cody shared library",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Bumps the version for cody-shared to prepare for publishing.

## Test plan

N/A
