### PR TITLE
Autocomplete: Set default for tree sitter

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -931,7 +931,7 @@
         },
         "cody.autocomplete.experimental.syntacticPostProcessing": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Rank autocomplete results with tree-sitter."
         },
         "cody.autocomplete.experimental.graphContext": {


### PR DESCRIPTION
Follow-up from #1172. I tried the changes and they weren't working for me. Turns out we also have to change the default in `package.json`

## Test plan

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:completion:accepted {"multiline":false,"providerIdentifier":"anthropic","providerModel":"claude-instant-infill","languageId":"typescript","type":"inline","multilineMode":null,"id":"ej0smjm3u","contextSummary":{"duration":0.6125419735908508},"source":"Network","lineCount":1,"charCount":11,"items":[{"lineCount":1,"charCount":11,"parseErrorCount":0,"nodeTypes":{"atCursor":"(","parent":"arguments","grandparent":"call_expression","greatGrandparent":"expression_statement"}},{"lineCount":1,"charCount":9,"parseErrorCount":0,"nodeTypes":{"atCursor":"(","parent":"arguments","grandparent":"call_expression","greatGrandparent":"expression_statement"}}],"otherCompletionProviderEnabled":false,"acceptedItem":{"lineCount":1,"charCount":11,"parseErrorCount":0,"nodeTypes":{"atCursor":"(","parent":"arguments","grandparent":"call_expression","greatGrandparent":"expression_statement"}}}
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
