### PR TITLE
Add a 'v' to the start of the version number in the update notice

### DIFF
--- a/vscode/webviews/Notices/VersionUpdatedNotice.tsx
+++ b/vscode/webviews/Notices/VersionUpdatedNotice.tsx
@@ -71,7 +71,7 @@ export const VersionUpdatedNotice: React.FunctionComponent<VersionUpdateNoticePr
     return (
         <Notice
             icon={<Icon />}
-            title={`Cody updated to ${majorMinorVersion}`}
+            title={`Cody updated to v${majorMinorVersion}`}
             linkHref={whatsNewURL(version)}
             linkText="See what’s new →"
             linkTarget="_blank"


### PR DESCRIPTION
Adds a 'v' to the start of the version number in the update notice.

| Before | After |
| - | - |
| <img width="385" alt="Screenshot 2023-08-22 at 12 28 20 pm" src="https://github.com/sourcegraph/cody/assets/153/605afbb2-171d-438c-92a2-cdde8c700370"> | <img width="385" alt="Screenshot 2023-08-22 at 12 27 59 pm" src="https://github.com/sourcegraph/cody/assets/153/6202ff14-bf50-454a-a1af-9a8cf22b98a7"> |

## Test plan

- Inspected the UI, verified 'v' was added