### PR TITLE
Autocomplete: enable tree-sitter by default

### DIFF
--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -38,7 +38,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteAdvancedEmbeddings: true,
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
-            autocompleteExperimentalSyntacticPostProcessing: false,
+            autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: false,
         })
     })
@@ -103,7 +103,7 @@ describe('getConfiguration', () => {
                     case 'cody.autocomplete.experimental.completeSuggestWidgetSelection':
                         return false
                     case 'cody.autocomplete.experimental.syntacticPostProcessing':
-                        return false
+                        return true
                     case 'cody.autocomplete.experimental.graphContext':
                         return true
                     case 'cody.advanced.agent.running':
@@ -144,7 +144,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteAdvancedEmbeddings: false,
             autocompleteExperimentalCompleteSuggestWidgetSelection: false,
-            autocompleteExperimentalSyntacticPostProcessing: false,
+            autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: true,
         })
     })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -73,7 +73,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         ),
         autocompleteExperimentalSyntacticPostProcessing: config.get(
             CONFIG_KEY.autocompleteExperimentalSyntacticPostProcessing,
-            false
+            true
         ),
         autocompleteExperimentalGraphContext: config.get<boolean>(
             CONFIG_KEY.autocompleteExperimentalGraphContext,


### PR DESCRIPTION
## Context

- Sets `config.autocompleteExperimentalSyntacticPostProcessing` to `true` by default to enable tree-sitter parsing for all supported languages for everybody.

## Test plan

CI
