### PR TITLE
Fix dev build by not overwriting CODY_TESTING env

### DIFF
--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -25,13 +25,9 @@ export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
     isExtensionModeDevOrTest: boolean
 ): Promise<void> {
-    if (config.telemetryLevel === 'off') {
+    if (config.telemetryLevel === 'off' || isExtensionModeDevOrTest) {
         eventLogger = null
         return
-    }
-
-    if (isExtensionModeDevOrTest) {
-        process.env.CODY_TESTING = 'true'
     }
 
     const { anonymousUserID, created } = await localStorage.anonymousUserID()


### PR DESCRIPTION
#468 added a new mechanism to publish logs to a seperate env for test builds. However as part of it it added a new branch that sets `process.env.CODY_TESTING` to true in development builds which breaks the current assumption that this is only true in test runs.

It's important we don't set this flag in dev builds since it also changes a bunch of other small things in the extension so I’m reverting this here. Not to mention that this was also breaking the changes in #468 as my dev env was now flooded in these errors:

```
Error logging event Error: error fetching Testing Sourcegraph API: FetchError: request to http://localhost:49300/.api/testLogging failed, reason: connect ECONNREFUSED 127.0.0.1:49300 (http://localhost:49300/.api/testLogging)
    at /Users/philipp/dev/cody/lib/shared/src/sourcegraph-api/graphql/client.ts:523:29
    at processTicksAndRejections (/Users/philipp/dev/cody/lib/internal/process/task_queues.js:96:5)
    at SourcegraphGraphQLAPIClient.sendEventLogRequestToTestingAPI (/Users/philipp/dev/cody/lib/shared/src/sourcegraph-api/graphql/client.ts:398:36) {vslsStack: Array(3), stack: 'Error: error fetching Testing Sourcegraph API…src/sourcegraph-api/graphql/client.ts:398:36)', message: 'error fetching Testing Sourcegraph API: Fetc…00 (http://localhost:49300/.api/testLogging)'}
```

@akalia25 I don't think that the env overwrite is a necessary branch here anyways, can you confirm that this change makes sense?

## Test plan

No more errors in the console when running dev mode
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
