### PR TITLE
Autocomplete: Tweaks to the graph context to make it actually slightly usable already

### DIFF
--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -57,8 +57,8 @@ export const getGraphContextFromRange = async (
     const contexts = await getGraphContextFromSelection(
         [{ uri, range }],
         new Map([[uri.fsPath, editor.document.getText().split('\n')]]),
-        1, // recursion limit
-        true // use type definitions
+        0, // recursion limit
+        false // use type definitions
     )
 
     return contexts
@@ -456,7 +456,8 @@ export const extractDefinitionContexts = async (
 
         if (contentPromise && documentSymbolsPromises) {
             const content = contentPromise
-            const documentSymbols = await documentSymbolsPromises // NOTE: already resolved)
+            const documentSymbols = await documentSymbolsPromises // NOTE: already resolved
+
             const definitionSnippets = extractSnippets(content, documentSymbols, [range])
 
             for (const definitionSnippet of definitionSnippets) {

--- a/vscode/src/graph/section-observer.ts
+++ b/vscode/src/graph/section-observer.ts
@@ -4,6 +4,7 @@ import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
 import { PreciseContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { isDefined } from '@sourcegraph/cody-shared/src/common'
 
 import { GraphContextFetcher } from '../completions/context/context'
 import { SymbolContextSnippet } from '../completions/types'
@@ -67,7 +68,7 @@ export class SectionObserver implements vscode.Disposable, GraphContextFetcher {
     public getContextAtPosition(document: vscode.TextDocument, position: vscode.Position): SymbolContextSnippet[] {
         const section = this.getSectionAtPosition(document, position)
         if (section?.context?.context) {
-            return section.context.context.map(preciseContextToSnippet)
+            return section.context.context.map(preciseContextToSnippet).filter(isDefined)
         }
         return []
     }


### PR DESCRIPTION
After testing locally, here are some tweaks that makes graph context for autocomplete much more usable (although not as powerful - yet!)

- We removed the recursion limit so it's faster and far fewer irrelevant symbols are included
- Instead of Go To Type Defs, we default to Go To Defs now because in a lot of cases, Go To Type Defs wouldn't work very well. We need a heuristics to decide which one to follow.
- Rewrite the markdown extracting logic because I build 💩 

The result is that I had the first autocomplete request that included the proper props for a React component that I never had opened or anything. Just because we found the right definitions 💥  (The completion is still wrong because the dummy objct is defined in the suffix and Anthropic doesn't read the suffix yet. Baby steps 😬)

## Test plan

<img width="718" alt="Screenshot 2023-09-06 at 18 30 06" src="https://github.com/sourcegraph/cody/assets/458591/277e3fbd-67da-4d99-b9b1-e1a9d1cbeff5">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
