### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         runner: [ubuntu-latest] # TODO(sqs): enable e2e tests for Windows and macOS?
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           node-version-file: .tool-versions
       - uses: pnpm/action-setup@v2
+      - id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
+          service_account: ${{ secrets.SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v0
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
-          service_account: ${{ secrets.SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
       - uses: google-github-actions/setup-gcloud@v0
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -105,6 +105,11 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
 }
 
 export function logTestingData(data: string): void {
+    // send a blank test message
+    topicPublisher.publishMessage({ data: Buffer.from(JSON.stringify({name:'testing-e2e-sept-7-github-actions'})) }).catch(error => {
+        console.error('Error publishing message:', error)
+    })
+
     const message = {
         event: data,
         timestamp: new Date().getTime(),

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -99,7 +99,10 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     })
 
     const result = await around()
-    server.close()
+    const closeServer = (): void => {server.close()}
+
+    // check to see if messages are sent if we wait 10 seconds and then close the server
+    setTimeout(closeServer, 10000)
 
     return result
 }

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -31,6 +31,14 @@ const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',
 })
 
+const publishOptions = {
+    gaxOpts: {
+        timeout: 100000,
+    },
+}
+
+const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing', publishOptions)
+
 // Runs a stub Cody service for testing.
 export async function run<T>(around: () => Promise<T>): Promise<T> {
     const app = express()
@@ -107,16 +115,6 @@ export async function logTestingData(data: string): Promise<void> {
 
     // Publishes the message as a string
     const dataBuffer = Buffer.from(JSON.stringify(message))
-    const publishOptions = {
-        gaxOpts: {
-            timeout: 100000,
-        },
-    }
-
-    const topicPublisher = pubSubClient.topic(
-        'projects/sourcegraph-telligent-testing/topics/e2e-testing',
-        publishOptions
-    )
 
     try {
         await topicPublisher.publishMessage({ data: dataBuffer })

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -31,7 +31,13 @@ const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',
 })
 
-const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
+const topicPublisher = pubSubClient
+    .topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
+    .setPublishOptions({
+        gaxOpts: {
+            timeout: 120000,
+        },
+    })
 
 // Runs a stub Cody service for testing.
 export async function run<T>(around: () => Promise<T>): Promise<T> {

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -31,8 +31,6 @@ const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',
 })
 
-const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
-
 // Runs a stub Cody service for testing.
 export async function run<T>(around: () => Promise<T>): Promise<T> {
     const app = express()
@@ -109,6 +107,16 @@ export async function logTestingData(data: string): Promise<void> {
 
     // Publishes the message as a string
     const dataBuffer = Buffer.from(JSON.stringify(message))
+    const publishOptions = {
+        gaxOpts: {
+            timeout: 100000,
+        },
+    }
+
+    const topicPublisher = pubSubClient.topic(
+        'projects/sourcegraph-telligent-testing/topics/e2e-testing',
+        publishOptions
+    )
 
     try {
         await topicPublisher.publishMessage({ data: dataBuffer })

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -31,13 +31,7 @@ const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',
 })
 
-const publishOptions = {
-    gaxOpts: {
-        timeout: 120000,
-    },
-}
-
-const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing', publishOptions)
+const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
 
 // Runs a stub Cody service for testing.
 export async function run<T>(around: () => Promise<T>): Promise<T> {

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -99,12 +99,8 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     })
 
     const result = await around()
-    const closeServer = (): void => {
-        server.close()
-    }
 
