### PR TITLE
Autocomplete: Don't init when not logged in and add UI to show that to users

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Added a UI indicator when you're not signed in. [pull/970](https://github.com/sourcegraph/cody/pull/970)
+
 ### Fixed
 
 - Fix feature flag initialization for autocomplete providers. [pull/965](https://github.com/sourcegraph/cody/pull/965)

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -22,7 +22,6 @@ interface InlineCompletionItemProviderArgs {
     contextProvider: ContextProvider
     featureFlagProvider: FeatureFlagProvider
     authProvider: AuthProvider
-    openSidebar: () => void
 }
 
 export async function createInlineCompletionItemProvider({
@@ -32,19 +31,12 @@ export async function createInlineCompletionItemProvider({
     contextProvider,
     featureFlagProvider,
     authProvider,
-    openSidebar,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
     if (!authProvider.getAuthStatus().isLoggedIn) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
-        const removeError = statusBar.addError({
-            title: 'Sign In To Use Cody',
-            description: 'You need to sign in to use Cody. Get started for free!',
-            onSelect: () => {
-                openSidebar?.()
-            },
-        })
+
         return {
-            dispose: () => removeError(),
+            dispose: () => {},
         }
     }
 

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -15,7 +15,7 @@ interface StatusBarError {
 export interface CodyStatusBar {
     dispose(): void
     startLoading(label: string): () => void
-    addError(error: StatusBarError): void
+    addError(error: StatusBarError): () => void
 }
 
 const DEFAULT_TEXT = '$(cody-logo-heavy)'
@@ -203,9 +203,18 @@ export function createStatusBar(): CodyStatusBar {
             }
         },
         addError(error: StatusBarError) {
-            errors.push({ error, createdAt: Date.now() })
+            const errorObject = { error, createdAt: Date.now() }
+            errors.push(errorObject)
             setTimeout(clearOutdatedErrors, ONE_HOUR)
             rerender()
+
+            return () => {
+                const index = errors.indexOf(errorObject)
+                if (index !== -1) {
+                    errors.splice(index, 1)
+                    rerender()
+                }
+            }
         },
         dispose() {
             statusBarItem.dispose()

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -86,7 +86,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
         statusBar: {
             startLoading: () => () => {},
             dispose: () => {},
-            addError: () => {},
+            addError: () => () => {},
         },
         history,
         getCodebaseContext: () => codebaseContext,


### PR DESCRIPTION
Closes #928

Avoid setting up autocomplete when the user is not signed in and log the states properly to the UI.


## Test plan


https://github.com/sourcegraph/cody/assets/458591/1444833c-0bce-4377-a894-cb97022ec2fa



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
