### PR TITLE
Cody release v0.12.0

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,14 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.12.0]
+
+### Added
+
 - Add a UI indicator when you're not signed in. [pull/970](https://github.com/sourcegraph/cody/pull/970)
 - Added a completion statistics summary to the autocomplete trace view. [pull/973](https://github.com/sourcegraph/cody/pull/973)
 - Add experimental option `claude-instant-infill` to the `cody.autocomplete.advanced.model` config option that enables users using the Claude Instant model to get suggestions with context awareness (infill). [pull/974](https://github.com/sourcegraph/cody/pull/974)

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -42,7 +42,7 @@ We also have some build-in UI to help during the development of autocomplete req
 
 To publish a new release to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai):
 
-1. Increment the `version` in [`package.json`](package.json).
+1. Increment the `version` in [`package.json`](package.json) & [`CHANGELOG`](CHANGELOG.md).
 1. Commit the version increment.
 1. `git tag vscode-v$(jq -r .version package.json)`
 1. `git push --tags`

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "0.10.2",
+  "version": "0.12.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
pending https://github.com/sourcegraph/cody/pull/1124

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

version bump