### PR TITLE
Autocomplete: Use location key rather then location object for uniqueness test

### DIFF
--- a/vscode/src/completions/context/graph-section-observer.test.ts
+++ b/vscode/src/completions/context/graph-section-observer.test.ts
@@ -281,7 +281,6 @@ describe('GraphSectionObserver', () => {
             └─ foo (1 snippets)
 
           Last visited sections:
-            ├ file:/document1.ts foo
             └ file:/document1.ts foo"
         `)
     })

--- a/vscode/src/completions/context/graph-section-observer.ts
+++ b/vscode/src/completions/context/graph-section-observer.ts
@@ -523,12 +523,11 @@ function logHydratedContext(context: HoverContext[], editor: vscode.TextEditor, 
     )
 }
 
-function pushUniqueAndTruncate<T>(array: T[], item: T, truncate: number): T[] {
-    if (array.includes(item)) {
-        // put the item to the front
-        array.splice(array.indexOf(item), 1)
-        array.unshift(item)
-        return array
+function pushUniqueAndTruncate(array: vscode.Location[], item: vscode.Location, truncate: number): vscode.Location[] {
+    const indexOf = array.findIndex(i => locationKeyFn(i) === locationKeyFn(item))
+    if (indexOf > -1) {
+        // Remove the item so it is put to the front again
+        array.splice(indexOf, 1)
     }
     if (array.length >= truncate) {
         array.pop()


### PR DESCRIPTION
I saw that sometimes the last sections are full of the same section. Turns out we compare on the object instead the key function 🤦 

## Test plan

- select a bunch of sections in code
- ensure that the last sections is not containing dupes


<img width="411" alt="Screenshot 2023-09-25 at 17 42 06" src="https://github.com/sourcegraph/cody/assets/458591/d9fc4db6-9401-44dc-92ec-9d598088ddac">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
