### PR TITLE
Add notification when nightly build fails

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -26,3 +26,10 @@ jobs:
         env:
           VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
           VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
+      - name: Slack Notification
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: wg-cody-vscode
+          SLACK_ICON: https://github.com/sourcegraph.png?size=48
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Test plan

🤞  (It's just a CI step that runs after the publishing so it shouldn't break anything)

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
