### PR TITLE
Agent: fix bug when reading `.id` from null

### DIFF
--- a/agent/src/jsonrpc.ts
+++ b/agent/src/jsonrpc.ts
@@ -266,8 +266,8 @@ export class MessageHandler {
                         }
                     )
                     .finally(() => {
-                        this.cancelTokens.get(msg.params.id)?.dispose()
-                        this.cancelTokens.delete(msg.params.id)
+                        this.cancelTokens.get(msg.id)?.dispose()
+                        this.cancelTokens.delete(msg.id)
                     })
             } else {
                 console.error(`No handler for request with method ${msg.method}`)


### PR DESCRIPTION
## Test plan
* Run IntelliJ
* Open settings
* Update endpoint URL
* Click "Apply" button
* Confirm there is no stack trace from the agent

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
