### PR TITLE
Autocomplete: Remove common TS hover text for graph context

### DIFF
--- a/vscode/src/graph/graph.ts
+++ b/vscode/src/graph/graph.ts
@@ -544,30 +544,36 @@ const hoverContextFromResolvedHoverText = (t: ResolvedHoverText): HoverContext[]
     ].filter(isDefined)
 
 const hoverContextFromElement = (
-    e: ResolvedHoverElement | undefined,
+    element: ResolvedHoverElement | undefined,
     type: HoverContext['type'],
     sourceSymbolName?: string
 ): HoverContext | undefined => {
-    if (e === undefined) {
+    if (element === undefined) {
         return undefined
     }
 
-    const content = hoverToStrings(e.hover)
+    let content = hoverToStrings(element.hover)
+
+    // Filter out common hover texts that do not provide additional value
+    content = content.filter(
+        c => c.trim() !== `interface ${element.symbolName}` && c.trim() !== `class ${element.symbolName}`
+    )
+
     if (content.length === 0) {
         return undefined
     }
 
     return {
-        symbolName: e.symbolName,
+        symbolName: element.symbolName,
         sourceSymbolName,
         type,
         content,
-        uri: e.location.uri.toString(),
+        uri: element.location.uri.toString(),
         range: {
-            startLine: e.location.range.start.line,
-            startCharacter: e.location.range.start.character,
-            endLine: e.location.range.end.line,
-            endCharacter: e.location.range.end.character,
+            startLine: element.location.range.start.line,
+            startCharacter: element.location.range.start.character,
+            endLine: element.location.range.end.line,
+            endCharacter: element.location.range.end.character,
         },
     }
 }


### PR DESCRIPTION
This removes common and not helpful hover text like you can see in this screenshot:

<img width="1050" alt="Screenshot 2023-09-19 at 13 45 16" src="https://github.com/sourcegraph/cody/assets/458591/015b8ebe-4fdc-4caf-ada6-3e75193113a1">

## Test plan

The common and unhelpful hover text is no longer included in the context. Here instead we only see a previous selected section being added (the example does not have any references to code that is outside the context window) 
<img width="1061" alt="Screenshot 2023-09-19 at 13 55 46" src="https://github.com/sourcegraph/cody/assets/458591/82728032-be68-488d-8700-31feb75c363c">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
