### PR TITLE
Modify autocomplete to use all surrounding code as context 

### DIFF
--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -1488,7 +1488,7 @@ describe('getInlineCompletions', () => {
         expect(messages[messages.length - 1]).toMatchInlineSnapshot(`
             {
               "speaker": "assistant",
-              "text": "Here is the code: <CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+              "text": "Understood. Here is the completed code snippet aligned with your guidelines: <CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
                     this.startLine =",
             }
         `)
@@ -1516,7 +1516,9 @@ describe('getInlineCompletions', () => {
         )
         expect(requests).toHaveLength(3)
         const messages = requests[0].messages
-        expect(messages[messages.length - 1].text).toBe('Here is the code: <CODE5711>class Range {\n')
+        expect(messages[messages.length - 1].text).toBe(
+            'Understood. Here is the completed code snippet aligned with your guidelines: <CODE5711>class Range {\n'
+        )
     })
 
     test('synthesizes a completion from a prior request', async () => {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -64,25 +64,20 @@ export class AnthropicProvider extends Provider {
         const prefixMessages: Message[] = [
             {
                 speaker: 'human',
-                text: `You are a code completion AI that writes high-quality code like a senior engineer. You are looking at ${
-                    this.options.fileName
-                }. You write code in between tags like this: ${OPENING_CODE_TAG}${
-                    this.options.languageId === 'python' || this.options.languageId === 'ruby'
-                        ? '# Code goes here'
-                        : '/* Code goes here */'
-                }${CLOSING_CODE_TAG}.`,
+                text: 'You are a sophisticated code-completion AI, specifically designed to understand the intricacies of coding context. Your abilities include grasping the semantic and syntactic elements of the code I’m working on and offering completion suggestions that not only fit the functional requirements but also adhere to the stylistic and architectural patterns present in the existing codebase.',
             },
             {
                 speaker: 'assistant',
-                text: 'I am a code completion AI that writes high-quality code like a senior engineer.',
+                text: 'Acknowledged. My design incorporates advanced contextual understanding, which allows me to generate code completions that are functionally coherent, stylistically consistent, and architecturally aligned with your existing code.',
             },
             {
                 speaker: 'human',
-                text: `Complete this code: ${OPENING_CODE_TAG}${head.trimmed}${CLOSING_CODE_TAG}.`,
+                text: `I'd like you to focus on the following attributes while completing the code snippet enclosed in the ${OPENING_CODE_TAG}. First, adhere to the naming conventions present in the existing code. Second, maintain stylistic consistency. Third, make sure to define return types explicitly for functions if that's the practice in the surrounding code. Fourth, refrain from using any libraries or methods that aren't already imported or defined. Fifth, avoid redundancy by not repeating code, functions, or methods that are present in the existing code. Sixth: Focus on writing clean, efficient code that works seamlessly with surrounding code. Complete the following code: ${OPENING_CODE_TAG}
+                ${head.trimmed}${OPENING_CODE_TAG}${tail.trimmed}${CLOSING_CODE_TAG}${this.options.docContext.suffix}`,
             },
             {
                 speaker: 'assistant',
-                text: `Here is the code: ${OPENING_CODE_TAG}${tail.trimmed}`,
+                text: `Understood. Here is the completed code snippet aligned with your guidelines: ${OPENING_CODE_TAG}${tail.trimmed}`,
             },
         ]
         return { messages: prefixMessages, prefix: { head, tail, overlap } }
@@ -101,11 +96,11 @@ export class AnthropicProvider extends Provider {
             const snippetMessages: Message[] = [
                 {
                     speaker: 'human',
-                    text: `Here is a reference snippet of code: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,
+                    text: `Codebase context from a file with file path ${snippet.fileName}: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,
                 },
                 {
                     speaker: 'assistant',
-                    text: 'I have added the snippet to my knowledge base.',
+                    text: 'I will refer to this code when completing your next request.',
                 },
             ]
             const numSnippetChars = messagesToText(snippetMessages).length + 1
@@ -119,6 +114,7 @@ export class AnthropicProvider extends Provider {
         return { messages: [...referenceSnippetMessages, ...prefixMessages], prefix }
     }
 
+    // Returns completions based on the generated prompt
     public async generateCompletions(
         abortSignal: AbortSignal,
         snippets: ContextSnippet[],


### PR DESCRIPTION
This is a work from @abeatrix  on https://github.com/sourcegraph/cody/pull/885/ Just worded slightly differently so that I could understand how autocomplete actually functions. 


I am referencing this code for example
https://github.com/sourcegraph/cody/blob/66bf5f1d6bb991c106e59cbfe0fbbb5fc49083a9/vscode/src/custom-prompts/utils/menu.ts#L176-L218


Lets say the cursor is at Line 208 then if you look above the cursor you see a few config menu options

## Before
In the current behaviour when you try to add a comment it takes into account only the config menu options and makes a docstring

https://github.com/sourcegraph/cody/assets/11155207/7d1e747e-b1e2-4452-a896-4866fdf6c9ac

On asking GPT4 we realize the docstring doesn't make perfect sense(which is obviously try coz its missing the suffix context)
<img width="531" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/dae0aada-a252-4d96-8919-5db1cab7072d">


## After


https://github.com/sourcegraph/cody/assets/11155207/dd68c040-d3e0-469d-8e4e-1aed1e85ee32

Now in the new code the docstring makes a lot of sense coz it has the suffix context also and I checked whether the docstring makes sense with GPT4 also. 
<img width="515" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/1d78bcb3-9918-42a3-979d-5b3215eabfed">


The essence of this PR is that adding suffix context and sending that to the autocomplete gives much better results and I tried that in other contexts too. 



## Test plan
1. The local tests are passing
```
 ✓ |vscode| src/completions/context/bestJaccardMatch.test.ts (4)
 ✓ |vscode| src/services/InlineAssist.test.ts (16)
 ✓ |vscode| src/completions/utils/string-comparator.test.ts (12)
 ✓ |vscode| src/non-stop/utils.test.ts (3)
 ✓ |agent| src/index.test.ts (2)
 ✓ |e2e| src/entity-detection.test.ts (3)
 ✓ |vscode| src/completions/text-processing.test.ts (12)
 ✓ |agent| src/AgentTextDocument.test.ts (5)
 ✓ |web| src/sample.test.ts (1)
 ✓ |vscode| src/configuration.test.ts (2)
 ✓ |vscode| src/completions/vscodeInlineCompletionItemProvider.test.ts (11) 462ms
 ✓ |shared| src/utils.test.ts (11)
 ✓ |shared| src/experimentation/FeatureFlagProvider.test.ts (6)
 ✓ |shared| src/chat/transcript/transcript.test.ts (10)
 ✓ |shared| src/guardrails/index.test.ts (6)
 ✓ |shared| src/common/markdown/markdown.test.ts (12)
 ✓ |shared| src/chat/bot-response-multiplexer.test.ts (9)
 ✓ |shared| src/codebase-context/rerank.test.ts (1)
 ✓ |shared| src/sourcegraph-api/utils.test.ts (4)
 ✓ |shared| src/chat/recipes/fixup.test.ts (2)

 Test Files  31 passed (31)
      Tests  282 passed | 1 skipped (283)
   Start at  01:46:17
   Duration  6.44s (transform 1.40s, setup 1.18s, collect 9.97s, tests 1.56s, environment 9.21s, prepare 5.19s)


 PASS  Waiting for file changes...
       press h to show help, press q to quit
```

2. I stopped at the debugger at various places to actually check the prompt to make sure it includes text AFTER the cursor position and now that it does that we can get much better results. 
