### PR TITLE
Autocomplete: Limit parallel lang server hits and abort requests when rapidly changing sections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "outFiles": ["${workspaceRoot}/vscode/dist/**/*.js"],
       "env": {
         "NODE_ENV": "development",
-        "CODY_DEBUG_ENABLE": "true"
+        "CODY_DEBUG_ENABLE": "true",
+        "TSS_DEBUG": "5859"
       }
     },
     {

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -43,17 +43,23 @@ export function isNetworkError(error: Error): error is NetworkError {
     return error instanceof NetworkError
 }
 
+export function isAuthError(error: unknown): boolean {
+    return error instanceof NetworkError && (error.status === 401 || error.status === 403)
+}
+
+export class AbortError extends Error {}
+
 export function isAbortError(error: unknown): boolean {
     return (
         isError(error) &&
-        // http module
-        (error.message === 'aborted' ||
+        // custom abort error
+        (error instanceof AbortError ||
+            // http module
+            error.message === 'aborted' ||
             // fetch
             error.message.includes('The operation was aborted') ||
             error.message.includes('The user aborted a request'))
     )
 }
 
-export function isAuthError(error: unknown): boolean {
-    return error instanceof NetworkError && (error.status === 401 || error.status === 403)
-}
+export class TimeoutError extends Error {}

--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -233,7 +233,6 @@ export class GraphSectionObserver implements vscode.Disposable, GraphContextFetc
 
         // Abort previous requests that have not yet resolved and are for a different section
         if (this.lastRequestGraphContextSectionKey && this.lastRequestGraphContextSectionKey !== sectionKey) {
-            logDebug('errrr', 'argh we need to abort bruh')
             this.abortLastRequestGraphContext()
         }
         this.lastRequestGraphContextSectionKey = sectionKey

--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -6,10 +6,12 @@ import { URI } from 'vscode-uri'
 
 import { HoverContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { dedupeWith, isDefined } from '@sourcegraph/cody-shared/src/common'
+import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { getGraphContextFromRange as defaultGetGraphContextFromRange, locationKeyFn } from '../../graph/graph'
 import { getDocumentSections as defaultGetDocumentSections, DocumentSection } from '../../graph/sections'
-import { logDebug } from '../../log'
+import { logDebug, logError } from '../../log'
 import { ContextSnippet, SymbolContextSnippet } from '../types'
 import { createSubscriber } from '../utils'
 
@@ -60,6 +62,10 @@ export class GraphSectionObserver implements vscode.Disposable, GraphContextFetc
     })
     // A list of up to ten sections that were being visited last as identifier via their location.
     private lastVisitedSections: vscode.Location[] = []
+
+    // Some book keeping so we can abort non-resolved graph context requests.
+    private lastRequestGraphContextSectionKey: string | null = null
+    private abortLastRequestGraphContext: () => void = () => {}
 
     private constructor(
         private window: Pick<
@@ -222,12 +228,33 @@ export class GraphSectionObserver implements vscode.Disposable, GraphContextFetc
         debugSubscriber.notify()
 
         const start = performance.now()
-        const context = await this.getGraphContextFromRange(editor, section.location.range)
+        const sectionKey = locationKeyFn(section.location)
+        const abortController = new AbortController()
 
-        logHydratedContext(context, editor, section, start)
-        section.preloadedContext.graphContext = context
+        // Abort previous requests that have not yet resolved and are for a different section
+        if (this.lastRequestGraphContextSectionKey && this.lastRequestGraphContextSectionKey !== sectionKey) {
+            logDebug('errrr', 'argh we need to abort bruh')
+            this.abortLastRequestGraphContext()
+        }
+        this.lastRequestGraphContextSectionKey = sectionKey
+        this.abortLastRequestGraphContext = () => abortController.abort()
 
-        debugSubscriber.notify()
+        try {
+            const context = await this.getGraphContextFromRange(editor, section.location.range, abortController.signal)
+
+            logHydratedContext(context, editor, section, start)
+            section.preloadedContext.graphContext = context
+        } catch (error) {
+            section.preloadedContext = null
+
+            if (!isAbortError(error)) {
+                logError('GraphContext:error', isError(error) ? error.message : 'error', { verbose: error })
+            }
+
+            throw error
+        } finally {
+            debugSubscriber.notify()
+        }
     }
 
     private getSectionAtPosition(document: vscode.TextDocument, position: vscode.Position): Section | undefined {

--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -7,8 +7,15 @@ import { ActiveTextEditorSelectionRange, Editor } from '@sourcegraph/cody-shared
 
 import { logDebug } from '../log'
 
+import { createLimiter } from './limiter'
+
 // TODO(efritz) - move to options object
 const recursionLimit = 2
+
+const limiter = createLimiter(
+    20, // concurrent requests
+    5000 // ms timeout
+)
 
 /**
  * Return the definitions of symbols that occur within the editor's active document. If there is
@@ -24,8 +31,7 @@ export const getGraphContextFromEditor = async (editor: Editor): Promise<Precise
         return []
     }
 
-    // Debuggin'
-    const label = 'precise context from editor'
+    const label = 'getGraphContextFromEditor'
     performance.mark(label)
 
     const uri = workspaceRootUri.with({ path: activeEditor.filePath })
@@ -37,7 +43,6 @@ export const getGraphContextFromEditor = async (editor: Editor): Promise<Precise
 
     const filteredContexts = contexts.filter(({ filePath }) => filePath !== uri.fsPath)
 
-    // Debuggin'
     logDebug('GraphContext:filteredSnippetsRetrieved', `Retrieved ${filteredContexts.length} filtered context snippets`)
     performance.mark(label)
     return filteredContexts
@@ -53,14 +58,14 @@ export const getGraphContextFromEditor = async (editor: Editor): Promise<Precise
  */
 export const getGraphContextFromRange = async (
     editor: vscode.TextEditor,
-    range: vscode.Range
+    range: vscode.Range,
+    abortSignal?: AbortSignal
 ): Promise<HoverContext[]> => {
     const uri = editor.document.uri
     const contentMap = new Map([[uri.fsPath, editor.document.getText().split('\n')]])
     const selections = [{ uri, range }]
 
-    // Debuggin'
-    const label = 'precise context for completions'
+    const label = 'getGraphContextFromRange'
     performance.mark(label)
 
     // Get the document symbols in the current file and extract their definition range
@@ -69,19 +74,12 @@ export const getGraphContextFromRange = async (
     // Find the candidate identifiers to request definitions for in the selection
     const requestCandidates = gatherDefinitionRequestCandidates(definitionSelections, contentMap)
 
-    // Extract hover (symbol, definition, type def, impl) text related to all of the request candidates
-    const resolvedHoverText = await gatherHoverText(
-        contentMap,
-        requestCandidates,
-        defaultGetHover,
-        defaultGetDefinitions,
-        defaultGetTypeDefinitions,
-        defaultGetImplementations
-    )
+    // Extract hover (symbol, definition, type def, impl) text related to all of the request
+    // candidates
+    const resolvedHoverText = await gatherHoverText(contentMap, requestCandidates, abortSignal)
 
     const contexts = resolvedHoverText.flatMap(hoverContextFromResolvedHoverText)
 
-    // Debuggin'
     logDebug('GraphContext:snippetsRetrieved', `Retrieved ${contexts.length} hover context snippets`)
     performance.mark(label)
     return contexts
@@ -102,8 +100,7 @@ const getGraphContextFromSelection = async (
     contentMap: Map<string, string[]>,
     recursionLimit: number = 0
 ): Promise<PreciseContext[]> => {
-    // Debuggin'
-    const label = 'precise context from selection'
+    const label = 'getGraphContextFromSelection'
     performance.mark(label)
 
     // Get the document symbols in the current file and extract their definition range
@@ -113,14 +110,7 @@ const getGraphContextFromSelection = async (
     const requestCandidates = gatherDefinitionRequestCandidates(definitionSelections, contentMap)
 
     // Extract identifiers from the relevant document symbol ranges and request their definitions
-    const definitionMatches = await gatherDefinitions(
-        definitionSelections,
-        requestCandidates,
-        defaultGetHover,
-        defaultGetDefinitions,
-        defaultGetTypeDefinitions,
-        defaultGetImplementations
-    )
+    const definitionMatches = await gatherDefinitions(definitionSelections, requestCandidates)
 
     // NOTE: Before asking for data about a document it must be opened in the workspace. This forces
     // a resolution so that the following queries that require the document context will not fail with
@@ -146,7 +136,6 @@ const getGraphContextFromSelection = async (
     // Extract definition text from our matches
     const contexts = await extractDefinitionContexts(matches, contentMap)
 
-    // Debuggin'
     logDebug('GraphContext:snippetsRetrieved', `Retrieved ${contexts.length} context snippets`)
     performance.mark(label)
 
@@ -504,14 +493,9 @@ export const gatherDefinitions = async (
 interface UnresolvedHoverText {
     symbolName: string
     symbolLocation: vscode.Location
-    definition: UnresolvedHoverElement
-    typeDefinition: UnresolvedHoverElement
-    implementations: UnresolvedHoverElement
-}
-
-interface UnresolvedHoverElement {
-    locations: Thenable<vscode.Location[]>
-    hover?: Thenable<vscode.Hover[]>
+    definitionsPromise: Thenable<vscode.Location[]>
+    typeDefinitionsPromise: Thenable<vscode.Location[]>
+    implementationsPromise: Thenable<vscode.Location[]>
 }
 
 interface ResolvedHoverText {
@@ -597,6 +581,7 @@ function extractMarkdownCodeBlock(string: string): string {
 export const gatherHoverText = async (
     contentMap: Map<string, string[]>,
     requests: Request[],
+    abortSignal?: AbortSignal,
     getHover: typeof defaultGetHover = defaultGetHover,
     getDefinitions: typeof defaultGetDefinitions = defaultGetDefinitions,
     getTypeDefinitions: typeof defaultGetTypeDefinitions = defaultGetTypeDefinitions,
@@ -615,9 +600,9 @@ export const gatherHoverText = async (
         hoverMatches.push({
             symbolName,
             symbolLocation: new vscode.Location(uri, position),
-            definition: { locations: getDefinitions(uri, position), hover: getHover(uri, position) },
-            typeDefinition: { locations: getTypeDefinitions(uri, position) },
-            implementations: { locations: getImplementations(uri, position) },
+            definitionsPromise: limiter(() => getDefinitions(uri, position), abortSignal),
+            typeDefinitionsPromise: limiter(() => getTypeDefinitions(uri, position), abortSignal),
+            implementationsPromise: limiter(() => getImplementations(uri, position), abortSignal),
         })
     }
 
@@ -626,10 +611,10 @@ export const gatherHoverText = async (
     const locationsForHover = dedupeWith(
         (
             await Promise.all(
-                hoverMatches.map(async ({ definition, typeDefinition, implementations }) => [
-                    ...(await definition.locations),
-                    ...(await typeDefinition.locations),
-                    ...(await implementations.locations),
+                hoverMatches.map(async ({ definitionsPromise, typeDefinitionsPromise, implementationsPromise }) => [
+                    ...(await definitionsPromise),
+                    ...(await typeDefinitionsPromise),
+                    ...(await implementationsPromise),
                 ])
             )
         ).flat(),
@@ -642,66 +627,81 @@ export const gatherHoverText = async (
     await updateContentMap(contentMap, dedupeWith(locationsForHover.map(l => l.uri).flat(), 'fsPath'))
 
     // Request hover for every (deduplicated) location range we got from def/type def/impl queries
-    const hoverMap = await unwrapThenableMap(
-        new Map(
-            locationsForHover
-                .filter(l => !isCommonImport(l.uri))
-                .map(l => [locationKeyFn(l), getHover(l.uri, l.range.start)] as [string, Thenable<vscode.Hover[]>])
+    const hoverMap = new Map(
+        // Dedupe the locations, we don't want to hover the same range twice
+        dedupeWith(
+            locationsForHover.filter(l => !isCommonImport(l.uri)),
+            item => locationKeyFn(item)
+        ).map(
+            l =>
+                [locationKeyFn(l), limiter(() => getHover(l.uri, l.range.start), abortSignal)] as [
+                    string,
+                    Thenable<vscode.Hover[]>,
+                ]
         )
     )
+    const resolvedHoverMap = await unwrapThenableMap(hoverMap)
 
     return Promise.all(
-        hoverMatches.map(async ({ symbolName, symbolLocation, definition, typeDefinition, implementations }) => {
-            let definitionObj: ResolvedHoverElement | undefined
-            const definitionLocation = (await definition.locations).pop()
-            if (definitionLocation) {
-                const symbolName = extractRangeFromDocument(
-                    contentMap,
-                    definitionLocation.uri,
-                    definitionLocation.range
-                )
-
-                definitionObj = {
-                    symbolName,
-                    location: definitionLocation,
-                    hover: hoverMap.get(locationKeyFn(definitionLocation)) || [],
-                }
-            }
-
-            let typeDefinitionObj: ResolvedHoverElement | undefined
-            const typeDefinitionLocation = (await typeDefinition.locations).pop()
-            if (typeDefinitionLocation) {
-                const symbolName = extractRangeFromDocument(
-                    contentMap,
-                    typeDefinitionLocation.uri,
-                    typeDefinitionLocation.range
-                )
-
-                typeDefinitionObj = {
-                    symbolName,
-                    location: typeDefinitionLocation,
-                    hover: hoverMap.get(locationKeyFn(typeDefinitionLocation)) || [],
-                }
-            }
-
-            let implementationObjs: ResolvedHoverElement[] | undefined
-            const implementationsLocations = await implementations.locations
-            if (implementationsLocations.length > 0) {
-                implementationObjs = implementationsLocations.map(location => ({
-                    symbolName: extractRangeFromDocument(contentMap, location.uri, location.range),
-                    location,
-                    hover: hoverMap.get(locationKeyFn(location)) || [],
-                }))
-            }
-
-            return {
+        hoverMatches.map(
+            async ({
                 symbolName,
                 symbolLocation,
-                definition: definitionObj,
-                typeDefinition: typeDefinitionObj,
-                implementations: implementationObjs,
+                definitionsPromise,
+                typeDefinitionsPromise,
+                implementationsPromise,
+            }) => {
+                let definitionObj: ResolvedHoverElement | undefined
+                const definitionLocation = (await definitionsPromise).pop()
+                if (definitionLocation) {
+                    const symbolName = extractRangeFromDocument(
+                        contentMap,
+                        definitionLocation.uri,
+                        definitionLocation.range
+                    )
+
+                    definitionObj = {
+                        symbolName,
+                        location: definitionLocation,
+                        hover: resolvedHoverMap.get(locationKeyFn(definitionLocation)) || [],
+                    }
+                }
+
+                let typeDefinitionObj: ResolvedHoverElement | undefined
+                const typeDefinitionLocation = (await typeDefinitionsPromise).pop()
+                if (typeDefinitionLocation) {
+                    const symbolName = extractRangeFromDocument(
+                        contentMap,
+                        typeDefinitionLocation.uri,
+                        typeDefinitionLocation.range
+                    )
+
+                    typeDefinitionObj = {
+                        symbolName,
+                        location: typeDefinitionLocation,
+                        hover: resolvedHoverMap.get(locationKeyFn(typeDefinitionLocation)) || [],
+                    }
+                }
+
+                let implementationObjs: ResolvedHoverElement[] | undefined
+                const implementationsLocations = await implementationsPromise
+                if (implementationsLocations.length > 0) {
+                    implementationObjs = implementationsLocations.map(location => ({
+                        symbolName: extractRangeFromDocument(contentMap, location.uri, location.range),
+                        location,
+                        hover: resolvedHoverMap.get(locationKeyFn(location)) || [],
+                    }))
+                }
+
+                return {
+                    symbolName,
+                    symbolLocation,
+                    definition: definitionObj,
+                    typeDefinition: typeDefinitionObj,
+                    implementations: implementationObjs,
+                }
             }
-        })
+        )
     )
 }
 
@@ -883,14 +883,10 @@ export const locationKeyFn = (location: vscode.Location): string =>
 /**
  * Convert a mapping from K -> Thenable<V> to a map of K -> V.
  */
-const unwrapThenableMap = async <K, V>(m: Map<K, Thenable<V>>): Promise<Map<K, V>> => {
-    // Force resolution so that the await in the loop below is unblocked.
-    await Promise.all(m.values())
-
+const unwrapThenableMap = async <K, V>(map: Map<K, Thenable<V>>): Promise<Map<K, V>> => {
     const resolved = new Map<K, V>()
-    for (const [k, v] of [...m.entries()]) {
+    for (const [k, v] of map) {
         resolved.set(k, await v)
     }
-
     return resolved
 }

--- a/vscode/src/graph/limiter.test.ts
+++ b/vscode/src/graph/limiter.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AbortError, TimeoutError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+
+import { createLimiter, Limiter } from './limiter'
+
+describe('limiter', () => {
+    it('should limit the execution of promises', async () => {
+        const limiter = createLimiter(2, 100)
+
+        const req1 = createMockRequest(limiter)
+        const req2 = createMockRequest(limiter)
+        const req3 = createMockRequest(limiter)
+
+        expect(req1.hasStarted()).toBe(true)
+        expect(req2.hasStarted()).toBe(true)
+        expect(req3.hasStarted()).toBe(false)
+
+        req1.resolve('foo')
+        req2.resolve('bar')
+        await expect(req1.promise).resolves.toBe('foo')
+        await expect(req2.promise).resolves.toBe('bar')
+
+        expect(req3.hasStarted()).toBe(true)
+
+        req3.resolve('baz')
+        await expect(req3.promise).resolves.toBe('baz')
+    })
+
+    it('should abort pending promises', async () => {
+        const limiter = createLimiter(1, 100)
+
+        const req1 = createMockRequest(limiter)
+        const req2 = createMockRequest(limiter)
+
+        expect(req1.hasStarted()).toBe(true)
+        expect(req2.hasStarted()).toBe(false)
+
+        req1.abort()
+        req2.abort()
+
+        req1.resolve('foo')
+
+        await expect(req1.promise).resolves.toBe('foo')
+        await expect(req2.promise).rejects.toBeInstanceOf(AbortError)
+    })
+
+    describe('with fake timers', () => {
+        beforeEach(() => {
+            vi.useFakeTimers()
+        })
+        afterEach(() => {
+            vi.useRealTimers()
+        })
+
+        it('should time out a request if it takes too long', async () => {
+            const limiter = createLimiter(1, 100)
+
+            const req1 = createMockRequest(limiter)
+            const req2 = createMockRequest(limiter)
+
+            expect(req1.hasStarted()).toBe(true)
+            expect(req2.hasStarted()).toBe(false)
+
+            vi.advanceTimersByTime(100)
+
+            await expect(req1.promise).rejects.toBeInstanceOf(TimeoutError)
+            expect(req2.hasStarted()).toBe(true)
+
+            req2.resolve('foo')
+            await expect(req2.promise).resolves.toBe('foo')
+        })
+    })
+})
+
+function createMockRequest<T>(limiter: Limiter): {
+    resolve: (val: T) => void
+    hasStarted: () => boolean
+    abort: () => void
+    promise: Promise<T>
+} {
+    const abortController = new AbortController()
+    let resolve: ((val: T) => void) | null
+    const promise = limiter<T>(async () => new Promise(_resolve => (resolve = _resolve)), abortController.signal)
+
+    return {
+        resolve(val: T) {
+            if (!resolve) {
+                throw new Error('Promises not started yet')
+            }
+            resolve(val)
+        },
+        hasStarted() {
+            return !!resolve
+        },
+        abort() {
+            abortController.abort()
+        },
+        promise,
+    }
+}

--- a/vscode/src/graph/limiter.ts
+++ b/vscode/src/graph/limiter.ts
@@ -1,0 +1,88 @@
+import { AbortError, TimeoutError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+
+type PromiseCreator<T> = () => Promise<T>
+interface Queued<T> {
+    creator: PromiseCreator<T>
+    abortSignal?: AbortSignal
+    resolve: (value: T) => void
+    reject: (reason: Error) => void
+}
+
+export type Limiter = <T>(creator: PromiseCreator<T>, abortSignal?: AbortSignal) => Promise<T>
+
+export function createLimiter(limit: number, timeout: number): Limiter {
+    const queue: Queued<any>[] = []
+    let inflightPromises = 0
+
+    function processNext(): void {
+        if (inflightPromises >= limit) {
+            return
+        }
+
+        if (queue.length === 0) {
+            return
+        }
+
+        const next = queue.shift()!
+        inflightPromises += 1
+
+        let didTimeout = false
+
+        const timeoutId = setTimeout(() => {
+            didTimeout = true
+            next.reject(new TimeoutError())
+            inflightPromises -= 1
+            processNext()
+        }, timeout)
+
+        const runner = next.creator()
+        runner
+            .then(value => {
+                if (didTimeout) {
+                    return
+                }
+                next.resolve(value)
+            })
+            .catch(error => {
+                if (didTimeout) {
+                    return
+                }
+                next.reject(error)
+            })
+            .finally(() => {
+                if (didTimeout) {
+                    return
+                }
+                clearTimeout(timeoutId)
+                inflightPromises -= 1
+                processNext()
+            })
+    }
+
+    return function enqueue<T>(creator: () => Promise<T>, abortSignal?: AbortSignal): Promise<T> {
+        let queued: Queued<T>
+        const promise = new Promise<T>((resolve, reject) => {
+            queued = {
+                creator,
+                abortSignal,
+                resolve,
+                reject,
+            }
+        })
+        queue.push(queued!)
+        abortSignal?.addEventListener('abort', () => {
+            // Only abort queued requests
+            const index = queue.indexOf(queued!)
+            if (index < 0) {
+                return
+            }
+
+            queued.reject(new AbortError())
+            queue.splice(index, 1)
+        })
+
+        processNext()
+
+        return promise
+    }
+}


### PR DESCRIPTION
This PR adds a new promise limiter which can be used to:

- Define a parallel execution limit of promises 
- Add the ability to abort promises that have not started yet and have endured no work
- Add a timeout to prevent the queue to be filled with requests that never respond

This is an attempt to reduce the pressure on the lang server when querying for code graph context. Specifically, all lang server API calls are now called via the limiter and limited to 20 concurrent request (This value was chosen at random) and will be timing out after 5 seconds.

When quickly navigating through sections, the section observer will now reset a section if it can be aborted.

## Test plan

- Enable graph context experimental flag
- Open a large file
- Click into a section, observe that we set the state to `loading`
- Quickly click into a different section. Observe that we only resolve the new section and abort the old one


https://github.com/sourcegraph/cody/assets/458591/2bf93e5c-bbce-4e54-a82d-f835e6e83e4e


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
