### PR TITLE
Autocomplete: use tree-sitter incremental parsing

### DIFF
--- a/vscode/src/completions/processInlineCompletions.ts
+++ b/vscode/src/completions/processInlineCompletions.ts
@@ -5,7 +5,7 @@ import { dedupeWith } from '@sourcegraph/cody-shared'
 import { DocumentContext } from './get-current-doc-context'
 import { truncateMultilineCompletion } from './multiline'
 import { collapseDuplicativeWhitespace, removeTrailingWhitespace, trimUntilSuffix } from './text-processing'
-import { getCachedParseTreeForDocument } from './tree-sitter/parse-tree-cache'
+import { asPoint, getCachedParseTreeForDocument } from './tree-sitter/parse-tree-cache'
 import { InlineCompletionItem } from './types'
 
 export interface ProcessInlineCompletionsParams {
@@ -124,11 +124,12 @@ export function addParseInfoToCompletions(
         return items.map(item => ({ ...item, hasParseErrors: false }))
     }
 
-    const { parser } = parseTreeCache
+    const { parser, tree } = parseTreeCache
     const query = parser.getLanguage().query('(ERROR) @error')
 
     return items.map(completion => {
         const { range, insertText } = completion
+        const treeCopy = tree.copy()
 
         // Adjust suffix and prefix based on completion insert range.
         const prefix = range
@@ -139,13 +140,20 @@ export function addParseInfoToCompletions(
             : docContext.suffix
 
         const textWithCompletion = prefix + insertText + suffix
+        const completionEndPosition = position.translate(undefined, insertText.length)
+
+        treeCopy.edit({
+            startIndex: prefix.length,
+            oldEndIndex: prefix.length,
+            newEndIndex: prefix.length + insertText.length,
+            startPosition: asPoint(position),
+            oldEndPosition: asPoint(position),
+            newEndPosition: asPoint(completionEndPosition),
+        })
 
         // TODO: consider parsing only the changed part of the document to improve performance.
-        // TODO: move document parsing to a `onDidChangeTextDocument` handler to leverage incremental parsing.
         // parser.parse(textWithCompletion, tree, { includedRanges: [...]})
-        const treeWithCompletion = parser.parse(textWithCompletion)
-
-        const completionPositionEnd = position.translate(undefined, insertText.length)
+        const treeWithCompletion = parser.parse(textWithCompletion, treeCopy)
 
         // Search for ERROR nodes in the completion range.
         const matches = query.matches(
@@ -155,8 +163,8 @@ export function addParseInfoToCompletions(
                 column: position.character,
             },
             {
-                row: completionPositionEnd.line,
-                column: completionPositionEnd.character,
+                row: completionEndPosition.line,
+                column: completionEndPosition.character,
             }
         )
 

--- a/vscode/src/completions/processInlineCompletions.ts
+++ b/vscode/src/completions/processInlineCompletions.ts
@@ -147,7 +147,7 @@ export function addParseInfoToCompletions(
             oldEndIndex: prefix.length,
             newEndIndex: prefix.length + insertText.length,
             startPosition: asPoint(position),
-            oldEndPosition: asPoint(position),
+            oldEndPosition: asPoint(range?.end || position),
             newEndPosition: asPoint(completionEndPosition),
         })
 

--- a/vscode/src/completions/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/completions/tree-sitter/parse-tree-cache.ts
@@ -68,9 +68,9 @@ function getLanguageIfTreeSitterEnabled(document: TextDocument): SupportedLangua
     return null
 }
 
-export function updateParseTreeOnEdit(edit: vscode.TextDocumentChangeEvent) {
+export function updateParseTreeOnEdit(edit: vscode.TextDocumentChangeEvent): void {
     const { document, contentChanges } = edit
-    if (contentChanges.length == 0) {
+    if (contentChanges.length === 0) {
         return
     }
 
@@ -110,8 +110,8 @@ export function asPoint(position: Pick<vscode.Position, 'line' | 'character'>): 
     return { row: position.line, column: position.character }
 }
 
-export function parseAllVisibleDocuments() {
+export function parseAllVisibleDocuments(): void {
     for (const editor of vscode.window.visibleTextEditors) {
-        parseDocument(editor.document)
+        void parseDocument(editor.document)
     }
 }

--- a/vscode/src/completions/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/completions/tree-sitter/parse-tree-cache.ts
@@ -70,7 +70,7 @@ function getLanguageIfTreeSitterEnabled(document: TextDocument): SupportedLangua
 
 export function updateParseTreeOnEdit(edit: vscode.TextDocumentChangeEvent) {
     const { document, contentChanges } = edit
-    if (edit.contentChanges.length == 0) {
+    if (contentChanges.length == 0) {
         return
     }
 
@@ -85,9 +85,9 @@ export function updateParseTreeOnEdit(edit: vscode.TextDocumentChangeEvent) {
         const startIndex = change.rangeOffset
         const oldEndIndex = change.rangeOffset + change.rangeLength
         const newEndIndex = change.rangeOffset + change.text.length
-        const startPosition = edit.document.positionAt(startIndex)
-        const oldEndPosition = edit.document.positionAt(oldEndIndex)
-        const newEndPosition = edit.document.positionAt(newEndIndex)
+        const startPosition = document.positionAt(startIndex)
+        const oldEndPosition = document.positionAt(oldEndIndex)
+        const newEndPosition = document.positionAt(newEndIndex)
         const startPoint = asPoint(startPosition)
         const oldEndPoint = asPoint(oldEndPosition)
         const newEndPoint = asPoint(newEndPosition)

--- a/vscode/src/completions/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/completions/tree-sitter/parse-tree-cache.ts
@@ -106,7 +106,7 @@ export function updateParseTreeOnEdit(edit: vscode.TextDocumentChangeEvent) {
     parseTreesPerFile.set(cacheKey, updatedTree)
 }
 
-export function asPoint(position: vscode.Position): Parser.Point {
+export function asPoint(position: Pick<vscode.Position, 'line' | 'character'>): Parser.Point {
     return { row: position.line, column: position.character }
 }
 

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -19,7 +19,6 @@ import * as CompletionLogger from './logger'
 import { ProviderConfig } from './providers/provider'
 import { RequestManager } from './request-manager'
 import { ProvideInlineCompletionItemsTracer, ProvideInlineCompletionsItemTraceData } from './tracer'
-import { initParser } from './tree-sitter/parse-tree-cache'
 import { InlineCompletionItem } from './types'
 import { getNextNonEmptyLine } from './utils/text-utils'
 
@@ -33,7 +32,6 @@ export interface CodyCompletionItemProviderConfig {
     suffixPercentage?: number
     isEmbeddingsContextEnabled?: boolean
     completeSuggestWidgetSelection?: boolean
-    completeExperimentalSyntacticPostProcessing?: boolean
     tracer?: ProvideInlineCompletionItemsTracer | null
     contextFetcher?: (options: GetContextOptions) => Promise<GetContextResult>
     featureFlagProvider: FeatureFlagProvider
@@ -60,7 +58,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         suffixPercentage = 0.1,
         isEmbeddingsContextEnabled = true,
         completeSuggestWidgetSelection = false,
-        completeExperimentalSyntacticPostProcessing = false,
         tracer = null,
         ...config
     }: CodyCompletionItemProviderConfig) {
@@ -71,7 +68,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             suffixPercentage,
             isEmbeddingsContextEnabled,
             completeSuggestWidgetSelection,
-            completeExperimentalSyntacticPostProcessing,
             tracer,
             contextFetcher: config.contextFetcher ?? getContext,
         }
@@ -139,13 +135,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         // the text that is already in the editor, VS Code will never render the completion.
         if (!currentEditorContentMatchesPopupItem(document, context)) {
             return null
-        }
-
-        // Init tree-sitter parser asynchronously so we can use it later in the post-processing logic.
-        // If the parser won't be ready in time, we'll skip the tree-sitter post-processing.
-        // TODO: move to `onDidChangeTextDocument` handler.
-        if (this.config.completeExperimentalSyntacticPostProcessing) {
-            void initParser(document)
         }
 
         const docContext = getCurrentDocContext(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -11,6 +11,7 @@ import { InlineChatViewManager } from './chat/InlineChatViewProvider'
 import { MessageProviderOptions } from './chat/MessageProvider'
 import { CODY_FEEDBACK_URL } from './chat/protocol'
 import { createInlineCompletionItemProvider } from './completions/createVSCodeInlineCompletionItemProvider'
+import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './completions/tree-sitter/parse-tree-cache'
 import { getConfiguration, getFullConfig } from './configuration'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { PlatformContext } from './extension.common'
@@ -106,6 +107,12 @@ const register = async (
     // Could we use the `initialConfig` instead?
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
+
+    if (config.autocompleteExperimentalSyntacticPostProcessing) {
+        parseAllVisibleDocuments()
+        vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments)
+        vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit)
+    }
 
     const symfRunner = platform.createSymfRunner?.(config.experimentalSymfPath, config.experimentalSymfAnthropicKey)
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -110,8 +110,9 @@ const register = async (
 
     if (config.autocompleteExperimentalSyntacticPostProcessing) {
         parseAllVisibleDocuments()
-        vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments)
-        vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit)
+
+        disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
+        disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
     }
 
     const symfRunner = platform.createSymfRunner?.(config.experimentalSymfPath, config.experimentalSymfAnthropicKey)


### PR DESCRIPTION
## Context

- Enables incremental parsing for tree-sitter by subscribing to `onDidChangeTextDocument` and forwarding `edit.contentChanges` to the existing parse-tree + calling `parser.parse(text, oldTree)`.
- Closes #850 
- Part of #809 
- Planned follow-up https://github.com/sourcegraph/cody/issues/860

## Test plan

- Existing unit tests
- Verified manually that parse-trees are correctly updated for all visible documents.
