### PR TITLE
add null check before accessing editor in inline controller

### DIFF
--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -168,12 +168,13 @@ export class InlineController implements VsCodeInlineController {
         // Track clipboard text before a new inline chat is created
         // This is used for comparing the clipboard text when switching between editors to look for copy events
         vscode.window.onDidChangeVisibleTextEditors(async e => {
-            if (!this.commentController || !e.length) {
+            if (!this.commentController || !e.length || this.isInProgress) {
                 return
             }
+
             // get the last editor from the event list
             const editor = e[e.length - 1]
-            if (this.commentController && !this.isInProgress && editor?.document?.uri?.scheme === 'comment') {
+            if (editor?.document?.uri?.scheme === 'comment') {
                 this.lastClipboardText = await vscode.env.clipboard.readText()
             }
         })

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -168,6 +168,9 @@ export class InlineController implements VsCodeInlineController {
         // Track clipboard text before a new inline chat is created
         // This is used for comparing the clipboard text when switching between editors to look for copy events
         vscode.window.onDidChangeVisibleTextEditors(async e => {
+            if (!this.commentController || !e.length) {
+                return
+            }
             // get the last editor from the event list
             const editor = e[e.length - 1]
             if (this.commentController && !this.isInProgress && editor?.document?.uri?.scheme === 'comment') {


### PR DESCRIPTION
Added a null check for Inline Controller event on editor change before reading the clipboard text.

This avoids potential null pointer exceptions that cause errors in console
![image](https://github.com/sourcegraph/cody/assets/68532117/02b82d0a-8284-4b9e-bf04-c122f63d502b)


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

check console log to see the errors gone!

