### PR TITLE
feat: remove unwanted suggestion from the cache

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Add experimental option `claude-instant-infill` to the `cody.autocomplete.advanced.model` config option that enables users using the Claude Instant model to get suggestions with context awareness (infill). [pull/974](https://github.com/sourcegraph/cody/pull/974)
 - New `cody.chat.preInstruction` configuration option for adding custom message at the start of all chat messages sent to Cody. Extension reload required. [pull/963](https://github.com/sourcegraph/cody/pull/963)
 - Add a simplified sign-in. 50% of people will see these new sign-in buttons. [pull/1036](https://github.com/sourcegraph/cody/pull/1036)
+- Now removes completions from cache when the initial suggestion prefix is deleted by users after a suggestion was displayed. This avoids unhelpful/stale suggestions from persisting. [pull/1105](https://github.com/sourcegraph/cody/pull/1105)
 
 ### Fixed
 

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -96,6 +96,11 @@ export class RequestManager {
         return request.promise
     }
 
+    // Remove unwanted sugggestion from the cache
+    public removeUnwanted(params: RequestParams): void {
+        this.cache.delete(params)
+    }
+
     /**
      * Test if the result can be used for inflight requests. This only works
      * if a completion is a forward-typed version of a previous completion.
@@ -183,5 +188,9 @@ class RequestCache {
 
     public set(key: RequestParams, entry: InlineCompletionItem[]): void {
         this.cache.set(this.toCacheKey(key), entry)
+    }
+
+    public delete(key: RequestParams): void {
+        this.cache.delete(this.toCacheKey(key))
     }
 }


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/issues/969
Spin off from discussion in https://github.com/sourcegraph/cody/pull/1064

This PR adds the ability to remove an unwanted suggestion where the user performs deletion on a displayed suggestion from the cache.

This is built on @valerybugakov 's idea in the other issue comment https://github.com/sourcegraph/cody/pull/1064#pullrequestreview-1628364816 that we all agreed:

> It would be intuitive for me if we removed cached completions if a user deleted text past the initial trigger point. It covers the case @abeatrix mentioned in the PR description when you got an unhelpful completion, deleted the trigger point, typed com again, and got the same cached unhelpful completion. It would also preserve all the benefits of the request-manage cache PR (low jitter and high cache-hit rate). The rejection trigger (the moment when we remove the completions from the request manager cache) would be defined as deleting text past the trigger point.

If a user deletes text past/back-to the initial trigger point while a suggestion is on display, we would consider the suggestion unwanted and remove it from the cache. This ensures:
1. The unhelpful suggestion is removed from the cache
2. Displays suggestion from a new request instead. 

Note: Even if the new suggestion could be the same as the one we removed from the cache, we still want to make sure the old unhelpful suggestion is removed from the cache to begins with. This helps in cases where unhelpful suggestions are stuck even when prefix/suffix have been modified.

### Follow up

- Identify other unwanted suggestions from current logic and remove them from the cache

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before

In this example, you can see we got a suggestion `sortCompletions` from `sort`, and removing `sort`, then type `sort` again, we will still get `sortCompletions` as suggestion from the cache:

![before](https://github.com/sourcegraph/cody/assets/68532117/bda9a73f-11c6-4fd3-8a21-37fa37289e0b)

### After

Deleting past the initial trigger point `sort` will always remove the suggestion from the cache, and display result from the new request instead:

![after](https://github.com/sourcegraph/cody/assets/68532117/a2dd2f5d-b47f-4bb9-bb75-f967ef1057ec)


