### PR TITLE
experimental support for VS Code autocomplete with Code Llama (via Ollama running locally)

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -1,3 +1,5 @@
+import { OllamaOptions } from './modelProviders/ollama'
+
 export type ConfigurationUseContext = 'embeddings' | 'keyword' | 'none' | 'blended' | 'unified'
 
 // Should we share VS Code specific config via cody-shared?
@@ -20,13 +22,20 @@ export interface Configuration {
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
     experimentalLocalSymbols: boolean
-    autocompleteAdvancedProvider: 'anthropic' | 'unstable-codegen' | 'unstable-fireworks' | 'unstable-openai' | null
+    autocompleteAdvancedProvider:
+        | 'anthropic'
+        | 'unstable-codegen'
+        | 'unstable-fireworks'
+        | 'unstable-openai'
+        | 'ollama-experimental'
+        | null
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedModel: string | null
     autocompleteAdvancedAccessToken: string | null
     autocompleteExperimentalCompleteSuggestWidgetSelection?: boolean
     autocompleteExperimentalSyntacticPostProcessing?: boolean
     autocompleteExperimentalGraphContext?: boolean
+    autocompleteExperimentalOllamaOptions?: OllamaOptions
     isRunningInsideAgent?: boolean
 }
 

--- a/lib/shared/src/modelProviders/ollama.ts
+++ b/lib/shared/src/modelProviders/ollama.ts
@@ -1,0 +1,36 @@
+export interface OllamaOptions {
+    /**
+     * URL to the Ollama server.
+     *
+     * @example http://localhost:11434
+     */
+    url: string
+
+    /**
+     * The Ollama model to use. Currently only codellama and derived models are supported.
+     *
+     * @example codellama:7b-code
+     */
+    model: string
+
+    /**
+     * Parameters for how Ollama will run the model. See Ollama PARAMETER documentation.
+     */
+    parameters?: OllamaGenerateParameters
+}
+
+/**
+ * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/docs/modelfile.md#valid-parameters-and-values
+ * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L143
+ */
+export interface OllamaGenerateParameters {
+    seed?: number
+    num_ctx?: number
+    temperature?: number
+    stop?: string[]
+    top_k?: number
+    top_p?: number
+    penalize_newline?: boolean
+    num_thread?: number
+    num_predict?: number
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,6 +483,9 @@ importers:
       '@types/mock-require':
         specifier: ^2.0.1
         version: 2.0.1
+      '@types/node-fetch':
+        specifier: ^2.6.4
+        version: 2.6.4
       '@types/progress':
         specifier: ^2.0.5
         version: 2.0.5

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -880,7 +880,8 @@
             "anthropic",
             "unstable-codegen",
             "unstable-fireworks",
-            "unstable-openai"
+            "unstable-openai",
+            "ollama-experimental"
           ],
           "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
@@ -928,6 +929,39 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
+        },
+        "cody.autocomplete.experimental.ollamaOptions": {
+          "type": "object",
+          "markdownDescription": "Options for the Ollama experimental autocomplete provider.",
+          "default": {
+            "url": "http://localhost:11434",
+            "model": "codellama:7b-code"
+          },
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "The URL of the Ollama API.",
+              "default": "http://localhost:11434"
+            },
+            "model": {
+              "type": "string",
+              "default": "codellama:7b-code",
+              "examples": [
+                "codellama:7b-code",
+                "codellama:13b-code"
+              ]
+            },
+            "parameters": {
+              "type": "object",
+              "description": "Parameters for how Ollama will run the model. See Ollama PARAMETER documentation.",
+              "properties": {
+                "num_ctx": "number",
+                "temperature": "number",
+                "top_k": "number",
+                "top_p": "number"
+              }
+            }
+          }
         }
       }
     },
@@ -992,6 +1026,7 @@
     "@types/lodash": "^4.14.195",
     "@types/mocha": "^10.0.1",
     "@types/mock-require": "^2.0.1",
