### PR TITLE
update scrolling behavior

### DIFF
--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -63,15 +63,17 @@ export const Transcript: React.FunctionComponent<
     ChatButtonComponent,
     isTranscriptError,
 }) {
-    // Scroll down whenever a new human message is received as input.
+    // Scroll the last human message to the top whenever a new human message is received as input.
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
     const scrollAnchoredContainerRef = useRef<HTMLDivElement>(null)
+    const lastHumanMessageTopRef = useRef<HTMLDivElement>(null)
     const humanMessageCount = transcript.filter(message => message.speaker === 'human').length
     useEffect(() => {
         if (transcriptContainerRef.current) {
-            transcriptContainerRef.current?.scrollTo({
-                top: transcriptContainerRef.current.scrollHeight,
-                behavior: 'smooth',
+            lastHumanMessageTopRef.current?.scrollIntoView({
+                behavior: 'auto',
+                block: 'start',
+                inline: 'nearest',
             })
         }
     }, [humanMessageCount, transcriptContainerRef])
@@ -95,9 +97,10 @@ export const Transcript: React.FunctionComponent<
                         continue
                     }
                     if (wasIntersecting && !entry.isIntersecting) {
-                        root.scrollTo({
-                            top: root.scrollHeight,
-                            behavior: 'smooth',
+                        lastHumanMessageTopRef.current?.scrollIntoView({
+                            behavior: 'auto',
+                            block: 'start',
+                            inline: 'nearest',
                         })
                     }
                     wasIntersecting = entry.isIntersecting
@@ -114,41 +117,49 @@ export const Transcript: React.FunctionComponent<
         }
     }, [transcriptContainerRef, scrollAnchoredContainerRef])
 
+    const lastHumanMessageIndex = transcript.findLastIndex(
+        message => message.speaker === 'human' && message.displayText !== undefined
+    )
+    const earlierMessages = transcript.slice(0, lastHumanMessageIndex)
+    const lastInteractionMessages = transcript.slice(lastHumanMessageIndex)
+
+    const messageToTranscriptItem = (message: ChatMessage, index: number) =>
+        message?.displayText && (
+            <TranscriptItem
+                // eslint-disable-next-line react/no-array-index-key
+                key={index}
+                message={message}
+                inProgress={false}
+                beingEdited={index > 0 && transcript.length - index === 2 && messageBeingEdited}
+                setBeingEdited={setMessageBeingEdited}
+                fileLinkComponent={fileLinkComponent}
+                symbolLinkComponent={symbolLinkComponent}
+                codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
+                codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
+                transcriptItemClassName={transcriptItemClassName}
+                humanTranscriptItemClassName={humanTranscriptItemClassName}
+                transcriptItemParticipantClassName={transcriptItemParticipantClassName}
+                transcriptActionClassName={transcriptActionClassName}
+                textAreaComponent={textAreaComponent}
+                EditButtonContainer={EditButtonContainer}
+                editButtonOnSubmit={editButtonOnSubmit}
+                showEditButton={index > 0 && transcript.length - index === 2}
+                FeedbackButtonsContainer={FeedbackButtonsContainer}
+                feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                copyButtonOnSubmit={copyButtonOnSubmit}
+                showFeedbackButtons={index !== 0 && !isTranscriptError}
+                submitButtonComponent={submitButtonComponent}
+                chatInputClassName={chatInputClassName}
+                ChatButtonComponent={ChatButtonComponent}
+            />
+    )
+
     return (
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
             <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
-                {transcript.map(
-                    (message, index) =>
-                        message?.displayText && (
-                            <TranscriptItem
-                                // eslint-disable-next-line react/no-array-index-key
-                                key={index}
-                                message={message}
-                                inProgress={false}
-                                beingEdited={index > 0 && transcript.length - index === 2 && messageBeingEdited}
-                                setBeingEdited={setMessageBeingEdited}
-                                fileLinkComponent={fileLinkComponent}
-                                symbolLinkComponent={symbolLinkComponent}
-                                codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
-                                codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
-                                transcriptItemClassName={transcriptItemClassName}
-                                humanTranscriptItemClassName={humanTranscriptItemClassName}
-                                transcriptItemParticipantClassName={transcriptItemParticipantClassName}
-                                transcriptActionClassName={transcriptActionClassName}
-                                textAreaComponent={textAreaComponent}
-                                EditButtonContainer={EditButtonContainer}
-                                editButtonOnSubmit={editButtonOnSubmit}
-                                showEditButton={index > 0 && transcript.length - index === 2}
-                                FeedbackButtonsContainer={FeedbackButtonsContainer}
-                                feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                                copyButtonOnSubmit={copyButtonOnSubmit}
-                                showFeedbackButtons={index !== 0 && !isTranscriptError}
-                                submitButtonComponent={submitButtonComponent}
-                                chatInputClassName={chatInputClassName}
-                                ChatButtonComponent={ChatButtonComponent}
-                            />
-                        )
-                )}
+                {earlierMessages.map(messageToTranscriptItem)}
+                <div ref={lastHumanMessageTopRef}></div>
+                {lastInteractionMessages.map(messageToTranscriptItem)}
                 {messageInProgress && messageInProgress.speaker === 'assistant' && (
                     <TranscriptItem
                         message={messageInProgress}

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -123,8 +123,11 @@ export const Transcript: React.FunctionComponent<
     const earlierMessages = transcript.slice(0, lastHumanMessageIndex)
     const lastInteractionMessages = transcript.slice(lastHumanMessageIndex)
 
-    const messageToTranscriptItem = (message: ChatMessage, index: number) =>
-        message?.displayText && (
+    const messageToTranscriptItem = (message: ChatMessage, index: number): JSX.Element | null => {
+        if (!message?.displayText) {
+            return null
+        }
+        return (
             <TranscriptItem
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
@@ -152,13 +155,14 @@ export const Transcript: React.FunctionComponent<
                 chatInputClassName={chatInputClassName}
                 ChatButtonComponent={ChatButtonComponent}
             />
-    )
+        )
+    }
 
     return (
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
             <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
                 {earlierMessages.map(messageToTranscriptItem)}
-                <div ref={lastHumanMessageTopRef}></div>
+                <div ref={lastHumanMessageTopRef} />
                 {lastInteractionMessages.map(messageToTranscriptItem)}
                 {messageInProgress && messageInProgress.speaker === 'assistant' && (
                     <TranscriptItem


### PR DESCRIPTION
Previously the behavior was:
1. When a new human message is entered, scroll all the way to the bottom.
2. As the assistant response appears, continue scrolling to keep the bottom in view (this is done with the browser's default scroll anchor behavior).

This worked fine for most chat inputs, but it was not a good UX for `/search` and `/symf`, because both these commands often generate a response that's taller than the viewport, meaning the user has to scroll back up to get to the top of results.

This PR updates the scrolling behavior in the Cody sidebar to the following:
1. When a new human message is entered, scroll that human message up toward the top of the viewport, but not past the top.
2. If the assistant response is streamed (not the case for `/search` and `/symf`) and the bottom of the transcript is in view, then continue scrolling as the response generates.

(2) should preserve the existing behavior for commands/chat that are not `/search` or `/symf`.

https://github.com/sourcegraph/cody/assets/1646931/a1cfa61b-ab71-47db-ab62-eb776f0affd4

## Test plan

Tested locally