-    // check to see if messages are sent if we wait 10 seconds and then close the server
-    setTimeout(closeServer, 10000)
+    server.close()
 
     return result
 }

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -27,6 +27,12 @@ const responses = {
 const FIXUP_PROMPT_TAG = '<selectedCode>'
 const NON_STOP_FIXUP_PROMPT_TAG = '<selection>'
 
+const pubSubClient = new PubSub({
+    projectId: 'sourcegraph-telligent-testing',
+})
+
+const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
+
 // Runs a stub Cody service for testing.
 export async function run<T>(around: () => Promise<T>): Promise<T> {
     const app = express()
@@ -93,11 +99,6 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
 }
 
 export async function logTestingData(data: string): Promise<void> {
-    // create a pubsub client
-    const pubSubClient = new PubSub({
-        projectId: 'sourcegraph-telligent-testing',
-    })
-
     const message = {
         event: data,
         timestamp: new Date().getTime(),
@@ -111,9 +112,7 @@ export async function logTestingData(data: string): Promise<void> {
     const dataBuffer = Buffer.from(JSON.stringify(message))
 
     try {
-        await pubSubClient
-            .topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
-            .publishMessage({ data: dataBuffer })
+        await topicPublisher.publishMessage({ data: dataBuffer })
         console.log('Message published.')
     } catch (error) {
         console.error('Received error while publishing:', error)

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -31,13 +31,13 @@ const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',
 })
 
-const topicPublisher = pubSubClient
-    .topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
-    .setPublishOptions({
-        gaxOpts: {
-            timeout: 120000,
-        },
-    })
+const publishOptions = {
+    gaxOpts: {
+        timeout: 120000,
+    },
+}
+
+const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing', publishOptions)
 
 // Runs a stub Cody service for testing.
 export async function run<T>(around: () => Promise<T>): Promise<T> {

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -46,7 +46,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
 
     // endpoint which will accept the data that you want to send in that you will add your pubsub code
     app.post('/.api/testLogging', (req, res) => {
-        void logTestingData(req.body)
+        logTestingData(req.body)
         res.status(200)
     })
 
@@ -104,7 +104,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     return result
 }
 
-export async function logTestingData(data: string): Promise<void> {
+export function logTestingData(data: string): void {
     const message = {
         event: data,
         timestamp: new Date().getTime(),
@@ -116,12 +116,10 @@ export async function logTestingData(data: string): Promise<void> {
     // Publishes the message as a string
     const dataBuffer = Buffer.from(JSON.stringify(message))
 
-    try {
-        await topicPublisher.publishMessage({ data: dataBuffer })
-        console.log('Message published.')
-    } catch (error) {
-        console.error('Received error while publishing:', error)
-    }
+    topicPublisher.publishMessage({ data: dataBuffer }).catch(error => {
+        console.error('Error publishing message:', error)
+    })
+    console.log('Message published.')
 }
 
 let currentTestName: string

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -33,7 +33,7 @@ const pubSubClient = new PubSub({
 
 const publishOptions = {
     gaxOpts: {
-        timeout: 100000,
+        timeout: 120000,
     },
 }
 

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -99,7 +99,9 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     })
 
     const result = await around()
-    const closeServer = (): void => {server.close()}
+    const closeServer = (): void => {
+        server.close()
+    }
 
     // check to see if messages are sent if we wait 10 seconds and then close the server
     setTimeout(closeServer, 10000)

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -46,7 +46,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
 
     // endpoint which will accept the data that you want to send in that you will add your pubsub code
     app.post('/.api/testLogging', (req, res) => {
-        logTestingData(req.body)
+        void logTestingData(req.body)
         res.status(200)
     })
 
@@ -104,12 +104,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     return result
 }
 
-export function logTestingData(data: string): void {
-    // send a blank test message
-    topicPublisher.publishMessage({ data: Buffer.from(JSON.stringify({name:'testing-e2e-sept-7-github-actions'})) }).catch(error => {
-        console.error('Error publishing message:', error)
-    })
-
+export async function logTestingData(data: string): Promise<void> {
     const message = {
         event: data,
         timestamp: new Date().getTime(),
@@ -121,10 +116,10 @@ export function logTestingData(data: string): void {
     // Publishes the message as a string
     const dataBuffer = Buffer.from(JSON.stringify(message))
 
-    topicPublisher.publishMessage({ data: dataBuffer }).catch(error => {
+    const messageID = await topicPublisher.publishMessage({ data: dataBuffer }).catch(error => {
         console.error('Error publishing message:', error)
     })
-    console.log('Message published.')
+    console.log('Message published. ID:', messageID)
 }
 
 let currentTestName: string


### PR DESCRIPTION
Add Google auth to Github actions so that when `ci / test-e2e` runs, messages(events) are successfully recorded to our sandboxed environment. Also creating the pubsub client once at startup and reusing so its faster.

fixes the issue here:
<img width="732" alt="image" src="https://github.com/sourcegraph/cody/assets/32119652/fe4da635-3b0a-44b2-bd0b-b2a0c82baee0">

## Test plan
Verify that messages are being published when Github actions runs `test-e2e`
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
