### PR TITLE
Agent: add support for custom User-Agent

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode'
 import { Client, createClient } from '@sourcegraph/cody-shared/src/chat/client'
 import { registeredRecipes } from '@sourcegraph/cody-shared/src/chat/recipes/agent-recipes'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
+import { setUserAgent } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 import { activate } from '../../vscode/src/extension.node'
 
@@ -82,6 +83,8 @@ export class Agent extends MessageHandler {
             if (extensionConfig) {
                 this.setClient(extensionConfig)
             }
+
+            setUserAgent(`${client?.name} / ${client?.version}`)
 
             const codyClient = await this.client
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -187,6 +187,16 @@ export interface event {
 type GraphQLAPIClientConfig = Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'> &
     Pick<Partial<ConfigurationWithAccessToken>, 'telemetryLevel'>
 
+export let useragent: string | undefined
+export function addCustomUseragent(headers: Headers): void {
+    if (useragent) {
+        headers.set('User-Agent', useragent)
+    }
+}
+export function setUserAgent(newUseragent: string): void {
+    useragent = newUseragent
+}
+
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = DOTCOM_URL
     constructor(private config: GraphQLAPIClientConfig) {}
@@ -484,6 +494,7 @@ export class SourcegraphGraphQLAPIClient {
         if (this.config.accessToken) {
             headers.set('Authorization', `token ${this.config.accessToken}`)
         }
+        addCustomUseragent(headers)
 
         const url = buildGraphQLUrl({ request: query, baseUrl: this.config.serverEndpoint })
         return fetch(url, {
@@ -499,9 +510,12 @@ export class SourcegraphGraphQLAPIClient {
     // make an anonymous request to the dotcom API
     private fetchSourcegraphDotcomAPI<T>(query: string, variables: Record<string, any>): Promise<T | Error> {
         const url = buildGraphQLUrl({ request: query, baseUrl: this.dotcomUrl.href })
+        const headers = new Headers()
+        addCustomUseragent(headers)
         return fetch(url, {
             method: 'POST',
             body: JSON.stringify({ query, variables }),
+            headers,
         })
             .then(verifyResponseCode)
             .then(response => response.json() as T)
@@ -511,11 +525,14 @@ export class SourcegraphGraphQLAPIClient {
     // make an anonymous request to the Testing API
     private fetchSourcegraphTestingAPI<T>(body: Record<string, any>): Promise<T | Error> {
         const url = 'http://localhost:49300/.api/testLogging'
+        const headers = new Headers({
+            'Content-Type': 'application/json',
+        })
+        addCustomUseragent(headers)
+
         return fetch(url, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers,
             body: JSON.stringify(body),
         })
             .then(verifyResponseCode)

--- a/vscode/src/fetch.ts
+++ b/vscode/src/fetch.ts
@@ -6,6 +6,8 @@ import type { Agent } from 'http'
  */
 import isomorphicFetch from 'isomorphic-fetch'
 
+import { addCustomUseragent, useragent } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+
 /**
  * In node environments, it might be necessary to set up a custom agent to control the network
  * requests being made.
@@ -19,6 +21,12 @@ import isomorphicFetch from 'isomorphic-fetch'
 export const agent: { current: ((url: URL) => Agent) | undefined } = { current: undefined }
 
 export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    if (useragent) {
+        init = init ?? {}
+        const headers = new Headers(init?.headers)
+        addCustomUseragent(headers)
+        init.headers = headers
+    }
     return isomorphicFetch(input, {
         ...init,
         agent: agent.current,

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -1,4 +1,3 @@
-import fetch from 'isomorphic-fetch'
 import * as vscode from 'vscode'
 
 import { LOCAL_APP_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
@@ -6,6 +5,7 @@ import { LOCAL_APP_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/envi
 import { version } from '../../package.json'
 import { isOsSupportedByApp, LocalEnv } from '../chat/protocol'
 import { constructFileUri } from '../custom-prompts/utils/helpers'
+import { fetch } from '../fetch'
 import { logDebug, logError } from '../log'
 
 import { AppJson, LOCAL_APP_LOCATIONS } from './LocalAppFsPaths'


### PR DESCRIPTION
Previously, there was no way for agent clients to customize the `User-Agent` HTTP header that is sent for network requests. This PR adds the ability to customize the `User-Agent` header based on the name and version of the client that is sent during the `initialize` handshake.

Fixes https://github.com/sourcegraph/sourcegraph-inc239/issues/65

## Test plan

- Add `console.log()` statements before `fetch` requests
- Start local build of the JetBrains plugin
- Use plugin, confirm that all requests have the `User-Agent` header set
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
