### PR TITLE
fix: add null check to inline controller on change

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Add null check to Inline Controller on file change that caused the `Cannot read properties of undefined (reading 'scheme')` error when starting a new chat session. [pull/781](https://github.com/sourcegraph/cody/pull/781)
+
 ### Changed
 
 ## [0.8.0]

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -171,7 +171,7 @@ export class InlineController implements VsCodeInlineController {
         vscode.window.onDidChangeVisibleTextEditors(async e => {
             // get the last editor from the event list
             const editor = e[e.length - 1]
-            if (this.commentController && !this.isInProgress && editor.document.uri.scheme === 'comment') {
+            if (this.commentController && !this.isInProgress && editor?.document?.uri?.scheme === 'comment') {
                 this.lastClipboardText = await vscode.env.clipboard.readText()
             }
         })

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -73,7 +73,6 @@ export class InlineController implements VsCodeInlineController {
 
         if (enableInlineChat) {
             this.commentController = this.init()
-            this._disposables.push(this.commentController)
         }
 
         // Toggle Inline Chat on Config Change
@@ -195,6 +194,7 @@ export class InlineController implements VsCodeInlineController {
                 return [new vscode.Range(0, 0, lineCount - 1, 0)]
             },
         }
+        this._disposables.push(commentController)
         return commentController
     }
     /**


### PR DESCRIPTION
fix: add null checks before accessing editor properties

The code to track copy action from inline chat was accessing properties on the editor object without first checking if it was null. This adds null checks before accessing the document and uri properties to avoid potential null reference errors.

This should fix an issue that I run into where VS Code is complaining about `Cannot read properties of undefined (reading 'scheme')` when I try to start a new chat session:

<img width="2050" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/8f11781c-025d-4642-8e6e-afc9ccfcf949">


![chaterror](https://github.com/sourcegraph/cody/assets/68532117/d5b59e72-e6d1-4e16-8b97-58382fd688e1)

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

I'm not sure what the exact steps to reproduce the issue I run into, but try interacting with Cody without using inline chat, then make changes to your text document and then start a new conversation, you should not see the error message about `Cannot read properties of undefined (reading 'scheme')`:
<img width="564" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/2bc577e5-796b-4ff3-b708-618da9213a36">
