### PR TITLE
VSCode: Add Sentry to extension host process

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,15 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.4.2
         version: 0.4.3
+      '@sentry/browser':
+        specifier: ^7.66.0
+        version: 7.66.0
+      '@sentry/core':
+        specifier: ^7.66.0
+        version: 7.66.0
+      '@sentry/node':
+        specifier: ^7.66.0
+        version: 7.66.0
       '@sourcegraph/cody-shared':
         specifier: workspace:*
         version: link:../lib/shared
@@ -4495,6 +4504,75 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
+  /@sentry-internal/tracing@7.66.0:
+    resolution: {integrity: sha512-3vCgC2hC3T45pn53yTDVcRpHoJTBxelDPPZVsipAbZnoOVPkj7n6dNfDhj3I3kwWCBPahPkXmE+R4xViR8VqJg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.66.0
+      '@sentry/types': 7.66.0
+      '@sentry/utils': 7.66.0
+      tslib: 2.1.0
+    dev: false
+
+  /@sentry/browser@7.66.0:
+    resolution: {integrity: sha512-rW037rf8jkhyykG38+HUdwkRCKHJEMM5NkCqPIO5zuuxfLKukKdI2rbvgJ93s3/9UfsTuDFcKFL1u43mCn6sDw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/tracing': 7.66.0
+      '@sentry/core': 7.66.0
+      '@sentry/replay': 7.66.0
+      '@sentry/types': 7.66.0
+      '@sentry/utils': 7.66.0
+      tslib: 2.1.0
+    dev: false
+
+  /@sentry/core@7.66.0:
+    resolution: {integrity: sha512-WMAEPN86NeCJ1IT48Lqiz4MS5gdDjBwP4M63XP4msZn9aujSf2Qb6My5uT87AJr9zBtgk8MyJsuHr35F0P3q1w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.66.0
+      '@sentry/utils': 7.66.0
+      tslib: 2.1.0
+    dev: false
+
+  /@sentry/node@7.66.0:
+    resolution: {integrity: sha512-PxqIqLr4Sh5xcDfECiBQ4PuZ7v8yTgLhaRkruWrZPYxQrcJFPkwbFkw/IskzVnhT2VwXUmeWEIlRMQKBJ0t83A==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/tracing': 7.66.0
+      '@sentry/core': 7.66.0
+      '@sentry/types': 7.66.0
+      '@sentry/utils': 7.66.0
+      cookie: 0.4.2
+      https-proxy-agent: 5.0.1
+      lru_map: 0.3.3
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@sentry/replay@7.66.0:
+    resolution: {integrity: sha512-5Y2SlVTOFTo3uIycv0mRneBakQtLgWkOnsJaC5LB0Ip0TqVKiMCbQ578vvXp+yvRj4LcS1gNd98xTTNojBoQNg==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sentry/core': 7.66.0
+      '@sentry/types': 7.66.0
+      '@sentry/utils': 7.66.0
+    dev: false
+
+  /@sentry/types@7.66.0:
+    resolution: {integrity: sha512-uUMSoSiar6JhuD8p7ON/Ddp4JYvrVd2RpwXJRPH1A4H4Bd4DVt1mKJy1OLG6HdeQv39XyhB1lPZckKJg4tATPw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@sentry/utils@7.66.0:
+    resolution: {integrity: sha512-9GYUVgXjK66uXXcLXVMXVzlptqMtq1eJENCuDeezQiEFrNA71KkLDg00wESp+LL+bl3wpVTBApArpbF6UEG5hQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.66.0
+      tslib: 2.1.0
+    dev: false
+
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
@@ -8060,6 +8138,17 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug@3.2.7(supports-color@5.5.0):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -11368,7 +11457,7 @@ packages:
     resolution: {integrity: sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==}
     engines: {node: '>= 7.6.0'}
     dependencies:
-      debug: 3.2.7(supports-color@5.5.0)
+      debug: 3.2.7
       koa-send: 5.0.1
     transitivePeerDependencies:
       - supports-color
@@ -11799,6 +11888,10 @@ packages:
   /lru-cache@9.1.1:
     resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
     engines: {node: 14 || >=16.14}
+    dev: false
+
+  /lru_map@0.3.3:
+    resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
     dev: false
 
   /lz-string@1.5.0:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -985,6 +985,9 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.4.2",
+    "@sentry/browser": "^7.66.0",
+    "@sentry/core": "^7.66.0",
+    "@sentry/node": "^7.66.0",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/cody-ui": "workspace:*",
     "@types/stream-json": "^1.7.3",

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -5,6 +5,7 @@ import { isAbortError, isRateLimitError } from '@sourcegraph/cody-shared/src/sou
 import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { logEvent } from '../services/EventLogger'
+import { captureException } from '../services/sentry/sentry'
 
 import { ContextSummary } from './context/context'
 import { InlineCompletionItem } from './types'
@@ -250,6 +251,8 @@ export function logError(error: Error): void {
     if (isAbortError(error) || isRateLimitError(error)) {
         return
     }
+
+    captureException(error)
 
     const message = error.message
 

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { Recipe } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
+import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { languagePromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import type { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/browserClient'
 import type { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
@@ -13,6 +14,7 @@ import type { LocalKeywordContextFetcher } from './local-context/local-keyword-c
 import type { SymfRunner } from './local-context/symf'
 import { start } from './main'
 import type { getRgPath } from './rg'
+import { SentryService } from './services/sentry/sentry'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T extends new (...args: any) => any> = T extends new (...args: infer A) => infer R
@@ -28,6 +30,7 @@ export interface PlatformContext {
     createCompletionsClient:
         | Constructor<typeof SourcegraphBrowserCompletionsClient>
         | Constructor<typeof SourcegraphNodeCompletionsClient>
+    createSentryService?: (config: Pick<Configuration, 'serverEndpoint'>) => SentryService
     recipes: Recipe[]
 }
 

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -14,7 +14,7 @@ import type { LocalKeywordContextFetcher } from './local-context/local-keyword-c
 import type { SymfRunner } from './local-context/symf'
 import { start } from './main'
 import type { getRgPath } from './rg'
-import { SentryService } from './services/sentry/sentry'
+import { captureException, SentryService } from './services/sentry/sentry'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T extends new (...args: any) => any> = T extends new (...args: infer A) => infer R
@@ -49,7 +49,10 @@ export function activate(context: vscode.ExtensionContext, platformContext: Plat
                 onActivationDevelopmentHelpers()
             }
         })
-        .catch(error => console.error(error))
+        .catch(error => {
+            captureException(error)
+            console.error(error)
+        })
 
     return api
 }

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -15,6 +15,7 @@ import { FilenameContextFetcher } from './local-context/filename-context-fetcher
 import { LocalKeywordContextFetcher } from './local-context/local-keyword-context-fetcher'
 import { SymfRunner } from './local-context/symf'
 import { getRgPath } from './rg'
+import { NodeSentryService } from './services/sentry/sentry.node'
 
 /**
  * Activation entrypoint for the VS Code extension when running VS Code as a desktop app
@@ -28,6 +29,7 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
         createFilenameContextFetcher: (...args) => new FilenameContextFetcher(...args),
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createSymfRunner: (...args) => new SymfRunner(...args),
+        createSentryService: (...args) => new NodeSentryService(...args),
 
         // Include additional recipes that require Node packages (such as `child_process`).
         recipes: [

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -20,6 +20,7 @@ import { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/sr
 import { ExtensionApi } from './extension-api'
 import { activate as activateCommon } from './extension.common'
 import { logDebug } from './log'
+import { WebSentryService } from './services/sentry/sentry.web'
 
 /**
  * Recipes that can run in VS Code Web (and do not rely on Node packages such as `child_process`).
@@ -48,6 +49,7 @@ export const VSCODE_WEB_RECIPES: Recipe[] = [
 export function activate(context: vscode.ExtensionContext): ExtensionApi {
     return activateCommon(context, {
         createCompletionsClient: (...args) => new SourcegraphBrowserCompletionsClient(...args),
+        createSentryService: (...args) => new WebSentryService(...args),
         recipes: VSCODE_WEB_RECIPES,
     })
 }

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -49,9 +49,13 @@ export async function configureExternalServices(
     telemetryService: TelemetryService,
     platform: Pick<
         PlatformContext,
-        'createLocalKeywordContextFetcher' | 'createFilenameContextFetcher' | 'createCompletionsClient'
+        | 'createLocalKeywordContextFetcher'
+        | 'createFilenameContextFetcher'
+        | 'createCompletionsClient'
+        | 'createSentryService'
     >
 ): Promise<ExternalServices> {
+    const sentryService = platform.createSentryService?.(initialConfig)
     const client = new SourcegraphGraphQLAPIClient(initialConfig)
     const featureFlagProvider = new FeatureFlagProvider(client)
     const completionsClient = platform.createCompletionsClient(initialConfig, featureFlagProvider, logger)
@@ -91,6 +95,7 @@ export async function configureExternalServices(
         codeCompletionsClient,
         guardrails,
         onConfigurationChange: newConfig => {
+            sentryService?.onConfigurationChange(newConfig)
             client.onConfigurationChange(newConfig)
             completionsClient.onConfigurationChange(newConfig)
             codeCompletionsClient.onConfigurationChange(newConfig)

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -12,7 +12,7 @@ import { LocalStorage } from './LocalStorageProvider'
 export let eventLogger: EventLogger | null = null
 let globalAnonymousUserID: string
 
-const extensionDetails: ExtensionDetails = {
+export const extensionDetails: ExtensionDetails = {
     ide: 'VSCode',
     ideExtensionType: 'Cody',
     // Prefer the runtime package json over the version that is inlined during build times. This

--- a/vscode/src/services/sentry/sentry.node.ts
+++ b/vscode/src/services/sentry/sentry.node.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node'
+
+import { SentryOptions, SentryService } from './sentry'
+
+export class NodeSentryService extends SentryService {
+    public reconfigure(options: SentryOptions): void {
+        Sentry.init(options)
+    }
+}

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -29,8 +29,8 @@ export abstract class SentryService {
             environment: this.config.isRunningInsideAgent
                 ? 'agent'
                 : typeof process !== 'undefined'
-                ? 'vscode-web'
-                : 'vscode-node',
+                ? 'vscode-node'
+                : 'vscode-web',
 
             // In dev mode, have Sentry log extended debug information to the console.
             debug: !isProd,

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -4,6 +4,8 @@ import type { init as nodeInit } from '@sentry/node'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
+import { extensionDetails } from '../EventLogger'
+
 export * from '@sentry/core'
 export const SENTRY_DSN = 'https://f565373301c9c7ef18448a1c60dfde8d@o19358.ingest.sentry.io/4505743319564288'
 
@@ -23,6 +25,12 @@ export abstract class SentryService {
         const isProd = process.env.NODE_ENV === 'production'
         const options: SentryOptions = {
             dsn: SENTRY_DSN,
+            release: extensionDetails.version,
+            environment: this.config.isRunningInsideAgent
+                ? 'agent'
+                : typeof process !== 'undefined'
+                ? 'vscode-web'
+                : 'vscode-node',
 
             // In dev mode, have Sentry log extended debug information to the console.
             debug: !isProd,

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -23,14 +23,24 @@ export abstract class SentryService {
         const isProd = process.env.NODE_ENV === 'production'
         const options: SentryOptions = {
             dsn: SENTRY_DSN,
+
+            // In dev mode, have Sentry log extended debug information to the console.
             debug: !isProd,
+
+            // Only send errors when connected to dotcom
             beforeSend: event => {
-                // Only send errors when connected to dotcom
                 if (!isDotCom(this.config.serverEndpoint) && isProd) {
                     return null
                 }
                 return event
             },
+
+            // The extension host is shared across other extensions, so listening on the default
+            // unhandled error listeners would not be helpful in case other extensions or VS Code
+            // throw.
+            //
+            // Instead, use the manual `captureException` API.
+            defaultIntegrations: false,
         }
         this.reconfigure(options)
     }

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -1,0 +1,39 @@
+import type { init as browserInit } from '@sentry/browser'
+import type { init as nodeInit } from '@sentry/node'
+
+import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+
+export * from '@sentry/core'
+export const SENTRY_DSN = 'https://f565373301c9c7ef18448a1c60dfde8d@o19358.ingest.sentry.io/4505743319564288'
+
+export type SentryOptions = Parameters<typeof nodeInit | typeof browserInit>[0]
+
+export abstract class SentryService {
+    constructor(protected config: Pick<Configuration, 'serverEndpoint'>) {
+        this.prepareReconfigure()
+    }
+
+    public onConfigurationChange(newConfig: Pick<Configuration, 'serverEndpoint'>): void {
+        this.config = newConfig
+        this.prepareReconfigure()
+    }
+
+    private prepareReconfigure(): void {
+        const isProd = process.env.NODE_ENV === 'production'
+        const options: SentryOptions = {
+            dsn: SENTRY_DSN,
+            debug: !isProd,
+            beforeSend: event => {
+                // Only send errors when connected to dotcom
+                if (!isDotCom(this.config.serverEndpoint) && isProd) {
+                    return null
+                }
+                return event
+            },
+        }
+        this.reconfigure(options)
+    }
+
+    protected abstract reconfigure(options: Parameters<typeof nodeInit | typeof browserInit>[0]): void
+}

--- a/vscode/src/services/sentry/sentry.web.ts
+++ b/vscode/src/services/sentry/sentry.web.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/browser'
+
+import { SentryOptions, SentryService } from './sentry'
+
+export class WebSentryService extends SentryService {
+    public reconfigure(options: SentryOptions): void {
+        Sentry.init(options)
+    }
+}


### PR DESCRIPTION
This PR adds a simple setup for Sentry to be used inside the extension host thread. It does not set up any default integration and we will instead need to wrap top-level entry points with calls to `Setnry.captureException`.

This also wires up autocomplete errors to be routed to Sentry so we have an easy service in place to understand the reliability of the product.

Note: When the user is connected to an instance other than dotcom, this does not send any events. 

## Test plan

- Add a throw case into the anthropic handler
- Force the env to be production
- See that the error is logged to Sentry

<img width="1100" alt="Screenshot 2023-08-31 at 14 03 13" src="https://github.com/sourcegraph/cody/assets/458591/99febc73-f79f-4b70-951f-e4e2a3ec0bb8">

I have also changed the backend to S2 and observed that no error is logged.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
