### PR TITLE
Sentry: Don't crash the extension when we can't init

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "tsc --build",
     "watch": "tsc --build --watch",
     "lint": "pnpm run lint:js && pnpm run lint:css",
-    "lint:js": "eslint --quiet --cache '**/*.[tj]s?(x)'",
+    "lint:js": "NODE_OPTIONS=--max-old-space-size=4096 eslint --quiet --cache '**/*.[tj]s?(x)'",
     "lint:css": "stylelint --quiet --cache '**/*.css'",
     "format": "prettier '**/{*.{js?(on),ts?(x),md,scss},.*.js?(on)}' --list-different --config .prettierrc.js --write",
     "format:check": "prettier '**/{*.{js?(on),ts?(x),md,scss},.*.js?(on)}' --config .prettierrc.js --check --write=false",

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -22,37 +22,42 @@ export abstract class SentryService {
     }
 
     private prepareReconfigure(): void {
-        const isProd = process.env.NODE_ENV === 'production'
-        const options: SentryOptions = {
-            dsn: SENTRY_DSN,
-            release: extensionDetails.version,
-            environment: this.config.isRunningInsideAgent
-                ? 'agent'
-                : typeof process !== 'undefined'
-                ? 'vscode-node'
-                : 'vscode-web',
+        try {
+            const isProd = process.env.NODE_ENV === 'production'
+            const options: SentryOptions = {
+                dsn: SENTRY_DSN,
+                release: extensionDetails.version,
+                environment: this.config.isRunningInsideAgent
+                    ? 'agent'
+                    : typeof process !== 'undefined'
+                    ? 'vscode-node'
+                    : 'vscode-web',
 
-            // In dev mode, have Sentry log extended debug information to the console.
-            debug: !isProd,
+                // In dev mode, have Sentry log extended debug information to the console.
+                debug: !isProd,
 
-            // Only send errors when connected to dotcom
-            beforeSend: event => {
-                if (!isDotCom(this.config.serverEndpoint) && isProd) {
-                    return null
-                }
-                return event
-            },
+                // Only send errors when connected to dotcom
+                beforeSend: event => {
+                    if (!isDotCom(this.config.serverEndpoint) && isProd) {
+                        return null
+                    }
+                    return event
+                },
 
-            // The extension host is shared across other extensions, so listening on the default
-            // unhandled error listeners would not be helpful in case other extensions or VS Code
-            // throw. Instead, use the manual `captureException` API.
-            //
-            // When running inside Agent, we control the whole Node environment so we can safely
-            // listen to unhandled errors/rejections.
-            ...(this.config.isRunningInsideAgent ? {} : { defaultIntegrations: false }),
+                // The extension host is shared across other extensions, so listening on the default
+                // unhandled error listeners would not be helpful in case other extensions or VS Code
+                // throw. Instead, use the manual `captureException` API.
+                //
+                // When running inside Agent, we control the whole Node environment so we can safely
+                // listen to unhandled errors/rejections.
+                ...(this.config.isRunningInsideAgent ? {} : { defaultIntegrations: false }),
+            }
+
+            this.reconfigure(options)
+        } catch (error) {
+            // We don't want to crash the extension host or VS Code if Sentry fails to load.
+            console.error('Failed to initialize Sentry', error)
         }
-
-        this.reconfigure(options)
     }
 
     protected abstract reconfigure(options: Parameters<typeof nodeInit | typeof browserInit>[0]): void


### PR DESCRIPTION
## Test plan

👀 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
