### PR TITLE
Fix main: Don't use shared import

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           run_install: true
+      - run: pnpm build
       - run: pnpm run test
       - run: xvfb-run -a pnpm -C vscode run test:integration
       - run: xvfb-run -a pnpm -C vscode run test:e2e

--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -37,6 +37,7 @@ jobs:
             echo "Release tag and version in vscode/package.json do not match: '${TAGGED_VERSION}' vs. '${WRITTEN_VERSION}'"
             exit 1
           fi
+      - run: pnpm build
       - run: pnpm run test
       - run: xvfb-run -a pnpm -C vscode run test:integration
       - run: xvfb-run -a pnpm -C vscode run test:e2e

--- a/vscode/src/completions/processInlineCompletions.ts
+++ b/vscode/src/completions/processInlineCompletions.ts
@@ -1,6 +1,6 @@
 import { Position, Range, TextDocument } from 'vscode'
 
-import { dedupeWith } from '@sourcegraph/cody-shared'
+import { dedupeWith } from '@sourcegraph/cody-shared/src/common'
 
 import { DocumentContext } from './get-current-doc-context'
 import { truncateMultilineCompletion } from './multiline'


### PR DESCRIPTION
`main` builds is failing again with this:

```
 FAIL  |vscode| src/completions/vscodeInlineCompletionItemProvider.test.ts [ vscode/src/completions/vscodeInlineCompletionItemProvider.test.ts ]
Error: Failed to resolve entry for package "@sourcegraph/cody-shared". The package may have incorrect main/module/exports specified in its package.json.
 ❯ packageEntryFailure node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:28691:11
 ❯ resolvePackageEntry node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:28688:5
 ❯ tryNodeResolve node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:28422:20
 ❯ Context.resolveId node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:28183:28
 ❯ Object.resolveId node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:44123:64
 ❯ TransformContext.resolve node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:43839:23
 ❯ normalizeUrl node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:41715:34
 ❯ async file:/home/runner/work/cody/cody/node_modules/.pnpm/vite@4.4.3_@types+node@20.4.0/node_modules/vite/dist/node/chunks/dep-210e5610.js:41867:47
```

It seems like we did not run the build step before running the tests, so I’m adding this in the hope that this issue does not return. It's unclear why we bother doing exports from the shared entrypoint though if we can just import the source file directly. 



## Test plan

🤞 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
