### PR TITLE
Agent: add `graphql/getRepoIdIfEmbeddingExists`

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -224,6 +224,15 @@ export class Agent extends MessageHandler {
             return null
         })
 
+        this.registerRequest('graphql/getRepoIdIfEmbeddingExists', async ({ repoName }) => {
+            const client = await this.client
+            const result = await client?.graphqlClient.getRepoIdIfEmbeddingExists(repoName)
+            if (result instanceof Error) {
+                console.error('getRepoIdIfEmbeddingExists', result)
+            }
+            return typeof result === 'string' ? result : null
+        })
+
         this.registerNotification('autocomplete/clearLastCandidate', async () => {
             const provider = await vscode_shim.completionProvider
             if (!provider) {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -39,6 +39,7 @@ export type Requests = {
 
     'graphql/currentUserId': [null, string]
     'graphql/logEvent': [event, null]
+    'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
 
     // ================
     // Server -> Client


### PR DESCRIPTION
Previously, there was no way for clients to determine whether a repository had embeddings available. This PR closes the gap by adding a new request endpoint `graphql/getRepoIdIfEmbeddingExists`.

## Test plan

Tested with [IntelliJ](https://github.com/sourcegraph/sourcegraph/pull/56584)

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
