### PR TITLE
Autocomplete: Split minimum latency tests into two thresholds

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -12,7 +12,8 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
     CodyAutocompleteClaudeInstantInfill = 'cody-autocomplete-claude-instant-infill',
-    CodyAutocompleteMinimumLatency = 'cody-autocomplete-minimum-latency',
+    CodyAutocompleteMinimumLatency350 = 'cody-autocomplete-minimum-latency-350',
+    CodyAutocompleteMinimumLatency600 = 'cody-autocomplete-minimum-latency-600',
     CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',
 }
 

--- a/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/vscodeInlineCompletionItemProvider.ts
@@ -40,12 +40,6 @@ export interface CodyCompletionItemProviderConfig {
     featureFlagProvider: FeatureFlagProvider
 }
 
-// Only used when the CodyAutocompleteMinimumLatency feature flag is turned on:
-//
-// We don't want to show completions immediately after a user types a character (unless we show the
-// last candidate) to avoid churning the UI too much. Instead, we wait at least
-const MINIMUM_LATENCY_MS = 350
-
 export class InlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private promptChars: number
     private maxPrefixChars: number
@@ -131,9 +125,10 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         const start = performance.now()
         // We start the request early so that we have a high chance of getting a response before we
         // need it.
-        const minimumLatencyFlagPromise = this.config.featureFlagProvider.evaluateFeatureFlag(
-            FeatureFlag.CodyAutocompleteMinimumLatency
-        )
+        const minimumLatencyFlagsPromises = [
+            this.config.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteMinimumLatency350),
+            this.config.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteMinimumLatency600),
+        ]
         const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
         const graphContextFetcher = this.config.graphContextFetcher ?? undefined
 
@@ -209,11 +204,12 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             // latency so that we don't show a result before the user has paused typing for a brief
             // moment.
             if (result.source !== InlineCompletionsResultSource.LastCandidate) {
-                const minimumLatencyFlag = await minimumLatencyFlagPromise
-                if (minimumLatencyFlag) {
+                const [minimumLatency350, minimumLatency600] = await Promise.all(minimumLatencyFlagsPromises)
+                if (minimumLatency350 || minimumLatency600) {
+                    const minimumLatency = minimumLatency350 ? 350 : 600
                     const delta = performance.now() - start
-                    if (delta < MINIMUM_LATENCY_MS) {
-                        await new Promise(resolve => setTimeout(resolve, MINIMUM_LATENCY_MS - delta))
+                    if (delta < minimumLatency) {
+                        await new Promise(resolve => setTimeout(resolve, minimumLatency - delta))
                     }
                 }
             }


### PR DESCRIPTION
This splits up the minimum latency feature flag with results based on the data analysis we have done internally https://sourcegraph.slack.com/archives/C05AGQYD528/p1694703243819199?thread_ts=1694617270.496189&cid=C05AGQYD528

## Test plan

👀 
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
