### PR TITLE
Autocomplete: Add alt+\ shortcut to trigger autocomplete and bypass debouncing times

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -22,6 +22,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Enabled streaming responses for all autocomplete requests. [pull/995](https://github.com/sourcegraph/cody/pull/995)
 - Sign out immediately instead of showing the quick-pick menu. [pull/1032](https://github.com/sourcegraph/cody/pull/1032)
 - UX improvements to the custom command workflow (and new [custom command docs](https://docs.sourcegraph.com/cody/custom-commands)). [pull/992](https://github.com/sourcegraph/cody/pull/992)
+- You can now use `alt` + `\` to trigger autocomplete requests manually. [pull/1060](https://github.com/sourcegraph/cody/pull/1060)
+- Slightly reduce latency when manually triggering autocomplete requests. [pull/1060](https://github.com/sourcegraph/cody/pull/1060)
 
 ## [0.10.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -484,6 +484,11 @@
       {
         "command": "-github.copilot.generate",
         "key": "ctrl+enter"
+      },
+      {
+        "command": "editor.action.inlineSuggest.trigger",
+        "key": "alt+\\",
+        "when": "editorTextFocus && !editorHasSelection && cody.autocomplete.enabled && !inlineSuggestionsVisible"
       }
     ],
     "submenus": [

--- a/vscode/src/completions/getInlineCompletions.ts
+++ b/vscode/src/completions/getInlineCompletions.ts
@@ -205,7 +205,11 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 
     // Debounce to avoid firing off too many network requests as the user is still typing.
     const interval = multiline ? debounceInterval?.multiLine : debounceInterval?.singleLine
-    if (interval !== undefined && interval > 0) {
+    if (
+        context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic &&
+        interval !== undefined &&
+        interval > 0
+    ) {
         await new Promise<void>(resolve => setTimeout(resolve, interval))
     }
 


### PR DESCRIPTION
Closes #1019

This adds the manual completion shortcut to trigger completions.

This change also disables the debounce timings when the completion was manually requested (that is, either using this shortcut or when hovering over completions). This is done to slightly increase latency when we already have a strong sign that the user really wants that completion

## Test plan

- Move the cursor somewhere
- Press alt+\
- Observe a completion being loaded


https://github.com/sourcegraph/cody/assets/458591/be4f9070-8b4c-47c5-bd0c-5611519318a4



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
