### PR TITLE
Agent: improve langage detection 

### DIFF
--- a/agent/src/AgentTextDocument.ts
+++ b/agent/src/AgentTextDocument.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { getLanguageForFileName } from './language'
 import { DocumentOffsets } from './offsets'
 import { TextDocument } from './protocol'
 import * as vscode_shim from './vscode-shim'
@@ -14,7 +15,7 @@ export class AgentTextDocument implements vscode.TextDocument {
         this.uri = vscode_shim.Uri.from({ scheme: 'file', path: textDocument.filePath })
         this.fileName = textDocument.filePath
         this.isUntitled = false
-        this.languageId = this.fileName.split('.').splice(-1)[0]
+        this.languageId = getLanguageForFileName(this.fileName)
         this.offsets = new DocumentOffsets(textDocument)
         this.lineCount = this.offsets.lineCount()
     }

--- a/agent/src/language-file-extensions.json
+++ b/agent/src/language-file-extensions.json
@@ -1,168 +1,42 @@
 {
-  "actionscript": [
-    "as"
-  ],
-  "ada": [
-    "adb",
-    "ada",
-    "ads"
-  ],
-  "apache": [
-    "apacheconf"
-  ],
-  "apex": [
-    "cls",
-    "apex",
-    "trigger"
-  ],
-  "applescript": [
-    "applescript",
-    "scpt"
-  ],
-  "beancount": [
-    "beancount"
-  ],
-  "bibtex": [
-    "bib"
-  ],
-  "clojure": [
-    "clj",
-    "cljs",
-    "cljx"
-  ],
-  "cmake": [
-    "cmake",
-    "cmake.in",
-    "in"
-  ],
-  "coffescript": [
-    "coffee",
-    "cake",
-    "cson",
-    "cjsx",
-    "iced"
-  ],
-  "cpp": [
-    "c",
-    "cc",
-    "cpp",
-    "cxx",
-    "c++",
-    "h++",
-    "hh",
-    "h",
-    "hpp",
-    "pc",
-    "pcc"
-  ],
-  "csharp": [
-    "cs",
-    "csx"
-  ],
-  "css": [
-    "css"
-  ],
-  "cuda": [
-    "cu",
-    "cuh"
-  ],
-  "d": [
-    "d"
-  ],
-  "dot": [
-    "dot"
-  ],
-  "dart": [
-    "dart"
-  ],
-  "diff": [
-    "diff",
-    "patch"
-  ],
-  "dockerfile": [
-    "Dockerfile"
-  ],
-  "django": [
-    "jinja"
-  ],
-  "dos": [
-    "bat",
-    "cmd"
-  ],
-  "elixir": [
-    "ex",
-    "exs"
-  ],
-  "elm": [
-    "elm"
-  ],
-  "erlang": [
-    "erl"
-  ],
-  "fortran": [
-    "f",
-    "for",
-    "frt",
-    "fr",
-    "forth",
-    "4th",
-    "fth"
-  ],
-  "fsharp": [
-    "fs"
-  ],
-  "go": [
-    "go"
-  ],
-  "graphql": [
-    "graphql"
-  ],
-  "groovy": [
-    "groovy"
-  ],
-  "haml": [
-    "haml"
-  ],
-  "handlebars": [
-    "hbs",
-    "handlebars"
-  ],
-  "haskell": [
-    "hs",
-    "hsc"
-  ],
-  "hcl": [
-    "hcl",
-    "nomad",
-    "tf",
-    "tfvars",
-    "workflow"
-  ],
-  "html": [
-    "htm",
-    "html",
-    "xhtml"
-  ],
-  "ini": [
-    "ini",
-    "cfg",
-    "prefs",
-    "pro",
-    "properties"
-  ],
-  "java": [
-    "java"
-  ],
-  "javascript": [
-    "js",
-    "es",
-    "es6",
-    "jss",
-    "jsm"
-  ],
-  "javascriptreact": [
-    "jsx"
-  ],
+  "actionscript": ["as"],
+  "ada": ["adb", "ada", "ads"],
+  "apache": ["apacheconf"],
+  "apex": ["cls", "apex", "trigger"],
+  "applescript": ["applescript", "scpt"],
+  "beancount": ["beancount"],
+  "bibtex": ["bib"],
+  "clojure": ["clj", "cljs", "cljx"],
+  "cmake": ["cmake", "cmake.in", "in"],
+  "coffescript": ["coffee", "cake", "cson", "cjsx", "iced"],
+  "cpp": ["c", "cc", "cpp", "cxx", "c++", "h++", "hh", "h", "hpp", "pc", "pcc"],
+  "csharp": ["cs", "csx"],
+  "css": ["css"],
+  "cuda": ["cu", "cuh"],
+  "d": ["d"],
+  "dot": ["dot"],
+  "dart": ["dart"],
+  "diff": ["diff", "patch"],
+  "dockerfile": ["Dockerfile"],
+  "django": ["jinja"],
+  "dos": ["bat", "cmd"],
+  "elixir": ["ex", "exs"],
+  "elm": ["elm"],
+  "erlang": ["erl"],
+  "fortran": ["f", "for", "frt", "fr", "forth", "4th", "fth"],
+  "fsharp": ["fs"],
+  "go": ["go"],
+  "graphql": ["graphql"],
+  "groovy": ["groovy"],
+  "haml": ["haml"],
+  "handlebars": ["hbs", "handlebars"],
+  "haskell": ["hs", "hsc"],
+  "hcl": ["hcl", "nomad", "tf", "tfvars", "workflow"],
+  "html": ["htm", "html", "xhtml"],
+  "ini": ["ini", "cfg", "prefs", "pro", "properties"],
+  "java": ["java"],
+  "javascript": ["js", "es", "es6", "jss", "jsm"],
+  "javascriptreact": ["jsx"],
   "json": [
     "json",
     "sublime_metrics",
@@ -173,117 +47,25 @@
     "sublime-settings",
     "sublime-workspace"
   ],
-  "jsonnet": [
-    "jsonnet",
-    "libsonnet"
-  ],
-  "julia": [
-    "jl"
-  ],
-  "kotlin": [
-    "kt",
-    "ktm",
-    "kts"
-  ],
-  "less": [
-    "less"
-  ],
-  "lisp": [
-    "lisp",
-    "asd",
-    "cl",
-    "lsp",
-    "l",
-    "ny",
-    "podsl",
-    "sexp",
-    "el"
-  ],
-  "lua": [
-    "lua",
-    "fcgi",
-    "nse",
-    "pd_lua",
-    "rbxs",
-    "wlua"
-  ],
-  "makefile": [
-    "mk",
-    "mak"
-  ],
-  "markdown": [
-    "md",
-    "mkdown",
-    "mkd"
-  ],
-  "nginx": [
-    "nginxconf"
-  ],
-  "objectivec": [
-    "m",
-    "mm"
-  ],
-  "ocaml": [
-    "ml",
-    "eliom",
-    "eliomi",
-    "ml4",
-    "mli",
-    "mll",
-    "mly",
-    "re"
-  ],
-  "pascal": [
-    "p",
-    "pas",
-    "pp"
-  ],
-  "perl": [
-    "pl",
-    "al",
-    "cgi",
-    "perl",
-    "ph",
-    "plx",
-    "pm",
-    "pod",
-    "psgi",
-    "t"
-  ],
-  "php": [
-    "php",
-    "phtml",
-    "php3",
-    "php4",
-    "php5",
-    "php6",
-    "php7",
-    "phps"
-  ],
-  "powershell": [
-    "ps1",
-    "psd1",
-    "psm1"
-  ],
-  "protobuf": [
-    "proto"
-  ],
-  "python": [
-    "py",
-    "pyc",
-    "pyd",
-    "pyo",
-    "pyw",
-    "pyz"
-  ],
-  "r": [
-    "r",
-    "rd",
-    "rsx"
-  ],
-  "repro": [
-    "repro"
-  ],
+  "jsonnet": ["jsonnet", "libsonnet"],
+  "julia": ["jl"],
+  "kotlin": ["kt", "ktm", "kts"],
+  "less": ["less"],
+  "lisp": ["lisp", "asd", "cl", "lsp", "l", "ny", "podsl", "sexp", "el"],
+  "lua": ["lua", "fcgi", "nse", "pd_lua", "rbxs", "wlua"],
+  "makefile": ["mk", "mak"],
+  "markdown": ["md", "mkdown", "mkd"],
+  "nginx": ["nginxconf"],
+  "objectivec": ["m", "mm"],
+  "ocaml": ["ml", "eliom", "eliomi", "ml4", "mli", "mll", "mly", "re"],
+  "pascal": ["p", "pas", "pp"],
+  "perl": ["pl", "al", "cgi", "perl", "ph", "plx", "pm", "pod", "psgi", "t"],
+  "php": ["php", "phtml", "php3", "php4", "php5", "php6", "php7", "phps"],
+  "powershell": ["ps1", "psd1", "psm1"],
+  "protobuf": ["proto"],
+  "python": ["py", "pyc", "pyd", "pyo", "pyw", "pyz"],
+  "r": ["r", "rd", "rsx"],
+  "repro": ["repro"],
   "ruby": [
     "rb",
     "rbi",
@@ -306,87 +88,27 @@
     "thor",
     "watchr"
   ],
-  "rust": [
-    "rs",
-    "rs.in"
-  ],
-  "scala": [
-    "sbt",
-    "sc",
-    "scala"
-  ],
-  "scheme": [
-    "scm",
-    "sch",
-    "sls",
-    "sps",
-    "ss"
-  ],
-  "scss": [
-    "sass",
-    "scss"
-  ],
-  "shell": [
-    "sh",
-    "bash",
-    "zsh"
-  ],
-  "smalltalk": [
-    "st"
-  ],
-  "sql": [
-    "sql"
-  ],
-  "starlark": [
-    "bzl",
-    "bazel",
-    "BUILD",
-    "WORKSPACE"
-  ],
-  "stylus": [
-    "styl"
-  ],
-  "svelte": [
-    "svelte"
-  ],
-  "swift": [
-    "swift"
-  ],
-  "thrift": [
-    "thrift"
-  ],
-  "toml": [
-    "toml"
-  ],
-  "twig": [
-    "twig"
-  ],
-  "typescript": [
-    "ts"
-  ],
-  "typescriptreact": [
-    "tsx"
-  ],
-  "vbnet": [
-    "vb"
-  ],
-  "vbscrip": [
-    "vbs"
-  ],
-  "verilog": [
-    "v",
-    "veo",
-    "sv",
-    "svh",
-    "svi"
-  ],
-  "vhdl": [
-    "vhd",
-    "vhdl"
-  ],
-  "vim": [
-    "vim"
-  ],
+  "rust": ["rs", "rs.in"],
+  "scala": ["sbt", "sc", "scala"],
+  "scheme": ["scm", "sch", "sls", "sps", "ss"],
+  "scss": ["sass", "scss"],
+  "shell": ["sh", "bash", "zsh"],
+  "smalltalk": ["st"],
+  "sql": ["sql"],
+  "starlark": ["bzl", "bazel", "BUILD", "WORKSPACE"],
+  "stylus": ["styl"],
+  "svelte": ["svelte"],
+  "swift": ["swift"],
+  "thrift": ["thrift"],
+  "toml": ["toml"],
+  "twig": ["twig"],
+  "typescript": ["ts"],
+  "typescriptreact": ["tsx"],
+  "vbnet": ["vb"],
+  "vbscrip": ["vbs"],
+  "verilog": ["v", "veo", "sv", "svh", "svi"],
+  "vhdl": ["vhd", "vhdl"],
+  "vim": ["vim"],
   "xml": [
     "xml",
     "adml",
@@ -476,8 +198,5 @@
     "xul",
     "zcml"
   ],
-  "yaml": [
-    "yml",
-    "yaml"
-  ]
+  "yaml": ["yml", "yaml"]
 }

