### PR TITLE
export all chat history

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -696,7 +696,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      */
     public async exportHistory(): Promise<void> {
         this.telemetryService.log('CodyVSCodeExtension:exportChatHistoryButton:clicked')
-        const historyJson = await this.transcript.toJSON()
+        const historyJson = MessageProvider.chatHistory
         const exportPath = await vscode.window.showSaveDialog({ filters: { 'Chat History': ['json'] } })
         if (!exportPath) {
             return


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/829

just realized it was exporting the current chat only instead of the entire chat history 🥴 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

locally confirmed