### PR TITLE
Fix broken Cody Agent

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -75,7 +75,7 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
 }
 
 declare const WorkerGlobalScope: never
-const isRunningInWebWorker = WorkerGlobalScope !== undefined && self instanceof WorkerGlobalScope
+const isRunningInWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope
 
 if (isRunningInWebWorker) {
     // HACK: @microsoft/fetch-event-source tries to call document.removeEventListener, which is not

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -75,6 +75,7 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
 }
 
 declare const WorkerGlobalScope: never
+// eslint-disable-next-line unicorn/no-typeof-undefined
 const isRunningInWebWorker = typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope
 
 if (isRunningInWebWorker) {


### PR DESCRIPTION
The WorkerGlobalScope symbol is not defined when running the Cody Agent. This is rolling back one of Valery's changes from https://github.com/sourcegraph/cody/pull/1075 -- it must have looked as if the symbol was clearly defined, in the VSCode environment.


## Test plan

I would welcome ideas on how to test this, because clearly it's easy to break. But for now let's get it running again?
