### PR TITLE
Autocomplete: Add model specific feature flags

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -10,7 +10,8 @@ export enum FeatureFlag {
     CodyAutocompleteTracing = 'cody-autocomplete-tracing',
     CodyAutocompleteIncreasedDebounceTimeEnabled = 'cody-autocomplete-increased-debounce-time-enabled',
     CodyAutocompleteStreamingResponse = 'cody-autocomplete-streaming-response',
-    CodyAutocompleteDefaultProviderFireworks = 'cody-autocomplete-default-provider-fireworks',
+    CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
+    CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -854,8 +854,9 @@
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
-          "default": "anthropic",
+          "default": null,
           "enum": [
+            null,
             "anthropic",
             "unstable-codegen",
             "unstable-fireworks",
@@ -874,7 +875,9 @@
         },
         "cody.autocomplete.advanced.model": {
           "type": "string",
+          "default": null,
           "enum": [
+            null,
             "starcoder-16b",
             "starcoder-7b",
             "starcoder-3b",

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -16,7 +16,7 @@ export async function createProviderConfig(
     client: CodeCompletionsClient,
     featureFlagProvider?: FeatureFlagProvider
 ): Promise<ProviderConfig | null> {
-    const provider = await resolveDefaultProvider(config.autocompleteAdvancedProvider, featureFlagProvider)
+    const { provider, model } = await resolveDefaultProvider(config.autocompleteAdvancedProvider, featureFlagProvider)
     switch (provider) {
         case 'unstable-codegen': {
             if (config.autocompleteAdvancedServerEndpoint !== null) {
@@ -62,7 +62,7 @@ export async function createProviderConfig(
         case 'unstable-fireworks': {
             return createUnstableFireworksProviderConfig({
                 client,
-                model: config.autocompleteAdvancedModel,
+                model: config.autocompleteAdvancedModel ?? model ?? null,
             })
         }
         case 'anthropic': {
@@ -83,14 +83,19 @@ export async function createProviderConfig(
 async function resolveDefaultProvider(
     configuredProvider: string | null,
     featureFlagProvider?: FeatureFlagProvider
-): Promise<string> {
+): Promise<{ provider: string; model?: 'starcoder-7b' | 'starcoder-16b' }> {
     if (configuredProvider) {
-        return configuredProvider
+        return { provider: configuredProvider }
     }
 
-    if (await featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDefaultProviderFireworks)) {
-        return 'unstable-fireworks'
+    const [starCoder7b, starCoder16b] = await Promise.all([
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
+    ])
+
+    if (starCoder7b === true || starCoder16b === true) {
+        return { provider: 'unstable-fireworks', model: starCoder7b ? 'starcoder-7b' : 'starcoder-16b' }
     }
 
-    return 'anthropic'
+    return { provider: 'anthropic' }
 }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -101,7 +101,10 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             completeSuggestWidgetSelection: this.config.completeSuggestWidgetSelection,
         })
 
-        logDebug('CodyCompletionProvider:initialized', `provider: ${this.config.providerConfig.identifier}`)
+        logDebug(
+            'CodyCompletionProvider:initialized',
+            `${this.config.providerConfig.identifier}/${this.config.providerConfig.model}`
+        )
     }
 
     /** Set the tracer (or unset it with `null`). */


### PR DESCRIPTION
As part of our eval we want to test more than one model. Adding this second switch before our release will allow us to save 1-2 days because we don't have to do a patch release when we want to change the default.

Also tested everything locally where it turns out it didn't work before because the default was never `null` which needs to be added to the enum specifically.

## Test plan

👀 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
