### PR TITLE
fix: changelog item for pull/907

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -41,6 +41,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Configure autocomplete provider based on cody LLM settings in site config. [pull/1035](https://github.com/sourcegraph/cody/pull/1035)
 - Filters out single character autocomplete results. [pull/1109](https://github.com/sourcegraph/cody/pull/1109)
 - Register inline completion provider for text files and notebooks only to ensure autocomplete works in environments that are fully supported. [pull/1114](https://github.com/sourcegraph/cody/pull/1114)
+- The `Generate Unit Tests` command has been improved with an enhanced context fetching process that produces test results with better quality. [pull/907](https://github.com/sourcegraph/cody/pull/907)
 
 ## [0.10.2]
 


### PR DESCRIPTION
Moving changelog item for https://github.com/sourcegraph/cody/pull/907 from v0.8.0 to v0.12.0. It was added to the wrong release when it was merged.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

changelog update