### PR TITLE
lib/ui: only render scroll anchor "gutter" if there's more than one message

### DIFF
--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -174,7 +174,7 @@ export const Transcript: React.FunctionComponent<
                     />
                 )}
             </div>
-            <div className={classNames(styles.scrollAnchor)}>&nbsp;</div>
+            {transcript.length > 1 && <div className={classNames(styles.scrollAnchor)}>&nbsp;</div>}
         </div>
     )
 })


### PR DESCRIPTION
Fixes a visual bug introduced by https://github.com/sourcegraph/cody/pull/704 on Cody Web/App where the initial placeholder message in chat gets weirdly scrolled out of view when the chat is still empty.

| Before | After |
:-:|:-:
<video src="https://github.com/sourcegraph/cody/assets/8942601/6a534084-e650-450e-ab86-548c8bc623dc"> | <video src="https://github.com/sourcegraph/cody/assets/8942601/8da62c07-0e15-4654-9896-9f9b395bcb0c">



As an aside, note that the scroll anchoring doesn't actually work for the first pair of message interactions, for example in this extended "Before" clip I recorded:

https://github.com/sourcegraph/cody/assets/8942601/961436bc-a395-4c61-8365-b887a528cd44

It _does_ work once you manually scroll to the bottom of the chat for the first time, though (not included in the clip). I seem to experience this pretty consistently in VSCode, too, for what it's worth. This PR doesn't try to fix that problem, only correct the visual bug with the scroll of the first chat message.

## Test plan

- Start a new chat conversation in Web, App, and VSCode
- Verify the first message is not scrolled out of view
- Ask Cody to enumerate the 50 US states
- [After the first pair of messages,] verify scroll position follows the content as it streams in
