### PR TITLE
Autocomplete: separate tree-sitter analytics getter from queries

### DIFF
--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -4,6 +4,7 @@ import { dedupeWith } from '@sourcegraph/cody-shared/src/common'
 
 import { DocumentContext } from '../get-current-doc-context'
 import { ItemPostProcesssingInfo } from '../logger'
+import { astGetters } from '../tree-sitter/ast-getters'
 import { getDocumentQuerySDK } from '../tree-sitter/queries'
 import { InlineCompletionItem } from '../types'
 
@@ -73,10 +74,9 @@ export function processItem(params: ProcessItemParams): InlineCompletionItemWith
     let { insertText } = parsed
     const initialLineCount = insertText.split('\n').length
 
-    const documentQuerySDK = getDocumentQuerySDK(document.languageId)
-    if (parsed.tree && parsed.points && documentQuerySDK) {
+    if (parsed.tree && parsed.points) {
         const { tree, points } = parsed
-        const captures = documentQuerySDK.getNodeAtCursorAndParents(tree.rootNode, points?.trigger || points?.start)
+        const captures = astGetters.getNodeAtCursorAndParents(tree.rootNode, points?.trigger || points?.start)
 
         if (captures.length > 0) {
             const [atCursor, ...parents] = captures
@@ -92,7 +92,7 @@ export function processItem(params: ProcessItemParams): InlineCompletionItemWith
 
     if (multilineTrigger) {
         // Use tree-sitter for truncation if `config.autocompleteExperimentalSyntacticPostProcessing` is enabled.
-        if (parsed.tree && documentQuerySDK) {
+        if (parsed.tree && getDocumentQuerySDK(document.languageId)) {
             insertText = truncateParsedCompletion({ completion: parsed, document })
             parsed.truncatedWith = 'tree-sitter'
         } else {

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.ts
@@ -23,13 +23,13 @@ export function truncateParsedCompletion(context: CompletionContext): string {
     const parseTreeCache = getCachedParseTreeForDocument(document)
     const documentQuerySDK = getDocumentQuerySDK(context.document.languageId)
 
-    if (!completion.tree || !parseTreeCache || !documentQuerySDK) {
+    if (!completion.tree || !completion.points || !parseTreeCache || !documentQuerySDK) {
         throw new Error('Expected completion and document to have tree-sitter data for truncation')
     }
 
     const { tree, points } = completion
 
-    const [captureGroup] = documentQuerySDK.getFirstMultilineBlockForTruncation(
+    const [captureGroup] = documentQuerySDK.queries.blocks.getFirstMultilineBlockForTruncation(
         tree.rootNode,
         points?.trigger || points?.start,
         points?.end

--- a/vscode/src/completions/tree-sitter/ast-getters.ts
+++ b/vscode/src/completions/tree-sitter/ast-getters.ts
@@ -1,0 +1,39 @@
+import Parser, { Point, SyntaxNode } from 'web-tree-sitter'
+
+import { isDefined } from '@sourcegraph/cody-shared'
+
+import { Captures } from './queries/annotate-and-match-snapshot'
+
+interface AstGetters {
+    getNodeAtCursorAndParents: (
+        node: SyntaxNode,
+        startPosition: Point,
+        endPosition?: Point
+    ) => readonly [
+        { readonly name: 'at_cursor'; readonly node: Parser.SyntaxNode },
+        ...{ name: string; node: Parser.SyntaxNode }[],
+    ]
+}
+
+export const astGetters: AstGetters = {
+    /**
+     * Returns a descendant node at the start position and two parent nodes if they exist.
+     */
+    getNodeAtCursorAndParents: (node, startPosition) => {
+        const descendant = node.descendantForPosition(startPosition)
+        const parent = descendant.parent
+
+        const parents = [parent, parent?.parent, parent?.parent?.parent].filter(isDefined).map(node => ({
+            name: 'parents',
+            node,
+        }))
+
+        return [
+            {
+                name: 'at_cursor',
+                node: descendant,
+            },
+            ...parents,
+        ] as const
+    },
+} satisfies Record<string, Captures>

--- a/vscode/src/completions/tree-sitter/parser.ts
+++ b/vscode/src/completions/tree-sitter/parser.ts
@@ -54,7 +54,7 @@ export async function createParser(settings: ParserSettings): Promise<Parser> {
     parser.setLanguage(languageGrammar)
     PARSERS_LOCAL_CACHE[language] = parser
 
-    initQueries(languageGrammar, language)
+    initQueries(languageGrammar, language, parser)
 
     return parser
 }

--- a/vscode/src/completions/tree-sitter/queries.ts
+++ b/vscode/src/completions/tree-sitter/queries.ts
@@ -1,17 +1,17 @@
-import { memoize } from 'lodash'
 import Parser, { Language, Point, Query, SyntaxNode } from 'web-tree-sitter'
-
-import { isDefined } from '@sourcegraph/cody-shared'
 
 import { getParseLanguage, SupportedLanguage } from './grammars'
 import { getParser } from './parser'
+import { Captures } from './queries/annotate-and-match-snapshot'
 import { languages, QueryName } from './queries/languages'
 
 interface ParsedQuery {
     compiled: Query
     raw: string
 }
-type ResolvedQueries = Record<QueryName, ParsedQuery>
+type ResolvedQueries = {
+    [name in QueryName]: ParsedQuery & QueryWrappers[name]
+}
 
 const QUERIES_LOCAL_CACHE: Partial<Record<SupportedLanguage, ResolvedQueries>> = {}
 
@@ -19,7 +19,7 @@ const QUERIES_LOCAL_CACHE: Partial<Record<SupportedLanguage, ResolvedQueries>> =
  * Reads all language queries from disk and parses them.
  * Saves queries the local cache for further use.
  */
-export function initQueries(language: Language, languageId: SupportedLanguage): void {
+export function initQueries(language: Language, languageId: SupportedLanguage, parser: Parser): void {
     const cachedQueries = QUERIES_LOCAL_CACHE[languageId]
     if (cachedQueries) {
         return
@@ -41,15 +41,30 @@ export function initQueries(language: Language, languageId: SupportedLanguage): 
     })
 
     const queries = Object.fromEntries<ParsedQuery>(queryEntries) as ResolvedQueries
-    QUERIES_LOCAL_CACHE[languageId] = queries
+
+    // Add query wrappers to respective queries.
+    // The resulting object ensures that query wrappers are inaccessible for languages
+    // where queries are not defined yet.
+    const queryWrappers = getLanguageSpecificQueryWrappers(queries, parser)
+    const queriesWithQueryWrappers = Object.fromEntries(
+        Object.entries(queries).map(([name, query]) => {
+            return [name, { ...query, ...queryWrappers[name as keyof QueryWrappers] }] as const
+        })
+    ) as ResolvedQueries
+
+    QUERIES_LOCAL_CACHE[languageId] = queriesWithQueryWrappers
 }
 
-interface DocumentQuerySDK extends QueryWrappers {
+interface DocumentQuerySDK {
     parser: Parser
     queries: ResolvedQueries
     language: SupportedLanguage
 }
 
+/**
+ * Returns the query SDK only if the language has queries defined and
+ * the relevant laguage parser is initialized.
+ */
 export function getDocumentQuerySDK(language: string): DocumentQuerySDK | null {
     const supportedLanguage = getParseLanguage(language)
     if (!supportedLanguage) {
@@ -67,81 +82,48 @@ export function getDocumentQuerySDK(language: string): DocumentQuerySDK | null {
         parser,
         queries,
         language: supportedLanguage,
-        ...getQueryWrappers(queries, parser),
     }
 }
 
-export type Captures = (
-    node: SyntaxNode,
-    startPosition: Point,
-    endPosition?: Point
-) => readonly Readonly<Parser.QueryCapture>[]
-
 interface QueryWrappers {
-    getFirstMultilineBlockForTruncation: (
-        node: SyntaxNode,
-        startPosition?: Point,
-        endPosition?: Point
-    ) => never[] | readonly [{ readonly node: Parser.SyntaxNode; readonly name: 'blocks' }]
-    getNodeAtCursorAndParents: (
-        node: SyntaxNode,
-        startPosition: Point,
-        endPosition?: Point
-    ) => readonly [
-        { readonly name: 'at_cursor'; readonly node: Parser.SyntaxNode },
-        ...{ name: string; node: Parser.SyntaxNode }[],
-    ]
-}
-
-/**
- * Query wrappers with custom logic requred for specific goals.
- * Memoize this function for each query object because it will be called many times with
- * no functional changes.
- */
-const getQueryWrappers = memoize((queries: ResolvedQueries, _parser: Parser): QueryWrappers => {
-    return {
+    blocks: {
         /**
          * Returns the first block-like node (block_statement).
          * Handles special cases where we want to use the parent block instead
          * if it has a specific node type (if_statement).
          */
-        getFirstMultilineBlockForTruncation(node, startPosition, endPosition) {
-            const captures = queries.blocks.compiled.captures(node, startPosition, endPosition)
-
-            if (!captures.length) {
-                return []
-            }
-
-            // Taking the last result to get the most nested node.
-            // See https://github.com/tree-sitter/tree-sitter/discussions/2067
-            const initialNode = captures.at(-1)!.node
-
-            // Check for special cases where we need match a parent node.
-            const potentialParentNodes = captures.filter(capture => capture.name === 'parents')
-            const potentialParent = potentialParentNodes.find(capture => initialNode.parent?.id === capture.node.id)
-                ?.node
-
-            return [{ node: potentialParent || initialNode, name: 'blocks' }] as const
-        },
-        /**
-         * Returns a descendant node at the start position and two parent nodes if they exist.
-         */
-        getNodeAtCursorAndParents(node, startPosition) {
-            const descendant = node.descendantForPosition(startPosition)
-            const parent = descendant.parent
-
-            const parents = [parent, parent?.parent, parent?.parent?.parent].filter(isDefined).map(node => ({
-                name: 'parents',
-                node,
-            }))
-
-            return [
-                {
-                    name: 'at_cursor',
-                    node: descendant,
-                },
-                ...parents,
-            ] as const
-        },
+        getFirstMultilineBlockForTruncation: (
+            node: SyntaxNode,
+            startPosition: Point,
+            endPosition?: Point
+        ) => never[] | readonly [{ readonly node: Parser.SyntaxNode; readonly name: 'blocks' }]
     }
-})
+}
+
+/**
+ * Query wrappers with custom post-processing logic.
+ */
+function getLanguageSpecificQueryWrappers(queries: ResolvedQueries, _parser: Parser): QueryWrappers {
+    return {
+        blocks: {
+            getFirstMultilineBlockForTruncation: (node, startPosition, endPosition) => {
+                const captures = queries.blocks.compiled.captures(node, startPosition, endPosition)
+
+                if (!captures.length) {
+                    return []
+                }
+
+                // Taking the last result to get the most nested node.
+                // See https://github.com/tree-sitter/tree-sitter/discussions/2067
+                const initialNode = captures.at(-1)!.node
+
+                // Check for special cases where we need match a parent node.
+                const potentialParentNodes = captures.filter(capture => capture.name === 'parents')
+                const potentialParent = potentialParentNodes.find(capture => initialNode.parent?.id === capture.node.id)
+                    ?.node
+
+                return [{ node: potentialParent || initialNode, name: 'blocks' }] as const
+            },
+        },
+    } satisfies Record<QueryName, Record<string, Captures>>
+}

--- a/vscode/src/completions/tree-sitter/queries/annotate-and-match-snapshot.ts
+++ b/vscode/src/completions/tree-sitter/queries/annotate-and-match-snapshot.ts
@@ -4,11 +4,10 @@ import path from 'path'
 
 import dedent from 'dedent'
 import { expect } from 'vitest'
-import Parser, { Point } from 'web-tree-sitter'
+import Parser, { Point, SyntaxNode } from 'web-tree-sitter'
 
 import { getLanguageConfig } from '../../language'
 import { SupportedLanguage } from '../grammars'
-import { Captures } from '../queries'
 
 interface CommentSymbolInfo {
     delimiter: string
@@ -119,6 +118,13 @@ function initEmptyAnnotationsForPoint(annotations: Annotations, point: Point): v
         annotations[point.row][point.column] = []
     }
 }
+
+// Defines the signature for functions that annotate nodes.
+export type Captures = (
+    node: SyntaxNode,
+    startPosition: Point,
+    endPosition?: Point
+) => readonly Readonly<Parser.QueryCapture>[]
 
 interface AnnotateSnippetsParams {
     code: string

--- a/vscode/src/completions/tree-sitter/queries/blocks.test.ts
+++ b/vscode/src/completions/tree-sitter/queries/blocks.test.ts
@@ -12,15 +12,13 @@ describe('getFirstMultilineBlockForTruncation', () => {
     })
 
     it('typescript', async () => {
-        const { language, parser, queries, getFirstMultilineBlockForTruncation } = getDocumentQuerySDK(
-            SupportedLanguage.TypeScript
-        )!
+        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
 
         await annotateAndMatchSnapshot({
             parser,
             language,
             rawQuery: queries.blocks.raw,
-            captures: getFirstMultilineBlockForTruncation,
+            captures: queries.blocks.getFirstMultilineBlockForTruncation,
             sourcesPath: 'test-data/blocks.ts',
         })
     })

--- a/vscode/src/completions/tree-sitter/queries/node-at-cursor-and-parents.test.ts
+++ b/vscode/src/completions/tree-sitter/queries/node-at-cursor-and-parents.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, it } from 'vitest'
 
 import { initTreeSitterParser } from '../../test-helpers'
+import { astGetters } from '../ast-getters'
 import { SupportedLanguage } from '../grammars'
 import { getDocumentQuerySDK } from '../queries'
 
@@ -12,13 +13,13 @@ describe('getNodeAtCursorAndParents', () => {
     })
 
     it('typescript', async () => {
-        const { language, parser, getNodeAtCursorAndParents } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
+        const { language, parser } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
 
         await annotateAndMatchSnapshot({
             parser,
             language,
             rawQuery: 'Gets the "current" node at cursor position and tree parents.',
-            captures: getNodeAtCursorAndParents,
+            captures: astGetters.getNodeAtCursorAndParents,
             sourcesPath: 'test-data/parents.ts',
         })
     })


### PR DESCRIPTION
## Context

- Separates the tree-sitter analytics getter from queries SDK to ensure it's invoked for languages where queries are not defined.
- Follow-up for https://github.com/sourcegraph/cody/pull/1154

## Test plan

CI
