### PR TITLE
Autocomplete: Add tracing for network requests

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -7,6 +7,7 @@ export enum FeatureFlag {
     // product code
     TestFlagDoNotUse = 'test-flag-do-not-use',
 
+    CodyAutocompleteTracing = 'cody-autocomplete-tracing',
     CodyAutocompleteIncreasedDebounceTimeEnabled = 'cody-autocomplete-increased-debounce-time-enabled',
     CodyAutocompleteStreamingResponse = 'cody-autocomplete-streaming-response',
     CodyAutocompleteDefaultProviderFireworks = 'cody-autocomplete-default-provider-fireworks',

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -9,6 +9,24 @@ export class RateLimitError extends Error {
     }
 }
 
+export function isRateLimitError(error: Error): error is RateLimitError {
+    return error instanceof RateLimitError
+}
+
+export class NetworkError extends Error {
+    constructor(
+        message: string,
+        public traceId: string | undefined
+    ) {
+        super(message)
+        Object.setPrototypeOf(this, NetworkError.prototype)
+    }
+}
+
+export function isNetworkError(error: Error): error is NetworkError {
+    return error instanceof NetworkError
+}
+
 export function isAbortError(error: Error): boolean {
     return (
         // http module
@@ -17,8 +35,4 @@ export function isAbortError(error: Error): boolean {
         error.message.includes('The operation was aborted') ||
         error.message.includes('The user aborted a request')
     )
-}
-
-export function isRateLimitError(error: Error): boolean {
-    return error instanceof RateLimitError
 }


### PR DESCRIPTION
This PR adds request tracing for autocomplete behind a feature flag. The plan is to enable tracing for 5% of the population so we can start collecting traces.

## Test plan

- Connect to localhost and throw in the `codecompletion.go` file
- Enable the FF for your user
- Observe that a trace ID is included in the error ping

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:completion:error {"message":"error parsing response CodeCompletionResponse: SyntaxError: Unexpected token 'U', \"Unsupporte\"... is not valid JSON, response text: Unsupported custom model\n","traceId":"5a672ce14f16225b53e46f0afc6e02e9","count":1}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
