### PR TITLE
refactor: telemetry names for command events

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -482,12 +482,12 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (!text?.startsWith('/')) {
             return { text, recipeId }
         }
-        const commandKey = text.split(' ')[0].replace('/', '')
+
         switch (true) {
             case text === '/':
                 return vscode.commands.executeCommand('cody.action.commands.menu', 'sidebar')
             case text === '/commands-settings':
-                this.telemetryService.log('CodyVSCodeExtension:command:configMenuButton:clicked', { source: 'sidebar' })
+                this.telemetryService.log('CodyVSCodeExtension:commandConfigMenuButton:clicked', { source: 'sidebar' })
                 return vscode.commands.executeCommand('cody.settings.commands')
             case /^\/o(pen)?\s/.test(text) && this.editor.controllers.command !== undefined:
                 // open the user's ~/.vscode/cody.json file
@@ -514,9 +514,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 await vscode.commands.executeCommand('cody.fixup.new', { instruction: text })
                 return null
             case /^\/(explain|doc|test|smell)$/.test(text):
-                this.telemetryService.log(`CodyVSCodeExtension:command:${commandKey}:executed`, {
-                    source: 'chat',
-                })
             default: {
                 if (!this.editor.getActiveTextEditor()?.filePath) {
                     await this.addCustomInteraction('Command failed. Please open a file and try again.', text)

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -121,10 +121,10 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
     public find(id: string): string {
         const myPrompt = this.default.get(id)
 
-        logDebug('CommandsController:command:finding', id, { verbose: myPrompt })
+        logDebug('CommandsController:command:finding', id)
 
         if (!myPrompt) {
-            this.telemetryService.log('CodyVSCodeExtension:command:find:invalid')
+            this.telemetryService.log('CodyVSCodeExtension:command:invalid', { invalidCommand: id })
         }
 
         if (myPrompt) {
@@ -133,9 +133,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         }
 
         // Log custom command usage
-        if (myPrompt?.type !== 'default') {
-            this.telemetryService.log('CodyVSCodeExtension:command:custom:called')
-        }
+        const commandType = myPrompt?.type === 'default' ? 'default' : 'custom'
+        this.telemetryService.log(`CodyVSCodeExtension:command:${commandType}:executed`)
 
         return myPrompt?.prompt || ''
     }
@@ -174,7 +173,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         const commandOutput = await this.tools.exeCommand(fullCommand)
         currentContext.output = commandOutput
         this.myPromptInProgress.context = currentContext
-        this.telemetryService.log('CodyVSCodeExtension:command:execCommand')
+        logDebug('CodyVSCodeExtension:command:execCommand', fullCommand)
         return commandOutput || null
     }
 
@@ -182,7 +181,6 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      * Menu Controller
      */
     public async menu(type: 'custom' | 'config' | 'default'): Promise<void> {
-        this.telemetryService.log('CodyVSCodeExtension:command:menu:opened', { type })
         await this.refresh()
         switch (type) {
             case 'custom':


### PR DESCRIPTION
Updated event names for commands-related telemetryService events.

Removed events we logged for opening the menu as a command

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

log names updated