### PR TITLE
Autocomplete: Add feature flag to enable Fireworks as the default provider

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -26,6 +26,7 @@ export interface Configuration {
         | 'unstable-huggingface'
         | 'unstable-fireworks'
         | 'unstable-azure-openai'
+        | null
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedModel: string | null
     autocompleteAdvancedAccessToken: string | null

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -9,6 +9,7 @@ export enum FeatureFlag {
 
     CodyAutocompleteIncreasedDebounceTimeEnabled = 'cody-autocomplete-increased-debounce-time-enabled',
     CodyAutocompleteStreamingResponse = 'cody-autocomplete-streaming-response',
+    CodyAutocompleteDefaultProviderFireworks = 'cody-autocomplete-default-provider-fireworks',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -32,7 +32,7 @@ describe('getConfiguration', () => {
             debugVerbose: false,
             debugFilter: null,
             telemetryLevel: 'all',
-            autocompleteAdvancedProvider: 'anthropic',
+            autocompleteAdvancedProvider: null,
             autocompleteAdvancedServerEndpoint: null,
             autocompleteAdvancedModel: null,
             autocompleteAdvancedAccessToken: null,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -55,7 +55,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         experimentalLocalSymbols: config.get(CONFIG_KEY.experimentalLocalSymbols, false),
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
         experimentalEditorTitleCommandIcon: config.get(CONFIG_KEY.experimentalEditorTitleCommandIcon, false),
-        autocompleteAdvancedProvider: config.get(CONFIG_KEY.autocompleteAdvancedProvider, 'anthropic'),
+        autocompleteAdvancedProvider: config.get(CONFIG_KEY.autocompleteAdvancedProvider, null),
         experimentalSymfPath: config.get<string>(CONFIG_KEY.experimentalSymfPath, 'symf'),
         experimentalSymfAnthropicKey: config.get<string>(CONFIG_KEY.experimentalSymfAnthropicKey, ''),
         autocompleteAdvancedServerEndpoint: config.get<string | null>(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -402,7 +402,7 @@ const register = async (
 
     let completionsProvider: vscode.Disposable | null = null
     disposables.push({ dispose: () => completionsProvider?.dispose() })
-    const setupAutocomplete = (): void => {
+    const setupAutocomplete = async (): Promise<void> => {
         const config = getConfiguration(vscode.workspace.getConfiguration())
 
         if (!config.autocomplete) {
@@ -423,7 +423,7 @@ const register = async (
             completionsProvider.dispose()
         }
 
-        completionsProvider = createCompletionsProvider(
+        completionsProvider = await createCompletionsProvider(
             config,
             completionsClient,
             statusBar,
@@ -433,10 +433,10 @@ const register = async (
     }
     vscode.workspace.onDidChangeConfiguration(event => {
         if (event.affectsConfiguration('cody.autocomplete')) {
-            setupAutocomplete()
+            void setupAutocomplete()
         }
     })
-    setupAutocomplete()
+    await setupAutocomplete()
 
     // Initiate inline chat when feature flag is on
     if (!initialConfig.inlineChat) {
@@ -470,16 +470,16 @@ const register = async (
     }
 }
 
-function createCompletionsProvider(
+async function createCompletionsProvider(
     config: Configuration,
     completionsClient: SourcegraphCompletionsClient,
     statusBar: CodyStatusBar,
     contextProvider: ContextProvider,
     featureFlagProvider: FeatureFlagProvider
-): vscode.Disposable {
+): Promise<vscode.Disposable> {
     const disposables: vscode.Disposable[] = []
 
-    const providerConfig = createProviderConfig(config, completionsClient)
+    const providerConfig = await createProviderConfig(config, completionsClient, featureFlagProvider)
     if (providerConfig) {
         const history = new VSCodeDocumentHistory()
         const completionsProvider = new InlineCompletionItemProvider({

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -63,7 +63,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
 
     const history = new VSCodeDocumentHistory()
 
-    providerConfig = createProviderConfig(initialConfig, completionsClient)
+    providerConfig = await createProviderConfig(initialConfig, completionsClient)
     if (!providerConfig) {
         throw new Error('invalid completion config: no provider')
     }


### PR DESCRIPTION

## Test plan

Tested that anthropic is still the default locally

```
█ AuthProvider:init:lastEndpoint: https://sourcegraph.com/
█ CodyCompletionProvider:initialized: provider: anthropic
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
