### PR TITLE
E2E tests: Upload recording artifacts and fix flaky test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
         if: matrix.runner == 'ubuntu-latest'
       - run: pnpm -C vscode run test:e2e
         if: matrix.runner == 'windows-latest' || matrix.runner == 'macos-latest'
+      - uses: actions/upload-artifact@v3
+        with:
+          name: playwright-recordings
+          path: playwright/
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
-          name: playwright-recordings
+          name: playwright-recordings ${{ matrix.runner }}
           path: playwright/**/*.webm
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
         if: matrix.runner == 'ubuntu-latest'
       - run: pnpm -C vscode run test:e2e
         if: matrix.runner == 'windows-latest' || matrix.runner == 'macos-latest'
+      - run: pwd
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
-      - run: pwd
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         if: matrix.runner == 'ubuntu-latest'
       - run: pnpm -C vscode run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,11 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
+      - run: pwd
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         if: matrix.runner == 'ubuntu-latest'
       - run: pnpm -C vscode run test:e2e
         if: matrix.runner == 'windows-latest' || matrix.runner == 'macos-latest'
-      - run: pwd
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         if: ${{ failure() }}
         with:
           name: playwright-recordings
-          path: playwright/
+          path: playwright/**/*.webm
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - run: pnpm -C vscode run test:e2e
         if: matrix.runner == 'windows-latest' || matrix.runner == 'macos-latest'
       - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
         with:
           name: playwright-recordings
           path: playwright/

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -2,5 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
     workers: 1,
+    // Give failing tests a second chance
+    retries: 2,
     testDir: 'test/e2e',
 })

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtempSync, readdirSync, rmSync, writeFile } from 'fs'
+import { mkdir, mkdtempSync, rmSync, writeFile } from 'fs'
 import { tmpdir } from 'os'
 import * as path from 'path'
 
@@ -14,17 +14,16 @@ export const test = base
         page: async ({ page: _page }, use, testInfo) => {
             void _page
 
-            const codyRoot = path.resolve(__dirname, '..', '..')
+            const vscodeRoot = path.resolve(__dirname, '..', '..')
 
             const vscodeExecutablePath = await installDeps()
-            const extensionDevelopmentPath = codyRoot
+            const extensionDevelopmentPath = vscodeRoot
 
             const userDataDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))
             const extensionsDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))
-            const videoDirectory = path.join(codyRoot, '..', '..', 'playwright', escapeToPath(testInfo.title))
-            console.log({ videoDirectory })
+            const videoDirectory = path.join(vscodeRoot, '..', 'playwright', escapeToPath(testInfo.title))
 
-            const workspaceDirectory = path.join(codyRoot, 'test', 'fixtures', 'workspace')
+            const workspaceDirectory = path.join(vscodeRoot, 'test', 'fixtures', 'workspace')
 
             await buildWorkSpaceSettings(workspaceDirectory)
 
@@ -77,12 +76,9 @@ export const test = base
 
             await app.close()
 
-            console.log({ status: testInfo.status })
             // Delete the recorded video if the test passes
             if (testInfo.status === 'passed') {
                 rmSync(videoDirectory, { recursive: true })
-            } else {
-                console.log(readdirSync(videoDirectory))
             }
 
             rmSync(userDataDirectory, { recursive: true })

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -77,6 +77,7 @@ export const test = base
 
             await app.close()
 
+            console.log({ status: testInfo.status })
             // Delete the recorded video if the test passes
             if (testInfo.status === 'passed') {
                 rmSync(videoDirectory, { recursive: true })

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtempSync, rmSync, writeFile } from 'fs'
+import { mkdir, mkdtempSync, readdirSync, rmSync, writeFile } from 'fs'
 import { tmpdir } from 'os'
 import * as path from 'path'
 
@@ -22,6 +22,7 @@ export const test = base
             const userDataDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))
             const extensionsDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))
             const videoDirectory = path.join(codyRoot, '..', '..', 'playwright', escapeToPath(testInfo.title))
+            console.log({ videoDirectory })
 
             const workspaceDirectory = path.join(codyRoot, 'test', 'fixtures', 'workspace')
 
@@ -47,7 +48,6 @@ export const test = base
                     `--extensions-dir=${extensionsDirectory}`,
                     workspaceDirectory,
                 ],
