### PR TITLE
rename /fix command to /edit

### DIFF
--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -18,14 +18,14 @@ const FixupIntentClassification: IntentClassificationOption<FixupIntent>[] = [
     {
         id: 'edit',
         rawCommand: '/edit',
-        description: 'Edit part of the selected code',
-        examplePrompts: ['Edit this code', 'Change this code', 'Update this code'],
-    },
-    {
-        id: 'fix',
-        rawCommand: '/fix',
-        description: 'Fix a problem in a part of the selected code',
-        examplePrompts: ['Implement this TODO', 'Fix this code'],
+        description: 'Fix a problem or edit part of the selected code',
+        examplePrompts: [
+            'Edit this code',
+            'Change this code',
+            'Update this code',
+            'Implement this TODO',
+            'Fix this code',
+        ],
     },
     {
         id: 'document',

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -348,7 +348,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         }
 
         // Filter the human input to check for chat commands and retrieve the correct recipe id
-        // e.g. /fix from 'chat-question' should be redirected to use the 'fixup' recipe
+        // e.g. /edit from 'chat-question' should be redirected to use the 'fixup' recipe
         const command = await this.chatCommandsFilter(humanChatInput, recipeId)
         if (!command) {
             return
@@ -589,7 +589,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 return { text, recipeId: 'local-indexed-keyword-search' }
             case /^\/s(earch)?\s/.test(text):
                 return { text, recipeId: 'context-search' }
-            case /^\/fix(\s)?/.test(text):
+            case /^\/edit(\s)?/.test(text):
                 await vscode.commands.executeCommand('cody.fixup.new', { instruction: text })
                 return null
             case /^\/(explain|doc|test|smell)$/.test(text):

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -222,7 +222,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                     description = command.type === 'default' ? '' : command.type
                 }
 
-                return createQuickPickItem(label, description, label === '/fix')
+                return createQuickPickItem(label, description, label === '/edit')
             })
 
             // Show the list of prompts to the user using a quick pick menu

--- a/vscode/src/custom-prompts/PromptsProvider.ts
+++ b/vscode/src/custom-prompts/PromptsProvider.ts
@@ -3,7 +3,7 @@ import { CodyPrompt, getDefaultCommandsMap } from '@sourcegraph/cody-shared/src/
 import { debug } from '../log'
 
 // Manage default commands created by the prompts in prompts.json
