### PR TITLE
Fix insders build and make CI notification pretty

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -33,3 +33,7 @@ jobs:
           SLACK_CHANNEL: wg-cody-vscode
           SLACK_ICON: https://github.com/sourcegraph.png?size=48
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: Insiders build failed
+          SLACK_COLOR: danger
+          SLACK_FOOTER: ''
+          MSG_MINIMAL: actions url

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import { isDefined, PreciseContext } from '@sourcegraph/cody-shared'
+import { PreciseContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { isDefined } from '@sourcegraph/cody-shared/src/common'
 import { ActiveTextEditorSelectionRange, Editor } from '@sourcegraph/cody-shared/src/editor'
 import { GraphContextFetcher } from '@sourcegraph/cody-shared/src/graph-context'
 


### PR DESCRIPTION
I don't know why but for some reason we can't import from`'@sourcegraph/cody-shared'` directly. I've seen this error a couple of times now. This time it was only noticable on CI though (which is weird, I thought we fixed that but perhaps the PR was not based on the latest changes on `main` yet).

Anyway, this should fix the import and also makes the CI notification more useful.

## Test plan

```
α vscode (ps/fix-insiders)
pnpm run build

> cody-ai@0.8.0 build /Users/philipp/dev/cody/vscode
> tsc --build && pnpm run -s _build:esbuild:desktop && pnpm run -s _build:esbuild:web && pnpm run -s _build:webviews --mode production


  dist/extension.node.js      6.0mb ⚠️
  dist/extension.node.js.map  9.7mb

⚡ Done in 228ms

  dist/extension.web.js      5.0mb ⚠️
  dist/extension.web.js.map  7.7mb

⚡ Done in 167ms
vite v4.4.3 building for production...
✓ 438 modules transformed.
../dist/webviews/index.html                0.78 kB
../dist/webviews/codicon-2d58c995.ttf     70.78 kB
../dist/webviews/index-948936fc.css       58.00 kB
../dist/webviews/index.js              1,759.47 kB │ map: 12,839.81 kB
✓ built in 2.20s
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
