### PR TITLE
Intelligent Cody: Track which local variable types/implementations alter

### DIFF
--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -37,6 +37,7 @@ export interface PreciseContext {
 
 export interface HoverContext {
     symbolName: string
+    sourceSymbolName?: string
     type: 'definition' | 'typeDefinition' | 'implementation'
     content: string[]
 

--- a/vscode/src/completions/context/graph-section-observer.test.ts
+++ b/vscode/src/completions/context/graph-section-observer.test.ts
@@ -395,11 +395,13 @@ describe('GraphSectionObserver', () => {
                 {
                   "content": "function foo() {}",
                   "fileName": "/document1.ts",
+                  "sourceSymbolAndRelationship": undefined,
                   "symbol": "foo",
                 },
                 {
                   "content": "function bar() {}",
                   "fileName": "/document1.ts",
+                  "sourceSymbolAndRelationship": undefined,
                   "symbol": "bar",
                 },
               ]
@@ -436,6 +438,7 @@ describe('GraphSectionObserver', () => {
                 {
                   "content": "function bar() {}",
                   "fileName": "/document1.ts",
+                  "sourceSymbolAndRelationship": undefined,
                   "symbol": "bar",
                 },
               ]

--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -455,7 +455,6 @@ function hoverContextsToSnippets(contexts: HoverContext[]): SymbolContextSnippet
 }
 
 function hoverContextToSnippets(context: HoverContext): SymbolContextSnippet {
-    console.log({ context })
     return {
         fileName: path.normalize(vscode.workspace.asRelativePath(URI.parse(context.uri).fsPath)),
         symbol: context.symbolName,

--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -455,9 +455,15 @@ function hoverContextsToSnippets(contexts: HoverContext[]): SymbolContextSnippet
 }
 
 function hoverContextToSnippets(context: HoverContext): SymbolContextSnippet {
+    const sourceSymbolAndRelationship =
+        context.sourceSymbolName && context.type !== 'definition'
+            ? { symbol: context.sourceSymbolName, relationship: context.type }
+            : undefined
+
     return {
         fileName: path.normalize(vscode.workspace.asRelativePath(URI.parse(context.uri).fsPath)),
         symbol: context.symbolName,
+        sourceSymbolAndRelationship,
         content: context.content.join('\n').trim(),
     }
 }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -124,12 +124,32 @@ export class AnthropicProvider extends Provider {
         let remainingChars = this.promptChars - this.emptyPromptLength()
 
         for (const snippet of snippets) {
+            const formatRelationship = (
+                relationship:
+                    | {
+                          symbol: string
+                          relationship: 'typeDefinition' | 'implementation'
+                      }
+                    | undefined
+            ): string => {
+                if (relationship) {
+                    switch (relationship.relationship) {
+                        case 'typeDefinition':
+                            return ` (the type of \`${relationship.symbol}\`)`
+                        case 'implementation':
+                            return ` (an implementation of \`${relationship.symbol}\`)`
+                    }
+                }
+
+                return ''
+            }
+
             const snippetMessages: Message[] = [
                 {
                     speaker: 'human',
                     text:
                         'symbol' in snippet && snippet.symbol !== ''
-                            ? `Additional documentation for \`${snippet.symbol}\`: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
+                            ? `Additional documentation for \`${snippet.symbol}\`${formatRelationship(snippet.sourceSymbolAndRelationship)}: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
                             : `Codebase context from file path '${snippet.fileName}': ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,
                 },
                 {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -12,13 +12,14 @@ import {
     CLOSING_CODE_TAG,
     extractFromCodeBlock,
     fixBadCompletionStart,
+    formatSymbolContextRelationship,
     getHeadAndTail,
     MULTILINE_STOP_SEQUENCE,
     OPENING_CODE_TAG,
     PrefixComponents,
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
-import { Completion, ContextSnippet, SymbolContextSnippet } from '../types'
+import { Completion, ContextSnippet } from '../types'
 import { forkSignal, messagesToText } from '../utils'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
@@ -124,25 +125,12 @@ export class AnthropicProvider extends Provider {
         let remainingChars = this.promptChars - this.emptyPromptLength()
 
         for (const snippet of snippets) {
-            const formatRelationship = (relationship: SymbolContextSnippet['sourceSymbolAndRelationship']): string => {
-                if (relationship) {
-                    switch (relationship.relationship) {
-                        case 'typeDefinition':
-                            return ` (the type of \`${relationship.symbol}\`)`
-                        case 'implementation':
-                            return ` (an implementation of \`${relationship.symbol}\`)`
-                    }
-                }
-
-                return ''
-            }
-
             const snippetMessages: Message[] = [
                 {
                     speaker: 'human',
                     text:
                         'symbol' in snippet && snippet.symbol !== ''
-                            ? `Additional documentation for \`${snippet.symbol}\`${formatRelationship(
+                            ? `Additional documentation for \`${snippet.symbol}\`${formatSymbolContextRelationship(
                                   snippet.sourceSymbolAndRelationship
                               )}: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
                             : `Codebase context from file path '${snippet.fileName}': ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -18,7 +18,7 @@ import {
     PrefixComponents,
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
-import { Completion, ContextSnippet } from '../types'
+import { Completion, ContextSnippet, SymbolContextSnippet } from '../types'
 import { forkSignal, messagesToText } from '../utils'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
@@ -124,8 +124,7 @@ export class AnthropicProvider extends Provider {
         let remainingChars = this.promptChars - this.emptyPromptLength()
 
         for (const snippet of snippets) {
-            const formatRelationship = (
-                relationship: SymbolContextSnippet['sourceSymbolAndRelationship']): string => {
+            const formatRelationship = (relationship: SymbolContextSnippet['sourceSymbolAndRelationship']): string => {
                 if (relationship) {
                     switch (relationship.relationship) {
                         case 'typeDefinition':

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -149,7 +149,9 @@ export class AnthropicProvider extends Provider {
                     speaker: 'human',
                     text:
                         'symbol' in snippet && snippet.symbol !== ''
-                            ? `Additional documentation for \`${snippet.symbol}\`${formatRelationship(snippet.sourceSymbolAndRelationship)}: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
+                            ? `Additional documentation for \`${snippet.symbol}\`${formatRelationship(
+                                  snippet.sourceSymbolAndRelationship
+                              )}: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
                             : `Codebase context from file path '${snippet.fileName}': ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,
                 },
                 {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -125,13 +125,7 @@ export class AnthropicProvider extends Provider {
 
         for (const snippet of snippets) {
             const formatRelationship = (
-                relationship:
-                    | {
-                          symbol: string
-                          relationship: 'typeDefinition' | 'implementation'
-                      }
-                    | undefined
-            ): string => {
+                relationship: SymbolContextSnippet['sourceSymbolAndRelationship']): string => {
                 if (relationship) {
                     switch (relationship.relationship) {
                         case 'typeDefinition':

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -65,7 +65,7 @@ export class UnstableFireworksProvider extends Provider {
                     intro.push(
                         `Additional documentation for \`${snippet.symbol}\`${formatSymbolContextRelationship(
                             snippet.sourceSymbolAndRelationship
-                        )}\n\n${snippet.content}`
+                        )}:\n\n${snippet.content}`
                     )
                 } else {
                     intro.push(`Here is a reference snippet of code from ${snippet.fileName}:\n\n${snippet.content}`)

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -6,6 +6,7 @@ import {
 import { CodeCompletionsClient } from '../client'
 import { getLanguageConfig } from '../language'
 import { canUsePartialCompletion } from '../streaming'
+import { formatSymbolContextRelationship } from '../text-processing'
 import { Completion, ContextSnippet } from '../types'
 import { forkSignal } from '../utils'
 
@@ -61,7 +62,11 @@ export class UnstableFireworksProvider extends Provider {
             if (snippetsToInclude > 0) {
                 const snippet = snippets[snippetsToInclude - 1]
                 if ('symbol' in snippet && snippet.symbol !== '') {
-                    intro.push(`Additional documentation for ${snippet.symbol}:\n\n${snippet.content}`)
+                    intro.push(
+                        `Additional documentation for \`${snippet.symbol}\`${formatSymbolContextRelationship(
+                            snippet.sourceSymbolAndRelationship
+                        )}\n\n${snippet.content}`
+                    )
                 } else {
                     intro.push(`Here is a reference snippet of code from ${snippet.fileName}:\n\n${snippet.content}`)
                 }

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 import { getLanguageConfig } from '../language'
 import { logCompletionEvent } from '../logger'
+import { SymbolContextSnippet } from '../types'
 
 import { isAlmostTheSameString } from './string-comparator'
 
@@ -343,4 +344,19 @@ export function getPrevNonEmptyLine(prefix: string): string {
             .split('\n')
             .findLast(line => line.trim().length > 0) ?? ''
     )
+}
+
+export const formatSymbolContextRelationship = (
+    relationship: SymbolContextSnippet['sourceSymbolAndRelationship']
+): string => {
+    if (relationship) {
+        switch (relationship.relationship) {
+            case 'typeDefinition':
+                return ` (the type of \`${relationship.symbol}\`)`
+            case 'implementation':
+                return ` (an implementation of \`${relationship.symbol}\`)`
+        }
+    }
+
+    return ''
 }

--- a/vscode/src/completions/types.ts
+++ b/vscode/src/completions/types.ts
@@ -30,5 +30,9 @@ export interface SymbolContextSnippet {
     fileName: string
     symbol: string
     content: string
+    sourceSymbolAndRelationship?: {
+        symbol: string
+        relationship: 'typeDefinition' | 'implementation'
+    }
 }
 export type ContextSnippet = FileContextSnippet | SymbolContextSnippet

--- a/vscode/src/completions/types.ts
+++ b/vscode/src/completions/types.ts
@@ -1,5 +1,7 @@
 import { Range } from 'vscode-languageserver-textdocument'
 
+import { HoverContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+
 export interface Completion {
     content: string
     stopReason?: string
@@ -32,7 +34,7 @@ export interface SymbolContextSnippet {
     content: string
     sourceSymbolAndRelationship?: {
         symbol: string
-        relationship: 'typeDefinition' | 'implementation'
+        relationship: Omit<HoverContext['type'], 'definition'>
     }
 }
 export type ContextSnippet = FileContextSnippet | SymbolContextSnippet

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -535,15 +535,15 @@ const hoverContextFromElement = (e?: ResolvedHoverElement): HoverContext | undef
         return undefined
     }
 
-    const definitionHoverContent = hoverToStrings(e.hover)
-    if (definitionHoverContent.length === 0) {
+    const content = hoverToStrings(e.hover)
+    if (content.length === 0) {
         return undefined
     }
 
     return {
         symbolName: e.symbolName,
         type: 'definition',
-        content: definitionHoverContent,
+        content,
         uri: e.location.uri.toString(),
         range: {
             startLine: e.location.range.start.line,

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -526,11 +526,11 @@ const hoverToStrings = (h: vscode.Hover[]): string[] =>
 const hoverContextFromResolvedHoverText = (t: ResolvedHoverText): HoverContext[] =>
     [
         hoverContextFromElement(t.definition),
-        hoverContextFromElement(t.typeDefinition),
-        ...(t.implementations?.map(hoverContextFromElement) ?? []),
+        hoverContextFromElement(t.typeDefinition, t.symbolName),
+        ...(t.implementations?.map(e => hoverContextFromElement(e, t.typeDefinition?.symbolName)) ?? []),
     ].filter(isDefined)
 
-const hoverContextFromElement = (e?: ResolvedHoverElement): HoverContext | undefined => {
+const hoverContextFromElement = (e?: ResolvedHoverElement, sourceSymbolName?: string): HoverContext | undefined => {
     if (e === undefined) {
         return undefined
     }
@@ -542,6 +542,7 @@ const hoverContextFromElement = (e?: ResolvedHoverElement): HoverContext | undef
 
     return {
         symbolName: e.symbolName,
+        sourceSymbolName,
         type: 'definition',
         content,
         uri: e.location.uri.toString(),

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -533,7 +533,7 @@ const hoverContextFromResolvedHoverText = (t: ResolvedHoverText): HoverContext[]
 
 const hoverContextFromElement = (
     e: ResolvedHoverElement | undefined,
-    type: 'definition' | 'typeDefinition' | 'implementation',
+    type: HoverContext['type'],
     sourceSymbolName?: string
 ): HoverContext | undefined => {
     if (e === undefined) {

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -525,12 +525,17 @@ const hoverToStrings = (h: vscode.Hover[]): string[] =>
 
 const hoverContextFromResolvedHoverText = (t: ResolvedHoverText): HoverContext[] =>
     [
-        hoverContextFromElement(t.definition),
-        hoverContextFromElement(t.typeDefinition, t.symbolName),
-        ...(t.implementations?.map(e => hoverContextFromElement(e, t.typeDefinition?.symbolName)) ?? []),
+        hoverContextFromElement(t.definition, 'definition'),
+        hoverContextFromElement(t.typeDefinition, 'typeDefinition', t.symbolName),
+        ...(t.implementations?.map(e => hoverContextFromElement(e, 'implementation', t.typeDefinition?.symbolName)) ??
+            []),
     ].filter(isDefined)
 
-const hoverContextFromElement = (e?: ResolvedHoverElement, sourceSymbolName?: string): HoverContext | undefined => {
+const hoverContextFromElement = (
+    e: ResolvedHoverElement | undefined,
+    type: 'definition' | 'typeDefinition' | 'implementation',
+    sourceSymbolName?: string
+): HoverContext | undefined => {
     if (e === undefined) {
         return undefined
     }
@@ -543,7 +548,7 @@ const hoverContextFromElement = (e?: ResolvedHoverElement, sourceSymbolName?: st
     return {
         symbolName: e.symbolName,
         sourceSymbolName,
-        type: 'definition',
+        type,
         content,
         uri: e.location.uri.toString(),
         range: {


### PR DESCRIPTION
**Idea:** We have context snippets that contain type definition and implementation hover text, but that doesn't help link it to a local variable. We'll want to provide this data to the LLM in the form of _type `T` is the type of variable `X`_ or _type `T2` implements type `T1`_ so that the LLM can reason about the shape of `X` and `T1` (not just `T` and `T2`).

## Test plan

Manual testing.

![image](https://github.com/sourcegraph/cody/assets/103087/0247e19b-bb03-4b64-943e-92bdc0fc381d)
