### PR TITLE
Autocomplete: Add bare bones statistics logging and UI

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Added a completion statistics summary to the autocomplete trace view. [pull/973](https://github.com/sourcegraph/cody/pull/973)
+
 ### Fixed
 
 - Fix feature flag initialization for autocomplete providers. [pull/965](https://github.com/sourcegraph/cody/pull/965)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -50,7 +50,7 @@ export interface CompletionEvent {
     acceptedAt: number | null
 }
 
-const READ_TIMEOUT = 750
+const READ_TIMEOUT_MS = 750
 
 const displayedCompletions = new LRUCache<string, CompletionEvent>({
     max: 100, // Maximum number of completions that we are keeping track of
@@ -118,7 +118,7 @@ export function loaded(id: string): void {
 // them again (they are NOT accepted) or when they ARE accepted. This way, we can calculate the
 // duration they were actually visible for.
 //
-// For statistics logging we start a timeout matching the READ_TIMEOUT so we can increment the
+// For statistics logging we start a timeout matching the READ_TIMEOUT_MS so we can increment the
 // suggested completion count as soon as we count it as such.
 export function suggested(id: string, source: string, completion: InlineCompletionItem): void {
     const event = displayedCompletions.get(id)
@@ -141,11 +141,11 @@ export function suggested(id: string, source: string, completion: InlineCompleti
 
             if (event.suggestedAt && !event.suggestionAnalyticsLoggedAt && !event.suggestionLoggedAt) {
                 // We can assume that this completion will be marked as `read: true` because
-                // READ_TIMEOUT has passed without the completion being logged yet.
+                // READ_TIMEOUT_MS has passed without the completion being logged yet.
                 statistics.logSuggested()
                 event.suggestionAnalyticsLoggedAt = performance.now()
             }
-        }, READ_TIMEOUT)
+        }, READ_TIMEOUT_MS)
     }
 }
 
@@ -227,7 +227,7 @@ function logSuggestionEvents(): void {
 
         const latency = loadedAt - startedAt
         const displayDuration = now - suggestedAt
-        const seen = displayDuration >= READ_TIMEOUT
+        const seen = displayDuration >= READ_TIMEOUT_MS
         const accepted = acceptedAt !== null
         const read = accepted || seen
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -8,6 +8,7 @@ import { logEvent } from '../services/EventLogger'
 import { captureException } from '../services/sentry/sentry'
 
 import { ContextSummary } from './context/context'
+import * as statistics from './statistics'
 import { InlineCompletionItem } from './types'
 
 export interface CompletionEvent {
@@ -40,6 +41,11 @@ export interface CompletionEvent {
     // The timestamp of when the suggestion was logged to our analytics backend
     // This is to avoid double-logging
     suggestionLoggedAt: number | null
+    // The timestamp of when the suggestion was logged to our statistics backend
+    // This can happen before we log it to our analytics backend because we
+    // don't care about the total display duration but instead want to update
+    // the UI as soon as the completion is counted as visible
+    suggestionAnalyticsLoggedAt: number | null
     // The timestamp of when a completion was accepted and logged to our backend
     acceptedAt: number | null
 }
@@ -74,6 +80,7 @@ export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMo
         loadedAt: null,
         suggestedAt: null,
         suggestionLoggedAt: null,
+        suggestionAnalyticsLoggedAt: null,
         acceptedAt: null,
     })
 
