### PR TITLE
Modifying the chat prompts to respond with terminal commands if needed 

### DIFF
--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -10,14 +10,16 @@ const actions = `You are Cody, an AI-powered coding assistant created by Sourceg
 - Answer general programming questions.
 - Answer questions about the code that I have provided to you.
 - Generate code that matches a written description.
-- Explain what a section of code does.`
+- Explain what a section of code does.
+- Provide Linux or system commands to assist with tasks or answer questions.`
 
 const rules = `In your responses, obey the following rules:
 - If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
-- Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
-- Only reference file names, repository names or URLs if you are sure they exist.`
+- Answer questions only if you know the answer or can make a well-informed guess or if you can offer the user a linux command that will help them get an answer. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
+- Only reference file names, repository names or URLs if you are sure they exist.
+- If you can't find the answer yourself but simple linux commands can help guide the answer then share the linux commands`
 
 const multiRepoRules = `In your responses, obey the following rules:
 - If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
@@ -27,11 +29,11 @@ const multiRepoRules = `In your responses, obey the following rules:
 - If you do not have access to a repository, tell me to add additional repositories to the chat context using repositories selector below the input box to help you answer the question.
 - Only reference file names, repository names or URLs if you are sure they exist.`
 
-const answer = `Understood. I am Cody, an AI assistant made by Sourcegraph to help with programming tasks.
-I work inside a text editor. I have access to your currently open files in the editor.
-I will answer questions, explain code, and generate code as concisely and clearly as possible.
-My responses will be formatted using Markdown syntax for code blocks.
-I will acknowledge when I don't know an answer or need more context.`
+const answer = `Understood. I am Cody, an AI assistant made by Sourcegraph to assist with programming tasks.
+I work inside a text editor and have access to your currently open files.
+I can answer programming questions, explain code, and generate both code and Linux commands to assist you.
+My answers will be concise, clear, and formatted using Markdown syntax for code blocks.
+If I don't know an answer or need additional context, I will acknowledge that. Alternatively I can also give you linux commands to help you find some answers that I can't find because I don't have access.`
 
 /**
  * Creates and returns an array of two messages: one from a human, and the supposed response from the AI assistant.

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -11,15 +11,15 @@ const actions = `You are Cody, an AI-powered coding assistant created by Sourceg
 - Answer questions about the code that I have provided to you.
 - Generate code that matches a written description.
 - Explain what a section of code does.
-- Provide Linux or system commands to assist with tasks or answer questions.`
+- Provide ${process.platform} or system commands to assist with tasks or answer questions.`
 
 const rules = `In your responses, obey the following rules:
 - If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
-- Answer questions only if you know the answer or can make a well-informed guess or if you can offer the user a linux command that will help them get an answer. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
+- Answer questions only if you know the answer or can make a well-informed guess or if you can offer the user a ${process.platform} command that will help them get an answer. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
 - Only reference file names, repository names or URLs if you are sure they exist.
-- If you can't find the answer yourself but simple linux commands can help guide the answer then share the linux commands`
+- If you can't find the answer yourself but simple ${process.platform} commands can help guide the answer then share the ${process.platform} commands`
 
 const multiRepoRules = `In your responses, obey the following rules:
 - If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
@@ -31,9 +31,9 @@ const multiRepoRules = `In your responses, obey the following rules:
 
 const answer = `Understood. I am Cody, an AI assistant made by Sourcegraph to assist with programming tasks.
 I work inside a text editor and have access to your currently open files.
-I can answer programming questions, explain code, and generate both code and Linux commands to assist you.
+I can answer programming questions, explain code, and generate both code and ${process.platform} commands to assist you.
 My answers will be concise, clear, and formatted using Markdown syntax for code blocks.
-If I don't know an answer or need additional context, I will acknowledge that. Alternatively I can also give you linux commands to help you find some answers that I can't find because I don't have access.`
+If I don't know an answer or need additional context, I will acknowledge that. Alternatively I can also give you ${process.platform} commands to help you find some answers that I can't find because I don't have access.`
 
 /**
  * Creates and returns an array of two messages: one from a human, and the supposed response from the AI assistant.

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -7,7 +7,7 @@ import {
     populateCurrentEditorContextTemplate,
     populateCurrentEditorSelectedContextTemplate,
 } from '../../prompt/templates'
-import { truncateText } from '../../prompt/truncation'
+import { getLinuxCommandContextMessages, truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { isSingleWord, numResults } from './helpers'
@@ -71,9 +71,11 @@ export class ChatQuestion implements Recipe {
 
         // Add selected text as context when available
         if (selection?.selectedText) {
+            // Add some context messages so that the LLM has some context about how to respond with basic Linux commands
             contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
         }
 
+        contextMessages.push(...getLinuxCommandContextMessages())
         return contextMessages
     }
 

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -7,7 +7,7 @@ import {
     populateCurrentEditorContextTemplate,
     populateCurrentEditorSelectedContextTemplate,
 } from '../../prompt/templates'
-import { getLinuxCommandContextMessages, truncateText } from '../../prompt/truncation'
+import { getTerminalCommandContextMessages, truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { isSingleWord, numResults } from './helpers'
@@ -71,11 +71,11 @@ export class ChatQuestion implements Recipe {
 
         // Add selected text as context when available
         if (selection?.selectedText) {
-            // Add some context messages so that the LLM has some context about how to respond with basic Linux commands
+            // Add some context messages so that the LLM has some context about how to respond with basic terminal commands
             contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
         }
 
-        contextMessages.push(...getLinuxCommandContextMessages())
+        contextMessages.push(...getTerminalCommandContextMessages())
         return contextMessages
     }
 

--- a/lib/shared/src/chat/transcript/transcript.test.ts
+++ b/lib/shared/src/chat/transcript/transcript.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'vitest'
 
 import { CodebaseContext } from '../../codebase-context'
 import { MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
+import { getLinuxCommandContextMessages } from '../../prompt/truncation'
 import { Message } from '../../sourcegraph-api'
 import {
     defaultKeywordContextFetcher,
@@ -55,6 +56,7 @@ describe('Transcript', () => {
 
         const { prompt } = await transcript.getPromptForLastInteraction()
         const expectedPrompt = [
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -100,6 +102,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -143,6 +146,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -199,6 +203,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how to create a batch change' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -284,6 +289,7 @@ describe('Transcript', () => {
                 speaker: 'assistant',
                 text: 'Ok.',
             },
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -308,6 +314,7 @@ describe('Transcript', () => {
 
         const { prompt } = await transcript.getPromptForLastInteraction()
         const expectedPrompt = [
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -368,12 +375,9 @@ describe('Transcript', () => {
         const expectedPrompt = [
             { speaker: 'human', text: 'how do batch changes work in sourcegraph' },
             { speaker: 'assistant', text: 'Smartly.' },
-            { speaker: 'human', text: 'Use the following text from file `docs/README.md`:\n# Main' },
-            { speaker: 'assistant', text: 'Ok.' },
-            { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
-            { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: 'By setting the Authorization header.' },
+            ...getLinuxCommandContextMessages(),
             { speaker: 'human', text: 'how do to delete them' },
             { speaker: 'assistant', text: undefined },
         ]

--- a/lib/shared/src/chat/transcript/transcript.test.ts
+++ b/lib/shared/src/chat/transcript/transcript.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'vitest'
 
 import { CodebaseContext } from '../../codebase-context'
 import { MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
-import { getLinuxCommandContextMessages } from '../../prompt/truncation'
+import { getTerminalCommandContextMessages } from '../../prompt/truncation'
 import { Message } from '../../sourcegraph-api'
 import {
     defaultKeywordContextFetcher,
@@ -56,7 +56,7 @@ describe('Transcript', () => {
 
         const { prompt } = await transcript.getPromptForLastInteraction()
         const expectedPrompt = [
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -102,7 +102,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -146,7 +146,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -203,7 +203,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Ok.' },
             { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
             { speaker: 'assistant', text: 'Ok.' },
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how to create a batch change' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -289,7 +289,7 @@ describe('Transcript', () => {
                 speaker: 'assistant',
                 text: 'Ok.',
             },
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -314,7 +314,7 @@ describe('Transcript', () => {
 
         const { prompt } = await transcript.getPromptForLastInteraction()
         const expectedPrompt = [
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: undefined },
         ]
@@ -377,7 +377,7 @@ describe('Transcript', () => {
             { speaker: 'assistant', text: 'Smartly.' },
             { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
             { speaker: 'assistant', text: 'By setting the Authorization header.' },
-            ...getLinuxCommandContextMessages(),
+            ...getTerminalCommandContextMessages(),
             { speaker: 'human', text: 'how do to delete them' },
             { speaker: 'assistant', text: undefined },
         ]

--- a/lib/shared/src/prompt/truncation.ts
+++ b/lib/shared/src/prompt/truncation.ts
@@ -1,3 +1,5 @@
+import { ContextMessage } from '../codebase-context/messages'
+
 import { CHARS_PER_TOKEN } from './constants'
 
 /**
@@ -14,4 +16,39 @@ export function truncateText(text: string, maxTokens: number): string {
 export function truncateTextStart(text: string, maxTokens: number): string {
     const maxLength = maxTokens * CHARS_PER_TOKEN
     return text.length <= maxLength ? text : text.slice(-maxLength - 1)
+}
+
+export function getLinuxCommandContextMessages(): ContextMessage[] {
+    return [
+        { speaker: 'human', text: 'Human: What are all the files in my directory?' },
+        {
+            speaker: 'assistant',
+            text: 'Assistant: To list all files in your current directory, you can use the following command: `ls`.',
+        },
+        { speaker: 'human', text: 'Human: How do I check my current directory?' },
+        {
+            speaker: 'assistant',
+            text: 'Assistant: To check your current directory, you can use the following command: `pwd`.',
+        },
+        { speaker: 'human', text: 'Human: How do I create a new directory?' },
+        {
+            speaker: 'assistant',
+            text: 'Assistant: To create a new directory, you can use the following command: `mkdir <directory_name>`.',
+        },
+        { speaker: 'human', text: 'Human: List all the files where $SYMBOL being used?' },
+        {
+            speaker: 'assistant',
+            text: 'Assistant: To find where `$SYMBOL` is being used in your current directory and its subdirectories, you can use the following command: `grep -r "$SYMBOL" .`.',
+        },
+        { speaker: 'human', text: 'Human: How do I move a file?' },
+        {
+            speaker: 'assistant',
+            text: 'Assistant: To move a file, you can use the following command: `mv <source> <destination>`.',
+        },
+        { speaker: 'human', text: 'Human: How do I see disk usage?' },
+        {
+            speaker: 'assistant',
+            text: 'Assistant: To check disk usage, you can use the following command: `df -h`.',
+        },
+    ]
 }

--- a/lib/shared/src/prompt/truncation.ts
+++ b/lib/shared/src/prompt/truncation.ts
@@ -18,7 +18,7 @@ export function truncateTextStart(text: string, maxTokens: number): string {
     return text.length <= maxLength ? text : text.slice(-maxLength - 1)
 }
 
-export function getLinuxCommandContextMessages(): ContextMessage[] {
+export function getTerminalCommandContextMessages(): ContextMessage[] {
     return [
         { speaker: 'human', text: 'Human: What are all the files in my directory?' },
         {

--- a/lib/shared/src/prompt/truncation.ts
+++ b/lib/shared/src/prompt/truncation.ts
@@ -25,30 +25,10 @@ export function getTerminalCommandContextMessages(): ContextMessage[] {
             speaker: 'assistant',
             text: 'Assistant: To list all files in your current directory, you can use the following command: `ls`.',
         },
-        { speaker: 'human', text: 'Human: How do I check my current directory?' },
-        {
-            speaker: 'assistant',
-            text: 'Assistant: To check your current directory, you can use the following command: `pwd`.',
-        },
-        { speaker: 'human', text: 'Human: How do I create a new directory?' },
-        {
-            speaker: 'assistant',
-            text: 'Assistant: To create a new directory, you can use the following command: `mkdir <directory_name>`.',
-        },
         { speaker: 'human', text: 'Human: List all the files where $SYMBOL being used?' },
         {
             speaker: 'assistant',
             text: 'Assistant: To find where `$SYMBOL` is being used in your current directory and its subdirectories, you can use the following command: `grep -r "$SYMBOL" .`.',
-        },
-        { speaker: 'human', text: 'Human: How do I move a file?' },
-        {
-            speaker: 'assistant',
-            text: 'Assistant: To move a file, you can use the following command: `mv <source> <destination>`.',
-        },
-        { speaker: 'human', text: 'Human: How do I see disk usage?' },
-        {
-            speaker: 'assistant',
-            text: 'Assistant: To check disk usage, you can use the following command: `df -h`.',
         },
     ]
 }


### PR DESCRIPTION
Attempt to solve -> https://github.com/sourcegraph/cody/issues/789 from @beyang 
At first I made https://github.com/sourcegraph/cody/pull/1148 but that only worked for GPT 4 model so now I made this PR and it works great for many cases. 

I thought of a couple ways to solve this ^ problem. One way was mainly through classification of all the questions coming in into two forms. 
A. Those that can be answered by embeddings+ LLM
B. Those that can't be answered by embeddings+ LLM but can possibly be answered by terminal commands


I thought of separate the questions into two categories and then have a different prompt for the second category(Lots of work but it can be worth it if it's an absolute dealbreaker for new users). There were a few ways to separate questions into categories
1. Make a fast LLM call to classify the question itself(Similar to what I did here -> https://github.com/sourcegraph/cody/pull/1083)  -> Problem with this is that it adds to much latency and that's bad UX.
2. Use some kind of heuristics, regex match combination with weights to do a faster classification. But this wasn't easy to do and i couldn't capture the nuance. 
3.  Built like a small TensorFlow model that just classifies a question into a different types and just use that on the user prompt and then treat the two questions differently. It can theoretically be done and it's also fast enough but I felt like adding a small classifier model might be something that must be done if it's absolutely necessary. 

Looking at the problem again, I decided that another way to solve the problem would be just to encourage the existing prompts to be able to answer terminal commands when they feel more appropriate. I was actually quite cautious in making any changes to the existing prompt because this is the core of how Cody works and it should not be manipulated unless it's absolutely necessary. So I made the bare minimum change that I could make so that other stuff is not affected while we are still able to answer terminal commands as much as possible and the responses have been pretty good for most questions and it's great that I can extend this too if needed. 

This prompt change makes a slight improvement in the responses from cody and encourages it to give terminal commands where it can so it would be good to have this but I am happy to explore other methods posted above too. Also it was very important to give it examples of terminal commands coz it wouldn't give the answers without it. Also based on my testing it didn't affect the responses in other forms of questions asked to cody which is really awesome.  I would completely understand if people wouldn't want the core cody prompts to be untouched but I wanted to give one shot at this problem and this seemed like a good way. 


## Finding Files
### Before
<img width="802" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/c3245e4b-572a-4109-ba3e-68aac9fdc88f">


## After
<img width="752" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/ca7b6fb6-dd08-418b-83ba-39e9a705779c">


## Different types of controllers search
### Before
<img width="794" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/f698cfe8-015a-4bf3-a7f0-b275f5e8ea6c">


### After
<img width="716" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/1171c41e-c9b8-43b1-b616-97c3a53b6411">


## Search for TODO comments in code
### Before 
<img width="671" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/e8b6a044-fa39-4d75-a80e-0f221874a91c">


### After 
<img width="763" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/3487de53-9260-493a-a68f-e86d2d2c702a">


## Fixup Controller explaination
### Before 
<img width="675" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/eb17caf3-c818-4ce2-bba9-d1c50d0f67a0">
<img width="678" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/67a29a2a-1e8e-4b7d-8c18-5ba74f4823c6">


### After
<img width="792" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/32308026-fb24-4c8e-85aa-ace7b703124e">
<img width="787" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/b8636a01-0b43-4c6d-8e72-31a73bb2e9ac">


## Checking who wrote a selected block of code 
### Before
<img width="677" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/c943d785-2e1b-4a31-8473-233d8ceac080">

### After

<img width="787" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/c080dce9-a8fb-4d5e-85a3-c806b41ba737">



## Test plan

Just try out a few prompts and you shall know

## Test plan

Try out my branch with the examples that I showed