### PR TITLE
Temporary solution to remove failed fixup tasks from the fixup view

### DIFF
--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -61,7 +61,10 @@ export class Fixup implements Recipe {
         const quarterFileContext = Math.floor(MAX_CURRENT_FILE_TOKENS / 4)
         if (truncateText(fixupTask.selectedText, quarterFileContext * 2) !== fixupTask.selectedText) {
             const msg = "The amount of text selected exceeds Cody's current capacity."
-            await context.editor.showWarningMessage(msg)
+            context.editor.showWarningMessage(msg).catch(error => {
+                console.error('Failed to show warning message:', error)
+            })
+            fixupController.removeErrneousTask(taskId)
             return null
         }
 

--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -62,6 +62,7 @@ export interface VsCodeFixupTaskRecipeData {
 
 export interface VsCodeFixupController {
     getTaskRecipeData(taskId: string): Promise<VsCodeFixupTaskRecipeData | undefined>
+    removeErrneousTask(taskID: string): void
 }
 
 export interface VsCodeCommandsController {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -109,6 +109,14 @@ export class FixupController
         return task
     }
 
+    public removeErrneousTask(taskID: taskID): void {
+        const task = this.tasks.get(taskID)
+        if (!task) {
+            return
+        }
+        this.setTaskState(task, CodyTaskState.error)
+    }
+
     // Open fsPath at the selected line in editor on tree item click
     private showThisFixup(taskID: taskID): void {
         const task = this.tasks.get(taskID)
@@ -509,7 +517,7 @@ export class FixupController
             void vscode.commands.executeCommand('setContext', 'cody.fixup.running', false)
         }
 
-        if (task.state === CodyTaskState.fixed) {
+        if (task.state === CodyTaskState.fixed || task.state === CodyTaskState.error) {
             this.discard(task)
             return
         }


### PR DESCRIPTION
Solves https://github.com/sourcegraph/cody/issues/1088

## Before(Turn on voice)
https://github.com/sourcegraph/cody/assets/11155207/81810737-31a5-424e-b654-c6278f13e76d


## After(Turn on voice)
https://github.com/sourcegraph/cody/assets/11155207/a0e73968-fcd5-445a-80a7-431e23c95bfb



### Answering followup questions
From @abeatrix 
_> IIRC FixupTask has a method for displaying error, or somewhere in fixupController 😀_

That's true and the error is still gonna be displayed with this fix 
<img width="460" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/6e364c1a-d12c-46e9-b8cf-81f178c5ac09">

_IS this the perfect way to solve the problem?_ 
I think a more broader solution which has full blown error handling scenarios with a lot of different forms of failure would be a much nicer solution but for now this solution works and handles the error pretty well. As folks build more the understanding of the error handling scenarios would be better and maybe then that can be pursued but this seems okay for now. 


## Test plan
Just do what the video says
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
