### PR TITLE
Consistent event names for commands

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -514,7 +514,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 await vscode.commands.executeCommand('cody.fixup.new', { instruction: text })
                 return null
             case /^\/(explain|doc|test|smell)$/.test(text):
-                this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:called`, {
+                this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:executed`, {
                     source: 'chat',
                 })
             default: {


### PR DESCRIPTION
Any thoughts on this change @abeatrix ? Is there a reason why we've used `:called` in the past for the explain|doc|test|smell commands? Context: https://sourcegraph.slack.com/archives/CN4FC7XT4/p1694630386266389

Note that I left the various `:clicked` event names where the object in question was a "button"

## Test plan

No test required, just a string constant change
