### PR TITLE
Autocomplete: Include model identifier with autocomplete logs

### DIFF
--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -194,6 +194,7 @@ async function doGetInlineCompletions({
     const logId = CompletionLogger.create({
         multiline,
         providerIdentifier: providerConfig.identifier,
+        providerModel: providerConfig.model,
         languageId: document.languageId,
     })
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -15,6 +15,7 @@ export interface CompletionEvent {
         multiline: boolean
         multilineMode: null | 'block'
         providerIdentifier: string
+        providerModel: string
         languageId: string
         contextSummary?: ContextSummary
         source?: string

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -247,5 +247,6 @@ export function createProviderConfig(anthropicOptions: AnthropicOptions): Provid
         enableExtendedMultilineTriggers: true,
         identifier: 'anthropic',
         supportsInfilling: false,
+        model: 'claude-instant-1',
     }
 }

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -35,6 +35,11 @@ export interface ProviderConfig {
      * Indicating whether the provider supports infilling.
      */
     supportsInfilling: boolean
+
+    /**
+     * Defines which model is used with the respective provider.
+     */
+    model: string
 }
 
 export interface ProviderOptions {

--- a/vscode/src/completions/providers/unstable-azure-openai.ts
+++ b/vscode/src/completions/providers/unstable-azure-openai.ts
@@ -120,5 +120,6 @@ export function createProviderConfig(unstableAzureOpenAIOptions: UnstableAzureOp
         enableExtendedMultilineTriggers: false,
         identifier: PROVIDER_IDENTIFIER,
         supportsInfilling: false,
+        model: 'gpt-35-turbo',
     }
 }

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -153,5 +153,6 @@ export function createProviderConfig(unstableCodeGenOptions: UnstableCodeGenOpti
         enableExtendedMultilineTriggers: false,
         identifier: PROVIDER_IDENTIFIER,
         supportsInfilling: true,
+        model: 'codegen',
     }
 }

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -174,7 +174,7 @@ export function createProviderConfig(
         unstableFireworksOptions.model === null || unstableFireworksOptions.model === ''
             ? 'starcoder-7b'
             : Object.prototype.hasOwnProperty.call(MODEL_MAP, unstableFireworksOptions.model)
-            ? unstableFireworksOptions.model
+            ? (unstableFireworksOptions.model as keyof typeof MODEL_MAP)
             : null
 
     if (model === null) {

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -12,6 +12,7 @@ interface UnstableHuggingFaceOptions {
     accessToken: null | string
 }
 
+const MODEL = 'starcoder'
 const PROVIDER_IDENTIFIER = 'huggingface'
 const STOP_WORD = '<|endoftext|>'
 const CONTEXT_WINDOW_CHARS = 3500 // ~ 1280 token limit
@@ -105,7 +106,7 @@ export class UnstableHuggingFaceProvider extends Provider {
                 throw new Error(data.error)
             }
 
-            const completions: string[] = data.map(c => postProcess(c.generated_text, this.options.multiline))
+            const completions: string[] = data.map(c => postProcess(c.generated_text))
             log?.onComplete(completions)
 
             return completions.map(content => ({
@@ -121,16 +122,8 @@ export class UnstableHuggingFaceProvider extends Provider {
     }
 }
 
-function postProcess(content: string, multiline: boolean): string {
-    content = content.replace(STOP_WORD, '')
-
-    // The model might return multiple lines for single line completions because
-    // we are only able to specify a token limit.
-    if (!multiline && content.includes('\n')) {
-        content = content.slice(0, content.indexOf('\n'))
-    }
-
-    return content.trim()
+function postProcess(content: string): string {
+    return content.replace(STOP_WORD, '')
 }
 
 export function createProviderConfig(unstableHuggingFaceOptions: UnstableHuggingFaceOptions): ProviderConfig {
@@ -142,5 +135,6 @@ export function createProviderConfig(unstableHuggingFaceOptions: UnstableHugging
         enableExtendedMultilineTriggers: true,
         identifier: PROVIDER_IDENTIFIER,
         supportsInfilling: true,
+        model: MODEL,
     }
 }


### PR DESCRIPTION
This is going to be necessary only for the Fireworks provider where we will ship with the option to change models. For the A/B experiment, we need to be able to filter out users that have configured a different `model` from the on we want to test against.

This PR now includes the model next to the provider identifier in the autocomplete logs.

## Test plan

Check the outputs tab

```
CodyVSCodeExtension:completion:suggested {"multiline":false,"providerIdentifier":"anthropic","providerModel":"claude-instant-1","languageId":"typescript","type":"inline","multilineMode":null,"id":"qmq2pshbi","contextSummary":{"duration":0.20449999906122684},"source":"LastCandidate","lineCount":1,"charCount":27,"latency":989.3145000003278,"displayDuration":721.9014170002192,"read":true,"accepted":true,"otherCompletionProviderEnabled":true,"completionsStartedSinceLastSuggestion":4}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
