### PR TITLE
vscode: Add docs about the purpose of different kinds of tests

### DIFF
--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -11,8 +11,7 @@ Tip: Enable `cody.debug.enable` and `cody.debug.verbose` in VS Code settings dur
 
 - `src`: source code of the components for the extension host
 - `webviews`: source code of the extension sidebar webviews, built with Vite
-- `test/integration`: code for integration tests
-- `test/e2e`: code for playwright UI tests
+- `test`: [tests](test/README.md)
 - `dist`: build outputs from both webpack and vite
 - `resources`: everything in this directory will be move to the ./dist directory automatically during build time for easy packaging
 - `index.html`: the entry file that Vite looks for to build the webviews. The extension host reads this file at run time and replace the variables inside the file with webview specific uri and info

--- a/vscode/test/README.md
+++ b/vscode/test/README.md
@@ -1,0 +1,18 @@
+# Testing Cody VScode
+
+Cody VScode has four kinds of tests:
+
+1. Unit tests. These are stored alongside the code in files named `.test.ts`.
+   They are written in vitest and use VScode mocks. Run them with `pnpm test:unit`.
+
+2. Storybook. These are in the `webviews` directory in files named `.story.tsx`.
+   These render UI widgets and use VScode mocks.
+
+3. Integration tests, in `integration`. These run VScode and communicate with
+   the Cody extension directly through a "testing" API returned by the extension
+   after it activates. They use a mock server. Run them with `pnpm test:integration`.
+
+4. [End-to-end tests,](e2e/README.md) in `e2e`. These run VScode and interact with
+   the VScode UI using Playwright. These cover more code than the integration tests
+   but are harder to write and maintain because they don't have direct access to the
+   Cody extension. Run them with `pnpm test:e2e`.

--- a/vscode/test/README.md
+++ b/vscode/test/README.md
@@ -6,7 +6,7 @@ Cody VScode has four kinds of tests:
    They are written in vitest and use VScode mocks. Run them with `pnpm test:unit`.
 
 2. Storybook. These are in the `webviews` directory in files named `.story.tsx`.
-   These render UI widgets and use VScode mocks.
+   These render UI widgets and use VScode mocks. Run them with `pnpm storybook`.
 
 3. Integration tests, in `integration`. These run VScode and communicate with
    the Cody extension directly through a "testing" API returned by the extension

--- a/vscode/test/e2e/README.md
+++ b/vscode/test/e2e/README.md
@@ -1,5 +1,8 @@
 # Cody E2E Testing
 
+These tests interact with the VScode user interface and test Cody from a mock
+server through to VScode UI.
+
 ### Commands
 
 #### All Tests


### PR DESCRIPTION
I keep forgetting the difference between test/e2e and test/integration, so document that.

## Test plan

This is a doc-only change.