### PR TITLE
Autocomplete: Add a feature flag for graph context and only enable it for supported languages

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -12,6 +12,7 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
     CodyAutocompleteClaudeInstantInfill = 'cody-autocomplete-claude-instant-infill',
+    CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/completions/context/context-graph.ts
+++ b/vscode/src/completions/context/context-graph.ts
@@ -23,6 +23,10 @@ interface Options {
 }
 
 export async function getContextFromGraph(options: Options): Promise<GetContextResult | undefined> {
+    if (!supportedLanguageId(options.document.languageId)) {
+        return undefined
+    }
+
     const start = performance.now()
     const graphMatches = options.graphContextFetcher
         ? await options.graphContextFetcher.getContextAtPosition(
@@ -61,5 +65,19 @@ export async function getContextFromGraph(options: Options): Promise<GetContextR
             graph: includedGraphMatches,
             duration: performance.now() - start,
         },
+    }
+}
+
+function supportedLanguageId(languageId: string): boolean {
+    // allow go and js/ts
+    switch (languageId) {
+        case 'go':
+        case 'javascript':
+        case 'javascriptreact':
+        case 'typescript':
+        case 'typescriptreact':
+            return true
+        default:
+            return false
     }
 }

--- a/vscode/src/completions/context/context-graph.ts
+++ b/vscode/src/completions/context/context-graph.ts
@@ -69,7 +69,6 @@ export async function getContextFromGraph(options: Options): Promise<GetContextR
 }
 
 function supportedLanguageId(languageId: string): boolean {
-    // allow go and js/ts
     switch (languageId) {
         case 'go':
         case 'javascript':

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -42,12 +42,11 @@ export async function createInlineCompletionItemProvider({
 
     const disposables: vscode.Disposable[] = []
 
-    const providerConfig = await createProviderConfig(config, client, featureFlagProvider)
+    const [providerConfig, graphContextFlag] = await Promise.all([
+        createProviderConfig(config, client, featureFlagProvider),
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteGraphContext),
+    ])
     if (providerConfig) {
-        const graphContextFlag = await featureFlagProvider?.evaluateFeatureFlag(
-            FeatureFlag.CodyAutocompleteGraphContext
-        )
-
         const history = new VSCodeDocumentHistory()
         const sectionObserver =
             config.autocompleteExperimentalGraphContext || graphContextFlag

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
 import { ContextProvider } from '../chat/ContextProvider'
 import { logDebug } from '../log'
@@ -44,10 +44,15 @@ export async function createInlineCompletionItemProvider({
 
     const providerConfig = await createProviderConfig(config, client, featureFlagProvider)
     if (providerConfig) {
+        const graphContextFlag = await featureFlagProvider?.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteGraphContext
+        )
+
         const history = new VSCodeDocumentHistory()
-        const sectionObserver = config.autocompleteExperimentalGraphContext
-            ? GraphSectionObserver.createInstance()
-            : undefined
+        const sectionObserver =
+            config.autocompleteExperimentalGraphContext || graphContextFlag
+                ? GraphSectionObserver.createInstance()
+                : undefined
 
         const completionsProvider = new InlineCompletionItemProvider({
             providerConfig,


### PR DESCRIPTION
Add a feature flag so we can remotely enable graph context and only enable it for supported languages.

## Test plan

- Enable graph context via the VS Code setting
- Observe it still works using the trace view 	

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
