### PR TITLE
Agent: return `CompletionEvent` telemetry data from `autocomplete/execute`

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -150,7 +150,7 @@ export class Agent extends MessageHandler {
             )
         )
 
-        this.registerRequest('recipes/execute', async data => {
+        this.registerRequest('recipes/execute', async (data, token) => {
             const client = await this.client
             if (!client) {
                 return null
@@ -189,7 +189,7 @@ export class Agent extends MessageHandler {
                         : result.items.flatMap(({ insertText, range }) =>
                               typeof insertText === 'string' && range !== undefined ? [{ insertText, range }] : []
                           )
-                return { items }
+                return { items, completionEvent: (result as any)?.completionEvent }
             } catch (error) {
                 console.log('autocomplete failed', error)
                 return { items: [] }

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -3,6 +3,8 @@ import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { event } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
+import { CompletionEvent } from '../../vscode/src/completions/logger'
+
 // This file documents the Cody Agent JSON-RPC protocol. Consult the JSON-RPC
 // specification to learn about how JSON-RPC works https://www.jsonrpc.org/specification
 // The Cody Agent server only supports transport via stdout/stdin.
@@ -109,6 +111,7 @@ export interface AutocompleteParams {
 
 export interface AutocompleteResult {
     items: AutocompleteItem[]
+    completionEvent?: CompletionEvent
 }
 
 export interface AutocompleteItem {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -9,7 +9,7 @@ import { ContextSummary } from './context/context'
 import { InlineCompletionItem } from './types'
 import { isAbortError, isRateLimitError } from './utils'
 
-interface CompletionEvent {
+export interface CompletionEvent {
     params: {
         type: 'inline'
         multiline: boolean
@@ -153,6 +153,10 @@ export function accept(id: string, completion: InlineCompletionItem): void {
         ...lineAndCharCount(completion),
         otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
     })
+}
+
+export function completionEvent(id: string): CompletionEvent | undefined {
+    return displayedCompletions.get(id)
 }
 
 export function noResponse(id: string): void {

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -218,15 +218,18 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             return null
         }
 
+        const event = CompletionLogger.completionEvent(result.logId)
         if (items.length > 0) {
             CompletionLogger.suggested(result.logId, InlineCompletionsResultSource[result.source], items[0] as any)
         } else {
             CompletionLogger.noResponse(result.logId)
         }
 
-        return {
-            items,
-        }
+        const completionResult: vscode.InlineCompletionList = { items }
+
+        ;(completionResult as any).completionEvent = event
+
+        return completionResult
     }
 
     public handleDidAcceptCompletionItem(logId: string, completion: InlineCompletionItem): void {


### PR DESCRIPTION
Previously, it was not possible for agent clients to know if a completion result was powered by embeddings. This PR fixes the problem by adding a new `completionEvent` property to the return type.


## Test plan
n/a
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