--- a/agent/src/language-file-extensions.json
+++ b/agent/src/language-file-extensions.json
@@ -1,0 +1,483 @@
+{
+  "actionscript": [
+    "as"
+  ],
+  "ada": [
+    "adb",
+    "ada",
+    "ads"
+  ],
+  "apache": [
+    "apacheconf"
+  ],
+  "apex": [
+    "cls",
+    "apex",
+    "trigger"
+  ],
+  "applescript": [
+    "applescript",
+    "scpt"
+  ],
+  "beancount": [
+    "beancount"
+  ],
+  "bibtex": [
+    "bib"
+  ],
+  "clojure": [
+    "clj",
+    "cljs",
+    "cljx"
+  ],
+  "cmake": [
+    "cmake",
+    "cmake.in",
+    "in"
+  ],
+  "coffescript": [
+    "coffee",
+    "cake",
+    "cson",
+    "cjsx",
+    "iced"
+  ],
+  "cpp": [
+    "c",
+    "cc",
+    "cpp",
+    "cxx",
+    "c++",
+    "h++",
+    "hh",
+    "h",
+    "hpp",
+    "pc",
+    "pcc"
+  ],
+  "csharp": [
+    "cs",
+    "csx"
+  ],
+  "css": [
+    "css"
+  ],
+  "cuda": [
+    "cu",
+    "cuh"
+  ],
+  "d": [
+    "d"
+  ],
+  "dot": [
+    "dot"
+  ],
+  "dart": [
+    "dart"
+  ],
+  "diff": [
+    "diff",
+    "patch"
+  ],
+  "dockerfile": [
+    "Dockerfile"
+  ],
+  "django": [
+    "jinja"
+  ],
+  "dos": [
+    "bat",
+    "cmd"
+  ],
+  "elixir": [
+    "ex",
+    "exs"
+  ],
+  "elm": [
+    "elm"
+  ],
+  "erlang": [
+    "erl"
+  ],
+  "fortran": [
+    "f",
+    "for",
+    "frt",
+    "fr",
+    "forth",
+    "4th",
+    "fth"
+  ],
+  "fsharp": [
+    "fs"
+  ],
+  "go": [
+    "go"
+  ],
+  "graphql": [
+    "graphql"
+  ],
+  "groovy": [
+    "groovy"
+  ],
+  "haml": [
+    "haml"
+  ],
+  "handlebars": [
+    "hbs",
+    "handlebars"
+  ],
+  "haskell": [
+    "hs",
+    "hsc"
+  ],
+  "hcl": [
+    "hcl",
+    "nomad",
+    "tf",
+    "tfvars",
+    "workflow"
+  ],
+  "html": [
+    "htm",
+    "html",
+    "xhtml"
+  ],
+  "ini": [
+    "ini",
+    "cfg",
+    "prefs",
+    "pro",
+    "properties"
+  ],
+  "java": [
+    "java"
+  ],
+  "javascript": [
+    "js",
+    "es",
+    "es6",
+    "jss",
+    "jsm"
+  ],
+  "javascriptreact": [
+    "jsx"
+  ],
+  "json": [
+    "json",
+    "sublime_metrics",
+    "sublime_session",
+    "sublime-keymap",
+    "sublime-mousemap",
+    "sublime-project",
+    "sublime-settings",
+    "sublime-workspace"
+  ],
+  "jsonnet": [
+    "jsonnet",
+    "libsonnet"
+  ],
+  "julia": [
+    "jl"
+  ],
+  "kotlin": [
+    "kt",
+    "ktm",
+    "kts"
+  ],
+  "less": [
+    "less"
+  ],
+  "lisp": [
+    "lisp",
+    "asd",
+    "cl",
+    "lsp",
+    "l",
+    "ny",
+    "podsl",
+    "sexp",
+    "el"
+  ],
+  "lua": [
+    "lua",
+    "fcgi",
+    "nse",
+    "pd_lua",
+    "rbxs",
+    "wlua"
+  ],
+  "makefile": [
+    "mk",
+    "mak"
+  ],
+  "markdown": [
+    "md",
+    "mkdown",
+    "mkd"
+  ],
+  "nginx": [
+    "nginxconf"
+  ],
+  "objectivec": [
+    "m",
+    "mm"
+  ],
+  "ocaml": [
+    "ml",
+    "eliom",
+    "eliomi",
+    "ml4",
+    "mli",
+    "mll",
+    "mly",
+    "re"
+  ],
+  "pascal": [
+    "p",
+    "pas",
+    "pp"
+  ],
+  "perl": [
+    "pl",
+    "al",
+    "cgi",
+    "perl",
+    "ph",
+    "plx",
+    "pm",
+    "pod",
+    "psgi",
+    "t"
+  ],
+  "php": [
+    "php",
+    "phtml",
+    "php3",
+    "php4",
+    "php5",
+    "php6",
+    "php7",
+    "phps"
+  ],
+  "powershell": [
+    "ps1",
+    "psd1",
+    "psm1"
+  ],
+  "protobuf": [
+    "proto"
+  ],
+  "python": [
+    "py",
+    "pyc",
+    "pyd",
+    "pyo",
+    "pyw",
+    "pyz"
+  ],
+  "r": [
+    "r",
+    "rd",
+    "rsx"
+  ],
+  "repro": [
+    "repro"
+  ],
+  "ruby": [
+    "rb",
+    "rbi",
+    "builder",
+    "eye",
+    "gemspec",
+    "god",
+    "jbuilder",
+    "mspec",
+    "pluginspec",
+    "podspec",
+    "rabl",
+    "rake",
+    "rbuild",
+    "rbw",
+    "rbx",
+    "ru",
+    "ruby",
+    "spec",
+    "thor",
+    "watchr"
+  ],
+  "rust": [
+    "rs",
+    "rs.in"
+  ],
+  "scala": [
+    "sbt",
+    "sc",
+    "scala"
+  ],
+  "scheme": [
+    "scm",
+    "sch",
+    "sls",
+    "sps",
+    "ss"
+  ],
+  "scss": [
+    "sass",
+    "scss"
+  ],
+  "shell": [
+    "sh",
+    "bash",
+    "zsh"
+  ],
+  "smalltalk": [
+    "st"
+  ],
+  "sql": [
+    "sql"
+  ],
+  "starlark": [
+    "bzl",
+    "bazel",
+    "BUILD",
+    "WORKSPACE"
+  ],
+  "stylus": [
+    "styl"
+  ],
+  "svelte": [
+    "svelte"
+  ],
+  "swift": [
+    "swift"
+  ],
+  "thrift": [
+    "thrift"
+  ],
+  "toml": [
+    "toml"
+  ],
+  "twig": [
+    "twig"
+  ],
+  "typescript": [
+    "ts"
+  ],
+  "typescriptreact": [
+    "tsx"
+  ],
+  "vbnet": [
+    "vb"
+  ],
+  "vbscrip": [
+    "vbs"
+  ],
+  "verilog": [
+    "v",
+    "veo",
+    "sv",
+    "svh",
+    "svi"
+  ],
+  "vhdl": [
+    "vhd",
+    "vhdl"
+  ],
+  "vim": [
+    "vim"
+  ],
+  "xml": [
+    "xml",
+    "adml",
+    "admx",
+    "ant",
+    "axml",
+    "builds",
+    "ccxml",
+    "clixml",
+    "cproject",
+    "csl",
+    "csproj",
+    "ct",
+    "dita",
+    "ditamap",
+    "ditaval",
+    "dll.config",
+    "dotsettings",
+    "filters",
+    "fsproj",
+    "fxml",
+    "glade",
+    "gml",
+    "grxml",
+    "iml",
+    "ivy",
+    "jelly",
+    "jsproj",
+    "kml",
+    "launch",
+    "mdpolicy",
+    "mjml",
+    "mod",
+    "mxml",
+    "nproj",
+    "nuspec",
+    "odd",
+    "osm",
+    "pkgproj",
+    "plist",
+    "props",
+    "ps1xml",
+    "psc1",
+    "pt",
+    "rdf",
+    "resx",
+    "rss",
+    "scxml",
+    "sfproj",
+    "srdf",
+    "storyboard",
+    "stTheme",
+    "sublime-snippet",
+    "targets",
+    "tmCommand",
+    "tml",
+    "tmLanguage",
+    "tmPreferences",
+    "tmSnippet",
+    "tmTheme",
+    "ui",
+    "urdf",
+    "ux",
+    "vbproj",
+    "vcxproj",
+    "vsixmanifest",
+    "vssettings",
+    "vstemplate",
+    "vxml",
+    "wixproj",
+    "wsdl",
+    "wsf",
+    "wxi",
+    "wxl",
+    "wxs",
+    "x3d",
+    "xacro",
+    "xaml",
+    "xib",
+    "xlf",
+    "xliff",
+    "xmi",
+    "xml.dist",
+    "xproj",
+    "xsd",
+    "xspec",
+    "xul",
+    "zcml"
+  ],
+  "yaml": [
+    "yml",
+    "yaml"
+  ]
+}

