### PR TITLE
Autocomplete: Improved manual completion trigger

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -487,7 +487,7 @@
         "key": "ctrl+enter"
       },
       {
-        "command": "editor.action.inlineSuggest.trigger",
+        "command": "cody.autocomplete.manual-trigger",
         "key": "alt+\\",
         "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
       }

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -74,6 +74,9 @@ export async function createInlineCompletionItemProvider({
         })
 
         disposables.push(
+            vscode.commands.registerCommand('cody.autocomplete.manual-trigger', () =>
+                completionsProvider.manuallyTriggerCompletion()
+            ),
             vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyCompletion }) => {
                 completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyCompletion)
             }),

--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -41,10 +41,7 @@ describe('[getInlineCompletions] common', () => {
         expect(
             await getInlineCompletions(
                 params('array.so█', [completion`rt()`], {
-                    context: {
-                        triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
-                        selectedCompletionInfo: { text: 'sort', range: new vsCodeMocks.Range(0, 6, 0, 8) },
-                    },
+                    selectedCompletionInfo: { text: 'sort', range: new vsCodeMocks.Range(0, 6, 0, 8) },
                 })
             )
         ).toEqual<V>({

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -7,10 +7,13 @@ import {
     CompletionResponse,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-import { vsCodeMocks } from '../../testutils/mocks'
 import { CodeCompletionsClient } from '../client'
 import { getCurrentDocContext } from '../get-current-doc-context'
-import { getInlineCompletions as _getInlineCompletions, InlineCompletionsParams } from '../get-inline-completions'
+import {
+    getInlineCompletions as _getInlineCompletions,
+    InlineCompletionsParams,
+    TriggerKind,
+} from '../get-inline-completions'
 import { createProviderConfig, MULTI_LINE_STOP_SEQUENCES, SINGLE_LINE_STOP_SEQUENCES } from '../providers/anthropic'
 import { RequestManager } from '../request-manager'
 import { documentAndPosition } from '../test-helpers'
@@ -44,10 +47,8 @@ export function params(
     {
         languageId = 'typescript',
         onNetworkRequest,
-        context = {
-            triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
-            selectedCompletionInfo: undefined,
-        },
+        triggerKind = TriggerKind.Automatic,
+        selectedCompletionInfo,
         ...params
     }: Params = {}
 ): InlineCompletionsParams {
@@ -87,8 +88,9 @@ export function params(
     return {
         document,
         position,
-        context,
         docContext,
+        triggerKind,
+        selectedCompletionInfo,
         promptChars: 1000,
         isEmbeddingsContextEnabled: true,
         providerConfig,

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -2,7 +2,6 @@ import dedent from 'dedent'
 import { describe, expect, test } from 'vitest'
 import { Range } from 'vscode'
 
-import { vsCodeMocks } from '../../testutils/mocks'
 import { range } from '../../testutils/textDocument'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from '../get-inline-completions'
 import { documentAndPosition } from '../test-helpers'
@@ -244,12 +243,9 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                 await getInlineCompletions(
                     params('console█', [], {
                         lastCandidate: lastCandidate('console█', ' = 1', 'log'),
-                        context: {
-                            triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
-                            selectedCompletionInfo: {
-                                text: 'dir',
-                                range: range(0, 0, 0, 0),
-                            },
+                        selectedCompletionInfo: {
+                            text: 'dir',
+                            range: range(0, 0, 0, 0),
                         },
                         completeSuggestWidgetSelection: true,
                     })

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -22,7 +22,8 @@ export interface InlineCompletionsParams {
     // Context
     document: vscode.TextDocument
     position: vscode.Position
-    context: vscode.InlineCompletionContext
+    triggerKind: TriggerKind
+    selectedCompletionInfo: vscode.SelectedCompletionInfo | undefined
     docContext: DocumentContext
 
     // Prompt parameters
@@ -113,6 +114,21 @@ export enum InlineCompletionsResultSource {
     LastCandidate = 'LastCandidate',
 }
 
+/**
+ * Extends the default VS Code trigger kind to distinguish between manually invoking a completion
+ * via the keyboard shortcut and invoking a completion via hovering over ghost text.
+ */
+export enum TriggerKind {
+    /** Completion was triggered explicitly by a user hovering over ghost text. **/
+    Hover = 'Hover',
+
+    /** Completion was triggered automatically while editing. **/
+    Automatic = 'Automatic',
+
+    /** Completion was triggered manually by the user invoking the keyboard shortcut. **/
+    Manual = 'Manual',
+}
+
 export async function getInlineCompletions(params: InlineCompletionsParams): Promise<InlineCompletionsResult | null> {
     try {
         const result = await doGetInlineCompletions(params)
@@ -140,7 +156,8 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     const {
         document,
         position,
-        context,
+        triggerKind,
+        selectedCompletionInfo,
         docContext,
         docContext: { multilineTrigger, currentLineSuffix },
         promptChars,
@@ -163,7 +180,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         completeSuggestWidgetSelection = false,
     } = params
 
-    tracer?.({ params: { document, position, context } })
+    tracer?.({ params: { document, position, triggerKind, selectedCompletionInfo } })
 
     // If we have a suffix in the same line as the cursor and the suffix contains any word
     // characters, do not attempt to make a completion. This means we only make completions if
@@ -171,22 +188,23 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     //
     // VS Code will attempt to merge the remainder of the current line by characters but for
     // words this will easily get very confusing.
-    if (/\w/.test(currentLineSuffix)) {
+    if (triggerKind !== TriggerKind.Manual && /\w/.test(currentLineSuffix)) {
         return null
     }
 
     // Check if the user is typing as suggested by the last candidate completion (that is shown as
     // ghost text in the editor), and reuse it if it is still valid.
-    const resultToReuse = lastCandidate
-        ? reuseLastCandidate({
-              document,
-              position,
-              lastCandidate,
-              docContext,
-              context,
-              completeSuggestWidgetSelection,
-          })
-        : null
+    const resultToReuse =
+        triggerKind !== TriggerKind.Manual && lastCandidate
+            ? reuseLastCandidate({
+                  document,
+                  position,
+                  lastCandidate,
+                  docContext,
+                  selectedCompletionInfo,
+                  completeSuggestWidgetSelection,
+              })
+            : null
     if (resultToReuse) {
         return resultToReuse
     }
@@ -198,6 +216,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     const multiline = Boolean(multilineTrigger)
     const logId = CompletionLogger.create({
         multiline,
+        triggerKind,
         providerIdentifier: providerConfig.identifier,
         providerModel: providerConfig.model,
         languageId: document.languageId,
@@ -205,11 +224,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 
     // Debounce to avoid firing off too many network requests as the user is still typing.
     const interval = multiline ? debounceInterval?.multiLine : debounceInterval?.singleLine
-    if (
-        context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic &&
-        interval !== undefined &&
-        interval > 0
-    ) {
+    if (triggerKind === TriggerKind.Automatic && interval !== undefined && interval > 0) {
         await new Promise<void>(resolve => setTimeout(resolve, interval))
     }
 
@@ -241,7 +256,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     // Completion providers
     const completionProviders = getCompletionProviders({
         document,
-        context,
+        triggerKind,
         providerConfig,
         responsePercentage,
         prefixPercentage,
@@ -257,7 +272,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         document,
         docContext,
         position,
-        context,
+        selectedCompletionInfo,
     }
 
     // Get the processed completions from providers
@@ -289,7 +304,7 @@ interface GetCompletionProvidersParams
     extends Pick<
         InlineCompletionsParams,
         | 'document'
-        | 'context'
+        | 'triggerKind'
         | 'providerConfig'
         | 'responsePercentage'
         | 'prefixPercentage'
@@ -302,7 +317,7 @@ interface GetCompletionProvidersParams
 function getCompletionProviders(params: GetCompletionProvidersParams): Provider[] {
     const {
         document,
-        context,
+        triggerKind,
         providerConfig,
         responsePercentage,
         prefixPercentage,
@@ -334,7 +349,7 @@ function getCompletionProviders(params: GetCompletionProvidersParams): Provider[
             ...sharedProviderOptions,
             // Show more if manually triggered (but only showing 1 is faster, so we use it
             // in the automatic trigger case).
-            n: context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic ? 1 : 3,
+            n: triggerKind === TriggerKind.Automatic ? 1 : 3,
             multiline: false,
         }),
     ]

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -17,6 +17,7 @@ import {
     InlineCompletionsParams,
     InlineCompletionsResultSource,
     LastInlineCompletionCandidate,
+    TriggerKind,
 } from './get-inline-completions'
 import * as CompletionLogger from './logger'
 import { CompletionEvent } from './logger'
@@ -49,6 +50,10 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     private promptChars: number
     private maxPrefixChars: number
     private maxSuffixChars: number
+    // This field is going to be set if you use the keyboard shortcut to manually trigger a
+    // completion. Since VS Code does not provide a way to distinguish manual vs automatic
+    // completions, we use consult this field inside the completion callback instead.
+    private lastManualCompletionTimestamp: number | null = null
     // private reportedErrorMessages: Map<string, number> = new Map()
     private resetRateLimitErrorsAfter: number | null = null
 
@@ -137,6 +142,14 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
         const graphContextFetcher = this.config.graphContextFetcher ?? undefined
 
+        const triggerKind =
+            this.lastManualCompletionTimestamp && this.lastManualCompletionTimestamp > Date.now() - 500
+                ? TriggerKind.Manual
+                : context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic
+                ? TriggerKind.Automatic
+                : TriggerKind.Hover
+        this.lastManualCompletionTimestamp = null
+
         let stopLoading: () => void | undefined
         const setIsLoading = (isLoading: boolean): void => {
             if (isLoading) {
@@ -177,7 +190,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             const result = await this.getInlineCompletions({
                 document,
                 position,
-                context,
+                triggerKind,
+                selectedCompletionInfo: context.selectedCompletionInfo,
                 docContext,
                 promptChars: this.promptChars,
                 providerConfig: this.config.providerConfig,
@@ -226,7 +240,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     document,
                     docContext,
                     position,
-                    context,
+                    selectedCompletionInfo: context.selectedCompletionInfo,
                 })
             }
 
@@ -320,6 +334,12 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         this.clearLastCandidate()
 
         CompletionLogger.accept(logId, completion)
+    }
+
+    public async manuallyTriggerCompletion(): Promise<void> {
+        await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
+        this.lastManualCompletionTimestamp = Date.now()
+        await vscode.commands.executeCommand('editor.action.inlineSuggest.trigger')
     }
 
     /**

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -9,7 +9,7 @@ import { captureException, shouldErrorBeReported } from '../services/sentry/sent
 import { telemetryService } from '../services/telemetry'
 
 import { ContextSummary } from './context/context'
-import { InlineCompletionsResultSource } from './get-inline-completions'
+import { InlineCompletionsResultSource, TriggerKind } from './get-inline-completions'
 import * as statistics from './statistics'
 import { InlineCompletionItemWithAnalytics } from './text-processing/process-inline-completions'
 import { InlineCompletionItem } from './types'
@@ -19,6 +19,7 @@ export interface CompletionEvent {
         type: 'inline'
         multiline: boolean
         multilineMode: null | 'block'
+        triggerKind: TriggerKind
         providerIdentifier: string
         providerModel: string
         languageId: string

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { vsCodeMocks } from '../testutils/mocks'
-
 import { getCurrentDocContext } from './get-current-doc-context'
 import { Provider } from './providers/provider'
 import { RequestManager, RequestManagerResult, RequestParams } from './request-manager'
@@ -54,10 +52,7 @@ function docState(prefix: string, suffix: string = ';'): RequestParams {
             maxSuffixLength: 100,
             enableExtendedTriggers: true,
         }),
-        context: {
-            triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
-            selectedCompletionInfo: undefined,
-        },
+        selectedCompletionInfo: undefined,
     }
 }
 

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -19,8 +19,8 @@ export interface RequestParams {
     /** The request's document context **/
     docContext: DocumentContext
 
-    /** The request's inline completion context. **/
-    context: vscode.InlineCompletionContext
+    /** The state of the completion info box **/
+    selectedCompletionInfo: vscode.SelectedCompletionInfo | undefined
 
     /** The cursor position in the source file where the completion request was triggered. **/
     position: vscode.Position
@@ -101,7 +101,7 @@ export class RequestManager {
         return request.promise
     }
 
-    // Remove unwanted sugggestion from the cache
+    // Remove unwanted suggestions from the cache
     public removeUnwanted(params: RequestParams): void {
         this.cache.delete(params)
     }
@@ -114,13 +114,13 @@ export class RequestManager {
         resolvedRequest: InflightRequest,
         items: InlineCompletionItemWithAnalytics[]
     ): void {
-        const { document, position, docContext, context } = resolvedRequest.params
+        const { document, position, docContext, selectedCompletionInfo } = resolvedRequest.params
         const lastCandidate: LastInlineCompletionCandidate = {
             uri: document.uri,
             lastTriggerPosition: position,
             lastTriggerCurrentLinePrefix: docContext.currentLinePrefix,
             lastTriggerNextNonEmptyLine: docContext.nextNonEmptyLine,
-            lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
+            lastTriggerSelectedInfoItem: selectedCompletionInfo?.text,
             result: {
                 logId: '',
                 items,
@@ -141,7 +141,7 @@ export class RequestManager {
                 position: request.params.position,
                 lastCandidate,
                 docContext: request.params.docContext,
-                context: request.params.context,
+                selectedCompletionInfo: request.params.selectedCompletionInfo,
                 completeSuggestWidgetSelection: this.completeSuggestWidgetSelection,
             })
 

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -14,7 +14,7 @@ import { InlineCompletionItem } from './types'
 export function reuseLastCandidate({
     document,
     position,
-    context,
+    selectedCompletionInfo,
     lastCandidate: {
         lastTriggerPosition,
         lastTriggerCurrentLinePrefix,
@@ -27,7 +27,7 @@ export function reuseLastCandidate({
 }: Required<
     Pick<
         InlineCompletionsParams,
-        'document' | 'position' | 'context' | 'lastCandidate' | 'completeSuggestWidgetSelection'
+        'document' | 'position' | 'selectedCompletionInfo' | 'lastCandidate' | 'completeSuggestWidgetSelection'
     >
 > & {
     docContext: DocumentContext
@@ -39,7 +39,7 @@ export function reuseLastCandidate({
     // If completeSuggestWidgetSelection is enabled, we have to compare that a last candidate is
     // only reused if it is has same completion info selected.
     const isSameTriggerSelectedInfoItem = completeSuggestWidgetSelection
-        ? lastTriggerSelectedInfoItem === context.selectedCompletionInfo?.text
+        ? lastTriggerSelectedInfoItem === selectedCompletionInfo?.text
         : true
 
     if (!isSameDocument || !isSameLine || !isSameNextNonEmptyLine || !isSameTriggerSelectedInfoItem) {

--- a/vscode/src/completions/tracer/index.ts
+++ b/vscode/src/completions/tracer/index.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
 import { GetContextResult } from '../context/context'
-import { InlineCompletionsResult } from '../get-inline-completions'
+import { InlineCompletionsResult, TriggerKind } from '../get-inline-completions'
 import { CompletionProviderTracerResultData, Provider } from '../providers/provider'
 
 /**
@@ -27,7 +27,8 @@ export interface ProvideInlineCompletionsItemTraceData {
     params?: {
         document: vscode.TextDocument
         position: vscode.Position
-        context: vscode.InlineCompletionContext
+        triggerKind: TriggerKind
+        selectedCompletionInfo?: vscode.SelectedCompletionInfo
     }
     completers?: Provider['options'][]
 

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -97,13 +97,10 @@ function renderWebviewHtml(data: ProvideInlineCompletionsItemTraceData | undefin
 - ${markdownInlineCode(data.params.document.fileName)} @ ${data.params.position.line + 1}:${
                 data.params.position.character + 1
             }
-- triggerKind: ${vscode.InlineCompletionTriggerKind[data.params.context.triggerKind]}
+- triggerKind: ${data.params.triggerKind}
 - selectedCompletionInfo: ${
-                data.params.context.selectedCompletionInfo
-                    ? selectedCompletionInfoDescription(
-                          data.params.context.selectedCompletionInfo,
-                          data.params.document
-                      )
+                data.params.selectedCompletionInfo
+                    ? selectedCompletionInfoDescription(data.params.selectedCompletionInfo, data.params.document)
                     : 'none'
             }
 `,


### PR DESCRIPTION
This PR improves the manual completion triggered via the keyboard shortcut:

- We are now able to separate between manually triggered completions and hover over the ghost text
- The refined trigger kinds are now part of the suggestions logged
- When using the manual keyboard triggers, we now hide the current ghost text so that we are able to cycle through new completions with this shortcut
- Opt out from cache hits when manual suggestions are triggered

## Test plan

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:completion:suggested {"multiline":false,"triggerKind":"Automatic","providerIdentifier":"anthropic","providerModel":"claude-instant-infill","languageId":"typescript","type":"inline","multilineMode":null,"id":"6370b94f-4c07-44ac-903c-149aa75abba5","contextSummary":{"duration":0.13420796394348145},"source":"Network","lineCount":1,"charCount":13,"latency":443.20716601610184,"displayDuration":311.8174999952316,"read":false,"accepted":false,"otherCompletionProviderEnabled":false,"completionsStartedSinceLastSuggestion":1}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
