### PR TITLE
Autocomplete: add multi-line trigger info to `docContext`

### DIFF
--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCurrentDocContext } from './get-current-doc-context'
+import { documentAndPosition } from './testHelpers'
+
+describe('getCurrentDocContext', () => {
+    it('returns `docContext` for a function block', () => {
+        const { document, position } = documentAndPosition('function myFunction() {\n  █')
+
+        const result = getCurrentDocContext(document, position, 100, 100, true)
+
+        expect(result).toEqual({
+            prefix: 'function myFunction() {\n  ',
+            suffix: '',
+            currentLinePrefix: '  ',
+            currentLineSuffix: '',
+            prevNonEmptyLine: 'function myFunction() {',
+            nextNonEmptyLine: '',
+            multiline: true,
+            multilineTrigger: '{',
+        })
+    })
+
+    it('returns `docContext` for an if block', () => {
+        const { document, position } = documentAndPosition('const x = 1\nif (true) {\n  █\n}')
+
+        const result = getCurrentDocContext(document, position, 100, 100, true)
+
+        expect(result).toEqual({
+            prefix: 'const x = 1\nif (true) {\n  ',
+            suffix: '\n}',
+            currentLinePrefix: '  ',
+            currentLineSuffix: '',
+            prevNonEmptyLine: 'if (true) {',
+            nextNonEmptyLine: '}',
+            multiline: true,
+            multilineTrigger: '{',
+        })
+    })
+
+    it('returns correct multi-line trigger when `enableExtendedTriggers: true`', () => {
+        const { document, position } = documentAndPosition('const arr = [█\n];')
+
+        const result = getCurrentDocContext(document, position, 100, 100, true)
+
+        expect(result).toEqual({
+            prefix: 'const arr = [',
+            suffix: '\n];',
+            currentLinePrefix: 'const arr = [',
+            currentLineSuffix: '',
+            prevNonEmptyLine: '',
+            nextNonEmptyLine: '];',
+            multiline: true,
+            multilineTrigger: '[',
+        })
+    })
+})

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode'
 
+import { detectMultiline, DetectMultilineResult } from './detect-multiline'
 import { getNextNonEmptyLine, getPrevNonEmptyLine } from './text-processing'
 
-export interface DocumentContext {
+export type DocumentContext = DetectMultilineResult & {
     prefix: string
     suffix: string
 
@@ -36,6 +37,7 @@ export function getCurrentDocContext(
     position: vscode.Position,
     maxPrefixLength: number,
     maxSuffixLength: number,
+    enableExtendedTriggers: boolean,
     context?: vscode.InlineCompletionContext
 ): DocumentContext {
     const offset = document.offsetAt(position)
@@ -88,12 +90,19 @@ export function getCurrentDocContext(
     const prevNonEmptyLine = getPrevNonEmptyLine(prefix)
     const nextNonEmptyLine = getNextNonEmptyLine(suffix)
 
-    return {
+    const docContext = {
         prefix,
         suffix,
         currentLinePrefix,
         currentLineSuffix,
         prevNonEmptyLine,
         nextNonEmptyLine,
+    }
+
+    const multilineContext = detectMultiline(docContext, document.languageId, enableExtendedTriggers ?? false)
+
+    return {
+        ...docContext,
+        ...multilineContext,
     }
 }

--- a/vscode/src/completions/getInlineCompletions.test.ts
+++ b/vscode/src/completions/getInlineCompletions.test.ts
@@ -71,7 +71,13 @@ function params(
 
     const { document, position } = documentAndPosition(code, languageId, URI_FIXTURE.toString())
 
-    const docContext = getCurrentDocContext(document, position, 1000, 1000)
+    const docContext = getCurrentDocContext(
+        document,
+        position,
+        1000,
+        1000,
+        providerConfig.enableExtendedMultilineTriggers
+    )
     if (docContext === null) {
         throw new Error()
     }

--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -15,8 +15,15 @@ export interface CompletionContext {
 export interface ParsedCompletion extends InlineCompletionItem {
     tree?: Tree
     hasParseErrors?: boolean
-    startPosition?: Parser.Point
-    endPosition?: Parser.Point
+    // Points for parse-tree queries.
+    points?: {
+        // Start of completion.insertText in the parse-tree.
+        start?: Parser.Point
+        // End of completion.insertText in the parse-tree
+        end?: Parser.Point
+        // Start of the multi-line completion trigger if applicable
+        trigger?: Parser.Point
+    }
 }
 
 /**
@@ -43,23 +50,35 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     })
 
     const completionEndPosition = position.translate(0, completion.insertText.length)
-    const startPosition: Parser.Point = {
-        row: position.line,
-        column: position.character,
+
+    const points: ParsedCompletion['points'] = {
+        start: {
+            row: position.line,
+            column: position.character,
+        },
+        end: {
+            row: completionEndPosition.line,
+            column: completionEndPosition.character,
+        },
     }
-    const endPosition: Parser.Point = {
-        row: completionEndPosition.line,
-        column: completionEndPosition.character,
+
+    if (docContext.multiline) {
+        const triggerPosition = document.positionAt(docContext.prefix.lastIndexOf(docContext.multilineTrigger))
+
+        points.trigger = {
+            row: triggerPosition.line,
+            column: triggerPosition.character,
+        }
     }
 
     // Search for ERROR nodes in the completion range.
     const query = parser.getLanguage().query('(ERROR) @error')
-    const matches = query.matches(treeWithCompletion.rootNode, startPosition, endPosition)
+    // TODO: query bigger range to catch higher scope syntactic errors caused by the completion.
+    const matches = query.matches(treeWithCompletion.rootNode, points?.trigger || points.start, points.end)
 
     return {
         ...completion,
-        startPosition,
-        endPosition,
+        points,
         tree: treeWithCompletion,
         hasParseErrors: matches.length > 0,
     }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -149,6 +149,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             position,
             this.maxPrefixChars,
             this.maxSuffixChars,
+            this.config.providerConfig.enableExtendedMultilineTriggers,
             // We ignore the current context selection if completeSuggestWidgetSelection is not
             // enabled
             this.config.completeSuggestWidgetSelection ? context : undefined


### PR DESCRIPTION
## Context

- Adds information about a multi-line completion trigger for a current completion to the `docContext` object. This data will be used in a follow-up PR to get a starting position for a first block-like statement in a completion.
- Part of #910 

## Test plan

Added unit tests.
