### PR TITLE
Intelligent Cody: Fetch locations multiple hops in the graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
+      - run: pnpm build
       - run: pnpm run test:unit --run
 
   test-integration:

--- a/vscode/src/chat/GraphContextProvider.test.ts
+++ b/vscode/src/chat/GraphContextProvider.test.ts
@@ -57,7 +57,7 @@ func bonk() => { return new bar().Bar(new foo().Foo(), baz.Foo()) }
 
 describe('extractRelevantDocumentSymbolRanges', () => {
     test('returns all document symbol ranges by default', async () => {
-        const ranges = await extractRelevantDocumentSymbolRanges(URI.file('/test-1.test'), undefined, () =>
+        const ranges = await extractRelevantDocumentSymbolRanges({ uri: URI.file('/test-1.test') }, () =>
             Promise.resolve([
                 new vscode.Range(2, 0, 8, 1), // foo
                 new vscode.Range(10, 0, 16, 1), // bar
@@ -72,8 +72,7 @@ describe('extractRelevantDocumentSymbolRanges', () => {
 
     test('returns partial document symbol ranges with selection range', async () => {
         const ranges = await extractRelevantDocumentSymbolRanges(
-            URI.file('/test-1.test'),
-            new vscode.Range(4, 3, 5, 5),
+            { uri: URI.file('/test-1.test'), range: new vscode.Range(4, 3, 5, 5) },
             () =>
                 Promise.resolve([
                     new vscode.Range(2, 0, 8, 1), // foo
@@ -89,12 +88,13 @@ describe('extractRelevantDocumentSymbolRanges', () => {
 
 describe('gatherDefinitions', () => {
     test('returns definitions referencing multiple files', async () => {
+        const uri = Uri.parse('/test-3.test')
         const definitions = await gatherDefinitions(
-            Uri.parse('/test-3.test'),
-            testFile3.split('\n').slice(1),
+            uri,
             [
                 new vscode.Range(4, 0, 7, 67), // bonk
             ],
+            new Map([[uri.fsPath, testFile3.split('\n').slice(1)]]),
             // eslint-disable-next-line @typescript-eslint/require-await
             async (uri: URI, position: vscode.Position): Promise<vscode.Location[]> => {
                 switch (position.character) {

--- a/vscode/src/chat/GraphContextProvider.test.ts
+++ b/vscode/src/chat/GraphContextProvider.test.ts
@@ -57,7 +57,7 @@ func bonk() => { return new bar().Bar(new foo().Foo(), baz.Foo()) }
 
 describe('extractRelevantDocumentSymbolRanges', () => {
     test('returns all document symbol ranges by default', async () => {
-        const ranges = await extractRelevantDocumentSymbolRanges({ uri: URI.file('/test-1.test') }, () =>
+        const ranges = await extractRelevantDocumentSymbolRanges([{ uri: URI.file('/test-1.test') }], () =>
             Promise.resolve([
                 new vscode.Range(2, 0, 8, 1), // foo
                 new vscode.Range(10, 0, 16, 1), // bar
@@ -72,7 +72,7 @@ describe('extractRelevantDocumentSymbolRanges', () => {
 
     test('returns partial document symbol ranges with selection range', async () => {
         const ranges = await extractRelevantDocumentSymbolRanges(
-            { uri: URI.file('/test-1.test'), range: new vscode.Range(4, 3, 5, 5) },
+            [{ uri: URI.file('/test-1.test'), range: new vscode.Range(4, 3, 5, 5) }],
             () =>
                 Promise.resolve([
                     new vscode.Range(2, 0, 8, 1), // foo

--- a/vscode/src/chat/GraphContextProvider.test.ts
+++ b/vscode/src/chat/GraphContextProvider.test.ts
@@ -57,31 +57,31 @@ func bonk() => { return new bar().Bar(new foo().Foo(), baz.Foo()) }
 
 describe('extractRelevantDocumentSymbolRanges', () => {
     test('returns all document symbol ranges by default', async () => {
-        const ranges = await extractRelevantDocumentSymbolRanges([{ uri: URI.file('/test-1.test') }], () =>
+        const uri = URI.file('/test-1.test')
+        const ranges = await extractRelevantDocumentSymbolRanges([{ uri }], () =>
             Promise.resolve([
                 new vscode.Range(2, 0, 8, 1), // foo
                 new vscode.Range(10, 0, 16, 1), // bar
             ])
         )
 
-        expect(ranges).toEqual([
-            new vscode.Range(2, 0, 8, 1), // foo
-            new vscode.Range(10, 0, 16, 1), // bar
+        expect(ranges.map(({ uri, range }) => ({ uri: uri.fsPath, range }))).toEqual([
+            { uri: uri.fsPath, range: new vscode.Range(2, 0, 8, 1) }, // foo
+            { uri: uri.fsPath, range: new vscode.Range(10, 0, 16, 1) }, // bar
         ])
     })
 
     test('returns partial document symbol ranges with selection range', async () => {
-        const ranges = await extractRelevantDocumentSymbolRanges(
-            [{ uri: URI.file('/test-1.test'), range: new vscode.Range(4, 3, 5, 5) }],
-            () =>
-                Promise.resolve([
-                    new vscode.Range(2, 0, 8, 1), // foo
-                    new vscode.Range(10, 0, 16, 1), // bar
-                ])
+        const uri = URI.file('/test-1.test')
+        const ranges = await extractRelevantDocumentSymbolRanges([{ uri, range: new vscode.Range(4, 3, 5, 5) }], () =>
+            Promise.resolve([
+                new vscode.Range(2, 0, 8, 1), // foo
+                new vscode.Range(10, 0, 16, 1), // bar
+            ])
         )
 
-        expect(ranges).toEqual([
-            new vscode.Range(2, 0, 8, 1), // foo
+        expect(ranges.map(({ uri, range }) => ({ uri: uri.fsPath, range }))).toEqual([
+            { uri: uri.fsPath, range: new vscode.Range(2, 0, 8, 1) }, // foo
         ])
     })
 })
@@ -90,9 +90,11 @@ describe('gatherDefinitions', () => {
     test('returns definitions referencing multiple files', async () => {
         const uri = Uri.parse('/test-3.test')
         const definitions = await gatherDefinitions(
-            uri,
             [
-                new vscode.Range(4, 0, 7, 67), // bonk
+                {
+                    uri,
+                    range: new vscode.Range(4, 0, 7, 67), // bonk
+                },
             ],
             new Map([[uri.fsPath, testFile3.split('\n').slice(1)]]),
             // eslint-disable-next-line @typescript-eslint/require-await
@@ -119,10 +121,14 @@ describe('gatherDefinitions', () => {
         )
 
         expect(definitions).toEqual([
-            { symbolName: 'Some', locations: [] },
-            { symbolName: 'docstring', locations: [] },
-            { symbolName: 'here', locations: [] },
-            { symbolName: 'bonk', locations: [{ uri: Uri.file('/test-3.test'), range: new vscode.Range(7, 5, 7, 7) }] },
+            // Empty locations are pruned
+            // { symbolName: 'Some', locations: [] },
+            // { symbolName: 'docstring', locations: [] },
+            // { symbolName: 'here', locations: [] },
+
+            // Definitions within input selection are pruned
+            // { symbolName: 'bonk', locations: [{ uri: Uri.file('/test-3.test'), range: new vscode.Range(7, 5, 7, 7) }] },
+
             {
                 symbolName: 'bar',
                 locations: [{ uri: Uri.file('/test-1.test'), range: new vscode.Range(10, 6, 10, 9) }],

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -241,16 +241,16 @@ interface ResolvedSymbolDefinitionMatches {
  * in parallel before return.
  */
 export const gatherDefinitions = async (
-    activeEditorFileUri: URI,
-    activeEditorLines: string[],
-    relevantDocumentSymbolRanges: vscode.Range[],
+    uri: URI,
+    lines: string[],
+    ranges: vscode.Range[],
     getDefinitions: typeof defaultGetDefinitions = defaultGetDefinitions
 ): Promise<ResolvedSymbolDefinitionMatches[]> => {
     // Construct a list of symbol and definition location pairs by querying the LSP server
     // with all identifiers (heuristically chosen via regex) in the relevant code ranges.
     const definitionMatches: SymbolDefinitionMatches[] = []
-    for (const { start, end } of relevantDocumentSymbolRanges) {
-        for (const [lineIndex, line] of activeEditorLines.slice(start.line, end.line + 1).entries()) {
+    for (const { start, end } of ranges) {
+        for (const [lineIndex, line] of lines.slice(start.line, end.line + 1).entries()) {
             for (const match of line.matchAll(identifierPattern)) {
                 if (match.index === undefined || commonKeywords.has(match[0])) {
                     continue
@@ -258,10 +258,7 @@ export const gatherDefinitions = async (
 
                 definitionMatches.push({
                     symbolName: match[0],
-                    locations: getDefinitions(
-                        activeEditorFileUri,
-                        new vscode.Position(start.line + lineIndex, match.index + 1)
-                    ),
+                    locations: getDefinitions(uri, new vscode.Position(start.line + lineIndex, match.index + 1)),
                 })
             }
         }

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -35,10 +35,12 @@ export const getGraphContextFromEditor = async (editor: Editor): Promise<Precise
         new Map([[uri.fsPath, activeEditor.content.split('\n')]])
     )
 
+    const nonLocalContexts = contexts.filter(({ filePath }) => filePath !== uri.fsPath)
+
     // Debuggin'
-    console.debug(`Retrieved ${contexts.length} non-file-local context snippets`)
+    console.debug(`Retrieved ${nonLocalContexts.length} non-file-local context snippets`)
     performance.mark(label)
-    return contexts
+    return nonLocalContexts
 }
 
 interface Selection {

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -113,7 +113,7 @@ const getGraphContextFromSelection = async (
 }
 
 /**
- * Get the document symbols in file indicated by the given selections and extract the symbol ranges.
+ * Get the document symbols in files indicated by the given selections and extract the symbol ranges.
  * This will give us indication of where either the user selection and cursor is located or the range
  * of a relevant definition we've fetched in a previous iteration, which we assume to be the most
  * relevant code to the current question.

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -31,7 +31,7 @@ export const getGraphContextFromEditor = async (editor: Editor): Promise<Precise
 
     const uri = workspaceRootUri.with({ path: activeEditor.filePath })
     const contexts = await getGraphContextFromSelection(
-        { uri, range: activeEditor.selectionRange },
+        [{ uri, range: activeEditor.selectionRange }],
         new Map([[uri.fsPath, activeEditor.content.split('\n')]])
     )
 
@@ -53,21 +53,15 @@ interface Selection {
  * a defined range, we will cull the symbols to those referenced in intersecting document symbol ranges.
  */
 const getGraphContextFromSelection = async (
-    selection: Selection,
+    selections: Selection[],
     contentMap: Map<string, string[]>
 ): Promise<PreciseContext[]> => {
     // Debuggin'
     const label = 'precise context from selection'
     performance.mark(label)
 
-    const { uri: activeEditorFileUri } = selection
-    const activeEditorLines = contentMap.get(activeEditorFileUri.fsPath)
-    if (!activeEditorLines) {
-        return []
-    }
-
     // Get the document symbols in the current file and extract their definition range
-    const definitionSelections = await extractRelevantDocumentSymbolRanges([selection])
+    const definitionSelections = await extractRelevantDocumentSymbolRanges(selections)
 
     // Extract identifiers from the relevant document symbol ranges and request their definitions
     const definitionMatches = await gatherDefinitions(definitionSelections, contentMap)

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -282,7 +282,9 @@ export const extractDefinitionContexts = async (
     // Retrieve document symbols for each of the open documents, which we will use to extract the relevant
     // definition "bounds" given the range of the definition symbol (which is contained within the range).
     const documentSymbolsMap = new Map(
-        [...contentMap.keys()].map(fsPath => [fsPath, getDocumentSymbolRanges(vscode.Uri.file(fsPath))])
+        [...contentMap.keys()]
+            .filter(fsPath => matches.some(({ location }) => location.uri.fsPath === fsPath))
+            .map(fsPath => [fsPath, getDocumentSymbolRanges(vscode.Uri.file(fsPath))])
     )
 
     // NOTE: In order to make sure the loop below is unblocked we'll also force resolve the entirety

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -53,7 +53,7 @@ export const getGraphContextFromEditor = async (editor: Editor): Promise<Precise
         definitionMatches
             .map(({ locations }) => locations.map(({ uri }) => uri))
             .flat()
-            .filter(uri => uri.fsPath !== activeEditorFileUri.fsPath),
+            .filter(uri => uri.fsPath !== activeEditorFileUri.fsPath), // TODO - post-process, instead we should filter out locals in current scope
         uri => uri.fsPath
     )
 

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -114,23 +114,21 @@ const getGraphContextFromSelection = async (
 }
 
 /**
- * Get the document symbols in the current file and extract their definition range. This
- * will give us indication of where the user selection and cursor is located, which we
+ * Get the document symbols in the open file indicated by the given URI and extract their definition
+ * range. This will give us indication of where the user selection and cursor is located, which we
  * assume to be the most relevant code to the current question.
  */
 export const extractRelevantDocumentSymbolRanges = async (
-    activeEditorFileUri: URI,
-    selectionRange?: ActiveTextEditorSelectionRange,
+    uri: URI,
+    range?: ActiveTextEditorSelectionRange,
     getDocumentSymbolRanges: typeof defaultGetDocumentSymbolRanges = defaultGetDocumentSymbolRanges
 ): Promise<vscode.Range[]> => {
-    const documentSymbolRanges = await getDocumentSymbolRanges(activeEditorFileUri)
+    const documentSymbolRanges = await getDocumentSymbolRanges(uri)
 
     // Filter the document symbol ranges to just those whose range intersects the selection.
     // If no selection exists, keep all symbols, we'll utilize all document symbol ranges.
-    return selectionRange
-        ? documentSymbolRanges.filter(
-              ({ start, end }) => start.line <= selectionRange.end.line && selectionRange.start.line <= end.line
-          )
+    return range
+        ? documentSymbolRanges.filter(({ start, end }) => start.line <= range.end.line && range.start.line <= end.line)
         : documentSymbolRanges
 }
 


### PR DESCRIPTION
This PR modifies the initial implementation in #692 to not only track definitions _within the current user selection_, but also _definitions of symbols referenced in fetched definitions_. This goes two hops deep in the code navigation graph, but the implementation is general enough to go an arbitrary number of hops by updating a `recursionLimit` global variable.

## Test plan

Existing unit tests; validated by hand.