### PR TITLE
Autocomplete: Use UUID for compltion ids

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from 'lru-cache'
+import uuid from 'uuid'
 import * as vscode from 'vscode'
 
 import { isNetworkError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
@@ -82,7 +83,7 @@ export function logCompletionEvent(name: string, params?: TelemetryEventProperti
 }
 
 export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMode' | 'type' | 'id'>): string {
-    const id = createId()
+    const id = uuid.v4()
     const params: CompletionEvent['params'] = {
         ...inputParams,
         type: 'inline',
@@ -244,10 +245,6 @@ export function noResponse(id: string): void {
  */
 export function clear(): void {
     logSuggestionEvents()
-}
-
-function createId(): string {
-    return Math.random().toString(36).slice(2, 11)
 }
 
 function logSuggestionEvents(): void {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -1,5 +1,5 @@
 import { LRUCache } from 'lru-cache'
-import uuid from 'uuid'
+import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
 import { isNetworkError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'


### PR DESCRIPTION
Improve the uniqueness of autocomplete logger IDs by using UUIDs instead of the custom random thingy lol

## Test plan

<img width="1040" alt="Screenshot 2023-09-25 at 17 47 21" src="https://github.com/sourcegraph/cody/assets/458591/233d668b-d982-481d-9b9e-6f7ab470a8a4">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
