### PR TITLE
Agent: re-authenticate during configuration changes

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -265,7 +265,6 @@ export class Agent extends MessageHandler {
                 // functionality), we return true to always triggger the callback.
                 true,
         })
-        await vscode_shim.commands.executeCommand('cody.auth.sync')
         const client = await createClient({
             initialTranscript: this.oldClient?.transcript,
             editor: new AgentEditor(this),

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -249,7 +249,13 @@ export class Agent extends MessageHandler {
     }
 
     private async setClient(config: ExtensionConfiguration): Promise<void> {
+        const isAuthChange = vscode_shim.isAuthenticationChange(config)
         vscode_shim.setConnectionConfig(config)
+        // If this is an authentication change we need to reauthenticate prior to firing events
+        // that update the clients
+        if (isAuthChange) {
+            await vscode_shim.commands.executeCommand('agent.auth.reload')
+        }
         vscode_shim.onDidChangeConfiguration.fire({
             affectsConfiguration: () =>
                 // assuming the return value below only impacts performance (not

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -69,7 +69,21 @@ describe.each([
             },
         },
     },
-])('describe StandardAgent with $name', ({ clientInfo }) => {
+    {
+        name: 'NotConfigured',
+        clientInfo: {
+            name: 'test-client',
+            version: 'v1',
+            workspaceRootUri: 'file:///path/to/foo',
+            workspaceRootPath: '/path/to/foo',
+            connectionConfiguration: {
+                accessToken: '',
+                serverEndpoint: 'https://notarealserver.com',
+                customHeaders: {},
+            },
+        },
+    },
+])('describe StandardAgent with $name', ({ name, clientInfo }) => {
     if (process.env.SRC_ACCESS_TOKEN === undefined || process.env.SRC_ENDPOINT === undefined) {
         it('no-op test because SRC_ACCESS_TOKEN is not set. To actually run the Cody Agent tests, set the environment variables SRC_ENDPOINT and SRC_ACCESS_TOKEN', () => {})
         return
@@ -93,7 +107,18 @@ describe.each([
     it('initializes properly', async () => {
         const serverInfo = await client.handshake(clientInfo)
         assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
-        assert.deepStrictEqual(serverInfo.codyEnabled, true, 'Cody should be enabled')
+        assert.deepStrictEqual(
+            serverInfo.codyEnabled,
+            name != 'NotConfigured',
+            'Cody should be enabled when configured'
+        )
+    })
+    it('handles config changes correctly', () => {
+        client.notify('extensionConfiguration/didChange', {
+            accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
+            serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
+            customHeaders: {},
+        })
     })
 
     it('lists recipes correctly', async () => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -78,7 +78,7 @@ describe.each([
             workspaceRootPath: '/path/to/foo',
             connectionConfiguration: {
                 accessToken: '',
-                serverEndpoint: 'https://notarealserver.com',
+                serverEndpoint: '',
                 customHeaders: {},
             },
         },

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -42,8 +42,8 @@ describe.each([
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
             connectionConfiguration: {
-                accessToken: 'https://sourcegraph.com/',
-                serverEndpoint: '',
+                accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
+                serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
                 customHeaders: {},
                 autocompleteAdvancedProvider: 'anthropic',
                 autocompleteAdvancedAccessToken: '',
@@ -63,8 +63,8 @@ describe.each([
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
             connectionConfiguration: {
-                serverEndpoint: 'https://sourcegraph.com/',
-                accessToken: '',
+                accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
+                serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
                 customHeaders: {},
             },
         },
@@ -94,14 +94,6 @@ describe.each([
         const serverInfo = await client.handshake(clientInfo)
         assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
         assert.deepStrictEqual(serverInfo.codyEnabled, true, 'Cody should be enabled')
-    })
-
-    it('handles config changes correctly', () => {
-        client.notify('extensionConfiguration/didChange', {
-            accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
-            serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
-            customHeaders: {},
-        })
     })
 
     it('lists recipes correctly', async () => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -84,6 +84,10 @@ describe.each([
         },
     },
 ])('describe StandardAgent with $name', ({ name, clientInfo }) => {
+    if (process.env.VITEST_ONLY && !process.env.VITEST_ONLY.includes(name)) {
+        it(name + ' tests are skipped due to VITEST_ONLY environment variable', () => {})
+        return
+    }
     if (process.env.SRC_ACCESS_TOKEN === undefined || process.env.SRC_ENDPOINT === undefined) {
         it('no-op test because SRC_ACCESS_TOKEN is not set. To actually run the Cody Agent tests, set the environment variables SRC_ENDPOINT and SRC_ACCESS_TOKEN', () => {})
         return
@@ -109,12 +113,13 @@ describe.each([
         assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
         assert.deepStrictEqual(
             serverInfo.codyEnabled,
-            name != 'NotConfigured',
+            name !== 'NotConfigured',
             'Cody should be enabled when configured'
         )
     })
-    it('handles config changes correctly', () => {
-        client.notify('extensionConfiguration/didChange', {
+
+    it('handles config changes correctly', async () => {
+        await client.request('extensionConfiguration/didChange', {
             accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
             serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
             customHeaders: {},

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -78,7 +78,7 @@ describe.each([
             workspaceRootPath: '/path/to/foo',
             connectionConfiguration: {
                 accessToken: '',
-                serverEndpoint: '',
+                serverEndpoint: 'https://sourcegraph.com/',
                 customHeaders: {},
             },
         },
@@ -118,8 +118,17 @@ describe.each([
         )
     })
 
-    it('handles config changes correctly', async () => {
-        await client.request('extensionConfiguration/didChange', {
+    it('handles config changes correctly', () => {
+        // Send two config change notifications because this is what the
+        // JetBrains client does and there was a bug where everything worked
+        // fine as long as we didn't send the second unauthenticated config
+        // change.
+        client.notify('extensionConfiguration/didChange', {
+            accessToken: 'https://sourcegraph.com/',
+            serverEndpoint: '',
+            customHeaders: {},
+        })
+        client.notify('extensionConfiguration/didChange', {
             accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
             serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
             customHeaders: {},

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -42,8 +42,8 @@ describe.each([
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
             connectionConfiguration: {
-                accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
-                serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
+                accessToken: 'https://sourcegraph.com/',
+                serverEndpoint: '',
                 customHeaders: {},
                 autocompleteAdvancedProvider: 'anthropic',
                 autocompleteAdvancedAccessToken: '',
@@ -63,8 +63,8 @@ describe.each([
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
             connectionConfiguration: {
-                accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
-                serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
+                serverEndpoint: 'https://sourcegraph.com/',
+                accessToken: '',
                 customHeaders: {},
             },
         },
@@ -94,6 +94,14 @@ describe.each([
         const serverInfo = await client.handshake(clientInfo)
         assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
         assert.deepStrictEqual(serverInfo.codyEnabled, true, 'Cody should be enabled')
+    })
+
+    it('handles config changes correctly', () => {
+        client.notify('extensionConfiguration/didChange', {
+            accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
+            serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
+            customHeaders: {},
+        })
     })
 
     it('lists recipes correctly', async () => {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -42,13 +42,6 @@ export type Requests = {
 
     'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
 
-    // The server should use the provided connection configuration for all
-    // subsequent requests/notifications. The previous extension configuration
-    // should no longer be used.
-    // This notification is functionally equivalent to connectionConfiguration/didChange
-    // and provided to match the updated configuration naming
-    'extensionConfiguration/didChange': [ExtensionConfiguration, null]
-
     // ================
     // Server -> Client
     // ================
@@ -92,11 +85,10 @@ export type Notifications = {
     // The chat transcript grows indefinitely if this notification is never sent.
     'transcript/reset': [null]
 
-    // Removed: the notification below has been replaced with a notification
-    // with the same name. Make sure to await on the response to ensure that the
-    // updated configuration has propagated.
-    // 'extensionConfiguration/didChange': [ExtensionConfiguration]
-    // 'connectionConfiguration/didChange': [ExtensionConfiguration]
+    // The server should use the provided connection configuration for all
+    // subsequent requests/notifications. The previous extension configuration
+    // should no longer be used.
+    'extensionConfiguration/didChange': [ExtensionConfiguration]
 
     // ================
     // Server -> Client

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -42,6 +42,13 @@ export type Requests = {
 
     'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
 
+    // The server should use the provided connection configuration for all
+    // subsequent requests/notifications. The previous extension configuration
+    // should no longer be used.
+    // This notification is functionally equivalent to connectionConfiguration/didChange
+    // and provided to match the updated configuration naming
+    'extensionConfiguration/didChange': [ExtensionConfiguration, null]
+
     // ================
     // Server -> Client
     // ================
@@ -59,20 +66,6 @@ export type Notifications = {
     initialized: [null]
     // The 'exit' notification must be sent after the client receives the 'shutdown' response.
     exit: [null]
-
-    // The server should use the provided extension configuration for all
-    // subsequent requests/notifications. The previous extension configuration
-    // should no longer be used.
-    // This notification is functionally equivalent to extensionConfiguration/didChange
-    // and exists to match the previous naming of configuration
-    'connectionConfiguration/didChange': [ExtensionConfiguration]
-
-    // The server should use the provided connection configuration for all
-    // subsequent requests/notifications. The previous extension configuration
-    // should no longer be used.
-    // This notification is functionally equivalent to connectionConfiguration/didChange
-    // and provided to match the updated configuration naming
-    'extensionConfiguration/didChange': [ExtensionConfiguration]
 
     // Lifecycle notifications for the client to notify the server about text
     // contents of documents and to notify which document is currently focused.
@@ -98,6 +91,12 @@ export type Notifications = {
     // This notification should be sent when the user starts a new conversation.
     // The chat transcript grows indefinitely if this notification is never sent.
     'transcript/reset': [null]
+
+    // Removed: the notification below has been replaced with a notification
+    // with the same name. Make sure to await on the response to ensure that the
+    // updated configuration has propagated.
+    // 'extensionConfiguration/didChange': [ExtensionConfiguration]
+    // 'connectionConfiguration/didChange': [ExtensionConfiguration]
 
     // ================
     // Server -> Client

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -60,6 +60,11 @@ export type Notifications = {
     // The 'exit' notification must be sent after the client receives the 'shutdown' response.
     exit: [null]
 
+    // The server should use the provided connection configuration for all
+    // subsequent requests/notifications. The previous extension configuration
+    // should no longer be used.
+    'extensionConfiguration/didChange': [ExtensionConfiguration]
+
     // Lifecycle notifications for the client to notify the server about text
     // contents of documents and to notify which document is currently focused.
     'textDocument/didOpen': [TextDocument]
@@ -84,11 +89,6 @@ export type Notifications = {
     // This notification should be sent when the user starts a new conversation.
     // The chat transcript grows indefinitely if this notification is never sent.
     'transcript/reset': [null]
-
-    // The server should use the provided connection configuration for all
-    // subsequent requests/notifications. The previous extension configuration
-    // should no longer be used.
-    'extensionConfiguration/didChange': [ExtensionConfiguration]
 
     // ================
     // Server -> Client

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -84,6 +84,17 @@ export function setConnectionConfig(newConfig: ExtensionConfiguration): void {
     connectionConfig = newConfig
 }
 
+export function isAuthenticationChange(newConfig: ExtensionConfiguration): boolean {
+    if (!connectionConfig) {
+        return true
+    }
+
+    return (
+        connectionConfig.accessToken !== newConfig.accessToken ||
+        connectionConfig.serverEndpoint !== newConfig.serverEndpoint
+    )
+}
+
 const configuration: vscode.WorkspaceConfiguration = {
     has(section) {
         return true

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -32,6 +32,7 @@ export async function createInlineCompletionItemProvider({
     featureFlagProvider,
     authProvider,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
+    console.log({ authStatus: authProvider.getAuthStatus() })
     if (!authProvider.getAuthStatus().isLoggedIn) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -32,7 +32,6 @@ export async function createInlineCompletionItemProvider({
     featureFlagProvider,
     authProvider,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
-    console.log({ authStatus: authProvider.getAuthStatus() })
     if (!authProvider.getAuthStatus().isLoggedIn) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 

--- a/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
+++ b/vscode/src/completions/createVSCodeInlineCompletionItemProvider.ts
@@ -35,6 +35,15 @@ export async function createInlineCompletionItemProvider({
     if (!authProvider.getAuthStatus().isLoggedIn) {
         logDebug('CodyCompletionProvider:notSignedIn', 'You are not signed in.')
 
+        if (config.isRunningInsideAgent) {
+            // Register an empty completion provider when running inside the
+            // agent to avoid timeouts because it awaits for an
+            // `InlineCompletionItemProvider` to be registered.
+            return vscode.languages.registerInlineCompletionItemProvider('*', {
+                provideInlineCompletionItems: () => Promise.resolve({ items: [] }),
+            })
+        }
+
         return {
             dispose: () => {},
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -288,9 +288,12 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
-        vscode.commands.registerCommand('cody.auth.sync', async () => {
-            await contextProvider.syncAuthStatus()
+        vscode.commands.registerCommand('cody.auth.sync', () => {
+            const result = contextProvider.syncAuthStatus()
             void featureFlagProvider.syncAuthStatus()
+            // Important that we return a promise here to allow `AuthProvider`
+            // to `await` on the auth config changes to propagate.
+            return result
         }),
         // Commands
         vscode.commands.registerCommand('cody.interactive.clear', async () => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -289,7 +289,6 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
         vscode.commands.registerCommand('cody.auth.sync', () => {
-            void authProvider.reloadAuthStatus()
             void contextProvider.syncAuthStatus()
             void featureFlagProvider.syncAuthStatus()
         }),
@@ -393,6 +392,9 @@ const register = async (
                 query: 'cody.inlineChat.enabled',
                 openToSide: true,
             })
+        }),
+        vscode.commands.registerCommand('agent.auth.reload', async () => {
+            await authProvider.reloadAuthStatus()
         })
     )
 
@@ -422,7 +424,6 @@ const register = async (
     disposables.push({ dispose: () => completionsProvider?.dispose() })
     const setupAutocomplete = async (): Promise<void> => {
         const config = getConfiguration(vscode.workspace.getConfiguration())
-
         if (!config.autocomplete) {
             completionsProvider?.dispose()
             completionsProvider = null
@@ -452,7 +453,6 @@ const register = async (
     }
     // Reload autocomplete if either the configuration changes or the auth status is updated
     vscode.workspace.onDidChangeConfiguration(event => {
-        console.log('autocomplete;config;changed')
         if (event.affectsConfiguration('cody.autocomplete')) {
             void setupAutocomplete()
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -288,8 +288,8 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
-        vscode.commands.registerCommand('cody.auth.sync', () => {
-            void contextProvider.syncAuthStatus()
+        vscode.commands.registerCommand('cody.auth.sync', async () => {
+            await contextProvider.syncAuthStatus()
             void featureFlagProvider.syncAuthStatus()
         }),
         // Commands

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -289,6 +289,7 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
         vscode.commands.registerCommand('cody.auth.sync', () => {
+            void authProvider.reloadAuthStatus()
             void contextProvider.syncAuthStatus()
             void featureFlagProvider.syncAuthStatus()
         }),
@@ -451,6 +452,7 @@ const register = async (
     }
     // Reload autocomplete if either the configuration changes or the auth status is updated
     vscode.workspace.onDidChangeConfiguration(event => {
+        console.log('autocomplete;config;changed')
         if (event.affectsConfiguration('cody.autocomplete')) {
             void setupAutocomplete()
         }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -15,6 +15,7 @@ import {
     unauthenticatedStatus,
 } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
+import { getFullConfig } from '../configuration'
 import { logDebug } from '../log'
 
 import { AuthMenu, showAccessTokenInputBox, showInstanceURLInputBox } from './AuthMenus'
@@ -266,6 +267,7 @@ export class AuthProvider {
 
     // Set auth status in case of reload
     public async reloadAuthStatus(): Promise<void> {
+        this.config = await getFullConfig()
         await this.auth(this.config.serverEndpoint, this.config.accessToken, this.config.customHeaders)
     }
 


### PR DESCRIPTION
When the server or authtoken changes the agent needs to reload the auth status so that the autocomplete provider is regenerated with the new url & token.

This presented itself during first setup because the agent is initialized prior to the user providing account information.  Chat had continued to work because I new client was created when the configuration changed however the the autocomplete provider is created during activation and depends on events from the AuthHandler to reset itself.

resolves https://github.com/sourcegraph/sourcegraph/issues/56880 
## Test plan
Unit test added
Also did the following in IDE:

- Cleared all accounts and closed IDE
- Opened IDE created account on s2
- Verified autocomplete and chat worked
- Added a 2nd account to sourcegraph.com
- Switched account to dotcom
- Verified chat & autocomplete worked and verbose debugging showed requests to sourcegraph.com
- Switched account back to s2
- Verified chat & autocomplete worked and verbose debugging showed requests to s2 
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
