### PR TITLE
Autocomplete: add snapshot tests for tree-sitter queries

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 out/
 dist/
 build/
+**/test-data/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ const config = {
     'import/order': 'off',
     'id-length': 'off',
     'etc/no-deprecated': 'off', // slow
+    'arrow-body-style': 'off',
     'unicorn/switch-case-braces': 'off',
     'unicorn/prefer-event-target': 'off',
     'unicorn/prefer-top-level-await': 'off',

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist/
 vscode/.vscode-test/
 completions-review-tool/data/
 **/__snapshots__
+**/test-data

--- a/vscode/.eslintignore
+++ b/vscode/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+**/test-data/

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -37,7 +37,8 @@
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:unit": "vitest",
     "vscode:prepublish": "pnpm -s run build",
-    "generate:completions": "OUTFILE=/tmp/run-code-completions-on-dataset.js && esbuild ./test/completions/run-code-completions-on-dataset.ts --bundle --external:vscode --outfile=$OUTFILE --format=cjs --platform=node --sourcemap=inline && node --enable-source-maps $OUTFILE"
+    "generate:completions": "OUTFILE=/tmp/run-code-completions-on-dataset.js && esbuild ./test/completions/run-code-completions-on-dataset.ts --bundle --external:vscode --outfile=$OUTFILE --format=cjs --platform=node --sourcemap=inline && node --enable-source-maps $OUTFILE",
+    "test:unit:tree-sitter-queries": "vitest vscode/src/completions/tree-sitter/queries/**/*.test.ts"
   },
   "categories": [
     "Programming Languages",

--- a/vscode/src/completions/tree-sitter/queries/README.md
+++ b/vscode/src/completions/tree-sitter/queries/README.md
@@ -1,0 +1,22 @@
+# Snapshot tests for tree-sitter queries
+
+**Experimental** snapshot tests for tree-sitter queries. The main goal to foster rapid and iterative query development. By leveraging snapshot tests, developers can confidently refactor or enhance tree-sitter queries, ensuring that existing functionality remains intact and covers all the expected cases.
+
+## Usage
+
+- `./languages` contains the tree-sitter quries per language.
+- `./test-data` contains example source files for different languages, one per tree-sitter query.
+- Next to each file is a `.snap` file containing the annotated source code. Annotation highlights code matching a query.
+- To generate snapshots, run `pnpm test:unit:tree-sitter-queries --watch`
+
+The underlying command:
+
+```sh
+pnpm vitest --watch vscode/src/completions/tree-sitter/queries/**/*.test.ts
+```
+
+### Annotation format
+
+| - query start position in the source file.
+█ – query start position in the annotated file.
+^ – characters matching the last query result.`

--- a/vscode/src/completions/tree-sitter/queries/annotate-and-match-snapshot.ts
+++ b/vscode/src/completions/tree-sitter/queries/annotate-and-match-snapshot.ts
@@ -1,0 +1,196 @@
+/* eslint-disable no-sync */
+import fs from 'fs'
+import path from 'path'
+
+import dedent from 'dedent'
+import { expect } from 'vitest'
+import Parser, { Point, Query } from 'web-tree-sitter'
+
+import { getLanguageConfig } from '../../language'
+import { SupportedLanguage } from '../grammars'
+
+interface CommentSymbolInfo {
+    delimiter: string
+    indent: string
+    separator: string
+}
+
+const SNIPPET_SEPARATOR = '------------------------------------\n'
+
+function getCommentDelimiter(language: SupportedLanguage): CommentSymbolInfo {
+    const languageConfig = getLanguageConfig(language)
+
+    if (!languageConfig) {
+        throw new Error(`No language config found for ${language}`)
+    }
+
+    const delimiter = languageConfig.commentStart.trim()
+    const indent = ' '.repeat(delimiter.length)
+    const separator = `${delimiter} ${SNIPPET_SEPARATOR}`
+
+    return { delimiter, indent, separator }
+}
+
+function isCursorPositionLine(line: string, commentDelimiter: string): boolean {
+    const trimmed = line.trim()
+
+    return trimmed.startsWith(commentDelimiter) && trimmed.endsWith('|')
+}
+
+function getCaretPoint(lines: string[], commentDelimiter: string): Point | null {
+    for (let row = 0; row < lines.length; row++) {
+        const line = lines[row]
+        const column = line.indexOf('|')
+
+        if (isCursorPositionLine(line, commentDelimiter) && column !== -1) {
+            return { row, column }
+        }
+    }
+
+    return null
+}
+
+function generateAnnotation(line: string, lineStartColumn: number, lineEndColumn: number): string {
+    return line.slice(lineStartColumn, lineEndColumn).replaceAll(/\S/g, '^').replaceAll(/\s/g, ' ')
+}
+
+function replaceAt(value: string, index: number, replacement: string): string {
+    return value.slice(0, index) + replacement + value.slice(index + replacement.length)
+}
+
+interface AnnotateSnippetsParams {
+    code: string
+    language: SupportedLanguage
+    parser: Parser
+    query: Query
+}
+
+/**
+ * Adds "^" symbol under every character in the last captured the query node.
+ * Keeps the position of the query start position to make it easier to review snapshots.
+ */
+function annotateSnippets(params: AnnotateSnippetsParams): string {
+    const { code, language, parser, query } = params
+
+    const { delimiter, indent } = getCommentDelimiter(language)
+    const lines = code.split('\n')
+    const caretPoint = getCaretPoint(lines, delimiter)
+    if (!caretPoint) {
+        return code
+    }
+
+    const tree = parser.parse(code)
+    const captures = query.captures(tree.rootNode, caretPoint, caretPoint)
+    if (!captures.length) {
+        return code
+    }
+
+    // Taking the last result to get the most nested node.
+    // See https://github.com/tree-sitter/tree-sitter/discussions/2067
+    const initialNode = captures.at(-1)!.node
+    // Check for special cases where we need match a parent node.
+    // TODO(tree-sitter): extract this logic from the test utility.
+    const potentialParentNodes = captures.filter(capture => capture.name === 'parents')
+    const potentialParent = potentialParentNodes.find(capture => initialNode.parent?.id === capture.node.id)?.node
+    const { startPosition: start, endPosition: end } = potentialParent || initialNode
+
+    const result = []
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+
+        // Add the current line with the proper indentation
+        result.push(line.length === 0 || line.startsWith(delimiter) ? line : indent + line)
+
+        // Add annotations if necessary
+        if (i >= start.row && i <= end.row) {
+            // Skip caret lines
+            if (isCursorPositionLine(line, delimiter)) {
+                continue
+            }
+
+            const lineStartColumn = i === start.row ? start.column : 0
+            const lineEndColumn = i === end.row ? end.column : line.length
+            const annotation = generateAnnotation(line, lineStartColumn, lineEndColumn)
+
+            if (annotation.trim()) {
+                const spacesBefore = ' '.repeat(lineStartColumn)
+                let annotatedLine = delimiter + spacesBefore + annotation
+
+                // Keep cursor indicator if necessary
+                const nextLine = lines.at(i + 1)
+                const indicatorPosition =
+                    nextLine && isCursorPositionLine(nextLine, delimiter)
+                        ? nextLine.length - 1 + delimiter.length
+                        : undefined
+
+                if (indicatorPosition) {
+                    annotatedLine = replaceAt(annotatedLine, indicatorPosition, '█')
+                }
+
+                result.push(annotatedLine)
+            }
+        } else if (isCursorPositionLine(line, delimiter)) {
+            result.push(delimiter + ' '.repeat(line.length - 1) + '█')
+        }
+    }
+
+    return result.filter(line => !isCursorPositionLine(line, delimiter)).join('\n')
+}
+
+const DOCUMENTATION_HEADER = `
+| - query start position in the source file.
+█ – query start position in the annotated file.
+^ – characters matching the last query result.`
+
+function commentOutLines(text: string, commentSymbol: string): string {
+    return text
+        .split('\n')
+        .map(line => commentSymbol + ' ' + line)
+        .join('\n')
+}
+
+interface AnnotateAndMatchParams {
+    queryPath: string
+    sourcesPath: string
+    parser: Parser
+    language: SupportedLanguage
+}
+
+export async function annotateAndMatchSnapshot(params: AnnotateAndMatchParams): Promise<void> {
+    const { queryPath, sourcesPath, parser, language } = params
+
+    const { delimiter, separator } = getCommentDelimiter(language)
+
+    // Get the source code and split into snippets.
+    const code = fs.readFileSync(path.join(__dirname, sourcesPath), 'utf8')
+    // Queries are used on specific parts of the source code (e.g., range of the inserted multiline completion).
+    // Snippets are required to mimick such behavior and test the order of returned captures.
+    const snippets = code.split(separator)
+
+    // Compile the tree-sitter query.
+    // TODO(tree-sitter): add multi-lang support and extract from the text helper.
+    const rawQuery = fs.readFileSync(path.join(__dirname, queryPath), 'utf8').trim()
+    const query = parser.getLanguage().query(rawQuery)
+
+    const header = dedent`
+        ${commentOutLines(DOCUMENTATION_HEADER, delimiter)}
+        ${delimiter}
+        ${delimiter} Tree-sitter query:
+        ${delimiter}
+        ${commentOutLines(rawQuery, delimiter)}
+    `.trim()
+
+    const annotated = snippets
+        .map(snippet => {
+            return annotateSnippets({ code: snippet, language, parser, query })
+        })
+        .join(separator)
+
+    const content = header + '\n' + separator + '\n' + annotated
+
+    const { ext, dir, name } = path.parse(sourcesPath)
+    const snapshotFilePath = path.join(dir, name + '.snap' + ext)
+
+    await expect(content).toMatchFileSnapshot(snapshotFilePath)
+}

--- a/vscode/src/completions/tree-sitter/queries/blocks.test.ts
+++ b/vscode/src/completions/tree-sitter/queries/blocks.test.ts
@@ -1,0 +1,24 @@
+import { beforeAll, describe, it } from 'vitest'
+import Parser from 'web-tree-sitter'
+
+import { initTreeSitterParser } from '../../test-helpers'
+import { SupportedLanguage } from '../grammars'
+
+import { annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
+
+describe('the blocks query', () => {
+    let parser: Parser
+
+    beforeAll(async () => {
+        parser = await initTreeSitterParser(SupportedLanguage.TypeScript)
+    })
+
+    it('selects the first block-like statement at the cursor position', async () => {
+        await annotateAndMatchSnapshot({
+            parser,
+            language: SupportedLanguage.TypeScript,
+            sourcesPath: 'test-data/blocks.ts',
+            queryPath: './languages/javascript/blocks.scm',
+        })
+    })
+})

--- a/vscode/src/completions/tree-sitter/queries/languages/javascript/blocks.scm
+++ b/vscode/src/completions/tree-sitter/queries/languages/javascript/blocks.scm
@@ -1,0 +1,4 @@
+(_ ("{")) @blocks
+
+[(try_statement)
+ (if_statement)] @parents

--- a/vscode/src/completions/tree-sitter/queries/test-data/blocks.snap.ts
+++ b/vscode/src/completions/tree-sitter/queries/test-data/blocks.snap.ts
@@ -1,0 +1,107 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// Tree-sitter query:
+//
+// (_ ("{")) @blocks
+// 
+// [(try_statement)
+//  (if_statement)] @parents
+// ------------------------------------
+
+  interface kek {
+//              █
+      value: string
+//    ^^^^^^ ^^^^^^
+  }
+//^
+
+// ------------------------------------
+
+  export function pek() {
+//                      █
+      const data: kek = {
+//    ^^^^^ ^^^^^ ^^^ ^ ^
+          value: 'wow',
+//        ^^^^^^ ^^^^^^
+      }
+//    ^
+      return data
+//    ^^^^^^ ^^^^
+  }
+//^
+
+  export const hmmm = 1
+
+// ------------------------------------
+
+  class Animal {
+//             █
+      constructor() {}
+//    ^^^^^^^^^^^^^ ^^
+  }
+//^
+
+// ------------------------------------
+
+  export class Doggo extends Animal {
+      public bark() {
+//                  █
+          return {}
+//        ^^^^^^ ^^
+      }
+//    ^
+  }
+
+// ------------------------------------
+
+  export function inconsistentIndentation() {
+      if (Doggo) {
+          const value = null; const arrow = () => {
+//                                                █
+              console.log('Hello World!');
+//            ^^^^^^^^^^^^^^^^^^ ^^^^^^^^^
+          }
+//        ^
+      } else {
+          const a = 1
+      }
+  }
+
+// ------------------------------------
+// Captures the whole if_statement block
+
+  export function whatIf() {
+      if (Doggo) {
+//    ^^ ^^^^^^^ █
+          console.log('You are right!')
+//        ^^^^^^^^^^^^^^^^ ^^^ ^^^^^^^^
+      } else {
+//    ^ ^^^^ ^
+          console.log('Nope -_-')
+//        ^^^^^^^^^^^^^^^^^ ^^^^^
+      }
+//    ^
+  }
+
+// ------------------------------------
+// Captures the whole try_statement block
+
+  export function tryHard() {
+      try {
+//    ^^^ █
+          new Doggo()
+//        ^^^ ^^^^^^^
+      } catch (error) {
+//    ^ ^^^^^ ^^^^^^^ ^
+          console.error('Opps!')
+//        ^^^^^^^^^^^^^^^^^^^^^^
+      } finally {
+//    ^ ^^^^^^^ ^
+          console.log('Done trying...')
+//        ^^^^^^^^^^^^^^^^^ ^^^^^^^^^^^
+      }
+//    ^
+  }

--- a/vscode/src/completions/tree-sitter/queries/test-data/blocks.ts
+++ b/vscode/src/completions/tree-sitter/queries/test-data/blocks.ts
@@ -1,0 +1,71 @@
+interface kek {
+    //        |
+    value: string
+}
+
+// ------------------------------------
+
+export function pek() {
+    //                |
+    const data: kek = {
+        value: 'wow',
+    }
+    return data
+}
+
+export const hmmm = 1
+
+// ------------------------------------
+
+class Animal {
+    //       |
+    constructor() {}
+}
+
+// ------------------------------------
+
+export class Doggo extends Animal {
+    public bark() {
+        //        |
+        return {}
+    }
+}
+
+// ------------------------------------
+
+export function inconsistentIndentation() {
+    if (Doggo) {
+        const value = null; const arrow = () => {
+        //                                      |
+            console.log('Hello World!');
+        }
+    } else {
+        const a = 1
+    }
+}
+
+// ------------------------------------
+// Captures the whole if_statement block
+
+export function whatIf() {
+    if (Doggo) {
+    //         |
+        console.log('You are right!')
+    } else {
+        console.log('Nope -_-')
+    }
+}
+
+// ------------------------------------
+// Captures the whole try_statement block
+
+export function tryHard() {
+    try {
+    //  |
+        new Doggo()
+    } catch (error) {
+        console.error('Opps!')
+    } finally {
+        console.log('Done trying...')
+    }
+}

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -19,7 +19,7 @@
     "../lib/shared/src/telemetry/EventLogger.ts",
     "test/completions/completions-dataset.ts",
   ],
-  "exclude": ["scripts", "dist", "test/integration"],
+  "exclude": ["scripts", "dist", "test/integration", "**/test-data"],
   "references": [
     {
       "path": "../lib/shared",


### PR DESCRIPTION
## Context

- Adds an experimental logic for snapshot testing tree-sitter queries. This is the first iteration, which is not a final version, but it already provides great value — a bug found because of the visual representation of matching code. 
- Snapshot tests use tree-sitter queries defined in `.scm` files, whereas the application code still uses queries defined in TS sources. It will be fixed in #1056 
- Based on discussion with @olafurpg ([ref](https://sourcegraph.slack.com/archives/C05P6R9CV3Q/p1694769193088069))
- Part of #1076 
- Snapshot tests are powered by [vitest.toMatchFileSnapshot()](https://vitest.dev/guide/snapshot.html#file-snapshots), which means we can iterate on the logic easily in the watch mode and update snapshots if needed by pressing `u`.

## Example

Input for snapshot tests where the `|` symbol signifies the query start position (cursor position).

```ts
// Captures the whole if_statement block

export function whatIf() {
    if (Doggo) {
    //         |
        console.log('You are right!')
    } else {
        console.log('Nope -_-')
    }
}
```

Snapshot tests output.

```ts
// Captures the whole if_statement block

  export function whatIf() {
      if (Doggo) {
//    ^^ ^^^^^^^ █
          console.log('You are right!')
//        ^^^^^^^^^^^^^^^^ ^^^ ^^^^^^^^
      } else {
//    ^ ^^^^ ^
          console.log('Nope -_-')
//        ^^^^^^^^^^^^^^^^^ ^^^^^
      }
//    ^
  }
````

## Test plan

- See docs
- `pnpm test:unit:tree-sitter-queries`

