### PR TITLE
Enable embeddings in chat in agent

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -237,7 +237,7 @@ export class Agent extends MessageHandler {
         )
         this.client = createClient({
             editor: new AgentEditor(this),
-            config: { ...config, useContext: 'none', experimentalLocalSymbols: false },
+            config: { ...config, useContext: 'embeddings', experimentalLocalSymbols: false },
             setMessageInProgress: messageInProgress => {
                 this.notify('chat/updateMessageInProgress', messageInProgress)
             },


### PR DESCRIPTION
Sets `useContext` to `'embeddings'` so that chat messages with agent can use embeddings.

## Test plan

Does this make sense?

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
