### PR TITLE
Fix autocomplete embeddings refresh condition

### DIFF
--- a/vscode/src/completions/context/context-embeddings.ts
+++ b/vscode/src/completions/context/context-embeddings.ts
@@ -37,7 +37,7 @@ export function getContextFromEmbeddings(options: Options): ContextSnippet[] {
      * file significantly changed. We can use the `onDidChangeTextDocument`
      * event with some diffing logic for that in the improved version.
      */
-    if (!embeddingsForCurrentFile || differenceInMinutes(embeddingsForCurrentFile.lastChange, new Date()) > 5) {
+    if (!embeddingsForCurrentFile || differenceInMinutes(new Date(), embeddingsForCurrentFile.lastChange) > 5) {
         fetchAndSaveEmbeddings({
             getCodebaseContext,
             currentFilePath,


### PR DESCRIPTION
Noticed that embeddings for autocomplete were not refreshing every 5 min.  
## Test plan
Added temporary logging to confirm 
before:
```
embeddings for /projects/sourcegraph/cmd/frontend/backend/app.go are -3 minutes old
```

after:
```
embeddings for /Users/chriswarwick/projects/sourcegraph/cmd/frontend/backend/app.go are 1 minutes old
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
