### PR TITLE
fix: insert not replace for insert at cursor

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Fix a potential race condition for autocomplete requests that happen when a completion is stored as the last shown candidate when it will not be shown. [pull/1059](https://github.com/sourcegraph/cody/pull/1059)
+- Use `insert` instead of `replace` for `Insert at Cursor` button for inserting code to current cursor position. [pull/1118](https://github.com/sourcegraph/cody/pull/1118)
 
 ### Changed
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -220,7 +220,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
 
         const edit = new vscode.WorkspaceEdit()
         // trimEnd() to remove new line added by Cody
-        edit.insert(editor.document.uri, selectionRange.start, text.trimEnd())
+        edit.insert(editor.document.uri, selectionRange.start, text + '\n')
         await vscode.workspace.applyEdit(edit)
 
         // Log insert event

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -220,7 +220,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
 
         const edit = new vscode.WorkspaceEdit()
         // trimEnd() to remove new line added by Cody
-        edit.replace(editor.document.uri, selectionRange, text.trimEnd())
+        edit.insert(editor.document.uri, selectionRange.start, text.trimEnd())
         await vscode.workspace.applyEdit(edit)
 
         // Log insert event


### PR DESCRIPTION
Reported by @toolmantim, current insert at cursor button uses replace instead of insert

fix: Use insert instead of replace for ` insert at cursor` button

- Change edit.replace to edit.insert for code block insertion button
- Insert completion text at selection start instead of replacing by range


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- start cody from this branch
- use the insert at cursor button on code block

#### Before

current selection will be replaced by code block insertion on button click

#### After

code block will be inserted at the start of the current cursor, and current selection will not be replaced

![insert-fix](https://github.com/sourcegraph/cody/assets/68532117/719c5553-9822-469c-956a-742027ea0409)