-const editorCommands = [{ name: 'Refactor Selected Code', prompt: '/fix', slashCommand: '/fix' }]
+const editorCommands = [{ name: 'Request a code edit', prompt: '/edit', slashCommand: '/edit' }]
 export class PromptsProvider {
     // The default prompts
     private defaultPromptsMap = getDefaultCommandsMap(editorCommands)

--- a/vscode/src/custom-prompts/utils/menu.ts
+++ b/vscode/src/custom-prompts/utils/menu.ts
@@ -12,7 +12,7 @@ export const NewCustomCommandConfigMenuOptions = {
 
 const inlineSeparator: QuickPickItem = { kind: -1, label: 'inline' }
 const chatOption: QuickPickItem = { label: '/ask', description: 'Ask a Question', alwaysShow: true }
-const fixOption: QuickPickItem = { label: '/fix', description: 'Refactor Selected Code', alwaysShow: true }
+const fixOption: QuickPickItem = { label: '/edit', description: 'Request a code edit', alwaysShow: true }
 const commandsSeparator: QuickPickItem = { kind: -1, label: 'commands' }
 const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'custom commands (experimental)' }
 const configOption: QuickPickItem = { label: 'Configure Custom Commands...' }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -206,7 +206,7 @@ const register = async (
             return
         }
 
-        const task = options.instruction?.replace('/fix', '').trim()
+        const task = options.instruction?.replace('/edit', '').trim()
             ? fixup.createTask(document.uri, options.instruction, range)
             : await fixup.promptUserForTask()
         if (!task) {

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -12,10 +12,10 @@ export class FixupTypingUI {
     constructor(private readonly taskFactory: FixupTaskFactory) {}
 
     private async getInstructionFromQuickPick({
-        title = '/fix',
+        title = '/edit',
         placeholder = 'Your instructions',
         value = '',
-        prefix = '/fix',
+        prefix = '/edit',
     } = {}): Promise<string> {
         const quickPick = vscode.window.createQuickPick()
         quickPick.title = title

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -31,9 +31,9 @@ export class InlineController implements VsCodeInlineController {
     private readonly threadLabel =
         '[TIPS] New Inline Chat: `ctrl + shift + c` | Submit: `cmd + enter` | Hide: `shift + esc`'
     private options = {
-        prompt: 'Cody Inline Chat - Ask Cody a question or request inline fix with `/fix` or `/touch`.',
+        prompt: 'Cody Inline Chat - Ask Cody a question or request inline fix with `/edit` or `/touch`.',
         placeHolder:
-            'Examples: "How can I improve this?", "/fix convert tabs to spaces", "/touch Create 5 different versions of this function". "What does this regex do?"',
+            'Examples: "How can I improve this?", "/edit convert tabs to spaces", "/touch Create 5 different versions of this function". "What does this regex do?"',
     }
     private readonly codyIcon: vscode.Uri
     private readonly userIcon: vscode.Uri

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -32,7 +32,7 @@ test('decorations from un-applied Cody changes appear', async ({ page, sidebar }
     // Open the command palette by clicking on the Cody Icon
     await page.getByRole('button', { name: 'Commands' }).click()
     // Navigate to fixup input
-    await page.getByRole('option', { name: 'Refactor Selected Code' }).click()
+    await page.getByRole('option', { name: 'Request a code edit' }).click()
 
     // Wait for the input box to appear
     await page.getByPlaceholder('Your instructions').click()

--- a/vscode/test/e2e/inline-assist.test.ts
+++ b/vscode/test/e2e/inline-assist.test.ts
@@ -22,7 +22,7 @@ test('start a fixup job from inline chat with valid auth', async ({ page, sideba
     await page.waitForSelector('.monaco-text-button')
 
     // Type in the instruction for fixup
-    await page.keyboard.type('/fix replace hello with goodbye')
+    await page.keyboard.type('/edit replace hello with goodbye')
     // Click on the submit button with the name Ask Cody
     await page.click('.monaco-text-button')
 

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -29,7 +29,7 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     // Open the command palette by clicking on the Cody Icon
     await page.getByRole('button', { name: 'Commands' }).click()
     // Navigate to fixup input
-    await page.getByRole('option', { name: 'Refactor Selected Code' }).click()
+    await page.getByRole('option', { name: 'Request a code edit' }).click()
 
     // Wait for the input box to appear
     await page.getByPlaceholder('Your instructions').click()

--- a/vscode/walkthroughs/inline-assist.md
+++ b/vscode/walkthroughs/inline-assist.md
@@ -7,4 +7,4 @@
     />
 </video>
 
-Talk to Cody directly within the context of your code. Use Inline Chat to ask Cody questions about lines of code while remaining in your editor flow. Want to make changes? Use the "/fix" command and Cody will automatically update the code for you.
+Talk to Cody directly within the context of your code. Use Inline Chat to ask Cody questions about lines of code while remaining in your editor flow. Want to make changes? Use the "/edit" command and Cody will automatically update the code for you.


### PR DESCRIPTION
Next iteration on https://github.com/sourcegraph/cody/issues/631
Follow-up on https://github.com/sourcegraph/cody/pull/798

Updates `/fix` command labels to `/edit` according to the [design](https://www.figma.com/file/9112BsKsJc1BpO2j8XYwLL/%F0%9F%A4%96-Cody-VS-Code-%5BMain%5D?node-id=4560:14212&mode=dev).



||Before|After|
|-|--|--|
|Sidebar chat|<img width="299" alt="Screenshot 2023-08-28 at 11 23 56" src="https://github.com/sourcegraph/cody/assets/25318659/1e13d3b5-4363-4979-892b-bb82455d19dd">|<img width="299" alt="Screenshot 2023-08-28 at 11 22 50" src="https://github.com/sourcegraph/cody/assets/25318659/4298231a-7d32-4924-a07b-09f352ef88a0">|
|Main quick pick|<img width="602" alt="Screenshot 2023-08-28 at 11 24 12" src="https://github.com/sourcegraph/cody/assets/25318659/92216075-5fb0-43fc-8d1d-07afa2b38689">|<img width="608" alt="Screenshot 2023-08-28 at 11 22 30" src="https://github.com/sourcegraph/cody/assets/25318659/e000f578-a7a2-4479-88f5-9bdc3e617e8d">|

## Test plan
Tested manually (screenshots attached). CI passes.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
