### PR TITLE
dx: show `node_modules` in the VS Code explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
     "completions-review-tool/data/*": true
   },
   "files.exclude": {
-    "**/node_modules": true,
     "**/dist": true,
     "**/.eslintcache": true,
     "**/.vscode-test": true,


### PR DESCRIPTION
Makes `node_modules` visible in the VS Code explorer view.

## Context

Often, I need to dig into the implementation of the `npm` modules and modify their code for debugging purposes. 

The modified setting hides files from the explorer tree, which makes it hard to navigate the `node_modules` tree. `search.exclude` already prevents searches from going into the `node_modules` folder, so it should be fine keeping it accessible in the explorer view. We have the same setup in the main monorepo.

## Test plan

n/a
