### PR TITLE
Simplified onboarding experiment assignment and logging

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Added a completion statistics summary to the autocomplete trace view. [pull/973](https://github.com/sourcegraph/cody/pull/973)
 - Add experimental option `claude-instant-infill` to the `cody.autocomplete.advanced.model` config option that enables users using the Claude Instant model to get suggestions with context awareness (infill). [pull/974](https://github.com/sourcegraph/cody/pull/974)
 - New `cody.chat.preInstruction` configuration option for adding custom message at the start of all chat messages sent to Cody. Extension reload required. [pull/963](https://github.com/sourcegraph/cody/pull/963)
+- Add a simplified sign-in. 50% of people will see these new sign-in buttons. [pull/1036](https://github.com/sourcegraph/cody/pull/1036)
 
 ### Fixed
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -6,6 +6,7 @@ import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat
 import { View } from '../../webviews/NavBar'
 import { logDebug } from '../log'
 import { AuthProviderSimplified } from '../services/AuthProviderSimplified'
+import * as OnboardingExperiment from '../services/OnboardingExperiment'
 
 import { MessageProvider, MessageProviderOptions } from './MessageProvider'
 import { ExtensionMessage, WebviewMessage } from './protocol'
@@ -70,6 +71,10 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
                     const authProviderSimplified = new AuthProviderSimplified()
                     const authMethod = message.authMethod || 'dotcom'
                     void authProviderSimplified.openExternalAuthUrl(this.authProvider, authMethod)
+                    break
+                }
+                if (message.type === 'simplified-onboarding-exposure') {
+                    await OnboardingExperiment.logExposure()
                     break
                 }
                 // cody.auth.signin or cody.auth.signout

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -19,10 +19,11 @@ import { logDebug } from '../log'
 import { getRerankWithLog } from '../logged-rerank'
 import { repositoryRemoteUrl } from '../repository/repositoryHelpers'
 import { AuthProvider } from '../services/AuthProvider'
+import * as OnboardingExperiment from '../services/OnboardingExperiment'
 
 import { ChatViewProviderWebview } from './ChatViewProvider'
 import { GraphContextProvider } from './GraphContextProvider'
-import { ConfigurationSubsetForWebview, LocalEnv, OnboardingExperimentArm } from './protocol'
+import { ConfigurationSubsetForWebview, LocalEnv } from './protocol'
 
 export type Config = Pick<
     ConfigurationWithAccessToken,
@@ -206,7 +207,7 @@ export class ContextProvider implements vscode.Disposable {
                 ...localProcess,
                 debugEnable: this.config.debugEnable,
                 serverEndpoint: this.config.serverEndpoint,
-                experimentOnboarding: pickOnboardingExperimentArm(),
+                experimentOnboarding: OnboardingExperiment.pickArm(this.telemetryService),
             }
 
             // update codebase context on configuration change
@@ -287,13 +288,4 @@ export async function getCodebaseContext(
         undefined,
         getRerankWithLog(chatClient)
     )
-}
-
-export function pickOnboardingExperimentArm(): OnboardingExperimentArm {
-    // TODO(dpc): Actually pick, and cache, experiment arm selection.
-    // Integrate this cache with user settings, etc. but discourage editing.
-    const config = vscode.workspace.getConfiguration()
-    return config.has('cody.todo-internal-onboarding-qa')
-        ? OnboardingExperimentArm.Simplified
-        : OnboardingExperimentArm.Classic
 }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -19,11 +19,10 @@ import { logDebug } from '../log'
 import { getRerankWithLog } from '../logged-rerank'
 import { repositoryRemoteUrl } from '../repository/repositoryHelpers'
 import { AuthProvider } from '../services/AuthProvider'
-import { OnboardingExperimentArm } from '../services/OnboardingExperiment'
 
 import { ChatViewProviderWebview } from './ChatViewProvider'
 import { GraphContextProvider } from './GraphContextProvider'
-import { ConfigurationSubsetForWebview, LocalEnv } from './protocol'
+import { ConfigurationSubsetForWebview, LocalEnv, OnboardingExperimentArm } from './protocol'
 
 export type Config = Pick<
     ConfigurationWithAccessToken,

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -34,7 +34,14 @@ export type WebviewMessage =
     | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string }
     | {
           command: 'auth'
-          type: 'signin' | 'signout' | 'support' | 'app' | 'callback' | 'simplified-onboarding'
+          type:
+              | 'signin'
+              | 'signout'
+              | 'support'
+              | 'app'
+              | 'callback'
+              | 'simplified-onboarding'
+              | 'simplified-onboarding-exposure'
           endpoint?: string
           value?: string
           authMethod?: AuthMethod
@@ -189,7 +196,12 @@ export function archConvertor(arch: string): string {
 export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
 
 export enum OnboardingExperimentArm {
-    Classic, // Control
-    Simplified, // Treatment: simplified onboarding flow
-    Default = Classic,
+    // Note, these values are persisted to local storage, see pickArm. Do not
+    // change these values. Adding values is OK but don't delete them.
+    Classic = 0, // Control
+    Simplified = 1, // Treatment: simplified onboarding flow
+
+    MinValue = Classic,
+    // Update this when adding an arm to the trial.
+    MaxValue = Simplified,
 }

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -7,7 +7,6 @@ import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegra
 import type { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 
 import { View } from '../../webviews/NavBar'
-import { AuthMethod, OnboardingExperimentArm } from '../services/OnboardingExperiment'
 
 /**
  * A message sent from the webview to the extension host.
@@ -183,4 +182,14 @@ export function archConvertor(arch: string): string {
             return 'x86_64'
     }
     return arch
+}
+
+// Simplified Onboarding types which are shared between WebView and extension.
+
+export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
+
+export enum OnboardingExperimentArm {
+    Classic, // Control
+    Simplified, // Treatment: simplified onboarding flow
+    Default = Classic,
 }

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode'
 
 import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
+import { AuthMethod } from '../chat/protocol'
+
 import { AuthProvider } from './AuthProvider'
-import { AuthMethod } from './OnboardingExperiment'
 
 // An auth provider for simplified onboarding. This is a sidecar to AuthProvider
 // so we can deprecate the experiment later. AuthProviderSimplified only works

--- a/vscode/src/services/OnboardingExperiment.test.ts
+++ b/vscode/src/services/OnboardingExperiment.test.ts
@@ -50,6 +50,7 @@ describe('OnboardingExperiment', () => {
     })
 
     it('caches arms on exposure, not when picking them', async () => {
+        const random = vi.spyOn(global.Math, 'random').mockReturnValueOnce(2)
         const set = vi.spyOn(localStorage, 'set')
         OnboardingExperiment.pickArm(mockTelemetry)
         expect(set).not.toHaveBeenCalled()
@@ -65,7 +66,7 @@ describe('OnboardingExperiment', () => {
         expect(random).toBeCalled()
 
         OnboardingExperiment.resetForTesting()
-        random.mockReturnValueOnce(0)
+        random.mockReturnValueOnce(2)
         expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(OnboardingExperimentArm.Classic)
     })
 

--- a/vscode/src/services/OnboardingExperiment.test.ts
+++ b/vscode/src/services/OnboardingExperiment.test.ts
@@ -12,6 +12,13 @@ vi.mock('../log', mockLog)
 
 function mockVScode() {
     return {
+        UIKind: {
+            Desktop: 1,
+            Web: 42,
+        },
+        env: {
+            uiKind: 1, // Desktop
+        },
         workspace: {
             getConfiguration: () => ({
                 get: () => undefined,

--- a/vscode/src/services/OnboardingExperiment.test.ts
+++ b/vscode/src/services/OnboardingExperiment.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as vscode from 'vscode'
+
+import { OnboardingExperimentArm } from '../chat/protocol'
+
+import { localStorage } from './LocalStorageProvider'
+import * as OnboardingExperiment from './OnboardingExperiment'
+
+vi.mock('vscode', mockVScode)
+vi.mock('./LocalStorageProvider', mockLocalStorage)
+vi.mock('../log', mockLog)
+
+function mockVScode() {
+    return {
+        workspace: {
+            getConfiguration: () => ({
+                has: () => false,
+                get: () => undefined,
+            }),
+        },
+    }
+}
+
+function mockLog() {
+    return {
+        logDebug: () => {},
+    }
+}
+
+function mockLocalStorage() {
+    return {
+        localStorage: {
+            get: () => null,
+            set: () => {},
+        },
+    }
+}
+
+describe('OnboardingExperiment', () => {
+    const mockTelemetry = {
+        log: vi.fn(),
+    }
+
+    beforeEach(() => {
+        OnboardingExperiment.resetForTesting()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('caches arms on exposure, not when picking them', async () => {
+        const set = vi.spyOn(localStorage, 'set')
+        OnboardingExperiment.pickArm(mockTelemetry)
+        expect(set).not.toHaveBeenCalled()
+        await OnboardingExperiment.logExposure()
+        expect(set).toHaveBeenCalledWith('experiment.onboarding', '{"arm":0,"excludeFromExperiment":false}')
+    })
+
+    it('randomly assigns arms', () => {
+        // The treatment arm has 0 allocation now, so return a number less than
+        // zero.
+        const random = vi.spyOn(global.Math, 'random').mockReturnValueOnce(-1)
+        expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(OnboardingExperimentArm.Simplified)
+        expect(random).toBeCalled()
+
+        OnboardingExperiment.resetForTesting()
+        random.mockReturnValueOnce(0)
+        expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(OnboardingExperimentArm.Classic)
+    })
+
+    it('caches the arm in memory once picked', () => {
+        const localStorageGet = vi.spyOn(localStorage, 'get')
+        const random = vi.spyOn(global.Math, 'random')
+        const arm = OnboardingExperiment.pickArm(mockTelemetry)
+        expect(localStorageGet).toBeCalled()
+        expect(random).toBeCalled()
+
+        localStorageGet.mockReset()
+        random.mockReset()
+        expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(arm)
+        expect(localStorageGet).not.toBeCalled()
+        expect(random).not.toBeCalled()
+    })
+
+    it('logs exposures', async () => {
+        vi.spyOn(global.Math, 'random').mockReturnValueOnce(-1)
+        expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(OnboardingExperimentArm.Simplified)
+        const log = vi.spyOn(mockTelemetry, 'log')
+        await OnboardingExperiment.logExposure()
+        expect(log).toHaveBeenCalledWith('CodyVSCodeExtension:experiment:simplifiedOnboarding:exposed', {
+            arm: 'treatment',
+            excludeFromExperiment: false,
+        })
+    })
+
+    it('defers to arms cached in local storage', async () => {
+        const localStorageGet = vi.spyOn(localStorage, 'get').mockReturnValue('{"arm":0,"excludeFromExperiment":true}')
+        const random = vi.spyOn(global.Math, 'random')
+        expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(OnboardingExperimentArm.Classic)
+        expect(localStorageGet).toBeCalled()
+        expect(random).not.toBeCalled()
+
+        const log = vi.spyOn(mockTelemetry, 'log')
+        await OnboardingExperiment.logExposure()
+        expect(log).toHaveBeenCalledWith('CodyVSCodeExtension:experiment:simplifiedOnboarding:exposed', {
+            arm: 'control',
+            excludeFromExperiment: true,
+        })
+    })
+
+    it('can be overridden with a config parameter, override exposures are not logged', async () => {
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+            has: (key: string) => key === 'testing.simplified-onboarding',
+        } as unknown as vscode.WorkspaceConfiguration)
+        const localStorageGet = vi.spyOn(localStorage, 'get')
+        const random = vi.spyOn(global.Math, 'random')
+        expect(OnboardingExperiment.pickArm(mockTelemetry)).toBe(OnboardingExperimentArm.Simplified)
+        expect(localStorageGet).not.toBeCalled()
+        expect(random).not.toBeCalled()
+
+        const log = vi.spyOn(mockTelemetry, 'log')
+        await OnboardingExperiment.logExposure()
+        expect(log).not.toBeCalled()
+    })
+})

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -32,8 +32,13 @@ let selection: SelectedArm | undefined
 // undocumented configuration property. Use this for testing and development.
 function loadOverrideSelection(): SelectedArm | undefined {
     const config = vscode.workspace.getConfiguration()
-    return config.has('testing.simplified-onboarding')
-        ? { arm: OnboardingExperimentArm.Simplified, excludeFromExperiment: true, setByTestingOverride: true }
+    const override = config.get('testing.simplified-onboarding')
+    return typeof override === 'boolean'
+        ? {
+              arm: override ? OnboardingExperimentArm.Simplified : OnboardingExperimentArm.Classic,
+              excludeFromExperiment: true,
+              setByTestingOverride: true,
+          }
         : undefined
 }
 

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -1,1 +1,150 @@
-// TODO: Something here.
+import * as vscode from 'vscode'
+
+import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+
+import { OnboardingExperimentArm } from '../chat/protocol'
+import { logDebug } from '../log'
+
+import { localStorage } from './LocalStorageProvider'
+
+// The fraction of users to allocate to the simplified onboarding treatment.
+// This should be between 0 (no users) and 1 (all users).
+const SIMPLIFIED_ARM_ALLOCATION = 0
+
+const ONBOARDING_EXPERIMENT_STORAGE_KEY = 'experiment.onboarding'
+
+interface SelectedArm {
+    // Which arm has been selected
+    arm: OnboardingExperimentArm
+    // If a user manually overrides the onboarding experiment arm, or storage is
+    // corrupt, this flag is set and transmitted with logs so they can be
+    // excluded from experiment results.
+    excludeFromExperiment: boolean
+    // If a user uses the override for testing, we don't persist the selection
+    // to local storage
+    setByTestingOverride: boolean
+}
+
+let telemetryService: TelemetryService | undefined
+let selection: SelectedArm | undefined
+
+// Tries to load an override for the onboarding experiment arm based on an
+// undocumented configuration property. Use this for testing and development.
+function loadOverrideSelection(): SelectedArm | undefined {
+    const config = vscode.workspace.getConfiguration()
+    return config.has('testing.simplified-onboarding')
+        ? { arm: OnboardingExperimentArm.Simplified, excludeFromExperiment: true, setByTestingOverride: true }
+        : undefined
+}
+
+// Loads the previously selected arm from storage. If storage is present but
+// corrupt, returns an error.
+function loadCachedSelection(): SelectedArm | Error | undefined {
+    const storedSpec = localStorage.get(ONBOARDING_EXPERIMENT_STORAGE_KEY)
+    if (!storedSpec) {
+        return undefined
+    }
+    let arm
+    let excludeFromExperiment
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const store = JSON.parse(storedSpec)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        arm = store?.arm
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        excludeFromExperiment = !!store?.excludeFromExperiment
+    } catch {
+        // Storage is corrupt because it is not valid JSON.
+        return new Error(`storage present but not JSON: ${storedSpec}`)
+    }
+    if (typeof arm === 'number' && OnboardingExperimentArm.MinValue <= arm && arm <= OnboardingExperimentArm.MaxValue) {
+        return {
+            arm,
+            excludeFromExperiment,
+            setByTestingOverride: false,
+        }
+    }
+    // Storage is corrupt: it is JSON but properties aren't what we expect
+    return new Error(`storage present but properties invalid: ${storedSpec}`)
+}
+
+// Picks a new selection but does not cache it to local storage. We cache on
+// exposure so unexposed users can be allocated if experiment weights change
+// in later versions.
+function pickSelection(excludeFromExperiment: boolean): SelectedArm {
+    const arm =
+        Math.random() < SIMPLIFIED_ARM_ALLOCATION ? OnboardingExperimentArm.Simplified : OnboardingExperimentArm.Classic
+    return { arm, excludeFromExperiment, setByTestingOverride: false }
+}
+
+// Cache the current selection to local storage. Selections because of a manual
+// override for testing are not cached.
+async function cacheSelection(): Promise<void> {
+    if (selection === undefined) {
+        throw new Error('tried to cache selection before picking')
+    }
+    if (selection.setByTestingOverride) {
+        // Don't cache these so QA can remove the test override property and
+        // go back to a typical product configuration.
+        logDebug('simplified-onboarding', 'not caching experiment arm selected by testing override')
+        return
+    }
+    await localStorage.set(
+        ONBOARDING_EXPERIMENT_STORAGE_KEY,
+        JSON.stringify({ arm: selection.arm, excludeFromExperiment: selection.excludeFromExperiment })
+    )
+}
+
+export function pickArm(useThisTelemetryService: TelemetryService): OnboardingExperimentArm {
+    telemetryService = useThisTelemetryService
+
+    // Try to apply an override for testing.
+    const overrideSelection = loadOverrideSelection()
+    if (overrideSelection) {
+        logDebug('simplified-onboarding', 'user override onboarding experiment arm selection', overrideSelection)
+        selection = overrideSelection
+        return overrideSelection.arm
+    }
+
+    // `pickArm` is called repeatedly so we memoize the result. Return the
+    // arm cached in memory, if present.
+    if (selection?.arm !== undefined) {
+        return selection.arm
+    }
+
+    // Try to load an earlier selection from storage.
+    const cachedSelection = loadCachedSelection()
+    if (cachedSelection && !(cachedSelection instanceof Error)) {
+        logDebug('simplified-onboarding', 'using cached onboarding experiment arm selection', cachedSelection)
+        selection = cachedSelection
+        return selection.arm
+    }
+
+    if (cachedSelection instanceof Error) {
+        logDebug('simplified-onboarding', 'error loading cached selection', cachedSelection)
+    }
+
+    // This is the first time we are picking an arm. Pick randomly.
+    selection = pickSelection(cachedSelection instanceof Error)
+    logDebug('simplified-onboarding', 'picked new onboarding experiment arm selection', selection)
+    return selection.arm
+}
+
+export async function logExposure(): Promise<void> {
+    if (selection?.setByTestingOverride) {
+        logDebug('simplified-onboarding', 'not logging exposure for testing override selection')
+        return
+    }
+    await Promise.all([
+        telemetryService?.log('CodyVSCodeExtension:experiment:simplifiedOnboarding:exposed', {
+            arm: selection?.arm === OnboardingExperimentArm.Simplified ? 'treatment' : 'control',
+            excludeFromExperiment: selection?.excludeFromExperiment,
+        }),
+        cacheSelection(),
+    ])
+}
+
+export function resetForTesting(): void {
+    telemetryService = undefined
+    selection = undefined
+}

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -9,7 +9,7 @@ import { localStorage } from './LocalStorageProvider'
 
 // The fraction of users to allocate to the simplified onboarding treatment.
 // This should be between 0 (no users) and 1 (all users).
-const SIMPLIFIED_ARM_ALLOCATION = 0
+const SIMPLIFIED_ARM_ALLOCATION = 0.5
 
 const ONBOARDING_EXPERIMENT_STORAGE_KEY = 'experiment.onboarding'
 

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -25,6 +25,8 @@ interface SelectedArm {
     setByTestingOverride: boolean
 }
 
+// TODO(dpc): Refactor TelemetryService to be a globalton like the other
+// services, instead of catching one that's passed around.
 let telemetryService: TelemetryService | undefined
 let selection: SelectedArm | undefined
 
@@ -109,11 +111,6 @@ export function pickArm(useThisTelemetryService: TelemetryService): OnboardingEx
     // Try to apply an override for testing.
     const overrideSelection = loadOverrideSelection()
     if (overrideSelection) {
-        logDebug(
-            'simplified-onboarding',
-            'user override onboarding experiment arm selection',
-            JSON.stringify(overrideSelection)
-        )
         selection = overrideSelection
         return overrideSelection.arm
     }

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -1,7 +1,1 @@
-export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
-
-export enum OnboardingExperimentArm {
-    Classic,
-    Simplified,
-    Default = Classic,
-}
+// TODO: Something here.

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -77,6 +77,9 @@ function loadCachedSelection(): SelectedArm | Error | undefined {
 // exposure so unexposed users can be allocated if experiment weights change
 // in later versions.
 function pickSelection(excludeFromExperiment: boolean): SelectedArm {
+    if (vscode.env.uiKind === vscode.UIKind.Web) {
+        return { arm: OnboardingExperimentArm.Classic, excludeFromExperiment: true, setByTestingOverride: false }
+    }
     const arm =
         Math.random() < SIMPLIFIED_ARM_ALLOCATION ? OnboardingExperimentArm.Simplified : OnboardingExperimentArm.Classic
     return { arm, excludeFromExperiment, setByTestingOverride: false }

--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -101,7 +101,11 @@ export function pickArm(useThisTelemetryService: TelemetryService): OnboardingEx
     // Try to apply an override for testing.
     const overrideSelection = loadOverrideSelection()
     if (overrideSelection) {
-        logDebug('simplified-onboarding', 'user override onboarding experiment arm selection', overrideSelection)
+        logDebug(
+            'simplified-onboarding',
+            'user override onboarding experiment arm selection',
+            JSON.stringify(overrideSelection)
+        )
         selection = overrideSelection
         return overrideSelection.arm
     }
@@ -115,7 +119,11 @@ export function pickArm(useThisTelemetryService: TelemetryService): OnboardingEx
     // Try to load an earlier selection from storage.
     const cachedSelection = loadCachedSelection()
     if (cachedSelection && !(cachedSelection instanceof Error)) {
-        logDebug('simplified-onboarding', 'using cached onboarding experiment arm selection', cachedSelection)
+        logDebug(
+            'simplified-onboarding',
+            'using cached onboarding experiment arm selection',
+            JSON.stringify(cachedSelection)
+        )
         selection = cachedSelection
         return selection.arm
     }
@@ -126,7 +134,7 @@ export function pickArm(useThisTelemetryService: TelemetryService): OnboardingEx
 
     // This is the first time we are picking an arm. Pick randomly.
     selection = pickSelection(cachedSelection instanceof Error)
-    logDebug('simplified-onboarding', 'picked new onboarding experiment arm selection', selection)
+    logDebug('simplified-onboarding', 'picked new onboarding experiment arm selection', JSON.stringify(selection))
     return selection.arm
 }
 

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -134,6 +134,7 @@ export async function buildWorkSpaceSettings(workspaceDirectory: string): Promis
         'cody.serverEndpoint': 'http://localhost:49300',
         'cody.experimental.commandLenses': true,
         'cody.experimental.editorTitleCommandIcon': true,
+        'testing.simplified-onboarding': false,
     }
     // create a temporary directory with settings.json and add to the workspaceDirectory
     const workspaceSettingsPath = path.join(workspaceDirectory, '.vscode', 'settings.json')

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react'
 
-import { defaultAuthStatus } from '../src/chat/protocol'
-import { OnboardingExperimentArm } from '../src/services/OnboardingExperiment'
+import { defaultAuthStatus, OnboardingExperimentArm } from '../src/chat/protocol'
 
 import { App } from './App'
 import { VSCodeStoryDecorator } from './storybook/VSCodeStoryDecorator'

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -41,7 +41,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 hasAppJson: false,
                 uiKindIsWeb: false,
                 extensionVersion: '0.0.0',
-                experimentOnboarding: OnboardingExperimentArm.Default,
+                experimentOnboarding: OnboardingExperimentArm.Classic,
             },
             authStatus: {
                 ...defaultAuthStatus,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -7,8 +7,14 @@ import { CodyPrompt } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { ChatHistory, ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 
-import { AuthStatus, defaultAuthStatus, Experiments, LocalEnv } from '../src/chat/protocol'
-import { AuthMethod, OnboardingExperimentArm } from '../src/services/OnboardingExperiment'
+import {
+    AuthMethod,
+    AuthStatus,
+    defaultAuthStatus,
+    Experiments,
+    LocalEnv,
+    OnboardingExperimentArm,
+} from '../src/chat/protocol'
 
 import { Chat } from './Chat'
 import { LoadingPage } from './LoadingPage'

--- a/vscode/webviews/Login.tsx
+++ b/vscode/webviews/Login.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
@@ -54,6 +56,12 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     isAppRunning = false,
     onLoginRedirect,
 }) => {
+    useEffect(() => {
+        // Log that the user was exposed to the control arm of the simplified
+        // onboarding experiment.
+        vscodeAPI.postMessage({ command: 'auth', type: 'simplified-onboarding-exposure' })
+    }, [vscodeAPI])
+
     const isOSSupported = isOsSupportedByApp(appOS, appArch)
 
     const title = isAppInstalled ? (isAppRunning ? 'Connect with Cody App' : 'Cody App Not Running') : 'Get Started'
@@ -106,6 +114,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
         isInstalled: endpoint === LOCAL_APP_URL.href && isAppInstalled,
         isRunning: isAppRunning,
     }
+
     return (
         <div className={styles.container}>
             {authStatus && <ErrorContainer authStatus={authStatus} isApp={isApp} endpoint={endpoint} />}

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 
-import { AuthMethod } from '../src/services/OnboardingExperiment'
+import { AuthMethod } from '../src/chat/protocol'
 
 import onboardingSplashImage from './cody-onboarding-splash.svg'
 import signInLogoGitHub from './sign-in-logo-github.svg'

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
@@ -30,6 +32,9 @@ export const LoginSimplified: React.FunctionComponent<React.PropsWithoutRef<Logi
         telemetryService.log('CodyVSCodeExtension:auth:clickOtherSignInOptions')
         vscodeAPI.postMessage({ command: 'auth', type: 'signin' })
     }
+    useEffect(() => {
+        vscodeAPI.postMessage({ command: 'auth', type: 'simplified-onboarding-exposure' })
+    }, [vscodeAPI])
     return (
         <div className={styles.container}>
             <div className={styles.sectionsContainer}>


### PR DESCRIPTION
Users are randomly assigned to get the classic onboarding experience ('control') or a simplified onboarding experience without app setup ('treatment'.) This allocation is hard-coded in the extension; if we want a different rollout we need to update the extension.

Once we render the login component, we consider the user has been exposed to a specific arm of the trial and we cache this fact in local storage.

Currently fixes the rollout at 0.5 so people running main will get exposed to the experiment. We can bump `SIMPLIFIED_ARM_ALLOCATION` back to zero if we want to hold back the experiment.

Testers can set a boolean property, `testing.simplified-onboarding`, to force the extension to display the treatment (true) or control (false) arm of the trial.

Part of #632 

## Test plan

Automated test:

```
pnpm test:unit # new tests for experiment arm assigment, caching
pnpm test:e2e && pnpm test:integration # hard-coded to use the classic onboarding
# e2e tests for the new login flow TBD
```

Manual test:

1. Cody, ... menu, Sign out, sign out.
2. Control ("Other Sign in Options..." etc.) login should appear.
3. Open the VScode Output pane and change the dropdown to Cody by Sourcegraph. This log message should appear:

```
logEvent (telemetry disabled): CodyVSCodeExtension:experiment:simplifiedOnboarding:exposed {"arm":"control","excludeFromExperiment":false}
```

4. Verify that login, etc. works.
5. Preferences: Open User Settings JSON. Add a key `"testing.simplified-onboarding": true`. Reload VScode.
6. New login experience should appear.
7. VScode Output pane, this log message should appear:

```
simplified-onboarding: not logging exposure for testing override selection
``` 

8. Verify login works.