### PR TITLE
Autocomplete: do not report some network errors to Sentry

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -21,7 +21,7 @@ export class TracedError extends Error {
         public traceId: string | undefined
     ) {
         super(message)
-        Object.setPrototypeOf(this, NetworkError.prototype)
+        Object.setPrototypeOf(this, TracedError.prototype)
     }
 }
 

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -36,3 +36,17 @@ export function isAbortError(error: Error): boolean {
         error.message.includes('The user aborted a request')
     )
 }
+
+export class AuthError extends Error {
+    constructor(
+        message: string,
+        public traceId: string | undefined
+    ) {
+        super(message)
+        Object.setPrototypeOf(this, AuthError.prototype)
+    }
+}
+
+export function isAuthError(error: Error): error is AuthError {
+    return error instanceof AuthError
+}

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -7,7 +7,6 @@ export class RateLimitError extends Error {
         public retryAfter?: Date
     ) {
         super(message)
-        Object.setPrototypeOf(this, RateLimitError.prototype)
     }
 }
 
@@ -21,7 +20,6 @@ export class TracedError extends Error {
         public traceId: string | undefined
     ) {
         super(message)
-        Object.setPrototypeOf(this, TracedError.prototype)
     }
 }
 
@@ -38,7 +36,6 @@ export class NetworkError extends Error {
     ) {
         super(`Request to ${response.url} failed with ${response.status}: ${response.statusText}`)
         this.status = response.status
-        Object.setPrototypeOf(this, NetworkError.prototype)
     }
 }
 

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -98,12 +98,6 @@ export function createClient(
                 throw new TracedError('No response body', traceId)
             }
 
-            // Terminate early and do not report this error to Sentry if a request is unauthenticated.
-            if (response.status === 401) {
-                const result = await response.text()
-                throw new AuthError(result, traceId)
-            }
-
             // For backward compatibility, we have to check if the response is an SSE stream or a
             // regular JSON payload. This ensures that the request also works against older backends
             const isStreamingResponse = response.headers.get('content-type') === 'text/event-stream'

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,7 +1,12 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
-import { isAbortError, isNetworkError, isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import {
+    isAbortError,
+    isAuthError,
+    isNetworkError,
+    isRateLimitError,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { logEvent } from '../services/EventLogger'
@@ -290,7 +295,7 @@ function lineAndCharCount({ insertText }: InlineCompletionItem): { lineCount: nu
 const TEN_MINUTES = 1000 * 60 * 10
 const errorCounts: Map<string, number> = new Map()
 export function logError(error: Error): void {
-    if (isAbortError(error) || isRateLimitError(error)) {
+    if (isAbortError(error) || isRateLimitError(error) || isAuthError(error)) {
         return
     }
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,16 +1,11 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 
-import {
-    isAbortError,
-    isAuthError,
-    isNetworkError,
-    isRateLimitError,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { isNetworkError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { logEvent } from '../services/EventLogger'
-import { captureException } from '../services/sentry/sentry'
+import { captureException, shouldErrorBeReported } from '../services/sentry/sentry'
 
 import { ContextSummary } from './context/context'
 import * as statistics from './statistics'
@@ -295,7 +290,7 @@ function lineAndCharCount({ insertText }: InlineCompletionItem): { lineCount: nu
 const TEN_MINUTES = 1000 * 60 * 10
 const errorCounts: Map<string, number> = new Map()
 export function logError(error: Error): void {
-    if (isAbortError(error) || isRateLimitError(error) || isAuthError(error)) {
+    if (!shouldErrorBeReported(error)) {
         return
     }
 

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -30,6 +30,9 @@ export abstract class SentryService {
     private prepareReconfigure(): void {
         try {
             const isProd = process.env.NODE_ENV === 'production'
+            // Used to enable Sentry reporting in the development environment.
+            const isSentryEnabled = process.env.ENABLE_SENTRY === 'true'
+
             const options: SentryOptions = {
                 dsn: SENTRY_DSN,
                 release: extensionDetails.version,
@@ -45,7 +48,7 @@ export abstract class SentryService {
                 // Only send errors when connected to dotcom in the production build.
                 beforeSend: (event, hint) => {
                     if (
-                        isProd &&
+                        (isProd || isSentryEnabled) &&
                         isDotCom(this.config.serverEndpoint) &&
                         shouldErrorBeReported(hint.originalException)
                     ) {


### PR DESCRIPTION
## Context

- This PR makes our error reporting rules more strict on top of https://github.com/sourcegraph/cody/pull/1028 by omitting network errors with a network status >= 500. The assumption is that these errors are already monitored on the backend.
- Filtering logic is moved right into the Sentry's `beforeSend` hook to ensure we do not accidentally report these types of errors from another `captureException` call site.
- A separate `NetworkError` class is added in addition to the `TracedError` to distinguish between transport-level and application logic errors. 
- Disabled Sentry error reporting for non-production environments + introduced an environment variable to enable it for local debugging.
- Addresses the third most reported Sentry error `read ECONNRESET` ([292k events](https://sourcegraph.sentry.io/issues/4448881794/?query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=2)). It should help us to keep the volume of reported errors under control.

## Test plan

Tested locally.
