### PR TITLE
fix: use lastTriggerDocContext instead current

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -25,6 +25,16 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             lastTriggerCurrentLinePrefix: document.lineAt(position).text.slice(0, position.character),
             lastTriggerNextNonEmptyLine: nextNonEmptyLine,
             lastTriggerSelectedInfoItem,
+            lastTriggerDocContext: {
+                currentLinePrefix: 'const foo = ',
+                currentLineSuffix: '',
+                multilineTrigger: null,
+                nextNonEmptyLine: 'console.log(1)',
+                prefix: 'const foo = ',
+                prevNonEmptyLine: '',
+                suffix: '',
+                contextRange: new Range(14, 2, 0, 0),
+            },
             result: {
                 logId: '1',
                 items: Array.isArray(insertText) ? insertText.map(insertText => ({ insertText })) : [{ insertText }],

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -33,7 +33,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                 prefix: 'const foo = ',
                 prevNonEmptyLine: '',
                 suffix: '',
-                contextRange: new Range(14, 2, 0, 0),
+                contextRange: new Range(position.character, 0, position.character, 0),
             },
             result: {
                 logId: '1',

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -1,12 +1,11 @@
 import dedent from 'dedent'
 import { describe, expect, test } from 'vitest'
-import { Range } from 'vscode'
 
 import { vsCodeMocks } from '../../testutils/mocks'
 import { range } from '../../testutils/textDocument'
+import { getCurrentDocContext } from '../get-current-doc-context'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from '../get-inline-completions'
 import { documentAndPosition } from '../test-helpers'
-import { getCurrentDocContext } from '../text-processing'
 
 import { getInlineCompletions, params, V } from './helpers'
 
@@ -17,9 +16,13 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         lastTriggerSelectedInfoItem?: string
     ): LastInlineCompletionCandidate {
         const { document, position } = documentAndPosition(code)
-        const prefix = document.lineAt(position).text.slice(0, position.character)
-        const suffix = document.getText(new Range(position, document.lineAt(document.lineCount - 1).range.end))
-        const lastDocContext = getCurrentDocContext(position, prefix, suffix)
+        const lastDocContext = getCurrentDocContext({
+            document,
+            position,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
+            enableExtendedTriggers: true,
+        })
         return {
             uri: document.uri,
             lastTriggerPosition: position,

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -6,7 +6,7 @@ import { vsCodeMocks } from '../../testutils/mocks'
 import { range } from '../../testutils/textDocument'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from '../get-inline-completions'
 import { documentAndPosition } from '../test-helpers'
-import { getNextNonEmptyLine } from '../text-processing'
+import { getNextNonEmptyLine, getPrevNonEmptyLine } from '../text-processing'
 
 import { getInlineCompletions, params, V } from './helpers'
 
@@ -19,25 +19,25 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         const { document, position } = documentAndPosition(code)
         const suffix = document.getText(new Range(position, document.lineAt(document.lineCount - 1).range.end))
         const nextNonEmptyLine = getNextNonEmptyLine(suffix)
+        const prefix = document.lineAt(position).text.slice(0, position.character)
+        const prevNonEmptyLine = getPrevNonEmptyLine(prefix)
         return {
             uri: document.uri,
             lastTriggerPosition: position,
-            lastTriggerCurrentLinePrefix: document.lineAt(position).text.slice(0, position.character),
-            lastTriggerNextNonEmptyLine: nextNonEmptyLine,
             lastTriggerSelectedInfoItem,
-            lastTriggerDocContext: {
-                currentLinePrefix: 'const foo = ',
-                currentLineSuffix: '',
-                multilineTrigger: null,
-                nextNonEmptyLine: 'console.log(1)',
-                prefix: 'const foo = ',
-                prevNonEmptyLine: '',
-                suffix: '',
-                contextRange: new Range(position.character, 0, position.character, 0),
-            },
             result: {
                 logId: '1',
                 items: Array.isArray(insertText) ? insertText.map(insertText => ({ insertText })) : [{ insertText }],
+            },
+            lastTriggerDocContext: {
+                currentLinePrefix: prefix,
+                currentLineSuffix: suffix,
+                multilineTrigger: null,
+                nextNonEmptyLine,
+                prevNonEmptyLine,
+                prefix,
+                suffix,
+                contextRange: new Range(position.character, 0, position.character, 0),
             },
         }
     }

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -6,7 +6,7 @@ import { vsCodeMocks } from '../../testutils/mocks'
 import { range } from '../../testutils/textDocument'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from '../get-inline-completions'
 import { documentAndPosition } from '../test-helpers'
-import { getNextNonEmptyLine, getPrevNonEmptyLine } from '../text-processing'
+import { getCurrentDocContext } from '../text-processing'
 
 import { getInlineCompletions, params, V } from './helpers'
 
@@ -17,10 +17,9 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         lastTriggerSelectedInfoItem?: string
     ): LastInlineCompletionCandidate {
         const { document, position } = documentAndPosition(code)
-        const suffix = document.getText(new Range(position, document.lineAt(document.lineCount - 1).range.end))
-        const nextNonEmptyLine = getNextNonEmptyLine(suffix)
         const prefix = document.lineAt(position).text.slice(0, position.character)
-        const prevNonEmptyLine = getPrevNonEmptyLine(prefix)
+        const suffix = document.getText(new Range(position, document.lineAt(document.lineCount - 1).range.end))
+        const lastDocContext = getCurrentDocContext(position, prefix, suffix)
         return {
             uri: document.uri,
             lastTriggerPosition: position,
@@ -29,16 +28,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                 logId: '1',
                 items: Array.isArray(insertText) ? insertText.map(insertText => ({ insertText })) : [{ insertText }],
             },
-            lastTriggerDocContext: {
-                currentLinePrefix: prefix,
-                currentLineSuffix: suffix,
-                multilineTrigger: null,
-                nextNonEmptyLine,
-                prevNonEmptyLine,
-                prefix,
-                suffix,
-                contextRange: new Range(position.character, 0, position.character, 0),
-            },
+            lastTriggerDocContext: lastDocContext,
         }
     }
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -65,6 +65,9 @@ export interface LastInlineCompletionCandidate {
     /** The document URI for which this candidate was generated. */
     uri: URI
 
+    /** The doc context item */
+    lastTriggerDocContext: DocumentContext
+
     /** The position at which this candidate was generated. */
     lastTriggerPosition: vscode.Position
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -71,12 +71,6 @@ export interface LastInlineCompletionCandidate {
     /** The position at which this candidate was generated. */
     lastTriggerPosition: vscode.Position
 
-    /** The prefix of the line (before the cursor position) where this candidate was generated. */
-    lastTriggerCurrentLinePrefix: string
-
-    /** The next non-empty line in the suffix */
-    lastTriggerNextNonEmptyLine: string
-
     /** The selected info item. */
     lastTriggerSelectedInfoItem: string | undefined
 

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -134,8 +134,27 @@ describe('InlineCompletionItemProvider', () => {
         // But it is returned and saved.
         expect(provider.lastCandidate).toMatchInlineSnapshot(`
           {
-            "lastTriggerCurrentLinePrefix": "const foo = ",
-            "lastTriggerNextNonEmptyLine": "console.log(1)",
+            "lastTriggerDocContext": {
+              "contextRange": Range {
+                "end": Position {
+                  "character": 14,
+                  "line": 2,
+                },
+                "start": Position {
+                  "character": 0,
+                  "line": 0,
+                },
+              },
+              "currentLinePrefix": "const foo = ",
+              "currentLineSuffix": "",
+              "multilineTrigger": null,
+              "nextNonEmptyLine": "console.log(1)",
+              "prefix": "const foo = ",
+              "prevNonEmptyLine": "",
+              "suffix": "
+console.log(1)
+console.log(2)",
+            },
             "lastTriggerPosition": Position {
               "character": 12,
               "line": 0,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -215,17 +215,21 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             // meaning the previous result is unwanted/rejected.
             // In that case, we mark the last candidate as "unwanted", remove it from cache, and clear the last candidate
             const lastTriggeredResultId = this.lastCandidate?.result.logId
+            const lastTriggeredDocContext = this.lastCandidate?.lastTriggerDocContext
+            const lastTriggeredPosition = this.lastCandidate?.lastTriggerPosition
             const currentPrefix = docContext.currentLinePrefix
             const lastTriggeredPrefix = this.lastCandidate?.lastTriggerCurrentLinePrefix
             if (
                 lastTriggeredResultId &&
+                lastTriggeredDocContext &&
+                lastTriggeredPosition &&
                 lastTriggeredPrefix !== undefined &&
-                currentPrefix.length <= lastTriggeredPrefix.length
+                currentPrefix.length < lastTriggeredPrefix.length
             ) {
                 this.handleUnwantedCompletionItem(lastTriggeredResultId, {
                     document,
-                    docContext,
-                    position,
+                    docContext: lastTriggeredDocContext,
+                    position: lastTriggeredPosition,
                     context,
                 })
             }
@@ -253,6 +257,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             const candidate: LastInlineCompletionCandidate = {
                 uri: document.uri,
                 lastTriggerPosition: position,
+                lastTriggerDocContext: docContext,
                 lastTriggerCurrentLinePrefix: docContext.currentLinePrefix,
                 lastTriggerNextNonEmptyLine: docContext.nextNonEmptyLine,
                 lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
@@ -333,6 +338,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         if (!completionItem) {
             return
         }
+
+        console.log('removing', completionItem)
 
         this.clearLastCandidate()
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -218,7 +218,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             const lastTriggeredDocContext = this.lastCandidate?.lastTriggerDocContext
             const lastTriggeredPosition = this.lastCandidate?.lastTriggerPosition
             const currentPrefix = docContext.currentLinePrefix
-            const lastTriggeredPrefix = this.lastCandidate?.lastTriggerCurrentLinePrefix
+            const lastTriggeredPrefix = this.lastCandidate?.lastTriggerDocContext.currentLinePrefix
             if (
                 lastTriggeredResultId &&
                 lastTriggeredDocContext &&
@@ -258,8 +258,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 uri: document.uri,
                 lastTriggerPosition: position,
                 lastTriggerDocContext: docContext,
-                lastTriggerCurrentLinePrefix: docContext.currentLinePrefix,
-                lastTriggerNextNonEmptyLine: docContext.nextNonEmptyLine,
                 lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
                 result: {
                     logId: result.logId,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -339,8 +339,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             return
         }
 
-        console.log('removing', completionItem)
-
         this.clearLastCandidate()
 
         this.requestManager.removeUnwanted(reqContext)

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -119,8 +119,6 @@ export class RequestManager {
             uri: document.uri,
             lastTriggerPosition: position,
             lastTriggerDocContext: docContext,
-            lastTriggerCurrentLinePrefix: docContext.currentLinePrefix,
-            lastTriggerNextNonEmptyLine: docContext.nextNonEmptyLine,
             lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
             result: {
                 logId: '',

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -118,6 +118,7 @@ export class RequestManager {
         const lastCandidate: LastInlineCompletionCandidate = {
             uri: document.uri,
             lastTriggerPosition: position,
+            lastTriggerDocContext: docContext,
             lastTriggerCurrentLinePrefix: docContext.currentLinePrefix,
             lastTriggerNextNonEmptyLine: docContext.nextNonEmptyLine,
             lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -17,6 +17,7 @@ export function reuseLastCandidate({
     context,
     lastCandidate: {
         lastTriggerPosition,
+        lastTriggerDocContext,
         lastTriggerCurrentLinePrefix,
         lastTriggerNextNonEmptyLine,
         lastTriggerSelectedInfoItem,

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -15,14 +15,7 @@ export function reuseLastCandidate({
     document,
     position,
     context,
-    lastCandidate: {
-        lastTriggerPosition,
-        lastTriggerDocContext,
-        lastTriggerCurrentLinePrefix,
-        lastTriggerNextNonEmptyLine,
-        lastTriggerSelectedInfoItem,
-        ...lastCandidate
-    },
+    lastCandidate: { lastTriggerPosition, lastTriggerDocContext, lastTriggerSelectedInfoItem, ...lastCandidate },
     docContext: { currentLinePrefix, currentLineSuffix, nextNonEmptyLine },
     completeSuggestWidgetSelection,
 }: Required<
@@ -35,7 +28,7 @@ export function reuseLastCandidate({
 }): InlineCompletionsResult | null {
     const isSameDocument = lastCandidate.uri.toString() === document.uri.toString()
     const isSameLine = lastTriggerPosition.line === position.line
-    const isSameNextNonEmptyLine = lastTriggerNextNonEmptyLine === nextNonEmptyLine
+    const isSameNextNonEmptyLine = lastTriggerDocContext.nextNonEmptyLine === nextNonEmptyLine
 
     // If completeSuggestWidgetSelection is enabled, we have to compare that a last candidate is
     // only reused if it is has same completion info selected.
@@ -48,7 +41,7 @@ export function reuseLastCandidate({
     }
 
     // There are 2 reasons we can reuse a candidate: typing-as-suggested or change-of-indentation.
-
+    const lastTriggerCurrentLinePrefix = lastTriggerDocContext.currentLinePrefix
     const isIndentation = isWhitespace(currentLinePrefix) && currentLinePrefix.startsWith(lastTriggerCurrentLinePrefix)
     const isDeindentation =
         isWhitespace(lastTriggerCurrentLinePrefix) && lastTriggerCurrentLinePrefix.startsWith(currentLinePrefix)

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { DocumentContext } from '../get-current-doc-context'
 import { getLanguageConfig } from '../language'
 import { logCompletionEvent } from '../logger'
 import { SymbolContextSnippet } from '../types'
@@ -356,4 +357,20 @@ export const formatSymbolContextRelationship = (
 
 export function lines(text: string): string[] {
     return text.split(/\r?\n/)
+}
+
+export function getCurrentDocContext(position: vscode.Position, prefix: string, suffix: string): DocumentContext {
+    const nextNonEmptyLine = getNextNonEmptyLine(suffix)
+    const prevNonEmptyLine = getPrevNonEmptyLine(prefix)
+
+    return {
+        currentLinePrefix: prefix,
+        currentLineSuffix: suffix,
+        multilineTrigger: null,
+        nextNonEmptyLine,
+        prevNonEmptyLine,
+        prefix,
+        suffix,
+        contextRange: new vscode.Range(position.character, 0, position.character, 0),
+    }
 }

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode'
 
-import { DocumentContext } from '../get-current-doc-context'
 import { getLanguageConfig } from '../language'
 import { logCompletionEvent } from '../logger'
 import { SymbolContextSnippet } from '../types'
@@ -357,20 +356,4 @@ export const formatSymbolContextRelationship = (
 
 export function lines(text: string): string[] {
     return text.split(/\r?\n/)
-}
-
-export function getCurrentDocContext(position: vscode.Position, prefix: string, suffix: string): DocumentContext {
-    const nextNonEmptyLine = getNextNonEmptyLine(suffix)
-    const prevNonEmptyLine = getPrevNonEmptyLine(prefix)
-
-    return {
-        currentLinePrefix: prefix,
-        currentLineSuffix: suffix,
-        multilineTrigger: null,
-        nextNonEmptyLine,
-        prevNonEmptyLine,
-        prefix,
-        suffix,
-        contextRange: new vscode.Range(position.character, 0, position.character, 0),
-    }
 }


### PR DESCRIPTION
fix: use lastTriggerDocContext instead current 

- Add `lastTriggerDocContext` field to `LastInlineCompletionCandidate` interface to store document context for last triggered completion.
- Pass `lastTriggerDocContext instead` of current docContext when handling unwanted completion to ensure correct context is used.
- Update reuse logic to also check if the current prefix is shorter than the last triggered prefix before clearing the last candidate. 
- Set `lastTriggerDocContext` when creating a completion candidate.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

#### After

https://github.com/sourcegraph/cody/assets/68532117/b40a9294-3b53-430a-bf08-856904f21cff


