### PR TITLE
VS Code: remove sign-out menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,6 +19,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Remove `starter` and `premade` fields from the configuration files for custom commands (cody.json). [pull/939](https://github.com/sourcegraph/cody/pull/939)
 - Enabled streaming responses for all autocomplete requests. [pull/995](https://github.com/sourcegraph/cody/pull/995)
+- Sign out immediately instead of showing the quick-pick menu. [pull/1032](https://github.com/sourcegraph/cody/pull/1032)
 
 ## [0.10.1]
 

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -149,16 +149,14 @@ export class AuthProvider {
         await vscode.env.openExternal(vscode.Uri.parse(uri))
     }
 
-    // Display quickpick to select endpoint to sign out of
     public async signoutMenu(): Promise<void> {
         this.telemetryService.log('CodyVSCodeExtension:logout:clicked')
-        const endpointQuickPickItem = this.authStatus.endpoint ? [this.authStatus.endpoint] : []
-        const endpoint = await AuthMenu('signout', endpointQuickPickItem)
-        if (!endpoint?.uri) {
-            return
+        const { endpoint } = this.authStatus
+
+        if (endpoint) {
+            await this.signout(endpoint)
+            logDebug('AuthProvider:signoutMenu', endpoint)
         }
-        await this.signout(endpoint.uri)
-        logDebug('AuthProvider:signoutMenu', endpoint.uri)
     }
 
     // Log user out of the selected endpoint (remove token from secret)


### PR DESCRIPTION
## Context

- Sign out immediately instead of showing the quick-pick menu.
- [Slack discussion](https://sourcegraph.slack.com/archives/C05AGQYD528/p1694569149605279)

## Test plan

Signed-out locally.
