### PR TITLE
Add tooltips to the chat input buttons

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -246,6 +246,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                     className={styles.chatInputCommandButton}
                     onClick={onTextAreaCommandButtonClick}
                     disabled={!!value}
+                    title="Run a Command"
                 >
                     <i className="codicon codicon-terminal" />
                 </VSCodeButton>

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -246,7 +246,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                     className={styles.chatInputCommandButton}
                     onClick={onTextAreaCommandButtonClick}
                     disabled={!!value}
-                    title="Run a Command"
+                    title="Commands"
                 >
                     <i className="codicon codicon-terminal" />
                 </VSCodeButton>
@@ -262,6 +262,7 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({ classN
         type="button"
         disabled={disabled}
         onClick={onClick}
+        title="Send Message"
     >
         <SubmitSvg />
     </VSCodeButton>


### PR DESCRIPTION
Adds a tooltip to the command and send message buttons:

<p><img src="https://github.com/sourcegraph/cody/assets/153/487c6ba7-8eeb-4ee6-896f-e18dc0973964" width="321"></p>

<p><img src="https://github.com/sourcegraph/cody/assets/153/c49d51bc-f1b1-4bdf-b9e1-8bee64096428" width="321"></p>

Thanks to @philipp-spiess for the feedback!

## Test plan

- Hovered over button
- Witnessed tooltip