### PR TITLE
VS Code: use singleton storage providers in rest consumers

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -5,6 +5,7 @@ import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat
 
 import { View } from '../../webviews/NavBar'
 import { logDebug } from '../log'
+import { localStorage } from '../services/LocalStorageProvider'
 
 import { MessageProvider, MessageProviderOptions } from './MessageProvider'
 import { ExtensionMessage, WebviewMessage } from './protocol'
@@ -118,7 +119,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                 )
                 break
             case 'setEnabledPlugins':
-                await this.localStorage.setEnabledPlugins(message.plugins)
+                await localStorage.setEnabledPlugins(message.plugins)
                 this.handleEnabledPlugins(message.plugins)
                 break
             default:

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -25,7 +25,7 @@ import { PlatformContext } from '../extension.common'
 import { logDebug, logError } from '../log'
 import { FixupTask } from '../non-stop/FixupTask'
 import { AuthProvider, isNetworkError } from '../services/AuthProvider'
-import { LocalStorage } from '../services/LocalStorageProvider'
+import { localStorage } from '../services/LocalStorageProvider'
 import { TestSupport } from '../test-support'
 
 import { ContextProvider } from './ContextProvider'
@@ -64,7 +64,6 @@ export interface MessageProviderOptions {
     intentDetector: IntentDetector
     guardrails: Guardrails
     editor: VSCodeEditor
-    localStorage: LocalStorage
     authProvider: AuthProvider
     contextProvider: ContextProvider
     telemetryService: TelemetryService
@@ -91,7 +90,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     protected intentDetector: IntentDetector
     protected guardrails: Guardrails
     protected readonly editor: VSCodeEditor
-    protected localStorage: LocalStorage
     protected authProvider: AuthProvider
     protected contextProvider: ContextProvider
     protected telemetryService: TelemetryService
@@ -108,7 +106,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         this.intentDetector = options.intentDetector
         this.guardrails = options.guardrails
         this.editor = options.editor
-        this.localStorage = options.localStorage
         this.authProvider = options.authProvider
         this.contextProvider = options.contextProvider
         this.telemetryService = options.telemetryService
@@ -125,7 +122,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         this.loadChatHistory()
         this.sendTranscript()
         this.sendHistory()
-        this.sendEnabledPlugins(this.localStorage.getEnabledPlugins() ?? [])
+        this.sendEnabledPlugins(localStorage.getEnabledPlugins() ?? [])
         await this.loadRecentChat()
         await this.contextProvider.init()
         await this.sendCodyCommands()
@@ -146,7 +143,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     public async clearHistory(): Promise<void> {
         MessageProvider.chatHistory = {}
         MessageProvider.inputHistory = []
-        await this.localStorage.removeChatHistory()
+        await localStorage.removeChatHistory()
         // Reset the current transcript
         this.transcript = new Transcript()
         await this.clearAndRestartSession()
@@ -292,7 +289,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         humanChatInput: string
     ): Promise<{ prompt?: Message[]; executionInfos?: PluginFunctionExecutionInfo[] }> {
         this.telemetryService.log('CodyVSCodeExtension:getPluginsContext:used')
-        const enabledPluginNames = this.localStorage.getEnabledPlugins() ?? []
+        const enabledPluginNames = localStorage.getEnabledPlugins() ?? []
         const enabledPlugins = defaultPlugins.filter(plugin => enabledPluginNames.includes(plugin.name))
         if (enabledPlugins.length === 0) {
             return {}
@@ -671,7 +668,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             chat: MessageProvider.chatHistory,
             input: MessageProvider.inputHistory,
         }
-        await this.localStorage.setChatHistory(userHistory)
+        await localStorage.setChatHistory(userHistory)
     }
 
     /**
@@ -679,7 +676,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      */
     protected async deleteHistory(chatID: string): Promise<void> {
         delete MessageProvider.chatHistory[chatID]
-        await this.localStorage.deleteChatHistory(chatID)
+        await localStorage.deleteChatHistory(chatID)
         this.sendHistory()
         this.telemetryService.log('CodyVSCodeExtension:deleteChatHistoryButton:clicked')
     }
@@ -688,7 +685,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Loads chat history from local storage
      */
     private loadChatHistory(): void {
-        const localHistory = this.localStorage.getChatHistory()
+        const localHistory = localStorage.getChatHistory()
         if (localHistory) {
             MessageProvider.chatHistory = localHistory?.chat
             MessageProvider.inputHistory = localHistory.input
@@ -723,7 +720,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Loads the most recent chat
      */
     private async loadRecentChat(): Promise<void> {
-        const localHistory = this.localStorage.getChatHistory()
+        const localHistory = localStorage.getChatHistory()
         if (localHistory) {
             const chats = localHistory.chat
             const sortedChats = Object.entries(chats).sort(

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -9,7 +9,7 @@ import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environ
 
 import { CONFIG_KEY, ConfigKeys } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'
-import { getAccessToken, secretStorage } from './services/SecretStorageProvider'
+import { getAccessToken } from './services/SecretStorageProvider'
 
 interface ConfigGetter {
     get<T>(section: (typeof CONFIG_KEY)[ConfigKeys], defaultValue?: T): T
@@ -113,6 +113,6 @@ export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => 
     const config = getConfiguration()
     // Migrate endpoints to local storage
     config.serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
-    const accessToken = (await getAccessToken(secretStorage)) || null
+    const accessToken = (await getAccessToken()) || null
     return { ...config, accessToken }
 }

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -10,7 +10,7 @@ import { VsCodeCommandsController } from '@sourcegraph/cody-shared/src/editor'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { logDebug, logError } from '../log'
-import { LocalStorage } from '../services/LocalStorageProvider'
+import { localStorage } from '../services/LocalStorageProvider'
 
 import { CustomPromptsStore } from './CustomPromptsStore'
 import { showCommandConfigMenu, showCommandMenu, showCustomCommandMenu, showNewCustomCommandMenu } from './menus'
@@ -49,7 +49,6 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
     constructor(
         context: vscode.ExtensionContext,
-        private localStorage: LocalStorage,
         private telemetryService: TelemetryService
     ) {
         this.tools = new ToolsProvider(context)
@@ -58,7 +57,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         this.custom = new CustomPromptsStore(this.isEnabled, context.extensionPath, user?.workspaceRoot, user.homeDir)
         this.disposables.push(this.custom)
 
-        this.lastUsedCommands = new Set(this.localStorage.getLastUsedCommands())
+        this.lastUsedCommands = new Set(localStorage.getLastUsedCommands())
         this.custom.activate()
         this.fileWatcherInit()
     }
@@ -449,7 +448,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         // store the last 3 used commands
         const commands = [...this.lastUsedCommands].filter(command => command !== 'separator').slice(0, 3)
         if (commands.length > 0) {
-            await this.localStorage.setLastUsedCommands(commands)
+            await localStorage.setLastUsedCommands(commands)
         }
 
         this.lastUsedCommands = new Set(commands)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -73,7 +73,7 @@ const register = async (
     const isExtensionModeDevOrTest =
         context.extensionMode === vscode.ExtensionMode.Development ||
         context.extensionMode === vscode.ExtensionMode.Test
-    await createOrUpdateEventLogger(initialConfig, localStorage, isExtensionModeDevOrTest)
+    await createOrUpdateEventLogger(initialConfig, isExtensionModeDevOrTest)
     const telemetryService = createVSCodeTelemetryService()
 
     // Controller for inline Chat
@@ -88,7 +88,7 @@ const register = async (
     const editor = new VSCodeEditor({
         inline: commentController,
         fixups: fixup,
-        command: platform.createCommandsController?.(context, localStorage, telemetryService),
+        command: platform.createCommandsController?.(context, telemetryService),
     })
 
     // Could we use the `initialConfig` instead?
@@ -137,7 +137,6 @@ const register = async (
         intentDetector,
         guardrails,
         editor,
-        localStorage,
         authProvider,
         contextProvider,
         telemetryService,
@@ -161,7 +160,7 @@ const register = async (
         contextProvider.configurationChangeEvent.event(async () => {
             const newConfig = await getFullConfig()
             externalServicesOnDidConfigurationChange(newConfig)
-            await createOrUpdateEventLogger(newConfig, localStorage, isExtensionModeDevOrTest)
+            await createOrUpdateEventLogger(newConfig, isExtensionModeDevOrTest)
         })
     )
 
@@ -447,13 +446,13 @@ const register = async (
         await vscode.commands.executeCommand('setContext', 'cody.nonstop.fixups.enabled', true)
     }
 
-    await showSetupNotification(initialConfig, localStorage)
+    await showSetupNotification(initialConfig)
     return {
         disposable: vscode.Disposable.from(...disposables),
         onConfigurationChange: newConfig => {
             contextProvider.onConfigurationChange(newConfig)
             externalServicesOnDidConfigurationChange(newConfig)
-            void createOrUpdateEventLogger(newConfig, localStorage, isExtensionModeDevOrTest)
+            void createOrUpdateEventLogger(newConfig, isExtensionModeDevOrTest)
         },
     }
 }

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -2,14 +2,11 @@ import * as vscode from 'vscode'
 
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 
-import { LocalStorage } from '../services/LocalStorageProvider'
+import { localStorage } from '../services/LocalStorageProvider'
 
 import { showActionNotification } from '.'
 
-export const showSetupNotification = async (
-    config: ConfigurationWithAccessToken,
-    localStorage: LocalStorage
-): Promise<void> => {
+export const showSetupNotification = async (config: ConfigurationWithAccessToken): Promise<void> => {
     if (config.serverEndpoint && config.accessToken) {
         // User has already attempted to configure Cody.
         // Regardless of if they are authenticated or not, we don't want to prompt them.

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -38,7 +38,7 @@ export class AuthProvider {
     ) {
         this.authStatus.endpoint = 'init'
         this.loadEndpointHistory()
-        this.appDetector = new LocalAppDetector(secretStorage, { onChange: type => this.syncLocalAppState(type) })
+        this.appDetector = new LocalAppDetector({ onChange: type => this.syncLocalAppState(type) })
     }
 
     // Sign into the last endpoint the user was signed into

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -7,7 +7,7 @@ import { EventLogger, ExtensionDetails } from '@sourcegraph/cody-shared/src/tele
 import { version as packageVersion } from '../../package.json'
 import { logDebug } from '../log'
 
-import { LocalStorage } from './LocalStorageProvider'
+import { localStorage } from './LocalStorageProvider'
 
 export let eventLogger: EventLogger | null = null
 let globalAnonymousUserID: string
@@ -23,7 +23,6 @@ export const extensionDetails: ExtensionDetails = {
 
 export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
-    localStorage: LocalStorage,
     isExtensionModeDevOrTest: boolean
 ): Promise<void> {
     if (config.telemetryLevel === 'off' || isExtensionModeDevOrTest) {

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -9,7 +9,7 @@ import { constructFileUri } from '../custom-prompts/utils/helpers'
 import { logDebug, logError } from '../log'
 
 import { AppJson, LOCAL_APP_LOCATIONS } from './LocalAppFsPaths'
-import { SecretStorage } from './SecretStorageProvider'
+import { secretStorage } from './SecretStorageProvider'
 
 type OnChangeCallback = (type: string) => Promise<void>
 /**
@@ -28,10 +28,7 @@ export class LocalAppDetector implements vscode.Disposable {
     private _watchers: vscode.Disposable[] = []
     private onChange: OnChangeCallback
 
-    constructor(
-        private secretStorage: SecretStorage,
-        options: { onChange: OnChangeCallback }
-    ) {
+    constructor(options: { onChange: OnChangeCallback }) {
         this.onChange = options.onChange
         this.localEnv = { ...envInit }
         this.localAppMarkers = LOCAL_APP_LOCATIONS[this.localEnv.os]
@@ -107,7 +104,7 @@ export class LocalAppDetector implements vscode.Disposable {
             this.localEnv.hasAppJson = true
             this.tokenFsPath = null
             await this.found('token')
-            await this.secretStorage.storeToken(LOCAL_APP_URL.href, token)
+            await secretStorage.storeToken(LOCAL_APP_URL.href, token)
             await this.fetchServer()
         }
     }

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -6,7 +6,7 @@ import { logDebug, logError } from '../log'
 
 export const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
 
-export async function getAccessToken(secretStorage: SecretStorage): Promise<string | null> {
+export async function getAccessToken(): Promise<string | null> {
     try {
         const token = (await secretStorage.get(CODY_ACCESS_TOKEN_SECRET)) || null
         if (token) {


### PR DESCRIPTION
## Context

- A follow-up to https://github.com/sourcegraph/cody/pull/876: migrates other `localStorage` and `secretStorage` consumers to importing singletons instead of using them as arguments.
- Part of #874

The end goal of this effort (as stated in https://github.com/sourcegraph/cody/issues/874) is to decouple `getConfiguration` from the other entities in the codebase and introduce atomic and reactive getting for config values.

## Test plan

CI
