### PR TITLE
feat: add infill mode to anthropic claude instant

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -12,6 +12,7 @@ export enum FeatureFlag {
     CodyAutocompleteStreamingResponse = 'cody-autocomplete-streaming-response',
     CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
+    CodyAutocompleteClaudeInstantInfill = 'cody-autocomplete-claude-instant-infill',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -885,7 +885,8 @@
             "wizardcoder-15b",
             "llama-code-7b",
             "llama-code-13b",
-            "llama-code-13b-instruct"
+            "llama-code-13b-instruct",
+            "claude-instant-infill"
           ],
           "markdownDescription": "Overwrite the default model used for code autocompletion inference. This is only supported with the `unstable-fireworks` provider"
         },


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/811 https://github.com/sourcegraph/cody/issues/944

This PR contains changes related to adding "infill" mode to the Anthropic autocomplete provider for the Claude instant model:
- A new CodyAutocompleteClaudeInstantInfill feature flag was added to the FeatureFlagProvider.
- The vscode/package.json file was updated to include "claude-instant-infill" as a new advanced autocomplete model.
   - "cody.autocomplete.advanced.model": "claude-instant-infill"
- createProvider.ts was updated to use the "infill" mode when "claude-instant-infill" is configured instead of the default mode for Anthropic `claude-instant-1`
- AnthropicOptions now accepts a mode parameter to specify either 'default' (`claude-instant-1`) or 'infill' (`claude-instant-infill`).
- AnthropicProvider has a new useInfillPrefix property to track whether infill mode is enabled.
- When useInfillPrefix is true, getPromptPrefix will return different prompt context messages to guide the model to generate autocompletion with context awareness (infill).

## Quick Demo

See improved suggestions on the right, vs suggestions provided by the latest release build on the left:
<img width="1976" alt="Screenshot 2023-09-06 at 1 20 52 PM" src="https://github.com/sourcegraph/cody/assets/68532117/4db7a691-c6f8-4d10-a53d-5c62d5eabf13">

https://github.com/sourcegraph/cody/assets/68532117/cd4d314e-dfd1-42df-b063-725bc659f6ca

## Summary

This PR adds an "infill" mode to the Anthropic autocomplete provider Claude Instant model to generate more seamless completions based on surrounding code, which fixes issues where:

- The current version of completion does not support including context after the cursor which leads to generating a lot of irrelevant suggestions that could be more helpful.
- Issue where Cody suggests code that exists in the shared context

## Before 

https://github.com/sourcegraph/cody/assets/68532117/2802fc8b-bcef-4138-bd62-b3f39007cfb1

## After

https://github.com/sourcegraph/cody/assets/68532117/205ae8c1-3628-4f8f-9131-021d20fcffe8

- context awareness
- suggest code based on the pattern used in current file
- suggest codes that align with surrounding style
- won't suggest code that are duplicates (see video below) https://github.com/sourcegraph/cody/issues/811 https://github.com/sourcegraph/cody/issues/944

## Resolve the issue where Cody suggests code that already exists

RE: https://github.com/sourcegraph/cody/issues/811 https://github.com/sourcegraph/cody/issues/944

As Claude instant was not intended to be used as a code completions model, additional prompt engineering is required to guide Claude to do the "right" thing, which includes asking Cluade not to complete the code with code already implemented.

https://github.com/sourcegraph/cody/assets/68532117/d493e8e7-d5f7-42aa-a36a-efeb2432c712

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. In your user config file, add: `"cody.autocomplete.advanced.model": "claude-instant-infill"`
3. Try adding docstring above existing functions. 
  - At first, you might need to type more to guide Cody to generating helpful suggestions, but it should work well in more structured files.  
  
Compare the quality of suggestions you get from using this build with the ones from the stable release build that uses the claude instant model with the current prompt.

## More examples

claude instant with infill vs starcoder: 

https://github.com/sourcegraph/cody/assets/68532117/b25bf947-cb94-4bc3-90e9-723f99a0c62a

https://github.com/sourcegraph/cody/assets/68532117/5562f747-3778-4c51-9cbd-5ba306412073

https://github.com/sourcegraph/cody/assets/68532117/d1b235fa-776c-466f-a6fc-c46f8baca7de



