### PR TITLE
Worker: support correct transcript management

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -137,8 +137,8 @@ export class Agent extends MessageHandler {
             vscode_shim.onDidCloseTextDocument.fire(this.workspace.agentTextDocument(document))
         })
 
-        const configurationDidChange = (config: ExtensionConfiguration): void => {
-            this.setClient(config)
+        const configurationDidChange = (config: ExtensionConfiguration): Promise<void> => {
+            return this.setClient(config)
         }
 
         this.registerNotification('connectionConfiguration/didChange', configurationDidChange)
@@ -152,6 +152,14 @@ export class Agent extends MessageHandler {
                 }))
             )
         )
+
+        this.registerNotification('transcript/reset', async () => {
+            const client = await this.client
+            if (!client) {
+                return
+            }
+            client.reset()
+        })
 
         this.registerRequest('recipes/execute', async (data, token) => {
             const client = await this.client
@@ -242,7 +250,7 @@ export class Agent extends MessageHandler {
         })
     }
 
-    private setClient(config: ExtensionConfiguration): void {
+    private async setClient(config: ExtensionConfiguration): Promise<void> {
         vscode_shim.setConnectionConfig(config)
         vscode_shim.onDidChangeConfiguration.fire({
             affectsConfiguration: () =>
@@ -254,7 +262,9 @@ export class Agent extends MessageHandler {
             () => {},
             () => {}
         )
+        const oldClient = await this.client
         this.client = createClient({
+            initialTranscript: oldClient?.transcript,
             editor: new AgentEditor(this),
             config: { ...config, useContext: 'embeddings', experimentalLocalSymbols: false },
             setMessageInProgress: messageInProgress => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -81,7 +81,7 @@ export class Agent extends MessageHandler {
 
             const extensionConfig = client.extensionConfiguration ?? client.connectionConfiguration
             if (extensionConfig) {
-                this.setClient(extensionConfig)
+                await this.setClient(extensionConfig)
             }
 
             setUserAgent(`${client?.name} / ${client?.version}`)
@@ -137,9 +137,7 @@ export class Agent extends MessageHandler {
             vscode_shim.onDidCloseTextDocument.fire(this.workspace.agentTextDocument(document))
         })
 
-        const configurationDidChange = (config: ExtensionConfiguration): Promise<void> => {
-            return this.setClient(config)
-        }
+        const configurationDidChange = (config: ExtensionConfiguration): Promise<void> => this.setClient(config)
 
         this.registerNotification('connectionConfiguration/didChange', configurationDidChange)
         this.registerNotification('extensionConfiguration/didChange', configurationDidChange)

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -39,6 +39,7 @@ export type Requests = {
 
     'graphql/currentUserId': [null, string]
     'graphql/logEvent': [event, null]
+
     'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
 
     // ================
@@ -92,6 +93,11 @@ export type Notifications = {
     // The user no longer wishes to consider the last autocomplete candidate
     // and the current autocomplete id should not be reused.
     'autocomplete/clearLastCandidate': [null]
+
+    // Resets the chat transcript and clears any in-progress interactions.
+    // This notification should be sent when the user starts a new conversation.
+    // The chat transcript grows indefinitely if this notification is never sent.
+    'transcript/reset': [null]
 
     // ================
     // Server -> Client


### PR DESCRIPTION
Previously, the worker (aka. agent) didn't correctly manage the chat transcript:

- The transcript was reset on every `recipes/execute` request.
- The transcript was reset every time we updated extension configuration (including access tokens or codebase setting).

This PR fixes the problem by always preserving the transcript history unless the client sends a `transcript/reset` notification.

## Test plan

Tested with IntelliJ (will update  link to PR)
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
