### PR TITLE
Autocomplete: Add back support for unsaved files

### DIFF
--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -69,7 +69,7 @@ export async function createInlineCompletionItemProvider({
                 completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyCompletion)
             }),
             vscode.languages.registerInlineCompletionItemProvider(
-                [{ scheme: 'file', language: '*' }, { notebookType: '*' }],
+                [{ scheme: 'file', language: '*' }, { scheme: 'untitled', language: '*' }, { notebookType: '*' }],
                 completionsProvider
             ),
             registerAutocompleteTraceView(completionsProvider)


### PR DESCRIPTION
This fixes a small regression added by #1114 that prevented autocomplete from working on unsaved files (I remember this as an early customer reported issue)

## Test plan


https://github.com/sourcegraph/cody/assets/458591/a76b7c22-8034-4507-ad87-c0898ed8bf1f



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