-                // Record a video that can be picked up by Buildkite. Since there is no way right
                 recordVideo: {
                     dir: videoDirectory,
                 },
@@ -80,6 +80,8 @@ export const test = base
             // Delete the recorded video if the test passes
             if (testInfo.status === 'passed') {
                 rmSync(videoDirectory, { recursive: true })
+            } else {
+                console.log(readdirSync(videoDirectory))
             }
 
             rmSync(userDataDirectory, { recursive: true })

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtempSync, rmdirSync, writeFile } from 'fs'
+import { mkdir, mkdtempSync, rmSync, writeFile } from 'fs'
 import { tmpdir } from 'os'
 import * as path from 'path'
 
@@ -79,11 +79,11 @@ export const test = base
 
             // Delete the recorded video if the test passes
             if (testInfo.status === 'passed') {
-                rmdirSync(videoDirectory, { recursive: true })
+                rmSync(videoDirectory, { recursive: true })
             }
 
-            rmdirSync(userDataDirectory, { recursive: true })
-            rmdirSync(extensionsDirectory, { recursive: true })
+            rmSync(userDataDirectory, { recursive: true })
+            rmSync(extensionsDirectory, { recursive: true })
         },
     })
     .extend<{ sidebar: Frame }>({

--- a/vscode/test/e2e/history.test.ts
+++ b/vscode/test/e2e/history.test.ts
@@ -24,13 +24,19 @@ test('checks if clear chat history button clears history and current session', a
     await sidebar.getByRole('textbox', { name: 'Chat message' }).fill('Hola')
     await sidebar.locator('vscode-button').getByRole('img').click()
 
+    await expect(sidebar.getByText('hello from the assistant')).toBeVisible()
+
     await page.click('[aria-label="Start a New Chat Session"]')
     await sidebar.getByRole('textbox', { name: 'Chat message' }).fill('Hey')
     await sidebar.locator('vscode-button').getByRole('img').click()
 
+    await expect(sidebar.getByText('hello from the assistant')).toBeVisible()
+    await expect(sidebar.getByText('Hola')).not.toBeVisible()
+
     await page.getByRole('button', { name: 'Chat History' }).click()
 
     // Remove Hey history item from chat history view
+    await expect(sidebar.getByText('Hola')).toBeVisible()
     await expect(sidebar.getByText('Hey')).toBeVisible()
     await sidebar.locator('vscode-button').filter({ hasText: 'Clear' }).click()
     await expect(sidebar.getByText('Hey')).not.toBeVisible()
@@ -42,8 +48,7 @@ test('checks if clear chat history button clears history and current session', a
     await page.keyboard.type('/explain')
     await page.keyboard.press('Enter')
 
-    // Go back to Chat View and check if the old message "Hey" is cleared
-    await page.click('[aria-label="Cody"]')
+    // Check if the old message "Hey" is cleared
     await expect(sidebar.getByText('Hey')).not.toBeVisible()
     await expect(sidebar.getByText('/explain')).toBeVisible()
 })

--- a/vscode/test/e2e/history.test.ts
+++ b/vscode/test/e2e/history.test.ts
@@ -49,7 +49,6 @@ test('checks if clear chat history button clears history and current session', a
     await page.keyboard.press('Enter')
 
     // Check if the old message "Hey" is cleared
-    await expect(sidebar.getByText('Hey')).toBeVisible()
     await expect(sidebar.getByText('Hey')).not.toBeVisible()
     await expect(sidebar.getByText('/explain')).toBeVisible()
 })

--- a/vscode/test/e2e/history.test.ts
+++ b/vscode/test/e2e/history.test.ts
@@ -49,6 +49,7 @@ test('checks if clear chat history button clears history and current session', a
     await page.keyboard.press('Enter')
 
     // Check if the old message "Hey" is cleared
+    await expect(sidebar.getByText('Hey')).toBeVisible()
     await expect(sidebar.getByText('Hey')).not.toBeVisible()
     await expect(sidebar.getByText('/explain')).toBeVisible()
 })


### PR DESCRIPTION
This fixes the flaky E2E test. It tried to bring the Cody sidebar into the foreground but it was never hidden in the first place. I also added additional assertions about the `Hola` case that was not asserted on before.

This PR also brings back video uploads from failed cases so we can easily debug CI errors again.

## Test plan

- Checked with a failing E2E test
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
