### PR TITLE
feat: add button to export chat history to JSON

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- New button in Chat UI to export chat history to a JSON file. [pull/829](https://github.com/sourcegraph/cody/pull/829)
+
 ### Fixed
 
 - Do not display error messages after clicking on the "stop-generating" button. [pull/776](https://github.com/sourcegraph/cody/pull/776)

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -77,8 +77,13 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
             case 'event':
                 this.telemetryService.log(message.eventName, message.properties)
                 break
-            case 'removeHistory':
-                await this.clearHistory()
+            case 'history':
+                if (message.action === 'clear') {
+                    await this.clearHistory()
+                }
+                if (message.action === 'export') {
+                    await this.exportHistory()
+                }
                 break
             case 'restoreHistory':
                 await this.restoreSession(message.chatID)

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -692,6 +692,30 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     }
 
     /**
+     * Export chat history to file system
+     */
+    public async exportHistory(): Promise<void> {
+        this.telemetryService.log('CodyVSCodeExtension:exportChatHistoryButton:clicked')
+        const historyJson = await this.transcript.toJSON()
+        const exportPath = await vscode.window.showSaveDialog({ filters: { 'Chat History': ['json'] } })
+        if (!exportPath) {
+            return
+        }
+        try {
+            const logContent = new TextEncoder().encode(JSON.stringify(historyJson))
+            await vscode.workspace.fs.writeFile(exportPath, logContent)
+            // Display message and ask if user wants to open file
+            void vscode.window.showInformationMessage('Chat history exported successfully.', 'Open').then(choice => {
+                if (choice === 'Open') {
+                    void vscode.commands.executeCommand('vscode.open', exportPath)
+                }
+            })
+        } catch (error) {
+            debug('MessageProvider:exportHistory', 'Failed to export chat history', error)
+        }
+    }
+
+    /**
      * Loads the most recent chat
      */
     private async loadRecentChat(): Promise<void> {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -17,7 +17,7 @@ export type WebviewMessage =
     | { command: 'event'; eventName: string; properties: TelemetryEventProperties | undefined } // new event log internal API (use createWebviewTelemetryService wrapper)
     | { command: 'submit'; text: string; submitType: 'user' | 'suggestion' | 'example' }
     | { command: 'executeRecipe'; recipe: RecipeID }
-    | { command: 'removeHistory' }
+    | { command: 'history'; action: 'clear' | 'export' }
     | { command: 'restoreHistory'; chatID: string }
     | { command: 'deleteHistory'; chatID: string }
     | { command: 'links'; value: string }

--- a/vscode/webviews/UserHistory.module.css
+++ b/vscode/webviews/UserHistory.module.css
@@ -9,8 +9,12 @@
     margin: 0;
 }
 
-.clear-button-container {
+.heading-button-container {
     margin-left: auto;
+}
+
+.heading-button {
+    margin-left: 1rem;
 }
 
 .items-container {
@@ -23,19 +27,19 @@
 .item-button {
     display: block;
     position: relative;
-    padding-top: .5rem;
-    padding-bottom: .5rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
 }
 
 .item-button-inner-container {
     text-align: left;
-    padding-top: .25rem;
-    padding-bottom: .25rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
 }
 
 .item-date {
     font-size: smaller;
-    margin-bottom: .25rem;
+    margin-bottom: 0.25rem;
 }
 
 .item-delete {

--- a/vscode/webviews/UserHistory.tsx
+++ b/vscode/webviews/UserHistory.tsx
@@ -37,13 +37,18 @@ export const UserHistory: React.FunctionComponent<React.PropsWithChildren<Histor
         [userHistory, setUserHistory, vscodeAPI]
     )
 
-    const onRemoveHistoryClick = useCallback(() => {
-        if (userHistory) {
-            vscodeAPI.postMessage({ command: 'removeHistory' })
-            setUserHistory(null)
-            setInputHistory([])
-        }
-    }, [setInputHistory, userHistory, setUserHistory, vscodeAPI])
+    const onAllHistoryClick = useCallback(
+        (action: 'clear' | 'export') => {
+            if (userHistory) {
+                vscodeAPI.postMessage({ command: 'history', action })
+                if (action === 'clear') {
+                    setUserHistory(null)
+                    setInputHistory([])
+                }
+            }
+        },
+        [setInputHistory, userHistory, setUserHistory, vscodeAPI]
+    )
 
     function restoreMetadata(chatID: string): void {
         vscodeAPI.postMessage({ command: 'restoreHistory', chatID })
@@ -55,14 +60,22 @@ export const UserHistory: React.FunctionComponent<React.PropsWithChildren<Histor
             <div className={chatStyles.nonTranscriptContainer}>
                 <div className={styles.headingContainer}>
                     <h3>Chat History</h3>
-                    <div className={styles.clearButtonContainer}>
+                    <div className={styles.headingButtonContainer}>
                         <VSCodeButton
-                            className={styles.clearButton}
+                            className={styles.headingButton}
                             type="button"
-                            onClick={onRemoveHistoryClick}
+                            onClick={() => onAllHistoryClick('export')}
                             disabled={!userHistory || !Object.keys(userHistory).length}
                         >
-                            Clear History
+                            Export
+                        </VSCodeButton>
+                        <VSCodeButton
+                            className={styles.headingButton}
+                            type="button"
+                            onClick={() => onAllHistoryClick('clear')}
+                            disabled={!userHistory || !Object.keys(userHistory).length}
+                        >
+                            Clear
                         </VSCodeButton>
                     </div>
                 </div>


### PR DESCRIPTION
feat: add chat history export

- Add exportHistory method to export chat history to a JSON file
- Add UI button and logic to trigger history export 
- Update protocol to support new 'history' message for export and clear history action

This will make debugging easier, as it's been difficult to debug/compare context and chat issues as we have to go through each history item in UI manually. 

Before:

![image](https://github.com/sourcegraph/cody/assets/68532117/5fb08f7c-f254-4866-a71d-a93cf00100e2)

After:

![image](https://github.com/sourcegraph/cody/assets/68532117/ffc7039f-0dc0-4df9-80ce-d0c75773f62a)

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

try clicking on the Export button


https://github.com/sourcegraph/cody/assets/68532117/4e3fe075-c58d-474e-95ce-3bc196e04fa4

