### PR TITLE
Intelligent Cody: Fix duplicate locations

### DIFF
--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -460,7 +460,7 @@ const extractSnippets = (lines: string[], symbolRanges: vscode.Range[], targetRa
  * Returns a key unique to a given location for use with `dedupeWith`.
  */
 const locationKeyFn = (location: vscode.Location): string =>
-    `${location.uri}?L${location.range.start.line}:${location.range.start.character}`
+    `${location.uri.fsPath}?L${location.range.start.line}:${location.range.start.character}`
 
 /**
  * Convert a mapping from K -> Thenable<V> to a map of K -> V.


### PR DESCRIPTION
The current implementation of `locationKeyFn` is not very deterministic as we serialize the uri _object_ instead of the underlying path that can be serialized independently. If we use the `fsPath` instead we get a single string.

This was causing issues before where a location URI may have additional internal state at different levels of construction, making it appear when we're deduplicating objects that logically equivalent URIs sometimes had distinct object identity.

## Test plan

Validated by hand.