### PR TITLE
change: use infill prompt by default for anthropic

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -14,7 +14,6 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
     CodyAutocompleteLlamaCode7B = 'cody-autocomplete-default-llama-code-7b',
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-default-llama-code-13b',
-    CodyAutocompleteClaudeInstantInfill = 'cody-autocomplete-claude-instant-infill',
     CodyAutocompleteMinimumLatency350 = 'cody-autocomplete-minimum-latency-350',
     CodyAutocompleteMinimumLatency600 = 'cody-autocomplete-minimum-latency-600',
     CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,8 +18,9 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
-- # Moved "Insert at Cursor" and "Copy" buttons to the bottom of code blocks, and no longer just show on hover. [pull/1119](https://github.com/sourcegraph/cody/pull/1119)
+- Moved "Insert at Cursor" and "Copy" buttons to the bottom of code blocks, and no longer just show on hover. [pull/1119](https://github.com/sourcegraph/cody/pull/1119)
 - Increased the token limit for the selection Cody uses for the `/edit` command. [pull/1139](https://github.com/sourcegraph/cody/pull/1139)
+- Autocomplete now supports infilling through the customized `claude-instant-infill` model created for Anthropic Claude Instant by default. [pull/1164](https://github.com/sourcegraph/cody/pull/1164)
 
 ## [0.12.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -914,8 +914,7 @@
             "wizardcoder-15b",
             "llama-code-7b",
             "llama-code-13b",
-            "llama-code-13b-instruct",
-            "claude-instant-infill"
+            "llama-code-13b-instruct"
           ],
           "markdownDescription": "Overwrite the default model used for code autocompletion inference. This is only supported with the `unstable-fireworks` provider"
         },

--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -86,7 +86,7 @@ describe('[getInlineCompletions] common', () => {
         )
         expect(requests).toHaveLength(3)
         const messages = requests[0].messages
-        expect(messages.at(-1)!.text).toBe('Here is the code: <CODE5711>class Range {\n')
+        expect(messages.at(-1)!.text).toBe('<CODE5711>class Range {\n')
     })
 
     test('uses a more complex prompt for larger files', async () => {
@@ -125,7 +125,7 @@ describe('[getInlineCompletions] common', () => {
         expect(messages.at(-1)).toMatchInlineSnapshot(`
             {
               "speaker": "assistant",
-              "text": "Here is the code: <CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+              "text": "<CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
                     this.startLine =",
             }
         `)

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -35,7 +35,7 @@ function tokensToChars(tokens: number): number {
 interface AnthropicOptions {
     contextWindowTokens: number
     client: Pick<CodeCompletionsClient, 'complete'>
-    mode?: 'default' | 'infill'
+    mode?: 'infill'
 }
 
 export class AnthropicProvider extends Provider {
@@ -244,6 +244,6 @@ export function createProviderConfig(anthropicOptions: AnthropicOptions): Provid
         maximumContextCharacters: tokensToChars(anthropicOptions.contextWindowTokens),
         enableExtendedMultilineTriggers: true,
         identifier: 'anthropic',
-        model: anthropicOptions.mode === 'infill' ? 'claude-instant-infill' : 'claude-instant-1',
+        model: 'claude-instant-infill',
     }
 }

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -63,6 +63,21 @@ describe('createProviderConfig', () => {
             )
             expect(provider).toBeNull()
         })
+    })
+
+    describe('if completions provider field is not defined in VSCode settings', () => {
+        it('returns "anthropic" if completions provider is not configured', async () => {
+            const provider = await createProviderConfig(
+                getVSCodeSettings({
+                    autocompleteAdvancedProvider: null as Configuration['autocompleteAdvancedProvider'],
+                }),
+                dummyCodeCompletionsClient,
+                undefined,
+                {}
+            )
+            expect(provider?.identifier).toBe('anthropic')
+            expect(provider?.model).toBe('claude-instant-infill')
+        })
 
         it('returns "codegen" provider config if the corresponding provider name and endpoint are specified', async () => {
             const provider = await createProviderConfig(
@@ -138,7 +153,7 @@ describe('createProviderConfig', () => {
                 {}
             )
             expect(provider?.identifier).toBe('anthropic')
-            expect(provider?.model).toBe('claude-instant-1')
+            expect(provider?.model).toBe('claude-instant-infill')
         })
 
         it('provider specified in VSCode settings takes precedence over the one defined in the site config', async () => {
@@ -165,30 +180,30 @@ describe('createProviderConfig', () => {
                 // sourcegraph
                 { codyLLMConfig: { provider: 'sourcegraph', completionModel: 'hello-world' }, expected: null },
                 {
-                    codyLLMConfig: { provider: 'sourcegraph', completionModel: 'anthropic/claude-instant-1' },
-                    expected: { provider: 'anthropic', model: 'claude-instant-1' },
+                    codyLLMConfig: { provider: 'sourcegraph', completionModel: 'anthropic/claude-instant-infill' },
+                    expected: { provider: 'anthropic', model: 'claude-instant-infill' },
                 },
                 {
                     codyLLMConfig: { provider: 'sourcegraph', completionModel: 'anthropic/' },
                     expected: null,
                 },
                 {
-                    codyLLMConfig: { provider: 'sourcegraph', completionModel: '/claude-instant-1' },
+                    codyLLMConfig: { provider: 'sourcegraph', completionModel: '/claude-instant-infill' },
                     expected: null,
                 },
 
                 // aws-bedrock
                 { codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'hello-world' }, expected: null },
                 {
-                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic.claude-instant-1' },
-                    expected: { provider: 'anthropic', model: 'claude-instant-1' },
+                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic.claude-instant-infill' },
+                    expected: { provider: 'anthropic', model: 'claude-instant-infill' },
                 },
                 {
                     codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic.' },
                     expected: null,
                 },
                 {
-                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic/claude-instant-1' },
+                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic/claude-instant-infill' },
                     expected: null,
                 },
 
@@ -231,7 +246,7 @@ describe('createProviderConfig', () => {
                 // provider not defined (backward compat)
                 {
                     codyLLMConfig: { provider: undefined, completionModel: 'llama-code-7b' },
-                    expected: { provider: 'anthropic', model: 'claude-instant-1' },
+                    expected: { provider: 'anthropic', model: 'claude-instant-infill' },
                 },
             ]
 
@@ -259,6 +274,6 @@ describe('createProviderConfig', () => {
     it('returns anthropic provider config if no completions provider specified in VSCode settings or site config', async () => {
         const provider = await createProviderConfig(getVSCodeSettings(), dummyCodeCompletionsClient, undefined, {})
         expect(provider?.identifier).toBe('anthropic')
-        expect(provider?.model).toBe('claude-instant-1')
+        expect(provider?.model).toBe('claude-instant-infill')
     })
 })

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -58,11 +58,7 @@ export async function createProviderConfig(
                 return createAnthropicProviderConfig({
                     client,
                     contextWindowTokens: 2048,
-                    mode:
-                        model === 'claude-instant-infill' ||
-                        config.autocompleteAdvancedModel === 'claude-instant-infill'
-                            ? 'infill'
-                            : 'default',
+                    mode: 'infill',
                 })
             }
             default:
@@ -112,7 +108,7 @@ export async function createProviderConfig(
                 return createAnthropicProviderConfig({
                     client,
                     contextWindowTokens: 2048,
-                    mode: config.autocompleteAdvancedModel === 'claude-instant-infill' ? 'infill' : 'default',
+                    mode: 'infill',
                 })
             default:
                 logError('createProviderConfig', `Unrecognized provider '${provider}' configured.`)
@@ -127,27 +123,25 @@ export async function createProviderConfig(
     return createAnthropicProviderConfig({
         client,
         contextWindowTokens: 2048,
-        mode: config.autocompleteAdvancedModel === 'claude-instant-infill' ? 'infill' : 'default',
+        mode: 'infill',
     })
 }
 
 async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     configuredProvider: string | null,
     featureFlagProvider?: FeatureFlagProvider
-): Promise<{ provider: string; model?: 'claude-instant-infill' | UnstableFireworksOptions['model'] } | null> {
+): Promise<{ provider: string; model?: UnstableFireworksOptions['model'] } | null> {
     if (configuredProvider) {
         return { provider: configuredProvider }
     }
 
-    const [starCoder7b, starCoder16b, starCoderHybrid, llamaCode7b, llamaCode13b, claudeInstantInfill] =
-        await Promise.all([
-            featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
-            featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
-            featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-            featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
-            featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
-            featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaudeInstantInfill),
-        ])
+    const [starCoder7b, starCoder16b, starCoderHybrid, llamaCode7b, llamaCode13b] = await Promise.all([
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
+        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
+    ])
 
     if (starCoder7b || starCoder16b || starCoderHybrid || llamaCode7b || llamaCode13b) {
         const model = starCoder7b
@@ -162,11 +156,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: 'unstable-fireworks', model }
     }
 
-    if (claudeInstantInfill) {
-        return { provider: 'anthropic', model: 'claude-instant-infill' }
-    }
-
-    return null
+    return { provider: 'anthropic' }
 }
 
 const delimiters: Record<string, string> = {

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -156,7 +156,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: 'unstable-fireworks', model }
     }
 
-    return { provider: 'anthropic' }
+    return null
 }
 
 const delimiters: Record<string, string> = {


### PR DESCRIPTION
Update to use infill prompt by default.

Based on the numbers, users are getting higher-quality of suggestions using the infill prompt. 

Removed the old prompt for anthropic that does not support infilling.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Set provider to anthropic without setting modal. You should see an infill prompt being used.

Keeping the infill model feature flag for now as it's being used in the A/B test