### PR TITLE
fix: use infillBlock not infillBlock.trimEnd()

### DIFF
--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -107,11 +107,11 @@ export class AnthropicProvider extends Provider {
         const { head, tail, overlap } = getHeadAndTail(this.options.docContext.prefix)
 
         // Infill block represents the code we want the model to complete
-        const infillBlock = `${tail.trimmed.trimEnd()}`
+        const infillBlock = `${tail.trimmed}`
         // code before the cursor, after removing the code for the infillBlock
         // Using this instead of head.trimmed to preserve the spacing from prefix so the model can determines the patterns of surrounding code
         // Use regex to makes sure only the last trimmedTail match is replaced to avoid replacing overlapping code
-        const infillBlockRegex = new RegExp(`${infillBlock}\\s*$`, 'g')
+        const infillBlockRegex = new RegExp(`${infillBlock.trimEnd()}\\s*$`, 'g')
         const infillPrefix = this.options.docContext.prefix.replace(infillBlockRegex, '')
         // code after the cursor
         const infillSuffix = this.options.docContext.suffix

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -111,7 +111,7 @@ export class AnthropicProvider extends Provider {
         // code before the cursor, after removing the code for the infillBlock
         // Using this instead of head.trimmed to preserve the spacing from prefix so the model can determines the patterns of surrounding code
         // Use regex to makes sure only the last trimmedTail match is replaced to avoid replacing overlapping code
-        const infillBlockRegex = new RegExp(`${infillBlock.trimEnd()}\\s*$`, 'g')
+        const infillBlockRegex = new RegExp(`${tail.trimmed.trim()}\\s*$`, 'g')
         const infillPrefix = this.options.docContext.prefix.replace(infillBlockRegex, '')
         // code after the cursor
         const infillSuffix = this.options.docContext.suffix
@@ -127,7 +127,7 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${this.options.fileName}. Detect the functionality, formats, style, patterns, and logics in use from code outside ${OPENING_CODE_TAG} XML tags. Then, use what you detect and reuse assetmethods/libraries to complete and enclose completed code only inside ${OPENING_CODE_TAG} tags precisely without duplicating existing implementations. Here is the code:
+                text: `Below is the code from file path ${this.options.fileName}. Detect the functionality, formats, style, patterns, and logics in use from code outside ${OPENING_CODE_TAG} XML tags. Then, use what you detect and reuse any methods/libraries to complete and enclose completed code only inside ${OPENING_CODE_TAG} tags precisely without duplicating existing implementations. Here is the code:
                 ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
             },
             {


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/1063

Sorry was sick on Thursday and wasn't thinking straight 😅 

This PR fixes my oversight in https://github.com/sourcegraph/cody/pull/1063.  

The trim() logic should be added [inside the replacement block](https://github.com/sourcegraph/cody/pull/1063/files#diff-2f517c653a75e0f3b05fcb8cfc041e5125a7d347878749f828e9d8d0bb732753L109), instead of trimming the whole infillBlock

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Test this change with the incomplete comment test case

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/713e3321-947c-4d88-b33a-1b8af97575b8)

#### After. 

![image](https://github.com/sourcegraph/cody/assets/68532117/4921c20d-3234-4b41-a0d9-48d78b71314b)
