### PR TITLE
fix: use editor font for code blocks in chat view

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Do not display error messages after clicking on the "stop-generating" button. [pull/776](https://github.com/sourcegraph/cody/pull/776)
 - Add null check to Inline Controller on file change that caused the `Cannot read properties of undefined (reading 'scheme')` error when starting a new chat session. [pull/781](https://github.com/sourcegraph/cody/pull/781)
 - Fixup: Resolved issue where `/fix` command incorrectly returned error "/fix is not a valid command". The `/fix` command now functions as expected when invoked in the sidebar chat. [pull/790](https://github.com/sourcegraph/cody/pull/790)
+- Set font family and size in side chat code blocks to match editor font. [pull/813](https://github.com/sourcegraph/cody/pull/813)
 
 ### Changed
 

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -34,6 +34,8 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     /* Our syntax highlighter emits colors intended for dark backgrounds only. */
     background-color: var(--code-background);
     color: var(--code-foreground);
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
 }
 
 .transcript-item ul:not(.transcript-action *),
@@ -88,7 +90,7 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 
 .chat-input-container::after {
     /* Note the weird space! Needed to preventy jumpy behavior */
-    content: attr(data-value) " ";
+    content: attr(data-value) ' ';
     /* This is how textarea text behaves */
     white-space: pre-wrap;
     /* Hidden from view, clicks, and screen readers */
@@ -96,7 +98,8 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
 }
 
 /* Both elements need the same styling so the height matches */
-.chat-input, .chat-input-container::after {
+.chat-input,
+.chat-input-container::after {
     box-sizing: border-box;
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
@@ -187,7 +190,8 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     color: var(--foreground);
 }
 
-.submit-button, .submit-button-disabled {
+.submit-button,
+.submit-button-disabled {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/issues/812

fix: use editor font and line height in chat view

- Set font family and size in code blocks to match editor font.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

![image](https://github.com/sourcegraph/cody/assets/68532117/8d7715be-4e53-47d0-bc20-f209f0fd965f)

