### PR TITLE
Autocomplete: Use <filename> token in StarCoder prompt

### DIFF
--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -53,7 +53,9 @@ export class UnstableFireworksProvider extends Provider {
         let prompt = ''
 
         const languageConfig = getLanguageConfig(this.options.languageId)
-        if (languageConfig) {
+
+        // In StarCoder we have a special token to announce the path of the file
+        if (!isStarCoderFamily(this.model)) {
             intro.push(`Path: ${this.options.fileName}`)
         }
 
@@ -71,12 +73,17 @@ export class UnstableFireworksProvider extends Provider {
                 intro
                     .join('\n\n')
                     .split('\n')
-                    .map(line => (languageConfig ? languageConfig.commentStart + line : ''))
+                    .map(line => (languageConfig ? languageConfig.commentStart + line : '// '))
                     .join('\n') + '\n'
 
             const suffixAfterFirstNewline = getSuffixAfterFirstNewline(suffix)
 
-            const nextPrompt = this.createInfillingPrompt(introString, prefix, suffixAfterFirstNewline)
+            const nextPrompt = this.createInfillingPrompt(
+                this.options.fileName,
+                introString,
+                prefix,
+                suffixAfterFirstNewline
+            )
 
             if (nextPrompt.length >= maxPromptChars) {
                 return prompt
@@ -126,12 +133,13 @@ export class UnstableFireworksProvider extends Provider {
         return completions
     }
 
-    private createInfillingPrompt(intro: string, prefix: string, suffix: string): string {
-        if (this.model.startsWith('starcoder') || this.model.startsWith('wizardcoder')) {
-            // c.f. https://starcoder.co/bigcode/starcoder#fill-in-the-middle
-            return `<fim_prefix>${intro}${prefix}<fim_suffix>${suffix}<fim_middle>`
+    private createInfillingPrompt(filename: string, intro: string, prefix: string, suffix: string): string {
+        if (isStarCoderFamily(this.model)) {
+            // c.f. https://huggingface.co/bigcode/starcoder#fill-in-the-middle
+            // c.f. https://arxiv.org/pdf/2305.06161.pdf
+            return `<filename>${filename}<fim_prefix>${intro}${prefix}<fim_suffix>${suffix}<fim_middle>`
         }
-        if (this.model.startsWith('llama-code')) {
+        if (isLlamaCode(this.model)) {
             // c.f. https://github.com/facebookresearch/codellama/blob/main/llama/generation.py#L402
             return `<PRE> ${intro}${prefix} <SUF>${suffix} <MID>`
         }
@@ -190,10 +198,10 @@ export class UnstableFireworksProvider extends Provider {
     }
 
     private postProcess(content: string): string {
-        if (this.model.startsWith('starcoder') || this.model.startsWith('wizardcoder')) {
+        if (isStarCoderFamily(this.model)) {
             return content.replace(EOT_STARCODER, '')
         }
-        if (this.model.startsWith('llama-code')) {
+        if (isLlamaCode(this.model)) {
             return content.replace(EOT_LLAMA_CODE, '')
         }
         return content
@@ -236,4 +244,12 @@ function getSuffixAfterFirstNewline(suffix: string): string {
     }
 
     return suffix.slice(suffix.indexOf('\n'))
+}
+
+function isStarCoderFamily(model: string): boolean {
+    return model.startsWith('starcoder') || model.startsWith('wizardcoder')
+}
+
+function isLlamaCode(model: string): boolean {
+    return model.startsWith('llama-code')
 }


### PR DESCRIPTION
Fixes: #1037

Prevents some rare cases where the prompt leaks into the completion (c.f. #1037) by using the `<filename>` token to announce the filename instead of injecting a code comment into the prefix.

## Test plan

- Change the model to starcoder and provider to fireworks in the VS Code settings and be connected to dotcom, additionally enable graph context
- create a file `test.ts` and export a random function 
- create a second file `test.test.ts` and see what StarCoder wants you to import there and to test
- Observer that it's the right stuff

<img width="520" alt="Screenshot 2023-09-13 at 15 27 04" src="https://github.com/sourcegraph/cody/assets/458591/06ee20ca-37f0-4452-8ee7-c34ed1d0f210">
<img width="981" alt="Screenshot 2023-09-13 at 15 26 57" src="https://github.com/sourcegraph/cody/assets/458591/6ed96c31-4be0-4b6d-8c5a-427692159b1f">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
