### PR TITLE
Autocomplete: Various section observer tweaks

### DIFF
--- a/vscode/src/completions/context/context.ts
+++ b/vscode/src/completions/context/context.ts
@@ -24,7 +24,11 @@ export interface GetContextOptions {
 }
 
 export interface GraphContextFetcher {
-    getContextAtPosition(document: vscode.TextDocument, position: vscode.Position): ContextSnippet[]
+    getContextAtPosition(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        contextRange?: vscode.Range
+    ): ContextSnippet[]
 }
 
 export type ContextSummary = Readonly<{

--- a/vscode/src/completions/context/context.ts
+++ b/vscode/src/completions/context/context.ts
@@ -15,6 +15,7 @@ export interface GetContextOptions {
     history: DocumentHistory
     prefix: string
     suffix: string
+    contextRange: vscode.Range
     jaccardDistanceWindowSize: number
     maxChars: number
     getCodebaseContext: () => CodebaseContext
@@ -48,8 +49,9 @@ export async function getContext(options: GetContextOptions): Promise<GetContext
      */
     const embeddingsMatches =
         isEmbeddingsContextEnabled && !graphContextFetcher ? getContextFromEmbeddings(options) : []
+
     const graphMatches = graphContextFetcher
-        ? graphContextFetcher.getContextAtPosition(options.document, options.position)
+        ? graphContextFetcher.getContextAtPosition(options.document, options.position, options.contextRange)
         : []
 
     // When we have graph matches, use it exclusively for the context

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -1,0 +1,57 @@
+import dedent from 'dedent'
+import { describe, expect, it } from 'vitest'
+
+import { getCurrentDocContext } from './get-current-doc-context'
+import { documentAndPosition } from './testHelpers'
+
+describe('get-current-doc-context', () => {
+    it('returns the right context for a document', () => {
+        const { document, position } = documentAndPosition(
+            dedent`
+            function bubbleSort(arr) {
+                for (let i = 0; i < arr.length; i++) {
+                    for (let j = 0; j < arr.length; j++) {
+                        if (arr[i] > arr[j]) {
+
+                            let temp = █;
+
+                            arr[i] = arr[j];
+                            arr[j] = temp;
+                        }
+                    }
+                }
+            }
+        `
+        )
+
+        const docContext = getCurrentDocContext(document, position, 140, 60)
+
+        expect(docContext.currentLinePrefix).toBe('                let temp = ')
+        expect(docContext.currentLineSuffix).toBe(';')
+        expect(docContext.nextNonEmptyLine).toBe('                arr[i] = arr[j];')
+        expect(docContext.prevNonEmptyLine).toBe('            if (arr[i] > arr[j]) {')
+        expect(docContext.prefix).toMatchInlineSnapshot(`
+          "        for (let j = 0; j < arr.length; j++) {
+                      if (arr[i] > arr[j]) {
+
+                          let temp = "
+        `)
+        expect(docContext.suffix).toMatchInlineSnapshot(`
+          ";
+
+                          arr[i] = arr[j];"
+        `)
+        expect(docContext.contextRange).toMatchInlineSnapshot(`
+          Range {
+            "end": Position {
+              "character": 32,
+              "line": 7,
+            },
+            "start": Position {
+              "character": 0,
+              "line": 2,
+            },
+          }
+        `)
+    })
+})

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -6,6 +6,9 @@ export interface DocumentContext {
     prefix: string
     suffix: string
 
+    /** The range that overlaps the included prefix and suffix */
+    contextRange: vscode.Range
+
     /** Text before the cursor on the same line. */
     currentLinePrefix: string
     /** Text after the cursor on the same line. */
@@ -91,6 +94,10 @@ export function getCurrentDocContext(
     return {
         prefix,
         suffix,
+        contextRange: new vscode.Range(
+            document.positionAt(offset - prefix.length),
+            document.positionAt(offset + suffix.length)
+        ),
         currentLinePrefix,
         currentLineSuffix,
         prevNonEmptyLine,

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -361,7 +361,7 @@ async function getCompletionContext({
     contextFetcher,
     getCodebaseContext,
     documentHistory,
-    docContext: { prefix, suffix },
+    docContext: { prefix, suffix, contextRange },
 }: GetCompletionContextParams): Promise<GetContextResult | null> {
     if (!contextFetcher) {
         return null
@@ -378,6 +378,7 @@ async function getCompletionContext({
         position,
         prefix,
         suffix,
+        contextRange,
         history: documentHistory,
         jaccardDistanceWindowSize: SNIPPET_WINDOW_SIZE,
         maxChars: promptChars,

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { vsCodeMocks } from '../testutils/mocks'
 
+import { getCurrentDocContext } from './get-current-doc-context'
 import { Provider } from './providers/provider'
 import { RequestManager, RequestManagerResult, RequestParams } from './request-manager'
 import { documentAndPosition } from './testHelpers'
-import { getNextNonEmptyLine, getPrevNonEmptyLine } from './text-processing'
 import { Completion } from './types'
 
 class MockProvider extends Provider {
@@ -47,15 +47,7 @@ function docState(prefix: string, suffix: string = ';'): RequestParams {
     return {
         document,
         position,
-        docContext: {
-            prefix,
-            suffix,
-            currentLinePrefix:
-                prefix.lastIndexOf('\n') === -1 ? prefix : prefix.slice(Math.max(0, prefix.lastIndexOf('\n') + 1)),
-            currentLineSuffix: suffix,
-            prevNonEmptyLine: getPrevNonEmptyLine(prefix),
-            nextNonEmptyLine: getNextNonEmptyLine(suffix),
-        },
+        docContext: getCurrentDocContext(document, position, 100, 100),
         context: {
             triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
             selectedCompletionInfo: undefined,


### PR DESCRIPTION
Just a few assorted graph context tweaks:

- We now extract the range of everything in the prefix and suffix. This is helpful so we can disregard definitions that are already in our context anyways. 
- Remove the `.d.ts` logic since it doesn't make sense to special case. Instead, we should fix this with other heuristics
- Add tests for the document context logic 

## Test plan

Tests green, this is not shipped yet anyways.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
