### PR TITLE
Agent: add `pnpm agent:debug` command

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -26,16 +26,18 @@ Currently, clients have to manually write bindings for the JSON-RPC methods.
 
 ## Useful commands
 
-- The command `pnpm run build-agent-binaries` builds standalone binaries for
+- The command `pnpm build-agent-binaries` builds standalone binaries for
   macOS, Linux, and Windows. By default, the binaries get written to the `dist/`
   directory. The destination directory can be configured with the environment
   variable `AGENT_EXECUTABLE_TARGET_DIRECTORY`.
-- The command `pnpm run test` runs the agent against a minimized testing client.
+- The command `pnpm test` runs the agent against a minimized testing client.
   The tests are disabled in CI because they run against uses an actual Sourcegraph
   instance. Set the environment variables `SRC_ENDPOINT` and `SRC_ACCESS_TOKEN`
   to run the tests against an actual Sourcegraph instance.
   See the file [`src/index.test.ts`](src/index.test.ts) for a detailed but minimized example
   interaction between an agent client and agent server.
+- The command `pnpm agent:debug` runs the agent, allowing attaching an
+  [inspector](https://nodejs.org/en/docs/inspector) to it.
 
 ## Client implementations
 

--- a/agent/package.json
+++ b/agent/package.json
@@ -12,9 +12,10 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "cd .. && pnpm build && cd agent && esbuild --bundle --outfile=dist/index.js --platform=node --log-level=warning --alias:vscode=$PWD/src/vscode-shim.ts src/index.ts",
+    "build": "cd .. && pnpm build && cd agent && esbuild --sourcemap --bundle --outfile=dist/index.js --platform=node --log-level=warning --alias:vscode=$PWD/src/vscode-shim.ts src/index.ts",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
+    "agent:debug": "pnpm run build && node --inspect ./dist/index.js",
     "build-ts": "tsc --build",
     "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t latest-linux-arm64,latest-linux-x64,latest-macos-arm64,latest-macos-x64,latest-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "lint": "pnpm run lint:js",


### PR DESCRIPTION
## Context

- Enables [sourcemaps](https://esbuild.github.io/api/#sourcemap) by default.
- Adds the `pnpm agent:debug` command which runs the agent, allowing attaching an
  [inspector](https://nodejs.org/en/docs/inspector) to it.

## Test plan

1. `pnpm agent:debug`
2. Attach the node-inspector to the running process.
3. Add a breakpoint to sources.
4. Verify that breakpoints work as expected with sourcemaps.
