### PR TITLE
Add dev flag to open output console on startup

### DIFF
--- a/vscode/src/dev/helpers.ts
+++ b/vscode/src/dev/helpers.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { outputChannel } from '../log'
+
 /**
  * A development helper that runs on activation to make the edit-debug loop easier.
  *
@@ -7,11 +9,16 @@ import * as vscode from 'vscode'
  * configuration JSON Schema, so they will not validate in your VS Code user settings file.)
  *
  * - `cody.dev.openAutocompleteTraceView`: boolean
+ * - `cody.dev.openOutputConsole`: boolean
  */
 export function onActivationDevelopmentHelpers(): void {
     const settings = vscode.workspace.getConfiguration('cody.dev')
 
     if (settings.get('openAutocompleteTraceView')) {
         void vscode.commands.executeCommand('cody.autocomplete.openTraceView')
+    }
+
+    if (settings.get('openOutputConsole')) {
+        outputChannel.show()
     }
 }


### PR DESCRIPTION
In 80% of the times I start VS Code in dev mode, I need to open the output console and find Cody in the dropdown list. This will save me some precious seconds lol 

## Test plan

- Set `"cody.dev.openOutputConsole": true,` in the VS Code config
- Start VS Code in dev mode => See that the output console opens

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
