### PR TITLE
Autocomplete: Add stop sequence to Fireworks

### DIFF
--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -104,6 +104,7 @@ export class UnstableFireworksProvider extends Provider {
             topP: 0.95,
             topK: 0,
             model: MODEL_MAP[this.model],
+            stopSequences: [this.options.multiline ? '\n\n' : '\n'],
         }
 
         tracer?.params(args)


### PR DESCRIPTION
This PR adds a stop sequence to Fireworks requests. We can rely on `\n` for single line completions because the prefix is not truncated. We also use `\n\n` in Anthropic to terminate multi-line requests so this just brings it on par.

## Test plan

- Enable StarCoder and be connected to dotcom
	- `cody.autocomplete.advanced.provider": "unstable-fireworks"`
- Observe that single line completions still work

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
