### PR TITLE
fix: support /fix command in chat

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Fixup: Resolved issue where `/fix` command incorrectly returned error "/fix is not a valid command". The `/fix` command now functions as expected when invoked in the sidebar chat. [pull/790](https://github.com/sourcegraph/cody/pull/790)
+
 ### Changed
 
 ## [0.8.0]

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -589,7 +589,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             case /^\/s(earch)?\s/.test(text):
                 return { text, recipeId: 'context-search' }
             case /^\/f(ix)?\s.*$/.test(text):
-                return { text, recipeId: 'fixup' }
+                await vscode.commands.executeCommand('cody.fixup.new', { instruction: text })
+                return null
             case /^\/(explain|doc|test|smell)$/.test(text):
                 this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:called`, {
                     source: 'chat',

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -588,7 +588,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 return { text, recipeId: 'local-indexed-keyword-search' }
             case /^\/s(earch)?\s/.test(text):
                 return { text, recipeId: 'context-search' }
-            case /^\/f(ix)?\s.*$/.test(text):
+            case /^\/fix(\s)?/.test(text):
                 await vscode.commands.executeCommand('cody.fixup.new', { instruction: text })
                 return null
             case /^\/(explain|doc|test|smell)$/.test(text):

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -268,7 +268,8 @@ const register = async (
         }),
         vscode.commands.registerCommand(
             'cody.fixup.new',
-            (range: vscode.Range): Promise<void> => executeFixup({ range })
+            (options: { range?: vscode.Range; instruction?: string; document?: vscode.TextDocument }) =>
+                executeFixup(options)
         ),
         vscode.commands.registerCommand('cody.inline.new', async () => {
             // move focus line to the end of the current selection

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -206,7 +206,7 @@ const register = async (
             return
         }
 
-        const task = options.instruction
+        const task = options.instruction?.replace('/fix', '').trim()
             ? fixup.createTask(document.uri, options.instruction, range)
             : await fixup.promptUserForTask()
         if (!task) {


### PR DESCRIPTION
fix: handle /fix command by executing `cody.fixup.new`

This PR includes:
- The `/fix` command now executes the `cody.fixup.new` command during the `chatCommandFilter` instead of executing the fixup recipe that returns an error (see image below). This allows the fixup flow to be handled in the correct way.
- The `cody.fixup.new` command now accepts the correct args to generate a fixup task. Previously, it was only accepting `range`, which is used as `options` and gets passed down incorrectly.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. Type `/fix` with instruction (e.g. /fix rename function to foo) in sidebar chat

###. Before: An error pop up saying "select some code to fixup" even when you have an active selection

![image](https://github.com/sourcegraph/cody/assets/68532117/d3b1198f-6f21-411e-b98e-392ceb55e822)

### After: fixup gets executed correctly

![image](https://github.com/sourcegraph/cody/assets/68532117/8501494b-133c-4156-ac93-b4ee678c894e)
