### PR TITLE
Introduce testRunID when logging events from e2e tests

### DIFF
--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -4,6 +4,7 @@ import * as path from 'path'
 
 import { test as base, Frame, Page } from '@playwright/test'
 import { _electron as electron } from 'playwright'
+import * as uuid from 'uuid'
 
 import { run, sendTestInfo } from '../fixtures/mock-server'
 
@@ -27,7 +28,7 @@ export const test = base
 
             await buildWorkSpaceSettings(workspaceDirectory)
 
-            sendTestInfo(testInfo.title, testInfo.testId)
+            sendTestInfo(testInfo.title, testInfo.testId, uuid.v4())
 
             // See: https://github.com/microsoft/vscode-test/blob/main/lib/runTest.ts
             const app = await electron.launch({

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -103,6 +103,7 @@ export async function logTestingData(data: string): Promise<void> {
         timestamp: new Date().getTime(),
         test_name: currentTestName,
         test_id: currentTestID,
+        test_run_id: currentTestRunID,
         UID: uuid.v4(),
     }
 
@@ -113,7 +114,7 @@ export async function logTestingData(data: string): Promise<void> {
         await pubSubClient
             .topic('projects/sourcegraph-telligent-testing/topics/e2e-testing')
             .publishMessage({ data: dataBuffer })
-        console.log('Message published.')
+        console.log('Message published. TestRunID:', currentTestRunID)
     } catch (error) {
         console.error('Received error while publishing:', error)
     }
@@ -121,8 +122,10 @@ export async function logTestingData(data: string): Promise<void> {
 
 let currentTestName: string
 let currentTestID: string
+let currentTestRunID: string
 
-export function sendTestInfo(testName: string, testID: string): void {
+export function sendTestInfo(testName: string, testID: string, testRunID: string): void {
     currentTestName = testName || ''
     currentTestID = testID || ''
+    currentTestRunID = testRunID || ''
 }


### PR DESCRIPTION
Adds `testRunID` to the logged data so that we can identify each test run uniquely. 
## Test plan
Verify events are coming through with updated fields
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
