### PR TITLE
Agent: add support to cancel chat

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -161,8 +161,18 @@ export class Agent extends MessageHandler {
             if (!client) {
                 return null
             }
+            const abortController = new AbortController()
+            if (token) {
+                if (token.isCancellationRequested) {
+                    abortController.abort()
+                }
+                token.onCancellationRequested(() => {
+                    abortController.abort()
+                })
+            }
 
             await client.executeRecipe(data.id, {
+                signal: abortController.signal,
                 humanChatInput: data.humanChatInput,
                 data: data.data,
             })

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -111,11 +111,6 @@ describe.each([
     it('initializes properly', async () => {
         const serverInfo = await client.handshake(clientInfo)
         assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
-        assert.deepStrictEqual(
-            serverInfo.codyEnabled,
-            name !== 'NotConfigured',
-            'Cody should be enabled when configured'
-        )
     })
 
     it('handles config changes correctly', () => {
@@ -143,7 +138,11 @@ describe.each([
     it('returns non-empty autocomplete', async () => {
         const filePath = '/path/to/foo/file.js'
         const content = 'function sum(a, b) {\n    \n}'
-        client.notify('textDocument/didOpen', { filePath, content })
+        client.notify('textDocument/didOpen', {
+            filePath,
+            content,
+            selection: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
+        })
         const completions = await client.request('autocomplete/execute', {
             filePath,
             position: { line: 1, character: 4 },
@@ -151,19 +150,37 @@ describe.each([
         assert(completions.items.length > 0)
     })
 
-    const streamingChatMessages = new Promise<void>(resolve => {
+    const streamingChatMessages = new Promise<void>((resolve, reject) => {
+        let hasReceivedNonNullMessage = false
+        let isResolved = false
         client.registerNotification('chat/updateMessageInProgress', msg => {
             if (msg === null) {
-                resolve()
+                if (isResolved) {
+                    return
+                }
+                isResolved = true
+                if (hasReceivedNonNullMessage) {
+                    resolve()
+                } else {
+                    reject(new Error('Received null message before non-null message'))
+                }
+            } else {
+                hasReceivedNonNullMessage = true
             }
         })
     })
 
     it('allows us to execute recipes properly', async () => {
-        await client.executeRecipe('chat-question', "What's 2+2?")
-    })
+        await client.executeRecipe('chat-question', 'How do I implement sum?')
+    }, 20_000)
 
-    it('sends back transcript updates and makes sense', () => streamingChatMessages, 20_000)
+    // Timeout is 100ms because we await on `recipes/execute` in the previous test
+    it('executing a recipe sends chat/updateMessageInProgress notifications', () => streamingChatMessages, 100)
+
+    it('allows us to cancel chat', async () => {
+        setTimeout(() => client.notify('$/cancelRequest', { id: client.id - 1 }), 200)
+        await client.executeRecipe('chat-question', 'How do I implement sum?')
+    }, 500)
 
     afterAll(async () => {
         await client.shutdownAndExit()

--- a/agent/src/jsonrpc.ts
+++ b/agent/src/jsonrpc.ts
@@ -214,7 +214,7 @@ type NotificationCallback<M extends NotificationMethodName> = (params: ParamsOf<
  * that can be piped with ReadStream/WriteStream.
  */
 export class MessageHandler {
-    private id = 0
+    public id = 0
     private requestHandlers: Map<RequestMethodName, RequestCallback<any>> = new Map()
     private cancelTokens: Map<Id, vscode.CancellationTokenSource> = new Map()
     private notificationHandlers: Map<NotificationMethodName, NotificationCallback<any>> = new Map()

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -42,6 +42,7 @@ export interface Client {
     executeRecipe: (
         recipeId: RecipeID,
         options?: {
+            signal?: AbortSignal
             prefilledOptions?: PrefilledOptions
             humanChatInput?: string
             data?: any // returned as is
@@ -117,6 +118,7 @@ export async function createClient({
         async function executeRecipe(
             recipeId: RecipeID,
             options?: {
+                signal?: AbortSignal
                 prefilledOptions?: PrefilledOptions
                 humanChatInput?: string
                 data?: any
@@ -148,30 +150,39 @@ export async function createClient({
 
             const responsePrefix = interaction.getAssistantMessage().prefix ?? ''
             let rawText = ''
-            chatClient.chat(prompt, {
-                onChange(_rawText) {
-                    rawText = _rawText
+            const chatPromise = new Promise<void>((resolve, reject) => {
+                const onAbort = chatClient.chat(prompt, {
+                    onChange(_rawText) {
+                        rawText = _rawText
 
-                    const text = reformatBotMessage(rawText, responsePrefix)
-                    transcript.addAssistantResponse(text)
+                        const text = reformatBotMessage(rawText, responsePrefix)
+                        transcript.addAssistantResponse(text)
 
-                    sendTranscript(options?.data)
-                },
-                onComplete() {
+                        sendTranscript(options?.data)
+                    },
+                    onComplete() {
+                        isMessageInProgress = false
+
+                        const text = reformatBotMessage(rawText, responsePrefix)
+                        transcript.addAssistantResponse(text)
+                        sendTranscript(options?.data)
+                        resolve()
+                    },
+                    onError(error) {
+                        // Display error message as assistant response
+                        transcript.addErrorAsAssistantResponse(error)
+                        isMessageInProgress = false
+                        sendTranscript(options?.data)
+                        console.error(`Completion request failed: ${error}`)
+                        reject(new Error(error))
+                    },
+                })
+                options?.signal?.addEventListener('abort', () => {
+                    onAbort()
                     isMessageInProgress = false
-
-                    const text = reformatBotMessage(rawText, responsePrefix)
-                    transcript.addAssistantResponse(text)
-                    sendTranscript(options?.data)
-                },
-                onError(error) {
-                    // Display error message as assistant response
-                    transcript.addErrorAsAssistantResponse(error)
-                    isMessageInProgress = false
-                    sendTranscript(options?.data)
-                    console.error(`Completion request failed: ${error}`)
-                },
+                })
             })
+            await chatPromise
         }
 
         return {


### PR DESCRIPTION
Previously, sending `$/cancelRequest` notification for `recipes/execute` did not correctly cancel the chat request. This PR fixes the problem with two changes:

- Don't return from `recipes/execute` until the last `chat/updateMessageInProgress` has been sent. This was necessary for cancelation to work correctly because the request needs to be running for it to be cancelable. We delete the `CancellationTokenSource` after a request returns.
- Correctly propagate the cancelation token from the agent into the chat client.


## Test plan

See updated `index.test.ts`

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
