### PR TITLE
Fix: replaceAll() should not be called with a non-global regular expression.

### DIFF
--- a/completions-review-tool/src/routes/_index.tsx
+++ b/completions-review-tool/src/routes/_index.tsx
@@ -137,7 +137,7 @@ function renderMarkdown(code: string) {
 
     return marked(
         `\`\`\`javascript
-${truncatedCode.replaceAll(/\\/, '\\\\')}
+${truncatedCode.replaceAll(/\\/g, '\\\\')}
 \`\`\``,
         { gfm: true }
     )


### PR DESCRIPTION
`pnpm run dev` from review completions tool fails with: 

```
String.replaceAll() should not be called with a non-global regular expression.
```

## Test plan

Manually run review tool.
