### PR TITLE
Worker: add `graphql/getRepoId`

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -237,7 +237,7 @@ export class Agent extends MessageHandler {
             if (!client) {
                 return null
             }
-            const result = getRepoHandler(client)
+            const result = await getRepoHandler(client)
             if (result instanceof Error) {
                 console.error('getRepoId', result)
             }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -238,9 +238,6 @@ export class Agent extends MessageHandler {
                 return null
             }
             const result = await getRepoHandler(client)
-            if (result instanceof Error) {
-                console.error('getRepoId', result)
-            }
             return typeof result === 'string' ? result : null
         }
 

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -39,7 +39,7 @@ export type Requests = {
 
     'graphql/currentUserId': [null, string]
     'graphql/logEvent': [event, null]
-
+    'graphql/getRepoId': [{ repoName: string }, string | null]
     'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
 
     // ================

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -76,6 +76,10 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
 
 declare const WorkerGlobalScope: never
 const isRunningInWebWorker =
+    // NOTE Do not compare agaist `undefined` like ESLint suggests because it
+    // makes this module crash during initialization if it's not running in the
+    // browser.
+    // eslint-disable-next-line unicorn/no-typeof-undefined
     typeof WorkerGlobalScope !== 'undefined' && WorkerGlobalScope !== undefined && self instanceof WorkerGlobalScope
 
 if (isRunningInWebWorker) {

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -75,7 +75,8 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
 }
 
 declare const WorkerGlobalScope: never
-const isRunningInWebWorker = WorkerGlobalScope !== undefined && self instanceof WorkerGlobalScope
+const isRunningInWebWorker =
+    typeof WorkerGlobalScope !== 'undefined' && WorkerGlobalScope !== undefined && self instanceof WorkerGlobalScope
 
 if (isRunningInWebWorker) {
     // HACK: @microsoft/fetch-event-source tries to call document.removeEventListener, which is not


### PR DESCRIPTION
Previously, there was no way for the client to know whether a repository existed on the sourcegraph instance. This PR adds a new `graphql/getRepoId` request for this purpose. For example, the JetBrains client will use this request to validate user input to customize the codebase for context.

## Test plan

n/a
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
