### PR TITLE
refactor: remove starter and premade from cody.json

### DIFF
--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -1,5 +1,3 @@
-import { Preamble } from '../preamble'
-
 import * as defaultPrompts from './default-prompts.json'
 import { toSlashCommand } from './utils'
 
@@ -32,25 +30,12 @@ export interface MyPrompts {
     commands: Map<string, CodyPrompt>
     // backward compatibility
     recipes?: Map<string, CodyPrompt>
-    // Premade is a set of prompts that are added to the start of every new conversation
-    // --this is where we define the "identity" and "rules" for Cody
-    premade?: Preamble
-    // A conversation starter --this is added to the start of every human input sent to Cody.
-    starter: string
 }
 
 // JSON format of MyPrompts
 export interface MyPromptsJSON {
     commands: { [id: string]: Omit<CodyPrompt, 'slashCommand'> }
     recipes?: { [id: string]: CodyPrompt }
-    premade?: CodyPremade
-    starter?: string
-}
-
-export interface CodyPremade {
-    actions: string
-    rules: string
-    answer: string
 }
 
 export interface CodyPrompt {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,7 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
-- Remove `starter` and `premade` fields from the configuration files for custom commands (cody.json). [pull/](https://github.com/sourcegraph/cody/pull/)
+- Remove `starter` and `premade` fields from the configuration files for custom commands (cody.json). [pull/939](https://github.com/sourcegraph/cody/pull/939)
 
 ## [0.10.0]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+- Remove `starter` and `premade` fields from the configuration files for custom commands (cody.json). [pull/](https://github.com/sourcegraph/cody/pull/)
+
 ## [0.10.0]
 
 ### Added

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -336,13 +336,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             default: {
                 this.sendTranscript()
 
-                const myPremade = (await this.editor.controllers.command?.getCustomConfig())?.premade
-                if (myPremade) {
-                    this.telemetryService.log('CodyVSCodeExtension:command:customPremade:applied')
-                }
-
                 const { prompt, contextFiles, preciseContexts } = await this.transcript.getPromptForLastInteraction(
-                    getPreamble(this.contextProvider.context.getCodebase(), myPremade),
+                    getPreamble(this.contextProvider.context.getCodebase()),
                     this.maxPromptTokens
                 )
                 this.transcript.setUsedContextFilesForLastInteraction(contextFiles, preciseContexts)
@@ -374,13 +369,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         }
         transcript.addInteraction(interaction)
 
-        const myPremade = (await this.editor.controllers.command?.getCustomConfig())?.premade
-        if (myPremade) {
-            this.telemetryService.log('CodyVSCodeExtension:command:customPremade:applied')
-        }
-
         const { prompt, contextFiles } = await transcript.getPromptForLastInteraction(
-            getPreamble(this.contextProvider.context.getCodebase(), myPremade),
+            getPreamble(this.contextProvider.context.getCodebase()),
             this.maxPromptTokens
         )
         transcript.setUsedContextFilesForLastInteraction(contextFiles)
@@ -476,14 +466,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         // Get prompt details from controller by title then execute prompt's command
         const promptText = this.editor.controllers.command?.find(title)
         await this.editor.controllers.command?.get('command')
-        logDebug('executeCustomCommand:starting', title)
-        if (!promptText) {
-            return
-        }
-        await this.executeRecipe('custom-prompt', promptText)
-        const starter = (await this.editor.controllers.command?.getCustomConfig())?.starter
-        if (starter) {
-            this.telemetryService.log('CodyVSCodeExtension:command:customStarter:applied')
+
+        if (promptText) {
+            logDebug('executeCustomCommand:starting', title)
+            await this.executeRecipe('custom-prompt', promptText)
         }
         return
     }


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1693983800785199

refactor: remove starter and premade fields from custom config

- Removed the `starter` and `premade` fields from the MyPrompts and MyPromptsJSON interfaces in the prompts module.
- Removed usage of the `premade` field in the MessageProvider class.
- Removed logs and telemetry related to the custom `premade` field.

Seems like permade was not working before as well so no harm in removing it

## Follow up

Move starter config option to user/workspace config

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- set `starter` and `premade` in your cody.json
- Check the output log, the starter and premade strings should not be found anywhere in the output:
![image](https://github.com/sourcegraph/cody/assets/68532117/7bc43306-a00b-468a-8e66-933b395097fe)
![image](https://github.com/sourcegraph/cody/assets/68532117/bd5923ab-5451-4c08-8ca4-a78418023507)

Before: 
![image](https://github.com/sourcegraph/cody/assets/68532117/0037bc0c-9bc0-4742-99da-a4cf30be1043)
