### PR TITLE
Agent: add cancelation support

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -162,13 +162,12 @@ export class Agent extends MessageHandler {
             })
             return null
         })
-        this.registerRequest('autocomplete/execute', async params => {
+        this.registerRequest('autocomplete/execute', async (params, token) => {
             const provider = await vscode_shim.completionProvider
             if (!provider) {
                 console.log('Completion provider is not initialized')
                 return { items: [] }
             }
-            const token = new vscode.CancellationTokenSource().token
             const document = this.workspace.getDocument(params.filePath)
             if (!document) {
                 console.log('No document found for file path', params.filePath, [...this.workspace.allFilePaths()])

--- a/agent/src/jsonrpc.ts
+++ b/agent/src/jsonrpc.ts
@@ -4,6 +4,8 @@ import { appendFileSync, existsSync, mkdirSync, rmSync } from 'fs'
 import { dirname } from 'path'
 import { Readable, Writable } from 'stream'
 
+import * as vscode from 'vscode'
+
 import { Notifications, Requests } from './protocol'
 
 // This file is a standalone implementation of JSON-RPC for Node.js
@@ -201,7 +203,10 @@ class MessageEncoder extends Readable {
     }
 }
 
-type RequestCallback<M extends RequestMethodName> = (params: ParamsOf<M>) => Promise<ResultOf<M>>
+type RequestCallback<M extends RequestMethodName> = (
+    params: ParamsOf<M>,
+    cancelToken: vscode.CancellationToken
+) => Promise<ResultOf<M>>
 type NotificationCallback<M extends NotificationMethodName> = (params: ParamsOf<M>) => void
 
 /**
@@ -211,6 +216,7 @@ type NotificationCallback<M extends NotificationMethodName> = (params: ParamsOf<
 export class MessageHandler {
     private id = 0
     private requestHandlers: Map<RequestMethodName, RequestCallback<any>> = new Map()
+    private cancelTokens: Map<Id, vscode.CancellationTokenSource> = new Map()
     private notificationHandlers: Map<NotificationMethodName, NotificationCallback<any>> = new Map()
     private responseHandlers: Map<Id, (params: any) => void> = new Map()
 
@@ -231,31 +237,38 @@ export class MessageHandler {
             // Requests have ids and methods
             const handler = this.requestHandlers.get(msg.method)
             if (handler) {
-                handler(msg.params).then(
-                    result => {
-                        const data: ResponseMessage<any> = {
-                            jsonrpc: '2.0',
-                            id: msg.id,
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                            result,
+                const cancelToken = new vscode.CancellationTokenSource()
+                this.cancelTokens.set(msg.id, cancelToken)
+                handler(msg.params, cancelToken.token)
+                    .then(
+                        result => {
+                            const data: ResponseMessage<any> = {
+                                jsonrpc: '2.0',
+                                id: msg.id,
+                                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                                result,
+                            }
+                            this.messageEncoder.send(data)
+                        },
+                        error => {
+                            const message = error instanceof Error ? error.message : `${error}`
+                            const stack = error instanceof Error ? `\n${error.stack}` : ''
+                            const data: ResponseMessage<any> = {
+                                jsonrpc: '2.0',
+                                id: msg.id,
+                                error: {
+                                    code: ErrorCode.InternalError,
+                                    message,
+                                    data: JSON.stringify({ error, stack }),
+                                },
+                            }
+                            this.messageEncoder.send(data)
                         }
-                        this.messageEncoder.send(data)
-                    },
-                    error => {
-                        const message = error instanceof Error ? error.message : `${error}`
-                        const stack = error instanceof Error ? `\n${error.stack}` : ''
-                        const data: ResponseMessage<any> = {
-                            jsonrpc: '2.0',
-                            id: msg.id,
-                            error: {
-                                code: ErrorCode.InternalError,
-                                message,
-                                data: JSON.stringify({ error, stack }),
-                            },
-                        }
-                        this.messageEncoder.send(data)
-                    }
-                )
+                    )
+                    .finally(() => {
+                        this.cancelTokens.get(msg.params.id)?.dispose()
+                        this.cancelTokens.delete(msg.params.id)
+                    })
             } else {
                 console.error(`No handler for request with method ${msg.method}`)
             }
@@ -270,11 +283,20 @@ export class MessageHandler {
             }
         } else if (msg.method) {
             // Notifications have methods
-            const notificationHandler = this.notificationHandlers.get(msg.method)
-            if (notificationHandler) {
-                notificationHandler(msg.params)
+            if (
+                msg.method === '$/cancelRequest' &&
+                msg.params &&
+                (typeof msg.params.id === 'string' || typeof msg.params.id === 'number')
+            ) {
+                this.cancelTokens.get(msg.params.id)?.cancel()
+                this.cancelTokens.delete(msg.params.id)
             } else {
-                console.error(`No handler for notification with method ${msg.method}`)
+                const notificationHandler = this.notificationHandlers.get(msg.method)
+                if (notificationHandler) {
+                    notificationHandler(msg.params)
+                } else {
+                    console.error(`No handler for notification with method ${msg.method}`)
+                }
             }
         }
     })

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -85,6 +85,8 @@ export type Notifications = {
     // Only the 'uri' property is required, other properties are ignored.
     'textDocument/didClose': [TextDocument]
 
+    '$/cancelRequest': [CancelParams]
+
     // ================
     // Server -> Client
     // ================
@@ -94,6 +96,10 @@ export type Notifications = {
     'chat/updateMessageInProgress': [ChatMessage | null]
 
     'debug/message': [DebugMessage]
+}
+
+export interface CancelParams {
+    id: string | number
 }
 
 export interface AutocompleteParams {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -34,6 +34,7 @@ export {
     emptyEvent,
     emptyDisposable,
     Range,
+    Location,
     Selection,
     Position,
     Disposable,


### PR DESCRIPTION
Previously, the agent didn't support canceling autocomplete requests. This PR adds support for cancellation through the new `$/cancelRequest` notification, which mirrors the structure of the same notification in LSP.

## Test plan
Manually tested with IntelliJ here https://github.com/sourcegraph/sourcegraph/pull/56119

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
