### PR TITLE
Autocomplete: Fix feature flag init

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Fix feature flag initialization for autocomplete providers. [pull/965](https://github.com/sourcegraph/cody/pull/965)
+
 ### Changed
 
 - Remove `starter` and `premade` fields from the configuration files for custom commands (cody.json). [pull/939](https://github.com/sourcegraph/cody/pull/939)

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -22,7 +22,7 @@ export async function createInlineCompletionItemProvider(
 ): Promise<vscode.Disposable> {
     const disposables: vscode.Disposable[] = []
 
-    const providerConfig = await createProviderConfig(config, client)
+    const providerConfig = await createProviderConfig(config, client, featureFlagProvider)
     if (providerConfig) {
         const history = new VSCodeDocumentHistory()
         const sectionObserver = config.autocompleteExperimentalGraphContext ? new SectionObserver() : undefined


### PR DESCRIPTION
Feature flags in the provider init code won't evaluate right now because I forgot to pass through the feature flag provider 🤦 

We need a patch release out with this, pronto.

## Test plan

<img width="747" alt="Screenshot 2023-09-07 at 11 55 57" src="https://github.com/sourcegraph/cody/assets/458591/d2ebc1af-cdc9-4bbf-a0cd-4cdbc619cc5d">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
