### PR TITLE
fix: custom command in context menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,6 +19,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Fix a potential race condition for autocomplete requests that happen when a completion is stored as the last shown candidate when it will not be shown. [pull/1059](https://github.com/sourcegraph/cody/pull/1059)
 - Use `insert` instead of `replace` for `Insert at Cursor` button for inserting code to current cursor position. [pull/1118](https://github.com/sourcegraph/cody/pull/1118)
+- Fix issue that caused the custom commands menu to unable to execute commands. [pull/1123](https://github.com/sourcegraph/cody/pull/1123)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -278,7 +278,7 @@
       {
         "command": "cody.command.smell-code",
         "category": "Ask Cody",
-        "title": "Smell Code"
+        "title": "Find Code Smells"
       },
       {
         "command": "cody.command.context-search",
@@ -371,7 +371,7 @@
       },
       {
         "command": "cody.inline.new",
-        "title": "Start New Thread",
+        "title": "Ask Cody Inline",
         "category": "Cody Inline Chat",
         "when": "cody.activated && config.cody.inlineChat.enabled",
         "enablement": "editorFocus"
@@ -433,8 +433,8 @@
       },
       {
         "command": "cody.action.commands.custom.menu",
-        "category": "Cody",
-        "title": "Custom Commands (Experimental)",
+        "category": "Ask Cody",
+        "title": "Custom Commands",
         "when": "cody.activated",
         "icon": "$(bookmark)"
       },
@@ -459,7 +459,7 @@
         "mac": "alt+/"
       },
       {
-        "command": "cody.fixup.new",
+        "command": "cody.command.edit-code",
         "key": "ctrl+shift+v",
         "mac": "shift+cmd+v",
         "when": "cody.activated && !editorReadonly"
@@ -502,11 +502,11 @@
       "commandPalette": [
         {
           "command": "cody.command.explain-code",
-          "when": "cody.activated"
+          "when": "false"
         },
         {
           "command": "cody.command.context-search",
-          "when": "cody.activated"
+          "when": "false"
         },
         {
           "command": "cody.command.inline-touch",
@@ -514,15 +514,15 @@
         },
         {
           "command": "cody.command.smell-code",
-          "when": "cody.activated"
+          "when": "false"
         },
         {
           "command": "cody.command.generate-tests",
-          "when": "cody.activated"
+          "when": "false"
         },
         {
           "command": "cody.command.document-code",
-          "when": "cody.activated"
+          "when": "false"
         },
         {
           "command": "cody.focus",
@@ -587,35 +587,47 @@
       "cody.submenu": [
         {
           "command": "cody.command.explain-code",
-          "when": "cody.activated"
+          "when": "cody.activated",
+          "group": "command"
         },
         {
           "command": "cody.command.edit-code",
-          "when": "cody.activated"
+          "when": "cody.activated",
+          "group": "ask"
         },
         {
           "command": "cody.command.generate-tests",
-          "when": "cody.activated"
+          "when": "cody.activated",
+          "group": "command"
         },
         {
           "command": "cody.command.document-code",
-          "when": "cody.activated"
+          "when": "cody.activated",
+          "group": "command"
         },
         {
           "command": "cody.command.smell-code",
-          "when": "cody.activated"
+          "when": "cody.activated",
+          "group": "command"
         },
         {
           "command": "cody.action.commands.custom.menu",
-          "when": "cody.activated"
+          "when": "cody.activated",
+          "group": "command"
         },
         {
           "command": "cody.focus",
-          "when": "!cody.activated"
+          "when": "!cody.activated",
+          "group": "other"
         },
         {
           "command": "cody.guardrails.debug",
-          "when": "cody.activated && config.cody.experimental.guardrails && editorHasSelection"
+          "when": "cody.activated && config.cody.experimental.guardrails && editorHasSelection",
+          "group": "other"
+        },
+        {
+          "command": "cody.inline.new",
+          "group": "ask"
         }
       ],
       "view/title": [

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -303,34 +303,34 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                 ?.filter(command => command !== null && command?.[1]?.type !== 'default')
                 .map(commandItem => {
                     const command = commandItem[1]
-                    const description = command.type
-                    return createQuickPickItem(command.description || commandItem[0], description)
+                    const description = commandItem[0]
+                    return createQuickPickItem(command.description, description)
                 })
 
             const configOption = menu_options.config
             const addOption = menu_options.add
+
             promptItems.push(menu_separators.settings, configOption, addOption)
 
             // Show the list of prompts to the user using a quick pick
-            const selectedPrompt = await showCustomCommandMenu([...promptItems])
-            // Find the prompt based on the selected prompt name
-            const promptTitle = selectedPrompt?.label
-            if (!selectedPrompt || !promptTitle) {
+            const selected = await showCustomCommandMenu([...promptItems])
+            const commandKey = selected?.description
+
+            if (!selected || !commandKey) {
                 return
             }
 
-            switch (promptTitle.length > 0) {
-                case promptTitle === addOption.label:
+            switch (commandKey.length > 0) {
+                case commandKey === addOption.label:
                     return await this.addNewUserCommandQuick()
-                case promptTitle === configOption.label:
+                case commandKey === configOption.label:
                     return await this.configMenu('custom')
                 default:
                     // Run the prompt
-                    await vscode.commands.executeCommand('cody.action.commands.exec', promptTitle)
+                    await vscode.commands.executeCommand('cody.action.commands.exec', commandKey)
                     break
             }
-
-            logDebug('CommandsController:promptsQuickPicker:selectedPrompt', promptTitle)
+            logDebug('CommandsController:promptsQuickPicker:selectedPrompt', commandKey)
         } catch (error) {
             logError('CommandsController:promptsQuickPicker', 'error', { verbose: error })
         }

--- a/vscode/src/custom-prompts/menus/index.ts
+++ b/vscode/src/custom-prompts/menus/index.ts
@@ -129,7 +129,7 @@ export async function showCommandMenu(
 
 export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<QuickPickItem> {
     const CustomCommandsMenuOptions: QuickPickOptions = {
-        title: 'Cody Custom Commands (Experimental)',
+        title: 'Cody: Custom Commands (Experimental)',
         placeHolder: 'Search command to run...',
     }
 
@@ -140,11 +140,19 @@ export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<Qui
         quickPick.placeholder = CustomCommandsMenuOptions.placeHolder
         quickPick.ignoreFocusOut = true
 
+        quickPick.buttons = [menu_buttons.back]
+
         quickPick.onDidAccept(() => {
             const selection = quickPick.activeItems[0]
             resolve(selection)
             quickPick.hide()
         })
+
+        quickPick.onDidTriggerButton(async () => {
+            quickPick.hide()
+            await commands.executeCommand('cody.action.commands.menu')
+        })
+
         quickPick.show()
     })
 }
@@ -154,7 +162,7 @@ export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<Qui
  */
 export async function showCommandConfigMenu(): Promise<CustomCommandsItem> {
     const CustomCommandConfigMenuOptions = {
-        title: 'Configure Custom Commands (Experimental)',
+        title: 'Cody: Configure Custom Commands (Experimental)',
         placeHolder: 'Choose an option',
     }
 


### PR DESCRIPTION
## Issue

Currently, none of the commands from the Custom Commands menu work. 

Steps to reproduce:

1. Open the Custom Command menu from the right click menu in your editor
![image](https://github.com/sourcegraph/cody/assets/68532117/63f77b0f-75aa-40a0-b396-279d3c77df5c)
2. Choose a Custom Command to run from the menu
3. None of the commands would work


This PR includes:

- Fixed the issue mentioned above
- added a back button to move from Custom Command Menu to Cody Menu

![image](https://github.com/sourcegraph/cody/assets/68532117/932700eb-e7af-445b-945d-2c3b98d4f6e1)


Also made the following changes in our package.json
- Rename "Smell Code" to "Find Code Smells" for clarity
- Move commands to "Ask Cody" category for better organization 
- Disable duplicated commands in command palette as /doc /test /smell etc are already covered in our Commands Menu
- Organize Cody submenu into "command" and "other" groups
- Rename "Start New Thread" to "Ask Cody Inline"
- Rename "Custom Commands (Experimental)" to just "Custom Commands"
- Rename "Fixup" command to "Edit Code"


|                   BEFORE                    |                     AFTER                  |
|:-------------------------------------:|:-------------------------------------:|
| ![image](https://github.com/sourcegraph/cody/assets/68532117/84ba8c9c-8775-4bae-be96-0e1291fc512d) | ![image](https://github.com/sourcegraph/cody/assets/68532117/5e9659ba-ea0f-456d-8810-2b2f1b309c08) |



## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. Open the Custom Command menu from the right-click menu in your editor
![image](https://github.com/sourcegraph/cody/assets/68532117/5e9659ba-ea0f-456d-8810-2b2f1b309c08)
3. Choose a Custom Command to run from the menu
4. Command should work as expected