### PR TITLE
[WIP] Handling support for questions that can be answered by linux commands

### DIFF
--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -7,9 +7,9 @@ export interface Preamble {
 }
 
 const actions = `You are Cody, an AI-powered coding assistant created by Sourcegraph. You work inside a text editor. You have access to my currently open files. You perform the following actions:
-- Answer general programming questions.
-- Answer questions about the code that I have provided to you.
-- Generate code that matches a written description.
+- Answer general programming questions, including those related to Linux commands and shell commands.
+- Answer questions about the code that I have provided to you, including symbol lookups and directory queries.
+- Generate code and shell commands that match a written description.
 - Explain what a section of code does.`
 
 const rules = `In your responses, obey the following rules:
@@ -17,7 +17,8 @@ const rules = `In your responses, obey the following rules:
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
 - Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
-- Only reference file names, repository names or URLs if you are sure they exist.`
+- Only reference file names, repository names or URLs if you are sure they exist.
+- If you can't find the answer yourself but simple linux commands can help guide the answer then share the linux commands`
 
 const multiRepoRules = `In your responses, obey the following rules:
 - If you do not have access to code, files or repositories always stay in character as Cody when you apologize.


### PR DESCRIPTION
Attempt to solve -> https://github.com/sourcegraph/cody/issues/789 

I thought of a couple ways to solve this ^ problem. One way was mainly through classification of all the questions coming in into two forms. 
A. Those that can be answered by embeddings+ LLM
B. Those that can't be answered by embeddings+ LLM but can possibly be answered by linux commands


I thought of separate the questions into two categories and then have a different prompt for the second category(Lots of work but it can be worth it if it's an absolute dealbreaker for new users). There were a few ways to separate questions into categories
1. Make a fast LLM call to classify the question itself(Similar to what I did here -> https://github.com/sourcegraph/cody/pull/1083)  -> Problem with this is that it adds to much latency and that's bad UX.
2. Use some kind of heuristics, regex match combination with weights to do a faster classification. But this wasn't easy to do and i couldn't capture the nuance. 
3.  Built like a small TensorFlow model that just classifies a question into a different types and just use that on the user prompt and then treat the two questions differently. It can theoretically be done and it's also fast enough but I felt like adding a small classifier model might be something that must be done if it's absolutely necessary. 

Looking at the problem again, I decided that another way to solve the problem would be just to encourage the existing prompts to be able to answer Linux commands when they feel more appropriate. I was actually quite cautious in making any changes to the existing prompt because this is the core of how Cody works and it should not be manipulated unless it's absolutely necessary. So I made the bare minimum change that I could make so that other stuff is not affected while we are still able to answer Linux commands as much as possible and the responses have been pretty good for some questions. 

This prompt change makes a slight improvement in the responses from cody and encourages it to give linux commands where it can so it would be good to have this but I am happy to explore other methods posted above too. 


## Before
<img width="614" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/f8b3bbbc-e580-4a88-a878-f70b937c1fe6">


## After
<img width="579" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/053a3b0c-2366-4ce4-a723-bfaa7883fe00">



## Before
<img width="617" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/c8d835dc-7bf9-4094-baaf-11a6eed49ee0">


## After
<img width="591" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/fa94fe04-cf90-412f-9c87-ee8f2bd09dea">


## Before 
<img width="619" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/9bbed72e-3b99-478d-99be-893fe2eed84b">

## After 
<img width="583" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/7afab0ef-504f-4cb1-aee2-c1079eb9b06b">


## Before 
<img width="625" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/20e4955a-4b5f-476e-a87e-c96e4d8f35fe">


## After
<img width="588" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/7e2e788d-673c-494d-9368-69a92ba24628">


## Before
<img width="609" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/648aa172-049b-424e-922b-9949be3110a3">

## After
<img width="595" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/52a35f42-413d-49e6-86ee-0de0ba520b34">




## Test plan

Just try out a few prompts and you shall know