### PR TITLE
Show commands format changed notification

### DIFF
--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -114,7 +114,8 @@ export class CustomPromptsStore implements vscode.Disposable {
             if (isOldFormat) {
                 void vscode.window
                     .showInformationMessage(
-                        `Commands format has changed. To be able to use custom commands, we suggest updating your ${type} configuration to the new format.`,
+                        `Your custom commands ${type} JSON (${type === 'user' ? '~/.vscode/cody.json' : '.vscode/cody.json'}) is using an old format, and needs to be upgraded.`,
+                        'Upgrade JSON',
                         'Update',
                         'Ignore'
                     )

--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -116,7 +116,7 @@ export class CustomPromptsStore implements vscode.Disposable {
                     .showInformationMessage(
                         `Your custom commands ${type} JSON (${type === 'user' ? '~/.vscode/cody.json' : '.vscode/cody.json'}) is using an old format, and needs to be upgraded.`,
                         'Upgrade JSON',
-                        'Update',
+                        'Upgrade JSON',
                         'Ignore'
                     )
                     .then(choice => {

--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -114,8 +114,9 @@ export class CustomPromptsStore implements vscode.Disposable {
             if (isOldFormat) {
                 void vscode.window
                     .showInformationMessage(
-                        `Your custom commands ${type} JSON (${type === 'user' ? '~/.vscode/cody.json' : '.vscode/cody.json'}) is using an old format, and needs to be upgraded.`,
-                        'Upgrade JSON',
+                        `Your custom commands ${type} JSON (${
+                            type === 'user' ? '~/.vscode/cody.json' : '.vscode/cody.json'
+                        }) is using an old format, and needs to be upgraded.`,
                         'Upgrade JSON',
                         'Ignore'
                     )

--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -120,7 +120,7 @@ export class CustomPromptsStore implements vscode.Disposable {
                         'Ignore'
                     )
                     .then(choice => {
-                        if (choice === 'Update') {
+                        if (choice === 'Upgrade JSON') {
                             // transform old format commands to the new format
                             const commands = promptEntries.reduce(
                                 (


### PR DESCRIPTION
If user/workspace Cody config file contains commands in old format, show notification with accept/ignore config update options. If user accepts, overwrite the config file and open it.

Previously we updated user/workspace cody config file if commands were in old format and then informed user about this change. This behavior may be annoying as there is no way for users to avoid these changes: if user discards or stashes config changes, these changes would be reapplied next time  user interacts with the main quick pick or sidebar chat ([thread](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1694010637819529)).




## Test plan
CI passes. Tested manually (video attached).

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