--- a/agent/src/language.test.ts
+++ b/agent/src/language.test.ts
@@ -34,7 +34,7 @@ describe('getLanguageForFileName', () => {
 
 describe('language-file-extensions.json mappings', () => {
     it('has no duplicates', () => {
-        const mappings = new Map<String, String>()
+        const mappings = new Map<string, string>()
         for (const [language, extensions] of Object.entries(extensionMapping)) {
             for (const extension of extensions) {
                 expect(mappings.get(extension)).toBeUndefined()

--- a/agent/src/language.test.ts
+++ b/agent/src/language.test.ts
@@ -1,0 +1,34 @@
+import assert from 'assert'
+
+import { describe, it } from 'vitest'
+
+import { getLanguageForFileName } from './language'
+
+describe('getLanguageForFileName', () => {
+    it('gets languages', () => {
+        assert.equal(getLanguageForFileName('test.go'), 'go')
+        assert.equal(getLanguageForFileName('test.java'), 'java')
+        assert.equal(getLanguageForFileName('test.ts'), 'typescript')
+        assert.equal(getLanguageForFileName('test.js'), 'javascript')
+    })
+
+    it('gets languages from multiple extension values', () => {
+        assert.equal(getLanguageForFileName('test.es'), 'javascript')
+        assert.equal(getLanguageForFileName('test.jsm'), 'javascript')
+        assert.equal(getLanguageForFileName('test.lisp'), 'lisp')
+        assert.equal(getLanguageForFileName('test.lsp'), 'lisp')
+        assert.equal(getLanguageForFileName('test.kt'), 'kotlin')
+        assert.equal(getLanguageForFileName('test.ktm'), 'kotlin')
+        assert.equal(getLanguageForFileName('test.kts'), 'kotlin')
+    })
+
+    it('gets custom languages overrides  ', () => {
+        assert.equal(getLanguageForFileName('test.jsx'), 'javascriptreact')
+        assert.equal(getLanguageForFileName('test.tsx'), 'typescriptreact')
+    })
+
+    it('returns the extension if the language is unknown', () => {
+        assert.equal(getLanguageForFileName('test.bad'), 'bad')
+        assert.equal(getLanguageForFileName('test.invalid'), 'invalid')
+    })
+})

--- a/agent/src/language.test.ts
+++ b/agent/src/language.test.ts
@@ -1,34 +1,45 @@
-import assert from 'assert'
-
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { getLanguageForFileName } from './language'
+import extensionMapping from './language-file-extensions.json'
 
 describe('getLanguageForFileName', () => {
     it('gets languages', () => {
-        assert.equal(getLanguageForFileName('test.go'), 'go')
-        assert.equal(getLanguageForFileName('test.java'), 'java')
-        assert.equal(getLanguageForFileName('test.ts'), 'typescript')
-        assert.equal(getLanguageForFileName('test.js'), 'javascript')
+        expect(getLanguageForFileName('test.go')).toBe('go')
+        expect(getLanguageForFileName('test.java')).toBe('java')
+        expect(getLanguageForFileName('test.ts')).toBe('typescript')
+        expect(getLanguageForFileName('test.js')).toBe('javascript')
     })
 
     it('gets languages from multiple extension values', () => {
-        assert.equal(getLanguageForFileName('test.es'), 'javascript')
-        assert.equal(getLanguageForFileName('test.jsm'), 'javascript')
-        assert.equal(getLanguageForFileName('test.lisp'), 'lisp')
-        assert.equal(getLanguageForFileName('test.lsp'), 'lisp')
-        assert.equal(getLanguageForFileName('test.kt'), 'kotlin')
-        assert.equal(getLanguageForFileName('test.ktm'), 'kotlin')
-        assert.equal(getLanguageForFileName('test.kts'), 'kotlin')
+        expect(getLanguageForFileName('test.es')).toBe('javascript')
+        expect(getLanguageForFileName('test.jsm')).toBe('javascript')
+        expect(getLanguageForFileName('test.lisp')).toBe('lisp')
+        expect(getLanguageForFileName('test.lsp')).toBe('lisp')
+        expect(getLanguageForFileName('test.kt')).toBe('kotlin')
+        expect(getLanguageForFileName('test.ktm')).toBe('kotlin')
+        expect(getLanguageForFileName('test.kts')).toBe('kotlin')
     })
 
     it('gets custom languages overrides  ', () => {
-        assert.equal(getLanguageForFileName('test.jsx'), 'javascriptreact')
-        assert.equal(getLanguageForFileName('test.tsx'), 'typescriptreact')
+        expect(getLanguageForFileName('test.jsx')).toBe('javascriptreact')
+        expect(getLanguageForFileName('test.tsx')).toBe('typescriptreact')
     })
 
     it('returns the extension if the language is unknown', () => {
-        assert.equal(getLanguageForFileName('test.bad'), 'bad')
-        assert.equal(getLanguageForFileName('test.invalid'), 'invalid')
+        expect(getLanguageForFileName('test.bad')).toBe('bad')
+        expect(getLanguageForFileName('test.invalid')).toBe('invalid')
+    })
+})
+
+describe('language-file-extensions.json mappings', () => {
+    it('has no duplicates', () => {
+        const mappings = new Map<String, String>()
+        for (const [language, extensions] of Object.entries(extensionMapping)) {
+            for (const extension of extensions) {
+                expect(mappings.get(extension)).toBeUndefined()
+                mappings.set(extension, language)
+            }
+        }
     })
 })

--- a/agent/src/language.ts
+++ b/agent/src/language.ts
@@ -1,0 +1,22 @@
+import extensionMapping from './language-file-extensions.json'
+
+let mapping: Map<string, string> | undefined
+
+function getMapping(): Map<string, string> {
+    if (mapping) {
+        return mapping
+    }
+    mapping = new Map<string, string>()
+    for (const [language, extensions] of Object.entries(extensionMapping)) {
+        for (const extension of extensions) {
+            mapping.set(extension, language)
+        }
+    }
+    return mapping
+}
+
+export function getLanguageForFileName(filename: string): string {
+    const extension = filename.split('.').splice(-1)[0]
+    const language = getMapping().get(extension)
+    return language ? language : extension
+}

--- a/agent/src/language.ts
+++ b/agent/src/language.ts
@@ -18,5 +18,5 @@ function getMapping(): Map<string, string> {
 export function getLanguageForFileName(filename: string): string {
     const extension = filename.split('.').splice(-1)[0]
     const language = getMapping().get(extension)
-    return language ? language : extension
+    return language || extension
 }

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es2019",
     "allowJs": true,
   },
-  "include": ["**/*", ".*", "package.json"],
+  "include": ["**/*", ".*", "package.json", "src/language-file-extensions.json"],
   "exclude": ["dist"],
   "references": [{ "path": "../lib/shared" }, { "path": "../vscode" }],
 }


### PR DESCRIPTION
Adds language detection to the AgentTextDocument, by porting over the language file extension file from the sourcegraph repo.  Added in additional languages to match the vscode languages for `javascriptreact` and `typescriptreact`  

resolves https://github.com/sourcegraph/cody/issues/785

## Test plan
unit tests added 

`./gradlew -PforceAgentBuild=true :runIde`
Verified that I got multi line autocompletes for typescript and react(typescript)
Verified logs contain the correct language id

```
[Trace - 04:48:07 PM] Sending request 'graphql/logEvent - (39)'
Params: {
  "event": "CodyJetBrainsPlugin:completion:suggested",
  "url": "",
  "source": "IDEEXTENSION",
  "referrer": "JETBRAINS",
  "publicArgument": {
    "latency": 805,
    "displayDuration": 1283,
    "isAnyKnownPluginEnabled": false,
    "contextSummary": {
      "embeddings": 2.0,
      "local": 1.0,
      "duration": 0.641791820526123
    },
    "id": "0hvuohv26",
    "languageId": "typescript",         <-----
    "source": "CacheAfterRequestStart",
    "charCount": 28,
    "lineCount": 1,
    "multilineMode": "block",
    "providerIdentifier": "anthropic",
    "serverEndpoint": "https://sourcegraph.sourcegraph.com/"
  },
  ...
}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
