### PR TITLE
dx: show `dist` in the VS Code explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
     "completions-review-tool/data/*": true
   },
   "files.exclude": {
-    "**/dist": true,
     "**/.eslintcache": true,
     "**/.vscode-test": true,
     "**/.vscode-test-web": true


### PR DESCRIPTION
- Same as https://github.com/sourcegraph/cody/pull/838 but for `dist` folders

> Often, I need to dig into the built code for debugging purposes.
> The modified setting hides files from the explorer tree, which makes it hard to explore `dist` folders. `search.exclude` already prevents searches from going into `dist` folders, so it should be fine keeping it accessible in the explorer view. We have the same setup in the main monorepo.

## Test plan

n/a