+    "@types/node-fetch": "^2.6.4",
     "@types/progress": "^2.0.5",
     "@types/semver": "^7.5.0",
     "@types/unzipper": "^0.10.7",

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -67,7 +67,7 @@ export function createClient(
             const enableStreaming = !!isNode
 
             const url = getCodeCompletionsEndpoint()
-            const response: Response = await fetch(url, {
+            const response = (await fetch(url, {
                 method: 'POST',
                 body: JSON.stringify({
                     ...params,
@@ -75,7 +75,7 @@ export function createClient(
                 }),
                 headers,
                 signal,
-            })
+            })) as Response
 
             const traceId = response.headers.get('x-trace') ?? undefined
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -475,9 +475,12 @@ let globalInvocationSequenceForTracer = 0
  * for that invocation.
  */
 function createTracerForInvocation(tracer: ProvideInlineCompletionItemsTracer): InlineCompletionsParams['tracer'] {
-    let data: ProvideInlineCompletionsItemTraceData = { invocationSequence: ++globalInvocationSequenceForTracer }
+    let data: ProvideInlineCompletionsItemTraceData = {
+        invocationSequence: ++globalInvocationSequenceForTracer,
+        startTime: performance.now(),
+    }
     return (update: Partial<ProvideInlineCompletionsItemTraceData>) => {
-        data = { ...data, ...update }
+        data = { ...data, ...update, modTime: performance.now() }
         tracer(data)
     }
 }

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -189,6 +189,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         const isIncreasedDebounceTimeEnabled = await this.config.featureFlagProvider.evaluateFeatureFlag(
             FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled
         )
+
         try {
             const result = await this.getInlineCompletions({
                 document,
@@ -204,7 +205,12 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 documentHistory: this.config.history,
                 requestManager: this.requestManager,
                 lastCandidate: this.lastCandidate,
-                debounceInterval: { singleLine: isIncreasedDebounceTimeEnabled ? 75 : 25, multiLine: 125 },
+                debounceInterval: this.config.providerConfig.useLongerDebounce
+                    ? {
+                          singleLine: 500,
+                          multiLine: 1000,
+                      }
+                    : { singleLine: isIncreasedDebounceTimeEnabled ? 75 : 25, multiLine: 125 },
                 setIsLoading,
                 abortSignal: abortController.signal,
                 tracer,

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -6,6 +6,7 @@ import { logError } from '../../log'
 import { CodeCompletionsClient } from '../client'
 
 import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
+import { createOllamaProviderConfig as createUnstableOllamaProviderConfig } from './ollama'
 import { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableCodeGenProviderConfig } from './unstable-codegen'
 import {
@@ -58,6 +59,16 @@ export async function createProviderConfig(
                     client,
                     mode: 'infill',
                 })
+            }
+            case 'ollama-experimental': {
+                if (!config.autocompleteExperimentalOllamaOptions) {
+                    logError(
+                        'createProviderConfig',
+                        'No Ollama options provided (in cody.autocomplete.experimental.ollamaOptions settings property).'
+                    )
+                    return null
+                }
+                return createUnstableOllamaProviderConfig(config.autocompleteExperimentalOllamaOptions)
             }
             default:
                 logError(

--- a/vscode/src/completions/providers/ollama.ts
+++ b/vscode/src/completions/providers/ollama.ts
@@ -1,0 +1,340 @@
+import type { Response as NodeResponse } from 'node-fetch'
+
+import { isDefined } from '@sourcegraph/cody-shared'
+import { OllamaGenerateParameters, OllamaOptions } from '@sourcegraph/cody-shared/src/modelProviders/ollama'
+import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+
+import { BrowserOrNodeResponse, fetch } from '../../fetch'
+import { logDebug, logger } from '../../log'
+import { Completion, ContextSnippet } from '../types'
+
+import { Provider, ProviderConfig, ProviderOptions } from './provider'
+
+export function createOllamaProviderConfig(ollamaOptions: OllamaOptions): ProviderConfig {
+    return {
+        create(options: ProviderOptions) {
+            return new OllamaProvider(options, {
+                ...ollamaOptions,
+                parameters: {
+                    seed: 1337,
+                    stop: [
+                        '\n\n',
+                        '// Path:',
+                        '\u001E',
+                        '\u001C',
+                        INFILL_TOKENS.EOT,
+
+                        // Tokens that reduce the quality of multi-line completions but improve performance.
+                        '}\n',
+                    ],
+                    temperature: 0.5,
+                    top_k: -1,
+                    top_p: -1,
+                    ...ollamaOptions.parameters,
+                },
+            })
+        },
+        contextSizeHints: {
+            // Ollama evaluates the prompt at ~50 tok/s for codellama:7b-code on a MacBook Air M2.
+            // If the prompt has a common prefix across inference requests, subsequent requests do
+            // not incur prompt reevaluation and are therefore much faster. So, we want a large
+            // document prefix that covers the entire document (except in cases where the document
+            // is very, very large, in which case Ollama would not work well anyway).
+            prefixChars: 10000,
+
+            // For the same reason above, we want a very small suffix because otherwise Ollama needs to
+            // reevaluate more tokens in the prompt. This is because the prompt is (roughly) `prefix
+            // (cursor position) suffix`, so even typing a single character at the cursor position
+            // invalidates the LLM's cache of the suffix.
+            suffixChars: 5,
+        },
+        enableExtendedMultilineTriggers: true,
+        identifier: PROVIDER_IDENTIFIER,
+        model: ollamaOptions.model,
+        useLongerDebounce: true,
+    }
+}
+
+const PROVIDER_IDENTIFIER = 'ollama'
+
+/**
+ * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L35
+ */
+interface OllamaGenerateRequest {
+    model: string
+    template: string
+    prompt: string
+    options?: OllamaGenerateParameters
+}
+
+/**
+ * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L88
+ */
+interface OllamaGenerateResponse {
+    model: string
+    response?: string
+    done: boolean
+    context?: number[]
+    total_duration?: number
+    load_duration?: number
+    prompt_eval_count?: number
+    prompt_eval_duration?: number
+    eval_count?: number
+    eval_duration?: number
+    sample_count?: number
+    sample_duration?: number
+}
+
+interface OllamaGenerateErrorResponse {
+    error?: string
+}
+
+/** Special tokens for Code Llama infill. */
+const INFILL_TOKENS = {
+    PRE: ' <PRE>',
+    SUF: ' <SUF>',
+    MID: ' <MID>',
+    EOT: ' <EOT>',
+}
+
+interface LlamaCodePrompt {
+    snippets: { fileName: string; content: string }[]
+
+    fileName: string
+    prefix: string
+    suffix: string
+}
+
+function llamaCodePromptString(prompt: LlamaCodePrompt, infill: boolean): string {
+    // TODO(sqs): use the correct comment syntax for the language (eg '#' for Python, not '//').
+    return (
+        prompt.snippets
+            .map(
+                ({ fileName, content }) =>
+                    `// Path: ${fileName}\n${content
+                        .split('\n')
+                        .map(line => `// ${line}`)
+                        .join('\n')}`
+            )
+            .join('\n\n') +
+        (infill
+            ? `${INFILL_TOKENS.PRE}// Path: ${prompt.fileName}\n${prompt.prefix}${INFILL_TOKENS.SUF}${prompt.suffix}${INFILL_TOKENS.MID}`
+            : `// Path: ${prompt.fileName}\n${prompt.prefix}`)
+    )
+}
+
+/**
+ * An *experimental* completion provider that uses [Ollama](https://ollama.ai), which is a tool for
+ * running LLMs locally.
+ *
+ * The provider communicates with an Ollama server's [REST
+ * API](https://github.com/jmorganca/ollama#rest-api).
+ */
+class OllamaProvider extends Provider {
+    constructor(
+        options: ProviderOptions,
+        private readonly ollamaOptions: OllamaOptions
+    ) {
+        super(options)
+    }
+
+    protected createPrompt(snippets: ContextSnippet[], infill: boolean): LlamaCodePrompt {
+        const prompt: LlamaCodePrompt = {
+            snippets: [],
+            fileName: this.options.fileName,
+            prefix: this.options.docContext.prefix,
+            suffix: this.options.docContext.suffix,
+        }
+        if (process.env.OTHER_FILES) {
+            // TODO(sqs)
+            const maxPromptChars = 1234 /* tokensToChars(
+                this.ollamaOptions.parameters.num_ctx * (1 - this.options.responsePercentage)
+            )    */
+            for (const snippet of snippets) {
+                const extendedSnippets = [...prompt.snippets, snippet]
+                const promptLengthWithSnippet = llamaCodePromptString(
+                    { ...prompt, snippets: extendedSnippets },
+                    infill
+                ).length
+                if (promptLengthWithSnippet > maxPromptChars) {
+                    break
+                }
+                prompt.snippets = extendedSnippets
+            }
+        }
+        return prompt
+    }
+
+    public async generateCompletions(abortSignal: AbortSignal, snippets: ContextSnippet[]): Promise<Completion[]> {
+        // Only use infill if the suffix has alphanumerics, where it might give us a var name we should refer to. TODO(sqs): playing around with this...
+        const useInfill = /\s*\w/.test(this.options.docContext.suffix)
+        const request: OllamaGenerateRequest = {
+            prompt: llamaCodePromptString(this.createPrompt(snippets, useInfill), useInfill),
+            template: '{{ .Prompt }}',
+            model: this.ollamaOptions.model,
+            options: {
+                num_predict: this.options.multiline ? 100 : 15,
+                ...this.ollamaOptions.parameters,
+                stop: this.options.multiline
+                    ? this.ollamaOptions.parameters?.stop
+                    : [...(this.ollamaOptions.parameters?.stop ?? []), '\n'],
+            },
+        }
+
+        const log = logger.startCompletion({
+            request,
+            provider: PROVIDER_IDENTIFIER,
+            serverEndpoint: this.ollamaOptions.url,
+        })
+
+        let responseText = ''
+
+        try {
+            const response: BrowserOrNodeResponse = await fetch(new URL('/api/generate', this.ollamaOptions.url), {
+                method: 'POST',
+                body: JSON.stringify(request),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                signal: abortSignal,
+            })
+            if (!response.ok) {
+                const errorResponse = (await response.json()) as OllamaGenerateErrorResponse
+                throw new Error(`ollama generation error: ${errorResponse?.error || 'unknown error'}`)
+            }
+
+            const processLine = (line: OllamaGenerateResponse): void => {
+                if (line.response) {
+                    responseText += line.response
+                }
+                if (line.done && line.total_duration) {
+                    const logKeys: (keyof OllamaGenerateResponse)[] = [
+                        'total_duration',
+                        'load_duration',
+                        'prompt_eval_count',
+                        'prompt_eval_duration',
+                        'eval_count',
+                        'eval_duration',
+                        'sample_count',
+                        'sample_duration',
+                    ]
+                    logDebug(
+                        'ollama',
+                        'generation done',
+                        [
+                            ...logKeys
+                                .filter(key => line[key] !== undefined)
+                                .map(
+                                    key =>
+                                        `${key}=${
+                                            key.endsWith('_duration')
+                                                ? `${(line[key] as number) / 1000000}ms`
+                                                : line[key]
+                                        }`
+                                ),
+                            line.prompt_eval_count !== undefined && line.prompt_eval_duration !== undefined
+                                ? `prompt_eval_tok/sec=${
+                                      line.prompt_eval_count / (line.prompt_eval_duration / 1000000000)
+                                  }`
+                                : null,
+                            line.eval_count !== undefined && line.eval_duration !== undefined
+                                ? `response_tok/sec=${line.eval_count / (line.eval_duration / 1000000000)}`
+                                : null,
+                        ]
+                            .filter(isDefined)
+                            .join(' ')
+                    )
+                }
+            }
+            if (isNodeResponse(response)) {
+                await readStreamNode(processLine)(response)
+            } else {
+                await readStreamBrowser(processLine)(response)
+            }
+
+            const completions: Completion[] = responseText ? [{ content: postProcess(responseText) }] : []
+            log?.onComplete(completions.map(c => c.content))
+            return completions
+        } catch (error: any) {
+            if (!isAbortError(error)) {
+                log?.onError(error)
+            }
+            throw error
+        }
+    }
+}
+
+function postProcess(content: string): string {
+    return content.trim()
+}
+
+function isNodeResponse(response: BrowserOrNodeResponse): response is NodeResponse {
+    return Boolean(response.body && !('getReader' in response.body))
+}
+
+const readStreamBrowser =
+    <L>(processLine: (line: L) => void) =>
+    (response: Response) => {
+        if (!response.body) {
+            throw new Error('response has no body')
+        }
+        const stream = response.body.getReader()
+        const matcher = /\r?\n/
+        const decoder = new TextDecoder()
+        let buf = ''
+
+        const loop = (): Promise<void> =>
+            stream.read().then(({ done, value }) => {
+                if (done) {
+                    if (buf.length > 0) {
+                        processLine(JSON.parse(buf))
+                    }
+                } else {
+                    const chunk = decoder.decode(value, { stream: true })
+                    buf += chunk
+
+                    const parts = buf.split(matcher)
+                    buf = parts.pop() ?? ''
+                    for (const i of parts.filter(p => p)) {
+                        processLine(JSON.parse(i))
+                    }
+                    return loop()
+                }
+                return
+            })
+
+        return loop()
+    }
+
+const readStreamNode =
+    <L>(processLine: (line: L) => void) =>
+    (response: NodeResponse) => {
+        const matcher = /\r?\n/
+        const decoder = new TextDecoder()
+        let buf = ''
+        const responseBody = response.body
+        if (!responseBody) {
+            throw new Error('response has no body')
+        }
+        return new Promise<void>((resolve, reject) => {
+            responseBody.on('data', v => {
+                const chunk = decoder.decode(v, { stream: true })
+                buf += chunk
+
+                const parts = buf.split(matcher)
+                buf = parts.pop() ?? ''
+                for (const i of parts.filter(p => p)) {
+                    processLine(JSON.parse(i))
+                }
+            })
+            responseBody.on('end', () => {
+                if (buf.length > 0) {
+                    processLine(JSON.parse(buf))
+                }
+                resolve()
+            })
+            responseBody.on('error', error => {
+                reject(error)
+            })
+        })
+    }

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -33,6 +33,12 @@ export interface ProviderConfig {
      * Defines which model is used with the respective provider.
      */
     model: string
+
+    /**
+     * Whether to wait longer to debounce requests. Slow models (such as models running locally)
+     * should set this to `true` to avoid overloading the user's machine while they type.
+     */
+    useLongerDebounce?: boolean
 }
 
 export interface ProviderContextSizeHints {

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -99,4 +99,7 @@ export interface CompletionProviderTracerResultData {
 
     /** The post-processed completions that are returned by the provider. */
     completions: Completion[]
+
+    /** Free-form text with debugging or timing information. */
+    debugMessage?: string
 }

--- a/vscode/src/completions/tracer/index.ts
+++ b/vscode/src/completions/tracer/index.ts
@@ -24,6 +24,7 @@ export type ProvideInlineCompletionItemsTracer = (data: ProvideInlineCompletions
  */
 export interface ProvideInlineCompletionsItemTraceData {
     invocationSequence: number
+    startTime: number
     params?: {
         document: vscode.TextDocument
         position: vscode.Position
@@ -41,4 +42,5 @@ export interface ProvideInlineCompletionsItemTraceData {
     context?: GetContextResult | null
     result?: InlineCompletionsResult | null
     error?: string
+    modTime?: number
 }

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -37,6 +37,7 @@ describe('getConfiguration', () => {
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: false,
+            autocompleteExperimentalOllamaOptions: { url: 'http://localhost:11434', model: 'codellama:7b-code' },
         })
     })
 
@@ -103,6 +104,8 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.advanced.agent.running':
                         return false
+                    case 'cody.autocomplete.experimental.ollamaOptions':
+                        return {}
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -138,6 +141,7 @@ describe('getConfiguration', () => {
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: true,
+            autocompleteExperimentalOllamaOptions: {},
         })
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -7,6 +7,8 @@ import type {
 } from '@sourcegraph/cody-shared/src/configuration'
 import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
+import packageJson from '../package.json'
+
 import { CONFIG_KEY, ConfigKeys } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'
 import { getAccessToken } from './services/SecretStorageProvider'
@@ -75,6 +77,10 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         autocompleteExperimentalGraphContext: config.get<boolean>(
             CONFIG_KEY.autocompleteExperimentalGraphContext,
             false
+        ),
+        autocompleteExperimentalOllamaOptions: config.get(
+            CONFIG_KEY.autocompleteExperimentalOllamaOptions,
+            packageJson.contributes.configuration.properties['cody.autocomplete.experimental.ollamaOptions'].default
         ),
 
         /**

--- a/vscode/src/fetch.ts
+++ b/vscode/src/fetch.ts
@@ -5,6 +5,7 @@ import type { Agent } from 'http'
  * `fetch` by default, we still use the `node-fetch` polyfill and have access to the networking code
  */
 import isomorphicFetch from 'isomorphic-fetch'
+import type { Response as NodeResponse } from 'node-fetch'
 
 import { addCustomUserAgent, customUserAgent } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
@@ -20,13 +21,16 @@ import { addCustomUserAgent, customUserAgent } from '@sourcegraph/cody-shared/sr
  */
 export const agent: { current: ((url: URL) => Agent) | undefined } = { current: undefined }
 
-export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+export type BrowserOrNodeResponse = Response | NodeResponse
+
+export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<BrowserOrNodeResponse> {
     if (customUserAgent) {
         init = init ?? {}
         const headers = new Headers(init?.headers)
         addCustomUserAgent(headers)
         init.headers = headers
     }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return isomorphicFetch(input, {
         ...init,
         agent: agent.current,


### PR DESCRIPTION
Adds support for autocomplete with Meta's Code Llama model, running locally in [Ollama](https://ollama.ai/).

~Depends on https://github.com/jmorganca/ollama/pull/457.~

Requires Ollama to be running, and the following VS Code settings:

```json
{
	"cody.autocomplete.advanced.provider": "ollama-experimental",
	"cody.autocomplete.experimental.ollamaOptions": {
		"url": "http://localhost:11434",
		"model": "codellama:7b-code"
	}
}
```

TODO instructions etc.


https://github.com/sourcegraph/cody/assets/1976/5d36d8e5-bd69-4786-a70f-0baf79604da8



## Test plan

TODO