### PR TITLE
Silence logspam from expected app connection failures

### DIFF
--- a/lib/shared/src/embeddings/EmbeddingsDetector.ts
+++ b/lib/shared/src/embeddings/EmbeddingsDetector.ts
@@ -20,7 +20,6 @@ export const EmbeddingsDetector = {
             const isError = result instanceof Error
             allFailed &&= isError
             if (isError) {
-                console.log('EmbeddingsDetector', `Error getting embeddings availability for ${codebase}`, result)
                 firstError ||= result
                 continue
             }
@@ -30,7 +29,11 @@ export const EmbeddingsDetector = {
             // We got a result, drop the rest of the promises on the floor.
             return result()
         }
-        return allFailed ? firstError : undefined
+        if (allFailed) {
+            console.log('EmbeddingsDetector', `Error getting embeddings availability for ${codebase}`, firstError)
+            return firstError
+        }
+        return undefined
     },
 
     // Detects whether *one* client has embeddings for the specified codebase.


### PR DESCRIPTION
Simplified onboarding pings App repeatedly via localhost. This is expected to fail if you're not using app, so don't log when these pings fail, just log when all pings fail.

## Test plan

1. Open user settings JSON, add `"testing.simplified-onboarding": true`
2. Exit Cody App, if it is running.
3. Open VScode, sign in to dotcom.
4. Create a git repository with a remote: `mkdir /tmp/foo; cd /tmp/foo; git init .; git remote add origin git@host.example/foo.git; touch README.md`
5. Open /tmp/foo folder in VScode. Open README.md.
6. Chat input context status should have a database with a cross, README.md.
7. Open VScode debug console, there should not be spam about EmbeddingsDetector.
