### PR TITLE
Intelligent Cody: Extract identifiers with Treesitter

### DIFF
--- a/vscode/src/graph/graph.test.ts
+++ b/vscode/src/graph/graph.test.ts
@@ -99,7 +99,7 @@ describe('gatherDefinitions', () => {
 
         const requests = gatherDefinitionRequestCandidates(
             selections,
-            new Map([[uri.fsPath, testFile3.split('\n').slice(1)]])
+            new Map([[uri.fsPath, { document: undefined, lines: testFile3.split('\n').slice(1) }]])
         )
         const getHover = (): Promise<vscode.Hover[]> => Promise.resolve([])
         // eslint-disable-next-line @typescript-eslint/require-await
@@ -215,10 +215,10 @@ describe('extractDefinitionContexts', () => {
                     location: { uri: Uri.file('/test-3.test'), range: new vscode.Range(7, 5, 7, 7) },
                 },
             ],
-            new Map<string, string[]>([
-                ['/test-1.test', testFile1.split('\n').slice(1)], // foo, bar
-                ['/test-2.test', testFile2.split('\n').slice(1)], // baz
-                ['/test-3.test', testFile3.split('\n').slice(1)], // bonk
+            new Map([
+                ['/test-1.test', { document: undefined, lines: testFile1.split('\n').slice(1) }], // foo, bar
+                ['/test-2.test', { document: undefined, lines: testFile2.split('\n').slice(1) }], // baz
+                ['/test-3.test', { document: undefined, lines: testFile3.split('\n').slice(1) }], // bonk
             ]),
             (uri: URI): Promise<vscode.Range[]> => {
                 switch (uri.fsPath) {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -101,7 +101,7 @@ const register = async (
         PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
     }
 
-    if (config.autocompleteExperimentalSyntacticPostProcessing) {
+    if (config.autocompleteExperimentalSyntacticPostProcessing || config.autocompleteExperimentalGraphContext) {
         parseAllVisibleDocuments()
 
         disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))


### PR DESCRIPTION
This is a WIP we should discuss about finishing. This currently replaces the looks-like-an-identifier parsing with a treesitter node walk. This should be equivalent in functionality with fewer false positives (trying to extract definitions from strings or in block comments, for example).

Where this shines is the ability (in the future, not implemented here) to try to reduce multiple requests to different occurrences of the same variable. We should be able to do a quick tree walk to see which variables reside in the same scope and deduplicate them in a semantically intelligent way.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
