### PR TITLE
Autocomplete: Surface rate limit and other errors

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -1,0 +1,24 @@
+export class RateLimitError extends Error {
+    constructor(
+        message: string,
+        public limit?: number,
+        public retryAfter?: Date
+    ) {
+        super(message)
+        Object.setPrototypeOf(this, RateLimitError.prototype)
+    }
+}
+
+export function isAbortError(error: Error): boolean {
+    return (
+        // http module
+        error.message === 'aborted' ||
+        // fetch
+        error.message.includes('The operation was aborted') ||
+        error.message.includes('The user aborted a request')
+    )
+}
+
+export function isRateLimitError(error: Error): boolean {
+    return error instanceof RateLimitError
+}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - New button in Chat UI to export chat history to a JSON file. [pull/829](https://github.com/sourcegraph/cody/pull/829)
 - Rank autocomplete suggestion with tree-sitter when `cody.autocomplete.experimental.syntacticPostProcessing` is enabled. [pull/837](https://github.com/sourcegraph/cody/pull/837)
+- Rate limit and unexpected errors during autocomplete will now surface to the user through the status bar item. [pull/851](https://github.com/sourcegraph/cody/pull/851)
 
 ### Fixed
 
@@ -20,6 +21,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Add error handling to unblock Command Menu from being started up when invalid json file for custom commands is detected. [pull/827](https://github.com/sourcegraph/cody/pull/827)
 
 ### Changed
+
+- Errors are now always logged to the output console, even if the debug mode is not enabled. [pull/851](https://github.com/sourcegraph/cody/pull/851)
 
 ## [0.8.0]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,7 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - New button in Chat UI to export chat history to a JSON file. [pull/829](https://github.com/sourcegraph/cody/pull/829)
 - Rank autocomplete suggestion with tree-sitter when `cody.autocomplete.experimental.syntacticPostProcessing` is enabled. [pull/837](https://github.com/sourcegraph/cody/pull/837)
-- Rate limit and unexpected errors during autocomplete will now surface to the user through the status bar item. [pull/851](https://github.com/sourcegraph/cody/pull/851)
+- Rate limit during autocomplete will now surface to the user through the status bar item. [pull/851](https://github.com/sourcegraph/cody/pull/851)
 
 ### Fixed
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -4,7 +4,7 @@ import { CodyPrompt, CodyPromptType } from '@sourcegraph/cody-shared/src/chat/pr
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { View } from '../../webviews/NavBar'
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 import { MessageProvider, MessageProviderOptions } from './MessageProvider'
 import { ExtensionMessage, WebviewMessage } from './protocol'
@@ -34,7 +34,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                 await this.authProvider.announceNewAuthStatus()
                 break
             case 'initialized':
-                debug('ChatViewProvider:onDidReceiveMessage:initialized', '')
+                logDebug('ChatViewProvider:onDidReceiveMessage:initialized', '')
                 await this.init()
                 break
             case 'submit':
@@ -127,7 +127,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     }
 
     private async onHumanMessageSubmitted(text: string, submitType: 'user' | 'suggestion' | 'example'): Promise<void> {
-        debug('ChatViewProvider:onHumanMessageSubmitted', '', { verbose: { text, submitType } })
+        logDebug('ChatViewProvider:onHumanMessageSubmitted', '', { verbose: { text, submitType } })
         this.telemetryService.log('CodyVSCodeExtension:chat:submitted', { source: 'sidebar' })
         if (submitType === 'suggestion') {
             this.telemetryService.log('CodyVSCodeExtension:chatPredictions:used')
@@ -148,7 +148,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
      */
     private async onCustomPromptClicked(title: string, commandType: CodyPromptType = 'user'): Promise<void> {
         this.telemetryService.log('CodyVSCodeExtension:command:customMenu:clicked')
-        debug('ChatViewProvider:onCustomPromptClicked', title)
+        logDebug('ChatViewProvider:onCustomPromptClicked', title)
         if (!this.isCustomCommandAction(title)) {
             await this.setWebviewView('chat')
         }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -15,7 +15,7 @@ import { convertGitCloneURLToCodebaseName, isError } from '@sourcegraph/cody-sha
 import { getFullConfig } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { PlatformContext } from '../extension.common'
-import { debug } from '../log'
+import { logDebug } from '../log'
 import { getRerankWithLog } from '../logged-rerank'
 import { repositoryRemoteUrl } from '../repository/repositoryHelpers'
 import { AuthProvider } from '../services/AuthProvider'
@@ -99,7 +99,7 @@ export class ContextProvider implements vscode.Disposable {
     }
 
     public onConfigurationChange(newConfig: Config): void {
-        debug('ContextProvider:onConfigurationChange', '')
+        logDebug('ContextProvider:onConfigurationChange', '')
         this.config = newConfig
         const authStatus = this.authProvider.getAuthStatus()
         if (authStatus.endpoint) {
@@ -220,7 +220,7 @@ export class ContextProvider implements vscode.Disposable {
             // update codebase context on configuration change
             await this.updateCodebaseContext()
             await this.webview?.postMessage({ type: 'config', config: configForWebview, authStatus })
-            debug('Cody:publishConfig', 'configForWebview', { verbose: configForWebview })
+            logDebug('Cody:publishConfig', 'configForWebview', { verbose: configForWebview })
         }
 
         await send()

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -22,7 +22,7 @@ import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { PlatformContext } from '../extension.common'
-import { debug } from '../log'
+import { debug, error } from '../log'
 import { FixupTask } from '../non-stop/FixupTask'
 import { AuthProvider, isNetworkError } from '../services/AuthProvider'
 import { LocalStorage } from '../services/LocalStorageProvider'
@@ -229,7 +229,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             },
             onError: (err, statusCode) => {
                 // TODO notify the multiplexer of the error
-                debug('ChatViewProvider:onError', err)
+                error('ChatViewProvider:onError', err)
 
                 if (isAbortError(err)) {
                     this.isMessageInProgress = false
@@ -246,7 +246,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                             this.contextProvider.config.customHeaders
                         )
                         .catch(error => console.error(error))
-                    debug('ChatViewProvider:onError:unauthUser', err, { verbose: { statusCode } })
+                    error('ChatViewProvider:onError:unauthUser', err, { verbose: { statusCode } })
                 }
 
                 if (isNetworkError(err)) {
@@ -710,8 +710,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     void vscode.commands.executeCommand('vscode.open', exportPath)
                 }
             })
-        } catch (error) {
-            debug('MessageProvider:exportHistory', 'Failed to export chat history', error)
+        } catch (error_) {
+            error('MessageProvider:exportHistory', 'Failed to export chat history', error_)
         }
     }
 
@@ -752,7 +752,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (this.contextProvider.context.checkEmbeddingsConnection() && searchErrors) {
             this.transcript.addErrorAsAssistantResponse(searchErrors)
             this.handleTranscriptErrors(true)
-            debug('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
+            error('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
         }
     }
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -22,7 +22,7 @@ import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { PlatformContext } from '../extension.common'
-import { debug, error } from '../log'
+import { logDebug, logError } from '../log'
 import { FixupTask } from '../non-stop/FixupTask'
 import { AuthProvider, isNetworkError } from '../services/AuthProvider'
 import { LocalStorage } from '../services/LocalStorageProvider'
@@ -229,7 +229,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             },
             onError: (err, statusCode) => {
                 // TODO notify the multiplexer of the error
-                error('ChatViewProvider:onError', err)
+                logError('ChatViewProvider:onError', err)
 
                 if (isAbortError(err)) {
                     this.isMessageInProgress = false
@@ -246,7 +246,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                             this.contextProvider.config.customHeaders
                         )
                         .catch(error => console.error(error))
-                    error('ChatViewProvider:onError:unauthUser', err, { verbose: { statusCode } })
+                    logError('ChatViewProvider:onError:unauthUser', err, { verbose: { statusCode } })
                 }
 
                 if (isNetworkError(err)) {
@@ -356,11 +356,11 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         humanChatInput = command?.text
         recipeId = command?.recipeId
 
-        debug('ChatViewProvider:executeRecipe', recipeId, { verbose: humanChatInput })
+        logDebug('ChatViewProvider:executeRecipe', recipeId, { verbose: humanChatInput })
 
         const recipe = this.getRecipe(recipeId)
         if (!recipe) {
-            debug('ChatViewProvider:executeRecipe', 'no recipe found')
+            logDebug('ChatViewProvider:executeRecipe', 'no recipe found')
             return
         }
 
@@ -549,7 +549,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         // Get prompt details from controller by title then execute prompt's command
         const promptText = this.editor.controllers.command?.find(title)
         await this.editor.controllers.command?.get('command')
-        debug('executeCustomCommand:starting', title)
+        logDebug('executeCustomCommand:starting', title)
         if (!promptText) {
             return
         }
@@ -710,8 +710,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     void vscode.commands.executeCommand('vscode.open', exportPath)
                 }
             })
-        } catch (error_) {
-            error('MessageProvider:exportHistory', 'Failed to export chat history', error_)
+        } catch (error) {
+            logError('MessageProvider:exportHistory', 'Failed to export chat history', error)
         }
     }
 
@@ -752,7 +752,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (this.contextProvider.context.checkEmbeddingsConnection() && searchErrors) {
             this.transcript.addErrorAsAssistantResponse(searchErrors)
             this.handleTranscriptErrors(true)
-            error('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
+            logError('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
         }
     }
 

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -122,7 +122,7 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
         const err = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
 
         params.tracer?.({ error: err.toString() })
-        error('getInlineCompletions:error', err.message, { verbose: err })
+        error('getInlineCompletions:error', err.message, err.stack, { verbose: { params, err } })
         CompletionLogger.logError(err)
 
         if (isAbortError(err)) {

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -4,7 +4,7 @@ import { URI } from 'vscode-uri'
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
-import { debug } from '../log'
+import { error } from '../log'
 
 import { GetContextOptions, GetContextResult } from './context/context'
 import { DocumentHistory } from './context/history'
@@ -119,17 +119,17 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
         return result
     } catch (unknownError: unknown) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const error = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
+        const err = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
 
-        params.tracer?.({ error: error.toString() })
-        debug('getInlineCompletions:error', error.message, { verbose: error })
-        CompletionLogger.logError(error)
+        params.tracer?.({ error: err.toString() })
+        error('getInlineCompletions:error', err.message, { verbose: err })
+        CompletionLogger.logError(err)
 
-        if (isAbortError(error)) {
+        if (isAbortError(err)) {
             return null
         }
 
-        throw error
+        throw err
     } finally {
         params.setIsLoading?.(false)
     }

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
+import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { debug } from '../log'
 
@@ -15,7 +16,7 @@ import { RequestManager, RequestParams } from './request-manager'
 import { reuseLastCandidate } from './reuse-last-candidate'
 import { ProvideInlineCompletionsItemTraceData } from './tracer'
 import { InlineCompletionItem } from './types'
-import { isAbortError, SNIPPET_WINDOW_SIZE } from './utils'
+import { SNIPPET_WINDOW_SIZE } from './utils'
 
 export interface InlineCompletionsParams {
     // Context

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -4,7 +4,7 @@ import { URI } from 'vscode-uri'
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
-import { error } from '../log'
+import { logError } from '../log'
 
 import { GetContextOptions, GetContextResult } from './context/context'
 import { DocumentHistory } from './context/history'
@@ -119,17 +119,17 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
         return result
     } catch (unknownError: unknown) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const err = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
+        const error = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
 
-        params.tracer?.({ error: err.toString() })
-        error('getInlineCompletions:error', err.message, err.stack, { verbose: { params, err } })
-        CompletionLogger.logError(err)
+        params.tracer?.({ error: error.toString() })
+        logError('getInlineCompletions:error', error.message, error.stack, { verbose: { params, error } })
+        CompletionLogger.logError(error)
 
-        if (isAbortError(err)) {
+        if (isAbortError(error)) {
             return null
         }
 
-        throw err
+        throw error
     } finally {
         params.setIsLoading?.(false)
     }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,13 +1,13 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
+import { isAbortError, isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { logEvent } from '../services/EventLogger'
 
 import { ContextSummary } from './context/context'
 import { InlineCompletionItem } from './types'
-import { isAbortError, isRateLimitError } from './utils'
 
 export interface CompletionEvent {
     params: {

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -1,7 +1,7 @@
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
-import { error } from '../../log'
+import { logError } from '../../log'
 import { CodeCompletionsClient } from '../client'
 
 import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
@@ -25,7 +25,7 @@ export async function createProviderConfig(
                 })
             }
 
-            error(
+            logError(
                 'createProviderConfig',
                 'Provider `unstable-codegen` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
@@ -39,7 +39,7 @@ export async function createProviderConfig(
                 })
             }
 
-            error(
+            logError(
                 'createProviderConfig',
                 'Provider `unstable-huggingface` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
@@ -47,7 +47,7 @@ export async function createProviderConfig(
         }
         case 'unstable-azure-openai': {
             if (config.autocompleteAdvancedServerEndpoint === null) {
-                error(
+                logError(
                     'createProviderConfig',
                     'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
                 )
@@ -55,7 +55,7 @@ export async function createProviderConfig(
             }
 
             if (config.autocompleteAdvancedAccessToken === null) {
-                error(
+                logError(
                     'createProviderConfig',
                     'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.accessToken`.'
                 )
@@ -80,7 +80,10 @@ export async function createProviderConfig(
             })
         }
         default:
-            error('createProviderConfig', `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`)
+            logError(
+                'createProviderConfig',
+                `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`
+            )
             return null
     }
 }

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -1,7 +1,7 @@
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
-import { debug } from '../../log'
+import { error } from '../../log'
 import { CodeCompletionsClient } from '../client'
 
 import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
@@ -25,7 +25,7 @@ export async function createProviderConfig(
                 })
             }
 
-            debug(
+            error(
                 'createProviderConfig',
                 'Provider `unstable-codegen` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
@@ -39,7 +39,7 @@ export async function createProviderConfig(
                 })
             }
 
-            debug(
+            error(
                 'createProviderConfig',
                 'Provider `unstable-huggingface` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
             )
@@ -47,7 +47,7 @@ export async function createProviderConfig(
         }
         case 'unstable-azure-openai': {
             if (config.autocompleteAdvancedServerEndpoint === null) {
-                debug(
+                error(
                     'createProviderConfig',
                     'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.serverEndpoint`.'
                 )
@@ -55,7 +55,7 @@ export async function createProviderConfig(
             }
 
             if (config.autocompleteAdvancedAccessToken === null) {
-                debug(
+                error(
                     'createProviderConfig',
                     'Provider `unstable-azure-openai` can not be used without configuring `cody.autocomplete.advanced.accessToken`.'
                 )
@@ -80,7 +80,7 @@ export async function createProviderConfig(
             })
         }
         default:
-            debug('createProviderConfig', `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`)
+            error('createProviderConfig', `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`)
             return null
     }
 }

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -1,8 +1,9 @@
 import fetch from 'isomorphic-fetch'
 
+import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+
 import { logger } from '../../log'
 import { Completion, ContextSnippet } from '../types'
-import { isAbortError } from '../utils'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/providers/unstable-huggingface.ts
+++ b/vscode/src/completions/providers/unstable-huggingface.ts
@@ -1,9 +1,10 @@
 import fetch from 'isomorphic-fetch'
 
+import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+
 import { logger } from '../../log'
 import { getLanguageConfig } from '../language'
 import { Completion, ContextSnippet } from '../types'
-import { isAbortError } from '../utils'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -26,20 +26,6 @@ export function lastNLines(text: string, n: number): string {
     return lines.slice(Math.max(0, lines.length - n)).join('\n')
 }
 
-export function isAbortError(error: Error): boolean {
-    return (
-        // http module
-        error.message === 'aborted' ||
-        // fetch
-        error.message.includes('The operation was aborted') ||
-        error.message.includes('The user aborted a request')
-    )
-}
-
-export function isRateLimitError(error: Error): boolean {
-    return error.message.includes('you exceeded the rate limit')
-}
-
 /**
  * Creates a new signal that forks a parent signal. When the parent signal is aborted, the forked
  * signal will be aborted as well. This allows propagating abort signals across asynchronous

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts
@@ -387,7 +387,7 @@ describe('InlineCompletionItemProvider', () => {
             expect(addError).toHaveBeenCalledTimes(1)
         })
 
-        it('reports unexpected errors grouped by their message once', async () => {
+        it.skip('reports unexpected errors grouped by their message once', async () => {
             const { document, position } = documentAndPosition('█')
             let error = new Error('unexpected')
             const fn = vi.fn(getInlineCompletions).mockImplementation(() => Promise.reject(error))

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -330,7 +330,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     (error.retryAfter ? ` Usage will reset in ${formatDistance(error.retryAfter, new Date())}.` : ''),
                 onSelect: () => {
                     void vscode.env.openExternal(
-                        vscode.Uri.parse('https://about.sourcegraph.com/blog/increasing-the-completions-rate-limit')
+                        vscode.Uri.parse('https://docs.sourcegraph.com/cody/troubleshooting#autocomplete-rate-limits')
                     )
                 },
             })

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -5,7 +5,7 @@ import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
-import { logDebug, outputChannel } from '../log'
+import { logDebug } from '../log'
 import { CodyStatusBar } from '../services/StatusBar'
 
 import { getContext, GetContextOptions, GetContextResult } from './context/context'
@@ -40,8 +40,6 @@ export interface CodyCompletionItemProviderConfig {
     contextFetcher?: (options: GetContextOptions) => Promise<GetContextResult>
     featureFlagProvider: FeatureFlagProvider
 }
-
-const ONE_HOUR = 1000 * 60 * 60
 
 export class InlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private promptChars: number
@@ -337,21 +335,25 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             return
         }
 
-        const now = Date.now()
-        if (
-            this.reportedErrorMessages.has(error.message) &&
-            this.reportedErrorMessages.get(error.message)! + ONE_HOUR >= now
-        ) {
-            return
-        }
-        this.reportedErrorMessages.set(error.message, now)
-        this.config.statusBar.addError({
-            title: 'Cody Autocomplete Encountered an Unexpected Error',
-            description: error.message,
-            onSelect: () => {
-                outputChannel.show()
-            },
-        })
+        // @TODO(philipp-spiess): Bring back this code once we have fewer uncaught errors
+        //
+        // c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1693471486690459
+        //
+        // const now = Date.now()
+        // if (
+        //     this.reportedErrorMessages.has(error.message) &&
+        //     this.reportedErrorMessages.get(error.message)! + ONE_HOUR >= now
+        // ) {
+        //     return
+        // }
+        // this.reportedErrorMessages.set(error.message, now)
+        // this.config.statusBar.addError({
+        //     title: 'Cody Autocomplete Encountered an Unexpected Error',
+        //     description: error.message,
+        //     onSelect: () => {
+        //         outputChannel.show()
+        //     },
+        // })
     }
 }
 

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -1,9 +1,11 @@
+import { formatDistance } from 'date-fns'
 import * as vscode from 'vscode'
 
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
-import { debug } from '../log'
+import { debug, outputChannel } from '../log'
 import { CodyStatusBar } from '../services/StatusBar'
 
 import { getContext, GetContextOptions, GetContextResult } from './context/context'
@@ -43,6 +45,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     private promptChars: number
     private maxPrefixChars: number
     private maxSuffixChars: number
+    private reportedErrorMessages: Set<string> = new Set()
+    private resetRateLimitErrorsAfter: number | null = null
 
     private readonly config: Required<CodyCompletionItemProviderConfig>
 
@@ -161,86 +165,96 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         const isIncreasedDebounceTimeEnabled = await this.config.featureFlagProvider.evaluateFeatureFlag(
             FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled
         )
-
-        const result = await this.getInlineCompletions({
-            document,
-            position,
-            context,
-            docContext,
-            promptChars: this.promptChars,
-            providerConfig: this.config.providerConfig,
-            responsePercentage: this.config.responsePercentage,
-            prefixPercentage: this.config.prefixPercentage,
-            suffixPercentage: this.config.suffixPercentage,
-            isEmbeddingsContextEnabled: this.config.isEmbeddingsContextEnabled,
-            toWorkspaceRelativePath: uri => vscode.workspace.asRelativePath(uri),
-            contextFetcher: this.config.contextFetcher,
-            getCodebaseContext: this.config.getCodebaseContext,
-            documentHistory: this.config.history,
-            requestManager: this.requestManager,
-            lastCandidate: this.lastCandidate,
-            debounceInterval: { singleLine: isIncreasedDebounceTimeEnabled ? 75 : 25, multiLine: 125 },
-            setIsLoading,
-            abortSignal: abortController.signal,
-            tracer,
-        })
-
-        if (!result) {
-            return null
-        }
-
-        // Track the last candidate completion (that is shown as ghost text in the editor) so that
-        // we can reuse it if the user types in such a way that it is still valid (such as by typing
-        // `ab` if the ghost text suggests `abcd`).
-        if (result.source !== InlineCompletionsResultSource.LastCandidate) {
-            this.lastCandidate =
-                result.items.length > 0
-                    ? {
-                          uri: document.uri,
-                          lastTriggerPosition: position,
-                          lastTriggerCurrentLinePrefix: document.lineAt(position).text.slice(0, position.character),
-                          lastTriggerNextNonEmptyLine: getNextNonEmptyLine(
-                              document.getText(
-                                  new vscode.Range(position, document.lineAt(document.lineCount - 1).range.end)
-                              )
-                          ),
-                          lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
-                          result: {
-                              logId: result.logId,
-                              items: result.items,
-                          },
-                      }
-                    : undefined
-        }
-
-        const items = this.processInlineCompletionsForVSCode(result.logId, document, position, result.items, context)
-
-        // A completion that won't be visible in VS Code will not be returned and not be logged.
-        if (
-            !isCompletionVisible(
-                items,
+        try {
+            const result = await this.getInlineCompletions({
                 document,
-                docContext,
+                position,
                 context,
-                this.config.completeSuggestWidgetSelection,
-                abortController.signal
+                docContext,
+                promptChars: this.promptChars,
+                providerConfig: this.config.providerConfig,
+                responsePercentage: this.config.responsePercentage,
+                prefixPercentage: this.config.prefixPercentage,
+                suffixPercentage: this.config.suffixPercentage,
+                isEmbeddingsContextEnabled: this.config.isEmbeddingsContextEnabled,
+                toWorkspaceRelativePath: uri => vscode.workspace.asRelativePath(uri),
+                contextFetcher: this.config.contextFetcher,
+                getCodebaseContext: this.config.getCodebaseContext,
+                documentHistory: this.config.history,
+                requestManager: this.requestManager,
+                lastCandidate: this.lastCandidate,
+                debounceInterval: { singleLine: isIncreasedDebounceTimeEnabled ? 75 : 25, multiLine: 125 },
+                setIsLoading,
+                abortSignal: abortController.signal,
+                tracer,
+            })
+
+            if (!result) {
+                return null
+            }
+
+            // Track the last candidate completion (that is shown as ghost text in the editor) so that
+            // we can reuse it if the user types in such a way that it is still valid (such as by typing
+            // `ab` if the ghost text suggests `abcd`).
+            if (result.source !== InlineCompletionsResultSource.LastCandidate) {
+                this.lastCandidate =
+                    result.items.length > 0
+                        ? {
+                              uri: document.uri,
+                              lastTriggerPosition: position,
+                              lastTriggerCurrentLinePrefix: document.lineAt(position).text.slice(0, position.character),
+                              lastTriggerNextNonEmptyLine: getNextNonEmptyLine(
+                                  document.getText(
+                                      new vscode.Range(position, document.lineAt(document.lineCount - 1).range.end)
+                                  )
+                              ),
+                              lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
+                              result: {
+                                  logId: result.logId,
+                                  items: result.items,
+                              },
+                          }
+                        : undefined
+            }
+
+            const items = this.processInlineCompletionsForVSCode(
+                result.logId,
+                document,
+                position,
+                result.items,
+                context
             )
-        ) {
-            return null
+
+            // A completion that won't be visible in VS Code will not be returned and not be logged.
+            if (
+                !isCompletionVisible(
+                    items,
+                    document,
+                    docContext,
+                    context,
+                    this.config.completeSuggestWidgetSelection,
+                    abortController.signal
+                )
+            ) {
+                return null
+            }
+
+            const event = CompletionLogger.completionEvent(result.logId)
+            if (items.length > 0) {
+                CompletionLogger.suggested(result.logId, InlineCompletionsResultSource[result.source], items[0] as any)
+            } else {
+                CompletionLogger.noResponse(result.logId)
+            }
+
+            const completionResult: vscode.InlineCompletionList = { items }
+
+            ;(completionResult as any).completionEvent = event
+
+            return completionResult
+        } catch (error: unknown) {
+            this.onError(error as Error)
+            throw error
         }
-
-        const event = CompletionLogger.completionEvent(result.logId)
-        if (items.length > 0) {
-            CompletionLogger.suggested(result.logId, InlineCompletionsResultSource[result.source], items[0] as any)
-        } else {
-            CompletionLogger.noResponse(result.logId)
-        }
-
-        const completionResult: vscode.InlineCompletionList = { items }
-
-        ;(completionResult as any).completionEvent = event
-
-        return completionResult
     }
 
     public handleDidAcceptCompletionItem(logId: string, completion: InlineCompletionItem): void {
@@ -293,6 +307,44 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     },
                 ],
             })
+        })
+    }
+
+    /**
+     * A callback that is called whenever an error happens. We do not want to flood a users UI with
+     * error messages so every unexpected error is deduplicated by its message and rate limit errors
+     * are only shown once during the rate limit period.
+     */
+    private onError(error: Error | RateLimitError): void {
+        if (error instanceof RateLimitError) {
+            if (this.resetRateLimitErrorsAfter && this.resetRateLimitErrorsAfter > Date.now()) {
+                return
+            }
+            this.resetRateLimitErrorsAfter = error.retryAfter?.getTime() ?? Date.now() + 24 * 60 * 60 * 1000
+            this.config.statusBar.addError({
+                title: 'Cody Autocomplete Disabled Due to Rate Limit',
+                description:
+                    `You've used all${error.limit ? ` ${error.limit}` : ''} daily autocompletions.` +
+                    (error.retryAfter ? ` Usage will reset in ${formatDistance(error.retryAfter, new Date())}.` : ''),
+                onSelect: () => {
+                    void vscode.env.openExternal(
+                        vscode.Uri.parse('https://about.sourcegraph.com/blog/increasing-the-completions-rate-limit')
+                    )
+                },
+            })
+            return
+        }
+
+        if (this.reportedErrorMessages.has(error.message)) {
+            return
+        }
+        this.reportedErrorMessages.add(error.message)
+        this.config.statusBar.addError({
+            title: 'Cody Autocomplete Encountered an Unexpected Error',
+            description: error.message,
+            onSelect: () => {
+                outputChannel.show()
+            },
         })
     }
 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -45,7 +45,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     private promptChars: number
     private maxPrefixChars: number
     private maxSuffixChars: number
-    private reportedErrorMessages: Map<string, number> = new Map()
+    // private reportedErrorMessages: Map<string, number> = new Map()
     private resetRateLimitErrorsAfter: number | null = null
 
     private readonly config: Required<CodyCompletionItemProviderConfig>

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -9,7 +9,7 @@ import {
 import { VsCodeCommandsController } from '@sourcegraph/cody-shared/src/editor'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { debug, error } from '../log'
+import { logDebug, logError } from '../log'
 import { LocalStorage } from '../services/LocalStorageProvider'
 
 import { CustomPromptsStore } from './CustomPromptsStore'
@@ -113,7 +113,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
     public find(id: string, isSlash = false): string {
         const myPrompt = this.default.get(id, isSlash)
 
-        debug('CommandsController:command:finding', id, { verbose: myPrompt })
+        logDebug('CommandsController:command:finding', id, { verbose: myPrompt })
 
         if (!myPrompt) {
             this.telemetryService.log('CodyVSCodeExtension:command:find:invalid')
@@ -268,8 +268,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             }
 
             await vscode.commands.executeCommand('cody.action.commands.exec', selectedCommandID)
-        } catch (error_) {
-            error('CommandsController:commandQuickPicker', 'error', { verbose: error_ })
+        } catch (error) {
+            logError('CommandsController:commandQuickPicker', 'error', { verbose: error })
         }
     }
 
@@ -321,9 +321,9 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                     break
             }
 
-            debug('CommandsController:promptsQuickPicker:selectedPrompt', promptTitle)
-        } catch (error_) {
-            error('CommandsController:promptsQuickPicker', 'error', { verbose: error_ })
+            logDebug('CommandsController:promptsQuickPicker:selectedPrompt', promptTitle)
+        } catch (error) {
+            logError('CommandsController:promptsQuickPicker', 'error', { verbose: error })
         }
     }
 
@@ -342,7 +342,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             return this.customCommandMenu()
         }
 
-        debug('CommandsController:customPrompts:menu', action)
+        logDebug('CommandsController:customPrompts:menu', action)
 
         switch (action) {
             case 'delete':
@@ -412,7 +412,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         await this.custom.save(newCommand.title, newCommand.prompt)
         await this.refresh()
 
-        debug('CommandsController:updateUserCommandQuick:newPrompt:', 'saved', { verbose: newCommand })
+        logDebug('CommandsController:updateUserCommandQuick:newPrompt:', 'saved', { verbose: newCommand })
     }
 
     /**
@@ -499,7 +499,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             )
         }
 
-        debug('CommandsController:fileWatcherInit', 'watchers created')
+        logDebug('CommandsController:fileWatcherInit', 'watchers created')
     }
 
     /**
@@ -517,6 +517,6 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         this.fileWatcherDisposables = []
         this.disposables = []
         this.myPromptsMap = new Map<string, CodyPrompt>()
-        debug('CommandsController:dispose', 'disposed')
+        logDebug('CommandsController:dispose', 'disposed')
     }
 }

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -9,7 +9,7 @@ import {
 import { VsCodeCommandsController } from '@sourcegraph/cody-shared/src/editor'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { debug } from '../log'
+import { debug, error } from '../log'
 import { LocalStorage } from '../services/LocalStorageProvider'
 
 import { CustomPromptsStore } from './CustomPromptsStore'
@@ -268,8 +268,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             }
 
             await vscode.commands.executeCommand('cody.action.commands.exec', selectedCommandID)
-        } catch (error) {
-            debug('CommandsController:commandQuickPicker', 'error', { verbose: error })
+        } catch (error_) {
+            error('CommandsController:commandQuickPicker', 'error', { verbose: error_ })
         }
     }
 
@@ -322,8 +322,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             }
 
             debug('CommandsController:promptsQuickPicker:selectedPrompt', promptTitle)
-        } catch (error) {
-            debug('CommandsController:promptsQuickPicker', 'error', { verbose: error })
+        } catch (error_) {
+            error('CommandsController:promptsQuickPicker', 'error', { verbose: error_ })
         }
     }
 

--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -10,7 +10,7 @@ import {
 } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 
-import { debug, error } from '../log'
+import { logDebug, logError } from '../log'
 
 import {
     constructFileUri,
@@ -84,8 +84,8 @@ export class CustomPromptsStore implements vscode.Disposable {
                     await this.build('workspace')
                 }
             }
-        } catch (error_) {
-            error('CustomPromptsStore:refresh', 'failed', { verbose: error_ })
+        } catch (error) {
+            logError('CustomPromptsStore:refresh', 'failed', { verbose: error })
         }
         return { commands: this.myPromptsMap, premade: this.myPremade, starter: this.myStarter }
     }
@@ -132,7 +132,7 @@ export class CustomPromptsStore implements vscode.Disposable {
             }
             this.promptSize[type] = this.myPromptsMap.size - 1
         } catch (error) {
-            debug('CustomPromptsStore:build', 'failed', { verbose: error })
+            logDebug('CustomPromptsStore:build', 'failed', { verbose: error })
         }
         return this.myPromptsMap
     }
@@ -193,7 +193,7 @@ export class CustomPromptsStore implements vscode.Disposable {
         } catch (error) {
             const errorMessage = 'Failed to create cody.json file: '
             void vscode.window.showErrorMessage(`${errorMessage} ${error}`)
-            debug('CustomPromptsStore:addJSONFile:create', 'failed', { verbose: error })
+            logDebug('CustomPromptsStore:addJSONFile:create', 'failed', { verbose: error })
         }
     }
 
@@ -207,7 +207,7 @@ export class CustomPromptsStore implements vscode.Disposable {
             void vscode.window.showInformationMessage(
                 'Fail: try deleting the .vscode/cody.json file in your repository or home directory manually.'
             )
-            error('CustomPromptsStore:clear:error:', 'Failed to remove cody.json file for' + type)
+            logError('CustomPromptsStore:clear:error:', 'Failed to remove cody.json file for' + type)
         }
         await deleteFile(uri)
     }

--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -10,7 +10,7 @@ import {
 } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 
-import { debug } from '../log'
+import { debug, error } from '../log'
 
 import {
     constructFileUri,
@@ -84,8 +84,8 @@ export class CustomPromptsStore implements vscode.Disposable {
                     await this.build('workspace')
                 }
             }
-        } catch (error) {
-            debug('CustomPromptsStore:refresh', 'failed', { verbose: error })
+        } catch (error_) {
+            error('CustomPromptsStore:refresh', 'failed', { verbose: error_ })
         }
         return { commands: this.myPromptsMap, premade: this.myPremade, starter: this.myStarter }
     }
@@ -207,7 +207,7 @@ export class CustomPromptsStore implements vscode.Disposable {
             void vscode.window.showInformationMessage(
                 'Fail: try deleting the .vscode/cody.json file in your repository or home directory manually.'
             )
-            debug('CustomPromptsStore:clear:error:', 'Failed to remove cody.json file for' + type)
+            error('CustomPromptsStore:clear:error:', 'Failed to remove cody.json file for' + type)
         }
         await deleteFile(uri)
     }

--- a/vscode/src/custom-prompts/PromptsProvider.ts
+++ b/vscode/src/custom-prompts/PromptsProvider.ts
@@ -1,6 +1,6 @@
 import { CodyPrompt, getDefaultCommandsMap } from '@sourcegraph/cody-shared/src/chat/prompts'
 
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 // Manage default commands created by the prompts in prompts.json
 const editorCommands = [{ name: 'Request a Code Edit', prompt: '/edit', slashCommand: '/edit' }]
@@ -51,6 +51,6 @@ export class PromptsProvider {
     // dispose and reset the controller and builder
     public dispose(): void {
         this.allCommands = new Map()
-        debug('CommandsController:dispose', 'disposed')
+        logDebug('CommandsController:dispose', 'disposed')
     }
 }

--- a/vscode/src/custom-prompts/ToolsProvider.ts
+++ b/vscode/src/custom-prompts/ToolsProvider.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util'
 
 import * as vscode from 'vscode'
 
-import { debug } from '../log'
+import { debug, error } from '../log'
 
 import { UserWorkspaceInfo } from './utils'
 import { outputWrapper } from './utils/helpers'
@@ -79,8 +79,8 @@ export class ToolsProvider {
             }
             debug('ToolsProvider:exeCommand', command, { verbose: outputString })
             return outputWrapper.replace('{command}', command).replace('{output}', outputString)
-        } catch (error) {
-            debug('ToolsProvider:exeCommand', 'failed', { verbose: error })
+        } catch (error_) {
+            error('ToolsProvider:exeCommand', 'failed', { verbose: error_ })
             void vscode.window.showErrorMessage(
                 'Failed to run command. Please make sure the command works in your terminal before trying again.'
             )

--- a/vscode/src/custom-prompts/ToolsProvider.ts
+++ b/vscode/src/custom-prompts/ToolsProvider.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util'
 
 import * as vscode from 'vscode'
 
-import { debug, error } from '../log'
+import { logDebug, logError } from '../log'
 
 import { UserWorkspaceInfo } from './utils'
 import { outputWrapper } from './utils/helpers'
@@ -77,10 +77,10 @@ export class ToolsProvider {
             if (!outputString) {
                 throw new Error('Empty output')
             }
-            debug('ToolsProvider:exeCommand', command, { verbose: outputString })
+            logDebug('ToolsProvider:exeCommand', command, { verbose: outputString })
             return outputWrapper.replace('{command}', command).replace('{output}', outputString)
-        } catch (error_) {
-            error('ToolsProvider:exeCommand', 'failed', { verbose: error_ })
+        } catch (error) {
+            logError('ToolsProvider:exeCommand', 'failed', { verbose: error })
             void vscode.window.showErrorMessage(
                 'Failed to run command. Please make sure the command works in your terminal before trying again.'
             )

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -19,13 +19,13 @@ import { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/sr
 
 import { ExtensionApi } from './extension-api'
 import { activate as activateCommon } from './extension.common'
-import { debug } from './log'
+import { logDebug } from './log'
 
 /**
  * Recipes that can run in VS Code Web (and do not rely on Node packages such as `child_process`).
  */
 export const VSCODE_WEB_RECIPES: Recipe[] = [
-    new ChatQuestion(debug),
+    new ChatQuestion(logDebug),
     new ExplainCodeDetailed(),
     new ExplainCodeHighLevel(),
     new FindCodeSmells(),
@@ -34,8 +34,8 @@ export const VSCODE_WEB_RECIPES: Recipe[] = [
     new GenerateTest(),
     new ImproveVariableNames(),
     new CustomPrompt(),
-    new InlineChat(debug),
-    new InlineTouch(debug),
+    new InlineChat(logDebug),
+    new InlineTouch(logDebug),
     new NextQuestions(),
     new TranslateToLanguage(),
     new ContextSearch(),

--- a/vscode/src/local-context/filename-context-fetcher.ts
+++ b/vscode/src/local-context/filename-context-fetcher.ts
@@ -8,7 +8,7 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult } from '@sourcegraph/cody-shared/src/local-context'
 
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 /**
  * A local context fetcher that uses a LLM to generate filename fragments, which are then used to
@@ -77,7 +77,7 @@ export class FilenameContextFetcher {
         )
 
         const time4 = performance.now()
-        debug(
+        logDebug(
             'FilenameContextFetcher:getContext',
             JSON.stringify({
                 duration: time4 - time0,

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -11,7 +11,7 @@ import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult, KeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 /**
  * Exclude files without extensions and hidden files (starts with '.')
@@ -130,7 +130,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
         )
         const searchDuration = performance.now() - startTime
         this.telemetryService.log('CodyVSCodeExtension:keywordContext:searchDuration', { searchDuration })
-        debug('LocalKeywordContextFetcher:getContext', JSON.stringify({ searchDuration }))
+        logDebug('LocalKeywordContextFetcher:getContext', JSON.stringify({ searchDuration }))
 
         return messagePairs.reverse().flat()
     }
@@ -176,7 +176,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                 stem,
             })
         }
-        debug(
+        logDebug(
             'LocalKeywordContextFetcher:userQueryToExpandedKeywords',
             JSON.stringify({ duration: performance.now() - start })
         )
@@ -194,7 +194,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
             }
             terms.set(stem, term)
         }
-        debug(
+        logDebug(
             'LocalKeywordContextFetcher:userQueryToKeywordQuery',
             'keyword expansion',
             JSON.stringify({
@@ -305,7 +305,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                 reject(error)
             }
         })
-        debug('fetchFileStats', JSON.stringify({ duration: performance.now() - start }))
+        logDebug('fetchFileStats', JSON.stringify({ duration: performance.now() - start }))
         return fileTermCounts
     }
 
@@ -377,7 +377,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                 })
             )
 
-        debug('LocalKeywordContextFetcher.fetchFileMatches', JSON.stringify({ duration: performance.now() - start }))
+        logDebug('LocalKeywordContextFetcher.fetchFileMatches', JSON.stringify({ duration: performance.now() - start }))
         let totalFilesSearched = -1
         for (const { filesSearched } of termFileCountsArr) {
             if (totalFilesSearched >= 0 && totalFilesSearched !== filesSearched) {
@@ -420,7 +420,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
         const fileMatches = await fileMatchesPromise
         const fileStats = await fileStatsPromise
         const fetchFilesDuration = performance.now() - fetchFilesStart
-        debug('LocalKeywordContextFetcher:fetchKeywordFiles', JSON.stringify({ fetchFilesDuration }))
+        logDebug('LocalKeywordContextFetcher:fetchKeywordFiles', JSON.stringify({ fetchFilesDuration }))
 
         const { fileTermCounts, termTotalFiles, totalFiles } = fileMatches
         const idfDict = idf(termTotalFiles, totalFiles)

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode'
 
 import { IndexedKeywordContextFetcher, Result } from '@sourcegraph/cody-shared/src/local-context'
 
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 const execFile = promisify(_execFile)
 
@@ -102,7 +102,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
                 return indexDir
             })
             .catch(error => {
-                debug('symf', 'symf index creation failed', error)
+                logDebug('symf', 'symf index creation failed', error)
                 throw error
             })
     }
@@ -121,7 +121,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
             rm(tmpIndexDir, { recursive: true }).catch(() => undefined),
         ])
 
-        debug('symf', 'creating index', indexDir)
+        logDebug('symf', 'creating index', indexDir)
         const args = ['--index-root', tmpIndexDir, 'add', '--langs', 'go,typescript,python', scopeDir]
         try {
             await execFile(this.symfPath, args)

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -9,7 +9,7 @@ import {
 
 import { getConfiguration } from './configuration'
 
-const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Cody by Sourcegraph', 'json')
+export const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel('Cody by Sourcegraph', 'json')
 
 /**
  * Logs text for debugging purposes to the "Cody by Sourcegraph" output channel.

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -16,11 +16,11 @@ export const outputChannel: vscode.OutputChannel = vscode.window.createOutputCha
  *
  * Usage:
  *
- *   debug('label', 'this is a message')
- *   debug('label', 'this is a message', 'some', 'args')
- *   debug('label', 'this is a message', 'some', 'args', { verbose: 'verbose info goes here' })
+ *   logDebug('label', 'this is a message')
+ *   logDebug('label', 'this is a message', 'some', 'args')
+ *   logDebug('label', 'this is a message', 'some', 'args', { verbose: 'verbose info goes here' })
  */
-export function debug(filterLabel: string, text: string, ...args: unknown[]): void {
+export function logDebug(filterLabel: string, text: string, ...args: unknown[]): void {
     log('error', filterLabel, text, ...args)
 }
 
@@ -29,11 +29,11 @@ export function debug(filterLabel: string, text: string, ...args: unknown[]): vo
  *
  * Usage:
  *
- *   debug('label', 'this is an error')
- *   debug('label', 'this is an error', 'some', 'args')
- *   debug('label', 'this is an error', 'some', 'args', { verbose: 'verbose info goes here' })
+ *   logError('label', 'this is an error')
+ *   logError('label', 'this is an error', 'some', 'args')
+ *   logError('label', 'this is an error', 'some', 'args', { verbose: 'verbose info goes here' })
  */
-export function error(filterLabel: string, text: string, ...args: unknown[]): void {
+export function logError(filterLabel: string, text: string, ...args: unknown[]): void {
     log('error', filterLabel, text, ...args)
 }
 
@@ -108,7 +108,7 @@ export const logger: CompletionLogger = {
                 return
             }
             hasFinished = true
-            error(
+            logError(
                 'CompletionLogger:onError',
                 JSON.stringify({
                     type,
@@ -126,7 +126,7 @@ export const logger: CompletionLogger = {
             }
             hasFinished = true
 
-            debug(
+            logDebug(
                 'CompletionLogger:onComplete',
                 JSON.stringify({
                     type,

--- a/vscode/src/logged-rerank.ts
+++ b/vscode/src/logged-rerank.ts
@@ -2,7 +2,7 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { LLMReranker } from '@sourcegraph/cody-shared/src/codebase-context/rerank'
 import { ContextResult } from '@sourcegraph/cody-shared/src/local-context'
 
-import { debug } from './log'
+import { logDebug } from './log'
 import { TestSupport } from './test-support'
 
 export function getRerankWithLog(
@@ -18,7 +18,7 @@ export function getRerankWithLog(
         const start = performance.now()
         const rerankedResults = await reranker.rerank(userQuery, results)
         const duration = performance.now() - start
-        debug('Reranker:rerank', JSON.stringify({ duration }))
+        logDebug('Reranker:rerank', JSON.stringify({ duration }))
         return rerankedResults
     }
 }

--- a/vscode/src/non-stop/FixupCodeLenses.ts
+++ b/vscode/src/non-stop/FixupCodeLenses.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 import { getLensesForTask } from './codelenses'
 import { FixupTask } from './FixupTask'
@@ -37,7 +37,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider {
         for (const task of this.files.tasksForFile(file)) {
             lenses.push(...(this.taskLenses.get(task) || []))
         }
-        debug('FixupCodeLenses:provideCodeLenses', 'CodeLenses', {
+        logDebug('FixupCodeLenses:provideCodeLenses', 'CodeLenses', {
             verbose: { lens: `${document.uri} (${lenses.length})` },
         })
         return lenses

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { VsCodeFixupController, VsCodeFixupTaskRecipeData } from '@sourcegraph/cody-shared/src/editor'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { debug } from '../log'
+import { logDebug } from '../log'
 import { countCode } from '../services/InlineAssist'
 
 import { computeDiff, Diff } from './diff'
@@ -123,7 +123,7 @@ export class FixupController
     // Apply single fixup from task ID. Public for testing.
     public async apply(id: taskID): Promise<void> {
         this.telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', { op: 'apply' })
-        debug('FixupController:apply', 'applying', { verbose: { id } })
+        logDebug('FixupController:apply', 'applying', { verbose: { id } })
         const task = this.tasks.get(id)
         if (!task) {
             console.error('cannot find task')
@@ -496,7 +496,7 @@ export class FixupController
             return
         }
 
-        debug('FixupController:setTaskState: ', 'changing state', { verbose: { task } })
+        logDebug('FixupController:setTaskState: ', 'changing state', { verbose: { task } })
         task.state = state
 
         // TODO: These state transition actions were moved from FixupTask, but

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -15,7 +15,7 @@ import {
     unauthenticatedStatus,
 } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 import { AuthMenu, showAccessTokenInputBox, showInstanceURLInputBox } from './AuthMenus'
 import { LocalAppDetector } from './LocalAppDetector'
@@ -49,7 +49,7 @@ export class AuthProvider {
         await this.appDetector.init()
         const lastEndpoint = this.localStorage?.getEndpoint() || this.config.serverEndpoint
         const token = (await this.secretStorage.get(lastEndpoint || '')) || this.config.accessToken
-        debug('AuthProvider:init:lastEndpoint', lastEndpoint)
+        logDebug('AuthProvider:init:lastEndpoint', lastEndpoint)
         const authState = await this.auth(lastEndpoint, token || null)
         if (authState?.isLoggedIn) {
             return
@@ -59,7 +59,7 @@ export class AuthProvider {
     // Display quickpick to select endpoint to sign in to
     public async signinMenu(type?: 'enterprise' | 'dotcom' | 'token' | 'app', uri?: string): Promise<void> {
         const mode = this.authStatus.isLoggedIn ? 'switch' : 'signin'
-        debug('AuthProvider:signinMenu', mode)
+        logDebug('AuthProvider:signinMenu', mode)
         this.telemetryService.log('CodyVSCodeExtension:login:clicked')
         const item = await AuthMenu(mode, this.endpointHistory)
         if (!item) {
@@ -106,7 +106,7 @@ export class AuthProvider {
                     const authStatusFromToken = await this.auth(selectedEndpoint, newToken || null)
                     this.showIsLoggedIn(authStatusFromToken?.authStatus || null)
                 }
-                debug('AuthProvider:signinMenu', mode, selectedEndpoint)
+                logDebug('AuthProvider:signinMenu', mode, selectedEndpoint)
             }
         }
     }
@@ -131,7 +131,7 @@ export class AuthProvider {
     }
 
     public async appAuth(uri?: string): Promise<void> {
-        debug('AuthProvider:appAuth:init', '')
+        logDebug('AuthProvider:appAuth:init', '')
         const token = await this.secretStorage.get('SOURCEGRAPH_CODY_APP')
         if (token) {
             const authStatus = await this.auth(LOCAL_APP_URL.href, token)
@@ -154,7 +154,7 @@ export class AuthProvider {
             return
         }
         await this.signout(endpoint.uri)
-        debug('AuthProvider:signoutMenu', endpoint.uri)
+        logDebug('AuthProvider:signoutMenu', endpoint.uri)
     }
 
     // Log user out of the selected endpoint (remove token from secret)

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -5,7 +5,7 @@ import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry
 import { EventLogger, ExtensionDetails } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
 
 import { version as packageVersion } from '../../package.json'
-import { debug } from '../log'
+import { logDebug } from '../log'
 
 import { LocalStorage } from './LocalStorageProvider'
 
@@ -62,7 +62,7 @@ export async function createOrUpdateEventLogger(
  * @deprecated Use TelemetryService instead.
  */
 export function logEvent(eventName: string, properties?: TelemetryEventProperties): void {
-    debug(`logEvent${eventLogger === null ? ' (telemetry disabled)' : ''}`, eventName, JSON.stringify(properties))
+    logDebug(`logEvent${eventLogger === null ? ' (telemetry disabled)' : ''}`, eventName, JSON.stringify(properties))
     if (!eventLogger || !globalAnonymousUserID) {
         return
     }

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -6,7 +6,7 @@ import { LOCAL_APP_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/envi
 import { version } from '../../package.json'
 import { isOsSupportedByApp, LocalEnv } from '../chat/protocol'
 import { constructFileUri } from '../custom-prompts/utils/helpers'
-import { debug, error } from '../log'
+import { logDebug, logError } from '../log'
 
 import { AppJson, LOCAL_APP_LOCATIONS } from './LocalAppFsPaths'
 import { SecretStorage } from './SecretStorageProvider'
@@ -51,11 +51,11 @@ export class LocalAppDetector implements vscode.Disposable {
         // Start with init state
         this.dispose()
         this.localEnv = { ...envInit }
-        debug('LocalAppDetector', 'initializing')
+        logDebug('LocalAppDetector', 'initializing')
         const homeDir = this.localEnv.homeDir
         // if conditions are not met, this will be a noop
         if (!this.isSupported || !homeDir) {
-            error('LocalAppDetector:init:failed', 'osNotSupported')
+            logError('LocalAppDetector:init:failed', 'osNotSupported')
             return
         }
         // Create filePaths and file watchers
@@ -136,7 +136,7 @@ export class LocalAppDetector implements vscode.Disposable {
     private async found(type: 'app' | 'token' | 'server'): Promise<void> {
         this.localEnv.isAppInstalled = true
         await this.onChange(type)
-        debug('LocalAppDetector:found', type)
+        logDebug('LocalAppDetector:found', type)
     }
 
     // We can dispose the file watcher when app is found or when user has logged in

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -6,7 +6,7 @@ import { LOCAL_APP_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/envi
 import { version } from '../../package.json'
 import { isOsSupportedByApp, LocalEnv } from '../chat/protocol'
 import { constructFileUri } from '../custom-prompts/utils/helpers'
-import { debug } from '../log'
+import { debug, error } from '../log'
 
 import { AppJson, LOCAL_APP_LOCATIONS } from './LocalAppFsPaths'
 import { SecretStorage } from './SecretStorageProvider'
@@ -55,7 +55,7 @@ export class LocalAppDetector implements vscode.Disposable {
         const homeDir = this.localEnv.homeDir
         // if conditions are not met, this will be a noop
         if (!this.isSupported || !homeDir) {
-            debug('LocalAppDetector:init:failed', 'osNotSupported')
+            error('LocalAppDetector:init:failed', 'osNotSupported')
             return
         }
         // Create filePaths and file watchers

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { isLocalApp } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
-import { debug, error } from '../log'
+import { logDebug, logError } from '../log'
 
 export const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
 
@@ -13,12 +13,12 @@ export async function getAccessToken(secretStorage: SecretStorage): Promise<stri
             return token
         }
         throw new Error('token not found')
-    } catch (error_) {
-        error('VSCodeSecretStorage:getAccessToken', 'failed', { verbose: error_ })
+    } catch (error) {
+        logError('VSCodeSecretStorage:getAccessToken', 'failed', { verbose: error })
         // Remove corrupted token from secret storage
         await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
         // Display system notification because the error was caused by system storage
-        console.error(`Failed to retrieve access token for Cody from secret storage: ${error_}`)
+        console.error(`Failed to retrieve access token for Cody from secret storage: ${error}`)
         return null
     }
 }
@@ -39,7 +39,7 @@ export class VSCodeSecretStorage implements SecretStorage {
         // For user that does not have secret storage implemented in their sever
         this.fsPath = config.get('experimental.localTokenPath') || null
         if (this.fsPath) {
-            debug('VSCodeSecretStorage:experimental.localTokenPath', 'enabled', { verbose: this.fsPath })
+            logDebug('VSCodeSecretStorage:experimental.localTokenPath', 'enabled', { verbose: this.fsPath })
         }
     }
     // Catch corrupted token in secret storage
@@ -67,8 +67,8 @@ export class VSCodeSecretStorage implements SecretStorage {
             if (value?.length > 0) {
                 await this.secretStorage.store(key, value)
             }
-        } catch (error_) {
-            error('VSCodeSecretStorage:store:failed', key, { verbose: error_ })
+        } catch (error) {
+            logError('VSCodeSecretStorage:store:failed', key, { verbose: error })
         }
     }
 
@@ -171,10 +171,10 @@ async function getAccessTokenFromFsPath(fsPath: string): Promise<string | null> 
         if (!json.token) {
             throw new Error('Failed to retrieve token from: ' + fsPath)
         }
-        debug('VSCodeSecretStorage:getAccessTokenFromFsPath', 'retrieved')
+        logDebug('VSCodeSecretStorage:getAccessTokenFromFsPath', 'retrieved')
         return json.token
-    } catch (error_) {
-        error('VSCodeSecretStorage:getAccessTokenFromFsPath', 'failed', { verbose: error_ })
+    } catch (error) {
+        logError('VSCodeSecretStorage:getAccessTokenFromFsPath', 'failed', { verbose: error })
         return null
     }
 }

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { isLocalApp } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
-import { debug } from '../log'
+import { debug, error } from '../log'
 
 export const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
 
@@ -13,12 +13,12 @@ export async function getAccessToken(secretStorage: SecretStorage): Promise<stri
             return token
         }
         throw new Error('token not found')
-    } catch (error) {
-        debug('VSCodeSecretStorage:getAccessToken', 'failed', { verbose: error })
+    } catch (error_) {
+        error('VSCodeSecretStorage:getAccessToken', 'failed', { verbose: error_ })
         // Remove corrupted token from secret storage
         await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
         // Display system notification because the error was caused by system storage
-        console.error(`Failed to retrieve access token for Cody from secret storage: ${error}`)
+        console.error(`Failed to retrieve access token for Cody from secret storage: ${error_}`)
         return null
     }
 }
@@ -67,8 +67,8 @@ export class VSCodeSecretStorage implements SecretStorage {
             if (value?.length > 0) {
                 await this.secretStorage.store(key, value)
             }
-        } catch (error) {
-            debug('VSCodeSecretStorage:store:failed', key, { verbose: error })
+        } catch (error_) {
+            error('VSCodeSecretStorage:store:failed', key, { verbose: error_ })
         }
     }
 
@@ -173,8 +173,8 @@ async function getAccessTokenFromFsPath(fsPath: string): Promise<string | null> 
         }
         debug('VSCodeSecretStorage:getAccessTokenFromFsPath', 'retrieved')
         return json.token
-    } catch (error) {
-        debug('VSCodeSecretStorage:getAccessTokenFromFsPath', 'failed', { verbose: error })
+    } catch (error_) {
+        error('VSCodeSecretStorage:getAccessTokenFromFsPath', 'failed', { verbose: error_ })
         return null
     }
 }

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -73,6 +73,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
         statusBar: {
             startLoading: () => () => {},
             dispose: () => {},
+            addError: () => {},
         },
         history,
         getCodebaseContext: () => codebaseContext,


### PR DESCRIPTION
Closes #634

This PR adds a UI indicator for autocomplete errors. We special case rate limiting errors to provider more information.

- When a rate limit error is encountered, we show it only once per rate limit interval (the UI indicator will reset with a VS Code restart). When the option is selected in quick pick, we open https://about.sourcegraph.com/blog/increasing-the-completions-rate-limit (the only resource I found that we have for rate limits)
- When any other (e.g. a network error) is encountered, we show the error message and open the output channel. We also add a new `error` API similar to the `debug` one but that will always log errors to the output channel. 

## ToDo

- [x] Add a new `error` API similar to the `debug` one but that will always log errors to the output channel. 
- [x] Add test cases

## Test plan

https://github.com/sourcegraph/cody/assets/458591/efa5f660-706e-47db-96e1-63b5f7b2d2fc



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
