### PR TITLE
add missing changelog for pull/1116 1139

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,9 +8,15 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Executed the `/doc` command now automatically adds the documentation directly above your selected code in your editor, instead of shown in chat. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+- New `mode` field in the Custom Commands config file enables a command to be configured on how the prompt should be run by Cody. Currently supports `inline` (run command prompt in inline chat), `edit` (run command prompt on selected code for refactoring purpose), and `insert` (run command prompt on selected code where Cody's response will be inserted on top of the selected code) modes. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+- Experimentally added `smart selection` which removes the need to manually highlight code before running the `/doc` and `/test` commands. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+
 ### Fixed
 
 ### Changed
+
+- Increased the token limit for the selection Cody uses for the `/edit` command. [pull/1139](https://github.com/sourcegraph/cody/pull/1139)
 
 ## [0.12.1]
 

--- a/vscode/src/code-actions/fixup.ts
+++ b/vscode/src/code-actions/fixup.ts
@@ -32,7 +32,7 @@ export class FixupCodeAction implements vscode.CodeActionProvider {
         const instruction = this.getCodeActionInstruction(diagnostics)
         action.command = {
             command: 'cody.fixup.new',
-            arguments: [instruction, range],
+            arguments: [{ instruction, range }],
             title: 'Ask Cody to Fix',
         }
         action.diagnostics = diagnostics

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -242,7 +242,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                 }
                 case selectedCommandID === menu_options.fix.slashCommand: {
                     if (userPrompt.trim()) {
-                        return await vscode.commands.executeCommand('cody.fixup.new', userPrompt)
+                        return await vscode.commands.executeCommand('cody.fixup.new', { instruction: userPrompt })
                     }
                     return await vscode.commands.executeCommand('cody.fixup.new')
                 }


### PR DESCRIPTION
This PR adds the missing Changelog items for [pull/1116 1139](https://github.com/sourcegraph/cody/pull/1116) & https://github.com/sourcegraph/cody/pull/1139

Also fixed a minor oversight from pull/1116.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

changelog update