### PR TITLE
Autocomplete: do not report auth errors to Sentry

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -36,3 +36,17 @@ export function isAbortError(error: Error): boolean {
         error.message.includes('The user aborted a request')
     )
 }
+
+export class AuthError extends Error {
+    constructor(
+        message: string,
+        public traceId: string | undefined
+    ) {
+        super(message)
+        Object.setPrototypeOf(this, AuthError.prototype)
+    }
+}
+
+export function isAuthError(error: Error): error is AuthError {
+    return error instanceof AuthError
+}

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,7 +1,12 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
-import { isAbortError, isNetworkError, isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import {
+    isAbortError,
+    isAuthError,
+    isNetworkError,
+    isRateLimitError,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { logEvent } from '../services/EventLogger'
@@ -290,7 +295,7 @@ function lineAndCharCount({ insertText }: InlineCompletionItem): { lineCount: nu
 const TEN_MINUTES = 1000 * 60 * 10
 const errorCounts: Map<string, number> = new Map()
 export function logError(error: Error): void {
-    if (isAbortError(error) || isRateLimitError(error)) {
+    if (isAbortError(error) || isRateLimitError(error) || isAuthError(error)) {
         return
     }
 


### PR DESCRIPTION
## Context

- Do not report auth errors ([467k reports in a couple of weeks](https://sourcegraph.sentry.io/issues/4448742691/?query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=0)) from completion generation to Sentry to reduce the volume of reported events.
- [Slack discussion](https://sourcegraph.slack.com/archives/C05AGQYD528/p1694556997905489)
- TODO follow-up https://github.com/sourcegraph/cody/issues/1027

## Test plan

1. Sign in to sourcegraph.com.
2. Drop the token via the DotCom interface.
3. Generate a completion.
4. Ensure that the `not authenticated` error is not reported to Sentry.
