### PR TITLE
Share a dotcom access token with app, when available

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -24,6 +24,7 @@ import { createOrUpdateEventLogger } from './services/EventLogger'
 import { showFeedbackSupportQuickPick } from './services/FeedbackOptions'
 import { GuardrailsProvider } from './services/GuardrailsProvider'
 import { Comment, InlineController } from './services/InlineController'
+import { LocalAppSetupPublisher } from './services/LocalAppSetupPublisher'
 import { localStorage } from './services/LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, secretStorage, VSCodeSecretStorage } from './services/SecretStorageProvider'
 import { createStatusBar } from './services/StatusBar'
@@ -135,6 +136,7 @@ const register = async (
         platform
     )
     disposables.push(contextProvider)
+    disposables.push(new LocalAppSetupPublisher(contextProvider))
     await contextProvider.init()
 
     // Shared configuration that is required for chat views to send and receive messages

--- a/vscode/src/services/LocalAppFsPaths.ts
+++ b/vscode/src/services/LocalAppFsPaths.ts
@@ -1,3 +1,8 @@
+export const LOCAL_APP_SETTINGS_DIR = new Map([
+    ['darwin', '~/Library/Application Support/com.sourcegraph.cody/'],
+    ['linux', '~/.local/share/com.sourcegraph.cody/'],
+])
+
 export const LOCAL_APP_LOCATIONS: LocalAppPaths = {
     darwin: [
         {

--- a/vscode/src/services/LocalAppSetupPublisher.ts
+++ b/vscode/src/services/LocalAppSetupPublisher.ts
@@ -71,8 +71,14 @@ export class LocalAppSetupPublisher implements vscode.Disposable {
         }
         const settingsDir = settingsDirPattern.replace(/^~/, homeDir)
         const settingsDirUri = vscode.Uri.file(settingsDir)
-        const settingsDirStats = await vscode.workspace.fs.stat(settingsDirUri)
+        let settingsDirStats
+        try {
+            settingsDirStats = await vscode.workspace.fs.stat(settingsDirUri)
+        } catch {
+            // We could not stat the directory, it probably doesn't exist. Try to create it.
+        }
         if (
+            settingsDirStats &&
             settingsDirStats.type === vscode.FileType.Directory &&
             settingsDirStats.permissions !== undefined &&
             settingsDirStats.permissions ^ vscode.FilePermission.Readonly

--- a/vscode/src/services/LocalAppSetupPublisher.ts
+++ b/vscode/src/services/LocalAppSetupPublisher.ts
@@ -10,6 +10,7 @@ import { LOCAL_APP_SETTINGS_DIR } from './LocalAppFsPaths'
 interface AppSetupJson {
     dotcomAccessToken: string
     repoPaths: string[]
+    redirect: string
 }
 
 // Listens for when a dotcom auth token is available, and pushes it into a file
@@ -51,6 +52,7 @@ export class LocalAppSetupPublisher implements vscode.Disposable {
         const settings: AppSetupJson = {
             dotcomAccessToken: accessToken,
             repoPaths: workspaceRoot ? [workspaceRoot] : [],
+            redirect: vscode.env.uriScheme + '://sourcegraph.cody-ai/app-done',
         }
         void vscode.workspace.fs.writeFile(
             settingsDirUri.with({ path: `${settingsDirUri.path}/vscode.json` }),

--- a/vscode/src/services/LocalAppSetupPublisher.ts
+++ b/vscode/src/services/LocalAppSetupPublisher.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode'
+
+import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+
+import { ContextProvider } from '../chat/ContextProvider'
+import { isOsSupportedByApp } from '../chat/protocol'
+
+import { LOCAL_APP_SETTINGS_DIR } from './LocalAppFsPaths'
+
+interface AppSetupJson {
+    dotcomAccessToken: string
+    repoPaths: string[]
+}
+
+// Listens for when a dotcom auth token is available, and pushes it into a file
+// so Cody App can use the same token.
+export class LocalAppSetupPublisher implements vscode.Disposable {
+    private disposables: vscode.Disposable[] = []
+
+    constructor(private readonly configProvider: ContextProvider) {
+        this.disposables.push(
+            configProvider.configurationChangeEvent.event(() => {
+                void this.onConfigurationChanged()
+            })
+        )
+    }
+
+    public dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose()
+        }
+    }
+
+    public async onConfigurationChanged(): Promise<void> {
+        const { accessToken, serverEndpoint } = this.configProvider.config
+        if (!(accessToken && isDotCom(serverEndpoint) && isOsSupportedByApp(process.platform, process.arch))) {
+            // - We need an access token.
+            // - App-less onboarding is only implemented for dotcom.
+            // - We need app for this platform.
+            return
+        }
+        let settingsDirUri
+        try {
+            settingsDirUri = await this.ensureAppConfigDir()
+        } catch {
+            // There's no app on this platform, we could not create the settings
+            // directory, etc.
+            return
+        }
+        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath
+        const settings: AppSetupJson = {
+            dotcomAccessToken: accessToken,
+            repoPaths: workspaceRoot ? [workspaceRoot] : [],
+        }
+        void vscode.workspace.fs.writeFile(
+            settingsDirUri.with({ path: `${settingsDirUri.path}/vscode.json` }),
+            Buffer.from(JSON.stringify(settings), 'utf-8')
+        )
+    }
+
+    // Tries to get the Cody App configuration directory, creating the directory
+    // if it does not exist.
+    private async ensureAppConfigDir(): Promise<vscode.Uri> {
+        const settingsDirPattern = LOCAL_APP_SETTINGS_DIR.get(process.platform)
+        if (!settingsDirPattern) {
+            throw new Error('no app for this platform')
+        }
+        const homeDir = process.env.HOME
+        if (!homeDir) {
+            throw new Error('no home directory')
+        }
+        const settingsDir = settingsDirPattern.replace(/^~/, homeDir)
+        const settingsDirUri = vscode.Uri.file(settingsDir)
+        const settingsDirStats = await vscode.workspace.fs.stat(settingsDirUri)
+        if (
+            settingsDirStats.type === vscode.FileType.Directory &&
+            settingsDirStats.permissions !== undefined &&
+            settingsDirStats.permissions ^ vscode.FilePermission.Readonly
+        ) {
+            return settingsDirUri
+        }
+        // Try creating the directory.
+        await vscode.workspace.fs.createDirectory(settingsDirUri)
+        return settingsDirUri
+    }
+}


### PR DESCRIPTION
Currently always reflects configuration changes by overwriting the whole file.

Part of #958 

## Test plan

Manual test:

1. Start VScode
2. Sign in with dotcom
3. `cat ~/Library/Application Support/com.sourcegraph.cody/vscode.json`

The access token and root of the current workspace should appear in the file, like this:

```
{"dotcomAccessToken":"sgp_etcetc","repoPaths":["/Users/foo/bar"],"redirect":"vscode://sourcegraph.cody-ai/etc"}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
