### PR TITLE
Autocomplete: Do not reset lastCandidate with invalidated requests

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -168,6 +168,19 @@ export function accept(id: string, completion: InlineCompletionItem): void {
     if (!completionEvent.suggestedAt) {
         logCompletionEvent('unexpectedNotSuggested')
     }
+    // It is still possible to accept a completion before it was logged as suggested. This is
+    // because we do not have direct access to know when a completion is being shown or hidden from
+    // VS Code. Instead, we rely on subsequent completion callbacks and other heuristics to know
+    // when the current one is rejected.
+    //
+    // One such condition is when using backspace. In VS Code, we create completions such that they
+    // always start at the binning of the line. This means when backspacing past the initial trigger
+    // point, we keep showing the currently rendered completion until the next request is finished.
+    // However, we do log the completion as rejected with the keystroke leaving a small window where
+    // the completion can be accepted after it was marked as suggested.
+    if (completionEvent.suggestionLoggedAt) {
+        logCompletionEvent('unexpectedAlreadySuggested')
+    }
 
     completionEvent.acceptedAt = performance.now()
 


### PR DESCRIPTION
During exploration outlined in [this thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1695136853673249) we found two situations when we currently mark a completion as `suggested` even though it is still visible on the UI for a bit.

One such scenario is when the network requests were resolving out-of-order (mostly noticeable via the `CacheAfterRequestStart` cache hit behavior). A _prior_ completion start would return `null` (because the VS Code check if the completion is visible checks for it being terminate) and that would in turn reset the `lastCandidate` even though that might already have been set by the request of a later network response that already succeeded.

The safest and easiest fix for this is to ignore any follow-up work if we notice a completion request to be outdated. This also saves some CPU resources.

A better fix for the future would be to completely reverse engineer when completions are made visible/invisible by VS Code which is work for a follow-up PR. 

This should fix the easiest reproducible form of completions being accepted after they were logged as suggested. I found a second race condition that is more nuanced but the fix for this is not in the scope of this PR. Instead, I've added some simple logging so we can assess the magnitude of this error. I suspect it to be very low (it's hard to reproduce locally).

## Test plan

- Add a debugging breakpoint at the new `logCompletionEvent('unexpectedAlreadySuggested')` line
- Cause a request to be synthesized by a previous network request. An example for this is to start typing something like `console`, wait a brief moment to start a request, continue with something that the LLM would suggest (e.g. `.log`) and then wait for the request to be resolved with the first network request. In this case, the completion callbacks will yield out of order  and you can observe a `lastCandidate` to be incorrectly reset.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
