### PR TITLE
vscode e2e: Download less, faster, update VScode version

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -31,7 +31,7 @@
     "download-wasm": "ts-node ./scripts/download-wasm-modules.ts",
     "release:dry-run": "pnpm run download-wasm && CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
     "storybook": "storybook dev -p 6007 --no-open --no-version-updates --no-release-notes",
-    "test:e2e": "pnpm exec playwright install && tsc --build && pnpm run -s build:dev:desktop && playwright test",
+    "test:e2e": "tsc --build && { pnpm exec playwright install chromium & install_pw=$!; node dist/tsc/test/e2e/install-deps.js & install_vscode=$1; wait $install_pw && wait $install_vscode; } && pnpm run -s build:dev:desktop && playwright test",
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:unit": "vitest",
     "vscode:prepublish": "pnpm -s run build",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -31,7 +31,7 @@
     "download-wasm": "ts-node ./scripts/download-wasm-modules.ts",
     "release:dry-run": "pnpm run download-wasm && CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
     "storybook": "storybook dev -p 6007 --no-open --no-version-updates --no-release-notes",
-    "test:e2e": "tsc --build && { pnpm exec playwright install chromium & install_pw=$!; node dist/tsc/test/e2e/install-deps.js & install_vscode=$1; wait $install_pw && wait $install_vscode; } && pnpm run -s build:dev:desktop && playwright test",
+    "test:e2e": "tsc --build && { pnpm exec playwright install chromium & install_pw_pid=$!; node dist/tsc/test/e2e/install-deps.js & install_vscode_pid=$!; wait $install_pw_pid && wait $install_vscode_pid; } && pnpm run -s build:dev:desktop && playwright test",
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:unit": "vitest",
     "vscode:prepublish": "pnpm -s run build",

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -3,10 +3,11 @@ import { tmpdir } from 'os'
 import * as path from 'path'
 
 import { test as base, Frame, Page } from '@playwright/test'
-import { downloadAndUnzipVSCode } from '@vscode/test-electron'
 import { _electron as electron } from 'playwright'
 
 import { run } from '../fixtures/mock-server'
+
+import { installDeps } from './install-deps'
 
 export const test = base
     .extend<{}>({
@@ -15,7 +16,7 @@ export const test = base
 
             const codyRoot = path.resolve(__dirname, '..', '..')
 
-            const vscodeExecutablePath = await downloadAndUnzipVSCode('1.79.2')
+            const vscodeExecutablePath = await installDeps()
             const extensionDevelopmentPath = codyRoot
 
             const userDataDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))

--- a/vscode/test/e2e/install-deps.ts
+++ b/vscode/test/e2e/install-deps.ts
@@ -1,0 +1,20 @@
+import { downloadAndUnzipVSCode } from '@vscode/test-electron'
+
+export const vscodeVersion = '1.81.1'
+
+export function installDeps(): Promise<string> {
+    return downloadAndUnzipVSCode(vscodeVersion)
+}
+
+if (require.main === module) {
+    const timeout = setTimeout(
+        () => {
+            console.error('timed out waiting to install dependencies')
+        },
+        5 * 60 * 1000 // 5 minutes
+    )
+    void (async () => {
+        await installDeps()
+        clearTimeout(timeout)
+    })()
+}

--- a/vscode/test/e2e/install-deps.ts
+++ b/vscode/test/e2e/install-deps.ts
@@ -10,6 +10,7 @@ if (require.main === module) {
     const timeout = setTimeout(
         () => {
             console.error('timed out waiting to install dependencies')
+            process.exit(1)
         },
         5 * 60 * 1000 // 5 minutes
     )

--- a/vscode/test/integration/main.ts
+++ b/vscode/test/integration/main.ts
@@ -30,7 +30,7 @@ async function main(): Promise<void> {
         // Download VS Code, unzip it, and run the integration test.
         await mockServer.run(() =>
             runTests({
-                version: '1.79.2',
+                version: '1.81.1',
                 extensionDevelopmentPath,
                 extensionTestsPath,
                 launchArgs: [


### PR DESCRIPTION
Updates the VScode version to 1.81.1 from 1.79.2.

Tells Playwright to just download Chromium and ffmpeg instead of all browsers. This saves roughly 200MB of serialized downloads. Chromium is required for now because Electron is a Chromium and Playwright expects to find Chromium in that configuration.

Changes the test:e2e launch to download VScode and Playwright in parallel.

Pre-caches VScode for test:e2e. Previously this download happened as under the auspices of the test runner and could hit test timeouts which, sadly, restarted the download from scratch on the very next test.

## Test plan

(macOS, adjust paths for other platforms)

```
# Clear caches
rm -rf ~/Library/Caches/ms-playwright/*
rm -rf vscode/.vscode-test
# Run the tests clean
pnpm test:e2e  # should see VScode and Playwright download concurrently
# Run the tests w/ dirty caches
pnpm test:e2e  # test runs w/ cached downloads
# Check we did not break the integration tests, which also use VScode
pnpm test:integration
```
