### PR TITLE
fix: fixup token limits

### DIFF
--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -59,7 +59,7 @@ export class Fixup implements Recipe {
         }
 
         const quarterFileContext = Math.floor(MAX_CURRENT_FILE_TOKENS / 4)
-        if (truncateText(fixupTask.selectedText, quarterFileContext * 2) !== fixupTask.selectedText) {
+        if (truncateText(fixupTask.selectedText, MAX_CURRENT_FILE_TOKENS) !== fixupTask.selectedText) {
             const msg = "The amount of text selected exceeds Cody's current capacity."
             await context.editor.showWarningMessage(msg)
             return null


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/issues/207

> There's a hard error "The amount of text selected exceeds Cody’s current capacity" which isn't true because the same thing is possible in chat.

We should use `MAX_CURRENT_FILE_TOKENS` for the current selection instead of limiting it to a quarter of it, because surrounding code is not as important if users cannot use the command in the first place.

We can limit the context to include the quarter rule instead.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- Start Cody from this branch
- Select line 198 to 234 and run the /edit command, you can use this instruction for testing `correct any typos`

#### Before

you will get an error from Cody say `The amount of text selected exceeds Cody's current capacity.` 

![image](https://github.com/sourcegraph/cody/assets/68532117/b3fbbbcb-b57f-4683-a1da-942a40bb6fbf)


#### After

Cody fixed all typos it found

![image](https://github.com/sourcegraph/cody/assets/68532117/a33effe2-6d54-4054-a8c9-31f22c37572c)
