### PR TITLE
change: register inline completion provider for files and notebooks only

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -29,6 +29,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Slightly reduce latency when manually triggering autocomplete requests. [pull/1060](https://github.com/sourcegraph/cody/pull/1060)
 - Configure autocomplete provider based on cody LLM settings in site config. [pull/1035](https://github.com/sourcegraph/cody/pull/1035)
 - Filters out single character autocomplete results. [pull/1109](https://github.com/sourcegraph/cody/pull/1109)
+- Register inline completion provider for text files and notebooks only to ensure autocomplete works in environments that are fully supported. [pull/1114](https://github.com/sourcegraph/cody/pull/1114)
 
 ## [0.10.2]
 

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -68,7 +68,10 @@ export async function createInlineCompletionItemProvider({
             vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyCompletion }) => {
                 completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyCompletion)
             }),
-            vscode.languages.registerInlineCompletionItemProvider('*', completionsProvider),
+            vscode.languages.registerInlineCompletionItemProvider(
+                [{ scheme: 'file', language: '*' }, { notebookType: '*' }],
+                completionsProvider
+            ),
             registerAutocompleteTraceView(completionsProvider)
         )
         if (sectionObserver) {


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/1112

The inline completion provider was previously registered for all languages ('*') at all places. 

This change updates the registration to explicitly include notebook and text documents with file scheme to ensure autocompletion only works in places that we currently support.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- Completions should work the same on saved text documents and notebook cells
- Completions should not work in source control input box or any other places that are not editor files / notebook files

### Before 

![image](https://github.com/sourcegraph/cody/assets/68532117/df8d16a0-999a-46ba-ae9a-f61c82a8e776)

### After

https://github.com/sourcegraph/cody/assets/68532117/7a9ec776-398d-47ba-b3cc-6aeda86c3b24

