### PR TITLE
Intelligent Cody: Add additional Go heuristics

### DIFF
--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -358,7 +358,14 @@ const commonImportPaths = new Set([
     'libexec/src/',
 ])
 
-const isCommonImport = (uri: vscode.Uri): boolean => [...commonImportPaths].some(p => uri.fsPath.includes(p))
+function isCommonImport(uri: vscode.Uri): boolean {
+    for (const importPath of commonImportPaths) {
+        if (uri.fsPath.includes(importPath)) {
+            return true
+        }
+    }
+    return false
+}
 
 export const commonKeywords = new Set([...goKeywords, ...typescriptKeywords])
 

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -271,6 +271,13 @@ const goKeywords = new Set([
     'switch',
     'type',
     'var',
+
+    // common variables, types we don't need to follow
+    'ctx',
+    'Context',
+    'err',
+    'error',
+    'ok',
 ])
 
 const typescriptKeywords = new Set([

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -346,16 +346,12 @@ const commonImportPaths = new Set([
     'node_modules/@types/react/',
     'node_modules/@types/prop-types',
     'node_modules/next/',
+
+    // Go stdlib installation (covers Brew installs at a minimum)
+    'libexec/src/',
 ])
 
-function isCommonImport(uri: vscode.Uri): boolean {
-    for (const importPath of commonImportPaths) {
-        if (uri.fsPath.includes(importPath)) {
-            return true
-        }
-    }
-    return false
-}
+const isCommonImport = (uri: vscode.Uri): boolean => [...commonImportPaths].some(p => uri.fsPath.includes(p))
 
 export const commonKeywords = new Set([...goKeywords, ...typescriptKeywords])
 


### PR DESCRIPTION
Reduce noise by not returning context/error or libexec/src (Go stdlib) entries.

## Test plan

Manually ensured go stdlib paths are not passed back to the provider.