### PR TITLE
Agent: add notification that clears the last autocomplete candidate

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -220,6 +220,14 @@ export class Agent extends MessageHandler {
             await client?.graphqlClient.logEvent(event)
             return null
         })
+
+        this.registerNotification('autocomplete/clearLastCandidate', async () => {
+            const provider = await vscode_shim.completionProvider
+            if (!provider) {
+                console.log('Completion provider is not initialized: unable to clear last candidate')
+            }
+            provider.clearLastCandidate()
+        })
     }
 
     private setClient(config: ExtensionConfiguration): void {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -88,6 +88,9 @@ export type Notifications = {
     'textDocument/didClose': [TextDocument]
 
     '$/cancelRequest': [CancelParams]
+    // The user no longer wishes to consider the last autocomplete candidate
+    // and the current autocomplete id should not be reused.
+    'autocomplete/clearLastCandidate': [null]
 
     // ================
     // Server -> Client

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -262,6 +262,9 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         CompletionLogger.accept(logId, completion)
     }
 
+    /**
+     * Should only be used by agent to allow it access to clear the last candidate
+     */
     public clearLastCandidate(): void {
         this.lastCandidate = undefined
     }

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -257,9 +257,13 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     public handleDidAcceptCompletionItem(logId: string, completion: InlineCompletionItem): void {
         // When a completion is accepted, the lastCandidate should be cleared. This makes sure the
         // log id is never reused if the completion is accepted.
-        this.lastCandidate = undefined
+        this.clearLastCandidate()
 
         CompletionLogger.accept(logId, completion)
+    }
+
+    public clearLastCandidate(): void {
+        this.lastCandidate = undefined
     }
 
     /**


### PR DESCRIPTION
Clearing the last candidate ensures that autocomplete id's and cached potential suggestions are not reused.  This adds a notification an extension can send when it no longer wishes the consider the last candidate.  The most common reason is that the suggestion was accepted. 
## Test plan
Tested using JetBrains extension 
Accepted an autocomplete and then immediately removed it and triggered another 
Got the same suggestion but verified the id was different.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
