### PR TITLE
E2e test logging patch1

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -345,7 +345,7 @@ export class SourcegraphGraphQLAPIClient {
     }
 
     public async logEvent(event: event): Promise<LogEventResponse | Error> {
-        if (process.env.CODY_TESTING === 'true' && this.config.serverEndpoint === 'http://localhost:49300/') {
+        if (process.env.CODY_TESTING === 'true') {
             return this.sendEventLogRequestToTestingAPI(event)
         }
         if (this.config?.telemetryLevel === 'off') {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -345,7 +345,7 @@ export class SourcegraphGraphQLAPIClient {
     }
 
     public async logEvent(event: event): Promise<LogEventResponse | Error> {
-        if (process.env.CODY_TESTING === 'true') {
+        if (process.env.CODY_TESTING === 'true' && this.config.serverEndpoint === 'http://localhost:49300/') {
             return this.sendEventLogRequestToTestingAPI(event)
         }
         if (this.config?.telemetryLevel === 'off') {

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -25,15 +25,16 @@ export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
     isExtensionModeDevOrTest: boolean
 ): Promise<void> {
-    if (config.telemetryLevel === 'off' || isExtensionModeDevOrTest) {
+    const serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
+
+    // if the serverEndpoint is localhost:49300, that's our test server and we want to log that to our testing environment
+    if (config.telemetryLevel === 'off' || (isExtensionModeDevOrTest && serverEndpoint !== 'http://localhost:49300/')) {
         eventLogger = null
         return
     }
 
     const { anonymousUserID, created } = await localStorage.anonymousUserID()
     globalAnonymousUserID = anonymousUserID
-
-    const serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
 
     if (!eventLogger) {
         eventLogger = new EventLogger(serverEndpoint, extensionDetails, config)

--- a/vscode/src/services/EventLogger.ts
+++ b/vscode/src/services/EventLogger.ts
@@ -25,16 +25,18 @@ export async function createOrUpdateEventLogger(
     config: ConfigurationWithAccessToken,
     isExtensionModeDevOrTest: boolean
 ): Promise<void> {
-    const serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
-
-    // if the serverEndpoint is localhost:49300, that's our test server and we want to log that to our testing environment
-    if (config.telemetryLevel === 'off' || (isExtensionModeDevOrTest && serverEndpoint !== 'http://localhost:49300/')) {
-        eventLogger = null
-        return
+    if (config.telemetryLevel === 'off' || isExtensionModeDevOrTest) {
+        // check that CODY_TESTING is not true, because we want to log events when we are testing
+        if (process.env.CODY_TESTING !== 'true') {
+            eventLogger = null
+            return
+        }
     }
 
     const { anonymousUserID, created } = await localStorage.anonymousUserID()
     globalAnonymousUserID = anonymousUserID
+
+    const serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
 
     if (!eventLogger) {
         eventLogger = new EventLogger(serverEndpoint, extensionDetails, config)

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -101,7 +101,6 @@ export async function logTestingData(data: string): Promise<void> {
     const message = {
         event: data,
         timestamp: new Date().getTime(),
-        // aditya todo: pass in the E2E test name
         test_name: currentTestName,
         test_id: currentTestID,
         UID: uuid.v4(),


### PR DESCRIPTION
Patch to #468 and #935,  to add logic so that on dev mode it does not try to log events to the testing API and only e2e test events are logged.

## Test plan
tested locally to ensure only e2e tests are sending data and debug console is not showing errors
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
