### PR TITLE
Agent: implement `vscode.env.language`

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -13,6 +13,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "cd .. && pnpm build && cd agent && node ./src/esbuild.mjs",
+    "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
     "build-ts": "tsc --build",
     "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t latest-linux-arm64,latest-linux-x64,latest-macos-arm64,latest-macos-x64,latest-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",

--- a/agent/src/esbuild.mjs
+++ b/agent/src/esbuild.mjs
@@ -6,10 +6,13 @@ import { build } from 'esbuild'
 import { aliasPath } from 'esbuild-plugin-alias-path'
 
 ;(async () => {
+    const minify = process.argv.includes('--minify')
+
     /** @type {import('esbuild').BuildOptions} */
     const esbuildOptions = {
         entryPoints: ['./src/index.ts'],
         bundle: true,
+        minify,
         outfile: './dist/index.js',
         platform: 'node',
         format: 'cjs',

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -249,7 +249,7 @@ const _window: Partial<typeof vscode.window> = {
             show: () => {},
             hide: () => {},
             dispose: () => {},
-        }) as vscode.OutputChannel) as any,
+        } as vscode.OutputChannel)) as any,
     createTextEditorDecorationType: () => ({ key: 'foo', dispose: () => {} }),
 }
 
@@ -305,6 +305,7 @@ const _env: Partial<typeof vscode.env> = {
     uriScheme: 'file',
     appRoot: process.cwd(),
     uiKind: UIKind.Web,
+    language: process.env.language,
     clipboard: {
         readText: () => Promise.resolve(''),
         writeText: () => Promise.resolve(),

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -249,7 +249,7 @@ const _window: Partial<typeof vscode.window> = {
             show: () => {},
             hide: () => {},
             dispose: () => {},
-        } as vscode.OutputChannel)) as any,
+        }) as vscode.OutputChannel) as any,
     createTextEditorDecorationType: () => ({ key: 'foo', dispose: () => {} }),
 }
 

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -47,6 +47,10 @@ export class PromptMixin {
  * End with a new statement to redirect Cody to the next prompt. This prevents Cody from responding to the language prompt.
  */
 export function languagePromptMixin(languageCode: string): PromptMixin {
+    if (!languageCode || languageCode.length === 0) {
+        return new PromptMixin('(Reply as Cody, a coding assistant developed by Sourcegraph) ')
+    }
+
     return new PromptMixin(
         `(Reply as Cody, a coding assistant developed by Sourcegraph, in the language with RFC5646/ISO language code "${languageCode}") `
     )

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -48,9 +48,7 @@ export class PromptMixin {
  */
 export function languagePromptMixin(languageCode: string): PromptMixin {
     const languagePrompt = languageCode ? `, in the language with RFC5646/ISO language code "${languageCode}"` : ''
-    return new PromptMixin(
-        `(Reply as Cody, a coding assistant developed by Sourcegraph${languagePrompt}) `
-    )
+    return new PromptMixin(`(Reply as Cody, a coding assistant developed by Sourcegraph${languagePrompt}) `)
 }
 
 export function newPromptMixin(text: string): PromptMixin {

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -47,12 +47,9 @@ export class PromptMixin {
  * End with a new statement to redirect Cody to the next prompt. This prevents Cody from responding to the language prompt.
  */
 export function languagePromptMixin(languageCode: string): PromptMixin {
-    if (!languageCode || languageCode.length === 0) {
-        return new PromptMixin('(Reply as Cody, a coding assistant developed by Sourcegraph) ')
-    }
-
+    const languagePrompt = languageCode ? `, in the language with RFC5646/ISO language code "${languageCode}"` : ''
     return new PromptMixin(
-        `(Reply as Cody, a coding assistant developed by Sourcegraph, in the language with RFC5646/ISO language code "${languageCode}") `
+        `(Reply as Cody, a coding assistant developed by Sourcegraph${languagePrompt}) `
     )
 }
 


### PR DESCRIPTION
Previously, Cody Chat would regularly complain how it doesn't understand the language `undefined` when running through the agent. This PR fixes the issue by implementing `vscode.env.language` in the `vscode` shim.

## Test plan

- [x] Tests still pass
- [x] Cody doesn't reply yelling at me about undefined RFC language