### PR TITLE
Fix VScode storybook CSS class name mangling

### DIFF
--- a/vscode/.storybook/main.ts
+++ b/vscode/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import { mergeConfig } from 'vite'
 
 const config: StorybookConfig = {
     stories: ['../webviews/**/*.story.@(js|jsx|ts|tsx)'],
@@ -9,6 +10,9 @@ const config: StorybookConfig = {
     },
     docs: {
         autodocs: 'tag',
+    },
+    async viteFinal(config) {
+        return mergeConfig(config, { css: { modules: { localsConvention: 'camelCaseOnly' } } })
     },
 }
 export default config


### PR DESCRIPTION
The VScode storybook config was not mangling kebab-case identifiers as camelCase. As a result, a bunch of rules weren't being applied in the storybook.

Before:

![Screenshot 2023-09-15 at 19 41 25](https://github.com/sourcegraph/cody/assets/55120/ef5add95-0a43-4f28-a483-7adcdb39f1f9)

After:

![Screenshot 2023-09-15 at 19 55 49](https://github.com/sourcegraph/cody/assets/55120/a3ab966e-8690-4833-9fe9-575256357cbd)

## Test plan

1. `pnpm -C vscode storybook`
2. Open http://localhost:6007/?path=/story/cody-loginexperiment--login
3. The sign-in buttons should be the same width.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
