### PR TITLE
fix: invalid json file for custom commands blocks command menu

### DIFF
--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -2,8 +2,17 @@ import { Preamble } from '../preamble'
 
 import * as defaultPrompts from './default-prompts.json'
 
-export function getDefaultCommandsMap(): Map<string, CodyPrompt> {
+export function getDefaultCommandsMap(editorCommands: CodyPrompt[] = []): Map<string, CodyPrompt> {
     const map = new Map<string, CodyPrompt>()
+
+    // Add editor specifc commands
+    for (const command of editorCommands) {
+        if (command.name) {
+            map.set(command.name, command)
+        }
+    }
+
+    // Add default commands
     const prompts = defaultPrompts.commands as Record<string, unknown>
     for (const key in prompts) {
         if (Object.prototype.hasOwnProperty.call(prompts, key)) {
@@ -17,6 +26,7 @@ export function getDefaultCommandsMap(): Map<string, CodyPrompt> {
             map.set(key, prompt)
         }
     }
+
     return map
 }
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Add null check to Inline Controller on file change that caused the `Cannot read properties of undefined (reading 'scheme')` error when starting a new chat session. [pull/781](https://github.com/sourcegraph/cody/pull/781)
 - Fixup: Resolved issue where `/fix` command incorrectly returned error "/fix is not a valid command". The `/fix` command now functions as expected when invoked in the sidebar chat. [pull/790](https://github.com/sourcegraph/cody/pull/790)
 - Set font family and size in side chat code blocks to match editor font. [pull/813](https://github.com/sourcegraph/cody/pull/813)
+- Add error handling to unblock Command Menu from being started up when invalid json file for custom commands is detected. [pull/827](https://github.com/sourcegraph/cody/pull/827)
 
 ### Changed
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -554,7 +554,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             return
         }
         await this.executeRecipe('custom-prompt', promptText)
-        this.telemetryService.log('CodyVSCodeExtension:command:started', { source: 'menu' })
         const starter = (await this.editor.controllers.command?.getCustomConfig())?.starter
         if (starter) {
             this.telemetryService.log('CodyVSCodeExtension:command:customStarter:applied')

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -222,14 +222,13 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                     description = command.type === 'default' ? '' : command.type
                 }
 
-                return createQuickPickItem(label, description)
+                return createQuickPickItem(label, description, label === '/fix')
             })
 
             // Show the list of prompts to the user using a quick pick menu
             const { selectedItem: selectedPrompt, input: userPrompt } = await showCommandMenu([
                 menu_separators.commands,
                 menu_options.chat,
-                menu_options.fix,
                 ...commands,
                 menu_separators.settings,
                 menu_options.config,

--- a/vscode/src/custom-prompts/PromptsProvider.ts
+++ b/vscode/src/custom-prompts/PromptsProvider.ts
@@ -3,9 +3,10 @@ import { CodyPrompt, getDefaultCommandsMap } from '@sourcegraph/cody-shared/src/
 import { debug } from '../log'
 
 // Manage default commands created by the prompts in prompts.json
+const editorCommands = [{ name: 'Refactor Selected Code', prompt: '/fix', slashCommand: '/fix' }]
 export class PromptsProvider {
     // The default prompts
-    private defaultPromptsMap = getDefaultCommandsMap()
+    private defaultPromptsMap = getDefaultCommandsMap(editorCommands)
 
     // The commands grouped by default prompts and custom prompts
     private allCommands = new Map<string, CodyPrompt>()

--- a/vscode/src/custom-prompts/utils/helpers.ts
+++ b/vscode/src/custom-prompts/utils/helpers.ts
@@ -79,7 +79,11 @@ export async function getFileToRemove(keys: string[]): Promise<string | undefine
 }
 
 export const createQuickPickSeparator = (label = '', detail = ''): vscode.QuickPickItem => ({ kind: -1, label, detail })
-export const createQuickPickItem = (label = '', description = ''): vscode.QuickPickItem => ({ label, description })
+export const createQuickPickItem = (label = '', description = '', alwaysShow = false): vscode.QuickPickItem => ({
+    label,
+    description,
+    alwaysShow,
+})
 
 export async function getFileContentText(uri: vscode.Uri): Promise<string> {
     try {

--- a/vscode/src/custom-prompts/utils/helpers.ts
+++ b/vscode/src/custom-prompts/utils/helpers.ts
@@ -30,17 +30,21 @@ export async function createJSONFile(
 
 // Add context from the sample files to the .vscode/cody.json file
 export async function saveJSONFile(context: string, filePath: vscode.Uri, isSaveMode = false): Promise<void> {
-    const workspaceEditor = new vscode.WorkspaceEdit()
-    // Clear the file before writing to it
-    workspaceEditor.deleteFile(filePath, { ignoreIfNotExists: true })
-    workspaceEditor.createFile(filePath, { ignoreIfExists: isSaveMode })
-    workspaceEditor.insert(filePath, new vscode.Position(0, 0), context)
-    await vscode.workspace.applyEdit(workspaceEditor)
-    // Save the file
-    const doc = await vscode.workspace.openTextDocument(filePath)
-    await doc.save()
-    if (!isSaveMode) {
-        await vscode.window.showTextDocument(filePath)
+    try {
+        const workspaceEditor = new vscode.WorkspaceEdit()
+        // Clear the file before writing to it
+        workspaceEditor.deleteFile(filePath, { ignoreIfNotExists: true })
+        workspaceEditor.createFile(filePath, { ignoreIfExists: isSaveMode })
+        workspaceEditor.insert(filePath, new vscode.Position(0, 0), context)
+        await vscode.workspace.applyEdit(workspaceEditor)
+        // Save the file
+        const doc = await vscode.workspace.openTextDocument(filePath)
+        await doc.save()
+        if (!isSaveMode) {
+            await vscode.window.showTextDocument(filePath)
+        }
+    } catch (error) {
+        throw new Error(`Failed to save your Custom Commands to a JSON file: ${error}`)
     }
 }
 
@@ -93,7 +97,7 @@ export const isCustomType = (type: CodyPromptType): boolean => type === 'user' |
 export const isNonCustomType = (type: CodyPromptType): boolean => type === 'recently used' || type === 'default'
 
 export const outputWrapper = `
-Here is the output of the \`{command}\` command, inside <output> tags.:
+Here is the output of \`{command}\` command from my terminal inside <output> tags:
 <output>
 {output}
 </output>`

--- a/vscode/src/custom-prompts/utils/menu.ts
+++ b/vscode/src/custom-prompts/utils/menu.ts
@@ -17,7 +17,7 @@ const commandsSeparator: QuickPickItem = { kind: -1, label: 'commands' }
 const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'custom commands (experimental)' }
 const configOption: QuickPickItem = { label: 'Configure Custom Commands...' }
 const settingsSeparator: QuickPickItem = { kind: -1, label: 'settings' }
-const addOption: QuickPickItem = { label: 'New Custom User Command...', alwaysShow: true }
+const addOption: QuickPickItem = { label: 'Create a New Custom User Command...', alwaysShow: true }
 
 export const recentlyUsedSeparatorAsPrompt: [string, CodyPrompt][] = [
     ['separator', { prompt: 'separator', type: 'recently used' }],
@@ -171,7 +171,7 @@ export async function showcommandTypeQuickPick(
 export const CustomCommandConfigMenuItems = [
     {
         kind: 0,
-        label: 'New Custom User Command...',
+        label: 'Create a New Custom User Command...',
         id: 'add',
         type: 'user',
         description: '',

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -15,7 +15,7 @@ test('open the Custom Commands in sidebar and add new user recipe', async ({ pag
     // Create Command via UI
     const recipeName = 'A Test Recipes'
     await page.getByText('Configure Custom Commands...').click()
-    await page.locator('a').filter({ hasText: 'New Custom User Command...' }).click()
+    await page.locator('a').filter({ hasText: 'Create a New Custom User Command...' }).click()
     await page.keyboard.type(recipeName)
     await page.keyboard.press('Enter')
     await page.keyboard.type('this is a test')


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/804

- fix issue where invalid json file for custom commands blocks command menu
  - Wrap prompt loading in try/catch to handle errors
  - Return empty prompt map on error instead of throwing
  - Log errors loading prompts using debug logging
- Add editor-specific commands to the default commands list
- Create editor-specific commands with /fix
- Add alwaysShow option to createQuickPickItem
- Minor menu item cleaning


![image](https://github.com/sourcegraph/cody/assets/68532117/70665316-4439-49eb-9d1e-74fffe737b41)

![image](https://github.com/sourcegraph/cody/assets/68532117/f1b4766f-f869-4760-a7c0-5e6161ea78df)

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Remove a line from your current workspace config file for cody custom commands so you can see an inline error, ex:
![image](https://github.com/sourcegraph/cody/assets/68532117/401e3fd3-3fc4-4643-9a2b-11c25f1dd937)

2. You should still be able to open the command menu:
![image](https://github.com/sourcegraph/cody/assets/68532117/f1b4766f-f869-4760-a7c0-5e6161ea78df)

Before - you won't be able to open the command menu and see this error message instead: 
![image](https://github.com/sourcegraph/cody/assets/68532117/03e16363-adcd-47ad-ae21-57302e264847)

