### PR TITLE
refactor: simplify prefix code extraction for anthropic

### DIFF
--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -107,12 +107,9 @@ export class AnthropicProvider extends Provider {
         const { head, tail, overlap } = getHeadAndTail(this.options.docContext.prefix)
 
         // Infill block represents the code we want the model to complete
-        const infillBlock = `${tail.trimmed}`
-        // code before the cursor, after removing the code for the infillBlock
-        // Using this instead of head.trimmed to preserve the spacing from prefix so the model can determines the patterns of surrounding code
-        // Use regex to makes sure only the last trimmedTail match is replaced to avoid replacing overlapping code
-        const infillBlockRegex = new RegExp(`${tail.trimmed.trim()}\\s*$`, 'g')
-        const infillPrefix = this.options.docContext.prefix.replace(infillBlockRegex, '')
+        const infillBlock = tail.trimmed
+        // code before the cursor, without the code extracted for the infillBlock
+        const infillPrefix = head.raw
         // code after the cursor
         const infillSuffix = this.options.docContext.suffix
 
@@ -127,8 +124,8 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${this.options.fileName}. Detect the functionality, formats, style, patterns, and logics in use from code outside ${OPENING_CODE_TAG} XML tags. Then, use what you detect and reuse any methods/libraries to complete and enclose completed code only inside ${OPENING_CODE_TAG} tags precisely without duplicating existing implementations. Here is the code:
-                ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
+                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations.
+                Here is the code: ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
             },
             {
                 speaker: 'assistant',

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -55,6 +55,7 @@ export interface TrimmedString {
     trimmed: string
     leadSpace: string
     rearSpace: string
+    raw?: string
 }
 
 /**
@@ -102,7 +103,7 @@ export function getHeadAndTail(s: string): PrefixComponents {
         headAndTail = { head: trimSpace(s), tail: trimSpace(s), overlap: s }
     } else {
         headAndTail = {
-            head: trimSpace(lines.slice(0, tailStart).join('\n')),
+            head: trimSpace(lines.slice(0, tailStart).join('\n') + '\n'),
             tail: trimSpace(lines.slice(tailStart).join('\n')),
         }
     }
@@ -131,7 +132,7 @@ export function getHeadAndTail(s: string): PrefixComponents {
 function trimSpace(s: string): TrimmedString {
     const trimmed = s.trim()
     const headEnd = s.indexOf(trimmed)
-    return { trimmed, leadSpace: s.slice(0, headEnd), rearSpace: s.slice(headEnd + trimmed.length) }
+    return { raw: s, trimmed, leadSpace: s.slice(0, headEnd), rearSpace: s.slice(headEnd + trimmed.length) }
 }
 
 /*


### PR DESCRIPTION
follow https://github.com/sourcegraph/cody/pull/1063#discussion_r1326883085

refactor: Simplify prefix code extraction for anthropic infill prompt building step

- Extract raw prefix code rather than reconstructing as suggested by @valerybugakov (thank you!)
- Remove custom infill block extraction from prefix
- Simplify infill model prompt

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

![image](https://github.com/sourcegraph/cody/assets/68532117/3810f1b9-d05e-4e12-b695-9e17cf09d182)

Infill model still works as expected.