### PR TITLE
Autocomplete: trigger multiline completions on empty block only

### DIFF
--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -8,7 +8,7 @@ import {
 } from './text-processing'
 
 export function detectMultiline(
-    docContext: Omit<DocumentContext, 'multiline' | 'multilineTrigger'>,
+    docContext: Omit<DocumentContext, 'multilineTrigger'>,
     languageId: string,
     enableExtendedTriggers: boolean
 ): string | null {
@@ -32,7 +32,13 @@ export function detectMultiline(
     }
 
     const openingBracketMatch = currentLinePrefix.match(OPENING_BRACKET_REGEX)
-    if (enableExtendedTriggers && openingBracketMatch) {
+    if (
+        enableExtendedTriggers &&
+        openingBracketMatch &&
+        // Only trigger multiline suggestions when the next non-empty line is indented less
+        // than the block start line (the newly created block is empty).
+        indentation(currentLinePrefix) >= indentation(nextNonEmptyLine)
+    ) {
         return openingBracketMatch[0]
     }
 

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -1,3 +1,5 @@
+import { isEqual } from 'lodash'
+import { expect } from 'vitest'
 import { URI } from 'vscode-uri'
 
 import {
@@ -9,7 +11,7 @@ import { vsCodeMocks } from '../../testutils/mocks'
 import { CodeCompletionsClient } from '../client'
 import { getCurrentDocContext } from '../get-current-doc-context'
 import { getInlineCompletions as _getInlineCompletions, InlineCompletionsParams } from '../getInlineCompletions'
-import { createProviderConfig } from '../providers/anthropic'
+import { createProviderConfig, MULTI_LINE_STOP_SEQUENCES, SINGLE_LINE_STOP_SEQUENCES } from '../providers/anthropic'
 import { RequestManager } from '../request-manager'
 import { documentAndPosition } from '../test-helpers'
 
@@ -115,3 +117,32 @@ export async function getInlineCompletionsInsertText(
 }
 
 export type V = Awaited<ReturnType<typeof getInlineCompletions>>
+
+expect.extend({
+    /**
+     * Checks if `CompletionParameters[]` contains one item with single-line stop sequences.
+     */
+    toBeSingleLine(requests: CompletionParameters[], _) {
+        const { isNot } = this
+
+        return {
+            pass: requests.length === 1 && isEqual(requests[0]?.stopSequences, SINGLE_LINE_STOP_SEQUENCES),
+            message: () => `Completion requests are${isNot ? ' not' : ''} single-line`,
+            actual: requests.map(r => ({ stopSequences: r.stopSequences })),
+            expected: [{ stopSequences: SINGLE_LINE_STOP_SEQUENCES }],
+        }
+    },
+    /**
+     * Checks if `CompletionParameters[]` contains three items with multi-line stop sequences.
+     */
+    toBeMultiLine(requests: CompletionParameters[], _) {
+        const { isNot } = this
+
+        return {
+            pass: requests.length === 3 && isEqual(requests[0]?.stopSequences, MULTI_LINE_STOP_SEQUENCES),
+            message: () => `Completion requests are${isNot ? ' not' : ''} multi-line`,
+            actual: requests.map(r => ({ stopSequences: r.stopSequences })),
+            expected: Array.from({ length: 3 }).map(() => ({ stopSequences: MULTI_LINE_STOP_SEQUENCES })),
+        }
+    },
+})

--- a/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
@@ -1,5 +1,5 @@
 import dedent from 'dedent'
-import { describe, expect, it, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
@@ -11,19 +11,19 @@ import { getInlineCompletions, params, V } from './helpers'
 
 describe('[getInlineCompletions] triggers', () => {
     describe('singleline', () => {
-        test('after whitespace', async () =>
+        it('after whitespace', async () =>
             expect(await getInlineCompletions(params('foo = █', [completion`bar`]))).toEqual<V>({
                 items: [{ insertText: 'bar' }],
                 source: InlineCompletionsResultSource.Network,
             }))
 
-        test('end of word', async () =>
+        it('end of word', async () =>
             expect(await getInlineCompletions(params('foo█', [completion`()`]))).toEqual<V>({
                 items: [{ insertText: '()' }],
                 source: InlineCompletionsResultSource.Network,
             }))
 
-        test('middle of line', async () =>
+        it('middle of line', async () =>
             expect(
                 await getInlineCompletions(
                     params('function bubbleSort(█)', [completion`array) {`, completion`items) {`])
@@ -37,16 +37,16 @@ describe('[getInlineCompletions] triggers', () => {
             }))
 
         describe('same line suffix behavior', () => {
-            test('does not trigger when there are alphanumeric chars in the line suffix', async () =>
+            it('does not trigger when there are alphanumeric chars in the line suffix', async () =>
                 expect(await getInlineCompletions(params('foo = █ // x', []))).toBeNull())
 
-            test('triggers when there are only non-alphanumeric chars in the line suffix', async () =>
+            it('triggers when there are only non-alphanumeric chars in the line suffix', async () =>
                 expect(await getInlineCompletions(params('foo = █;', []))).toBeTruthy())
         })
     })
 
     describe('multiline', () => {
-        test('triggers a multi-line completion at the start of a block', async () => {
+        it('triggers a multi-line completion at the start of a block', async () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('function bubbleSort() {\n  █', [], {
@@ -58,7 +58,7 @@ describe('[getInlineCompletions] triggers', () => {
             expect(requests).toBeMultiLine()
         })
 
-        test('does not trigger a multi-line completion at a function call', async () => {
+        it('does not trigger a multi-line completion at a function call', async () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('bar(█)', [], {
@@ -70,7 +70,7 @@ describe('[getInlineCompletions] triggers', () => {
             expect(requests).toBeSingleLine()
         })
 
-        test('does not trigger a multi-line completion at a method call', async () => {
+        it('does not trigger a multi-line completion at a method call', async () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('foo.bar(█)', [], {
@@ -127,7 +127,7 @@ describe('[getInlineCompletions] triggers', () => {
             })
         })
 
-        test('triggers a multi-line completion at a method declarations', async () => {
+        it('triggers a multi-line completion at a method declarations', async () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('method.hello () {█', [], {
@@ -139,7 +139,7 @@ describe('[getInlineCompletions] triggers', () => {
             expect(requests).toBeMultiLine()
         })
 
-        test('does not support multi-line completion on unsupported languages', async () => {
+        it('does not support multi-line completion on unsupported languages', async () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('function looksLegit() {\n  █', [], {
@@ -152,7 +152,7 @@ describe('[getInlineCompletions] triggers', () => {
             expect(requests).toBeSingleLine()
         })
 
-        test('requires an indentation to start a block', async () => {
+        it('requires an indentation to start a block', async () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('function bubbleSort() {\n█', [], {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -25,6 +25,8 @@ import { forkSignal, messagesToText } from '../utils'
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
 
 const CHARS_PER_TOKEN = 4
+export const MULTI_LINE_STOP_SEQUENCES = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG]
+export const SINGLE_LINE_STOP_SEQUENCES = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE]
 
 function tokensToChars(tokens: number): number {
     return tokens * CHARS_PER_TOKEN
@@ -189,13 +191,13 @@ export class AnthropicProvider extends Provider {
                   temperature: 0.5,
                   messages: prompt,
                   maxTokensToSample: this.responseTokens,
-                  stopSequences: [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG],
+                  stopSequences: MULTI_LINE_STOP_SEQUENCES,
               }
             : {
                   temperature: 0.5,
                   messages: prompt,
                   maxTokensToSample: Math.min(50, this.responseTokens),
-                  stopSequences: [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE],
+                  stopSequences: SINGLE_LINE_STOP_SEQUENCES,
               }
         tracer?.params(args)
 

--- a/vscode/src/vitest.d.ts
+++ b/vscode/src/vitest.d.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line unused-imports/no-unused-imports
 import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
 
 interface CustomMatchers<R = unknown> {

--- a/vscode/src/vitest.d.ts
+++ b/vscode/src/vitest.d.ts
@@ -1,0 +1,17 @@
+import type { Assertion, AsymmetricMatchersContaining } from 'vitest'
+
+interface CustomMatchers<R = unknown> {
+    /**
+     * Checks if `CompletionParameters[]` contains one item with single-line stop sequences.
+     */
+    toBeSingleLine(): R
+    /**
+     * Checks if `CompletionParameters[]` contains three items with multi-line stop sequences.
+     */
+    toBeMultiLine(): R
+}
+
+declare module 'vitest' {
+    interface Assertion<T = any> extends CustomMatchers<T> {}
+    interface AsymmetricMatchersContaining extends CustomMatchers {}
+}


### PR DESCRIPTION
## Context

- A follow-up for https://github.com/sourcegraph/cody/pull/913
- Apply the same logic to `enableExtendedTriggers` (non-empty-line multi-line triggers): do not trigger multi-line completions for opening brackets if the content already exists in the block.
- [Slack discussion](https://sourcegraph.slack.com/archives/C05AGQYD528/p1694609236944899)
- Added `vitest` custom matchers for multi vs sigle-line completions checks.

```ts
// Previously generated multi-line completions.
function bubbleSort() {█
   const a = []
}
```

```ts
// We request multi-line completions only for empty blocks now.
function bubbleSort() {█
   
}
```

## Test plan

Added unit-tests.
