### PR TITLE
Autocomplete: Fix cody-autocomplete-claude-instant-infill experiment

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,7 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Fixes an issue that caused the `cody-autocomplete-claude-instant-infill` feature flag to have no effect.
+- Fixes an issue that caused the `cody-autocomplete-claude-instant-infill` feature flag to have no effect. [pull/1132](https://github.com/sourcegraph/cody/pull/1132)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Fixes an issue that caused the `cody-autocomplete-claude-instant-infill` feature flag to have no effect.
+
 ### Changed
 
 ## [0.12.0]

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -20,12 +20,6 @@ export async function createProviderConfig(
     featureFlagProvider?: FeatureFlagProvider,
     codyLLMSiteConfig?: CodyLLMSiteConfiguration
 ): Promise<ProviderConfig | null> {
-    const defaultAnthropicProviderConfig = createAnthropicProviderConfig({
-        client,
-        contextWindowTokens: 2048,
-        mode: config.autocompleteAdvancedModel === 'claude-instant-infill' ? 'infill' : 'default',
-    })
-
     /**
      * Look for the autocomplete provider in VSCode settings and return matching provider config.
      */
@@ -61,7 +55,11 @@ export async function createProviderConfig(
                 })
             }
             case 'anthropic': {
-                return defaultAnthropicProviderConfig
+                return createAnthropicProviderConfig({
+                    client,
+                    contextWindowTokens: 2048,
+                    mode: model === 'claude-instant-infill' ? 'infill' : 'default',
+                })
             }
             default:
                 logError(
@@ -107,7 +105,11 @@ export async function createProviderConfig(
                 })
             case 'aws-bedrock':
             case 'anthropic':
-                return defaultAnthropicProviderConfig
+                return createAnthropicProviderConfig({
+                    client,
+                    contextWindowTokens: 2048,
+                    mode: config.autocompleteAdvancedModel === 'claude-instant-infill' ? 'infill' : 'default',
+                })
             default:
                 logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
                 return null

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -58,7 +58,11 @@ export async function createProviderConfig(
                 return createAnthropicProviderConfig({
                     client,
                     contextWindowTokens: 2048,
-                    mode: model === 'claude-instant-infill' ? 'infill' : 'default',
+                    mode:
+                        model === 'claude-instant-infill' ||
+                        config.autocompleteAdvancedModel === 'claude-instant-infill'
+                            ? 'infill'
+                            : 'default',
                 })
             }
             default:

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -124,7 +124,11 @@ export async function createProviderConfig(
      * If autocomplete provider is not defined neither in VSCode nor in Sourcegraph instance site config,
      * use the default provider config ("anthropic").
      */
-    return defaultAnthropicProviderConfig
+    return createAnthropicProviderConfig({
+        client,
+        contextWindowTokens: 2048,
+        mode: config.autocompleteAdvancedModel === 'claude-instant-infill' ? 'infill' : 'default',
+    })
 }
 
 async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(


### PR DESCRIPTION
Seems like there was a conflict between @abeatrix's addition of the feature flag and @taras-yemets' restructurings. The result of `resolveDefaultProviderFromVSCodeConfigOrFeatureFlags` was no longer used for the Anthropic initialization causing users to load the wrong prompt mode if `cody-autocomplete-claude-instant-infill` is enabled.

## Test plan

- Make sure you are connected to doctom
- Be in the control group of the StarCoder experiment (needs dotcom admin access)
- Ensure no model or provider overwrites are active
- Observe that the right mode is loaded

<img width="962" alt="Screenshot 2023-09-21 at 15 16 22" src="https://github.com/sourcegraph/cody/assets/458591/28ea32de-dd8d-41e0-8672-0f8680771514">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
