### PR TITLE
Add trufflehog secret scanning

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,47 @@
+name: TruffleHog Secrets Scan
+on: [pull_request]
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install TruffleHog
+        run: |
+          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz -O trufflehog.tar.gz
+          sudo tar xzf trufflehog.tar.gz --directory=/usr/local/bin/ trufflehog
+
+      - name: Run TruffleHog
+        id: scan
+        run: |
+          output=$(/usr/local/bin/trufflehog git file://./ --since-commit main --branch HEAD --no-update --github-actions --only-verified)
+          echo $output
+          if grep -q "Found verified" <<< "${output}"; then
+            echo "FOUND_SECRET=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "FOUND_SECRET=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Post to Slack
+        if: ${{ steps.scan.outputs.FOUND_SECRET == 'true' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": "🚨 *A secret was detected in a GitHub commit in the repo ${{ github.repository }}.*\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🚨 *A secret was detected in a GitHub commit in the repo ${{ github.repository }}.*\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TRUFFLEHOG_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This PR adds _**non-blocking** secret scanning_ action to scan for verified secrets and notifies Security team.

Additionally, this github action check should execute on diff changes and takes ~30-60 seconds to execute.

We have implemented one already in [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph/pull/56299) repo

## Test plan

CI should be 🟢  and notify security team if any verified secrets are reported by trufflehog.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
