### PR TITLE
Autocomplete: Don't cull symbols that are defined in common import paths

### DIFF
--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -461,7 +461,7 @@ function hoverContextToSnippets(context: HoverContext): SymbolContextSnippet {
             : undefined
 
     return {
-        fileName: path.normalize(vscode.workspace.asRelativePath(URI.parse(context.uri).fsPath)),
+        fileName: path.normalize(vscode.workspace.asRelativePath(URI.parse(context.uri))),
         symbol: context.symbolName,
         sourceSymbolAndRelationship,
         content: context.content.join('\n').trim(),

--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -461,7 +461,7 @@ function hoverContextToSnippets(context: HoverContext): SymbolContextSnippet {
             : undefined
 
     return {
-        fileName: path.normalize(vscode.workspace.asRelativePath(URI.parse(context.uri))),
+        fileName: path.normalize(vscode.workspace.asRelativePath(URI.parse(context.uri).fsPath)),
         symbol: context.symbolName,
         sourceSymbolAndRelationship,
         content: context.content.join('\n').trim(),


### PR DESCRIPTION
This is a small regression from the last changes. We were only filtering out these common imports path when loading the files into the content map, however if the location of a symbol would end up being inside a common import, we would still include its hover tooltips. We would not have a symbol name then, though, because that would require us to read the ranges of these files which we haven't loaded.

So this PR filters out all locations in these ultra common imports 

## Test plan

### Before

<img width="1228" alt="Screenshot 2023-09-13 at 16 00 00" src="https://github.com/sourcegraph/cody/assets/458591/ade85f7c-5c9c-4c98-9458-5f98f469a19a">

### After

<img width="1298" alt="Screenshot 2023-09-13 at 15 59 39" src="https://github.com/sourcegraph/cody/assets/458591/6748cedd-4b4a-4522-8b48-809793be7ef0">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
