### PR TITLE
[Cody Web] fix typewriter err handling and closing

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-shared",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Cody shared library",
   "license": "Apache-2.0",
   "repository": {

--- a/lib/shared/src/chat/useClient.ts
+++ b/lib/shared/src/chat/useClient.ts
@@ -351,16 +351,27 @@ export const useClient = ({
                 const abort = chatClient.chat(prompt, {
                     onChange(content) {
                         if (transcript.id !== transcriptIdRef.current) {
+                            typewriter.close()
                             typewriter.stop()
                             abort()
                             resolve(transcript)
                             return
                         }
 
-                        typewriter.update(content)
+                        try {
+                            typewriter.update(content)
+                        } catch (error: any) {
+                            console.error(`Error while updating typewriter: ${error}`)
+
+                            typewriter.close()
+                            typewriter.stop()
+                            abort()
+                            resolve(transcript)
+                        }
                     },
                     onComplete() {
                         if (transcript.id !== transcriptIdRef.current) {
+                            typewriter.close()
                             typewriter.stop()
                             abort()
                             resolve(transcript)
@@ -376,10 +387,14 @@ export const useClient = ({
                         onEvent?.('error')
 
                         typewriter.close()
+                        typewriter.stop()
+                        abort()
+                        resolve(transcript)
                     },
                 })
 
                 setAbortMessageInProgress(() => () => {
+                    typewriter.close()
                     typewriter.stop()
                     abort()
                     resolve(transcript)

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -45,13 +45,23 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
                 }
             },
             onmessage: message => {
-                const data: Event = { ...JSON.parse(message.data), type: message.event }
-                this.sendEvents([data], cb)
+                try {
+                    const data: Event = { ...JSON.parse(message.data), type: message.event }
+                    this.sendEvents([data], cb)
+                } catch (error: any) {
+                    cb.onError(error.message)
+                    abort.abort()
+                    console.error(error)
+                    // throw the error for not retrying
+                    throw error
+                }
             },
             onerror(error) {
                 cb.onError(error.message)
                 abort.abort()
                 console.error(error)
+                // throw the error for not retrying
+                throw error
             },
         }).catch(error => {
             cb.onError(error.message)


### PR DESCRIPTION
- Typewriter needs to be closed before stopping. 
- Need to catch error while updating typewriter.
- Stop retrying for fetchEventSource

Slack:
https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1694529000641279
https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1694466882019489

## Test plan

- Submit a chat message on /cody
- Go to network tab, search for `stream` XHR request and block it
- There should be a network request failed message in the chat
- But no infinite retries.