@@ -110,6 +117,9 @@ export function loaded(id: string): void {
 // Suggested completions will not be logged immediately. Instead, we log them when we either hide
 // them again (they are NOT accepted) or when they ARE accepted. This way, we can calculate the
 // duration they were actually visible for.
+//
+// For statistics logging we start a timeout matching the READ_TIMEOUT so we can increment the
+// suggested completion count as soon as we count it as such.
 export function suggested(id: string, source: string, completion: InlineCompletionItem): void {
     const event = displayedCompletions.get(id)
     if (!event) {
@@ -122,6 +132,20 @@ export function suggested(id: string, source: string, completion: InlineCompleti
         event.params.lineCount = lineCount
         event.params.charCount = charCount
         event.suggestedAt = performance.now()
+
+        setTimeout(() => {
+            const event = displayedCompletions.get(id)
+            if (!event) {
+                return
+            }
+
+            if (event.suggestedAt && !event.suggestionAnalyticsLoggedAt && !event.suggestionLoggedAt) {
+                // We can assume that this completion will be marked as `read: true` because
+                // READ_TIMEOUT has passed without the completion being logged yet.
+                statistics.logSuggested()
+                event.suggestionAnalyticsLoggedAt = performance.now()
+            }
+        }, READ_TIMEOUT)
     }
 }
 
@@ -155,6 +179,7 @@ export function accept(id: string, completion: InlineCompletionItem): void {
         ...lineAndCharCount(completion),
         otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
     })
+    statistics.logAccepted()
 }
 
 export function completionEvent(id: string): CompletionEvent | undefined {
@@ -182,8 +207,16 @@ function logSuggestionEvents(): void {
     const now = performance.now()
     // eslint-disable-next-line ban/ban
     displayedCompletions.forEach(completionEvent => {
-        const { loadedAt, suggestedAt, suggestionLoggedAt, startedAt, params, startLoggedAt, acceptedAt } =
-            completionEvent
+        const {
+            loadedAt,
+            suggestedAt,
+            suggestionLoggedAt,
+            startedAt,
+            params,
+            startLoggedAt,
+            acceptedAt,
+            suggestionAnalyticsLoggedAt,
+        } = completionEvent
 
         // Only log suggestion events that were already shown to the user and
         // have not been logged yet.
@@ -194,18 +227,27 @@ function logSuggestionEvents(): void {
 
         const latency = loadedAt - startedAt
         const displayDuration = now - suggestedAt
-        const read = displayDuration >= READ_TIMEOUT
+        const seen = displayDuration >= READ_TIMEOUT
         const accepted = acceptedAt !== null
+        const read = accepted || seen
+
+        if (!suggestionAnalyticsLoggedAt) {
+            completionEvent.suggestionAnalyticsLoggedAt = now
+            if (read) {
+                statistics.logSuggested()
+            }
+        }
 
         logCompletionEvent('suggested', {
             ...params,
             latency,
             displayDuration,
-            read: accepted || read,
+            read,
             accepted,
             otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
             completionsStartedSinceLastSuggestion,
         })
+
         completionsStartedSinceLastSuggestion = 0
     })
 

--- a/vscode/src/completions/statistics.ts
+++ b/vscode/src/completions/statistics.ts
@@ -1,0 +1,36 @@
+interface CompletionStatistics {
+    suggested: number
+    accepted: number
+}
+
+let statistics: CompletionStatistics = {
+    suggested: 0,
+    accepted: 0,
+}
+
+export function getStatistics(): CompletionStatistics {
+    return statistics
+}
+
+export function logSuggested(): void {
+    statistics = { ...statistics, suggested: statistics.suggested + 1 }
+    notifyAll()
+}
+export function logAccepted(): void {
+    statistics = { ...statistics, accepted: statistics.accepted + 1 }
+    notifyAll()
+}
+
+const listeners: Set<Listener> = new Set()
+type Listener = () => void
+type Unregister = () => void
+export function registerChangeListener(listener: Listener): Unregister {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+}
+
+function notifyAll(): void {
+    for (const listener of listeners) {
+        listener()
+    }
+}

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -261,8 +261,8 @@ ${
 }
 
 function rangeDescription(range: vscode.Range): string {
-    //  The VS Code extension API uses 0-indexed lines and columns, but the UI (and humans) use
-    //  1-indexed lines and columns. Show the latter.
+    // The VS Code extension API uses 0-indexed lines and columns, but the UI (and humans) use
+    // 1-indexed lines and columns. Show the latter.
     return `${range.start.line + 1}:${range.start.character + 1}${
         range.isEmpty
             ? ''

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -188,7 +188,7 @@ ${codeDetailsWithSummary('JSON for dataset', jsonForDataset(data))}
 function statisticSummary(): string {
     const { accepted, suggested } = statistics.getStatistics()
     return `📈 Suggested: ${suggested} | Accepted: ${accepted} | Acceptance rate: ${
-        suggested === 0 || accepted === 0 ? 'N/A' : `${((accepted / suggested) * 100).toFixed(2)}%`
+        suggested === 0 ? 'N/A' : `${((accepted / suggested) * 100).toFixed(2)}%`
     }`
 }
 


### PR DESCRIPTION
I often find myself wanting to know when exactly we count something as suggested vs. when we count it as accepted. Looking at the output tab is not super helpful here either so I added a small UI to the trace view.

This also adds the "infra" to support the trace view to show other views that re-render which I want to use for the section observer shortly.

I’m specifically hoping that this will help with #923.

## Test plan

https://github.com/sourcegraph/cody/assets/458591/2279928c-4056-4d0e-9f56-d5bdff6dbc03


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
