### PR TITLE
refactor: unify fixup and refactor commands&events

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -258,7 +258,8 @@
       {
         "command": "cody.command.edit-code",
         "category": "Ask Cody",
-        "title": "Refactor Code"
+        "title": "Refactor Code",
+        "icon": "$(sparkle)"
       },
       {
         "command": "cody.command.explain-code",
@@ -386,12 +387,6 @@
         "command": "cody.command.inline-touch",
         "category": "Cody",
         "title": "Touch"
-      },
-      {
-        "command": "cody.fixup.new",
-        "category": "Cody",
-        "title": "Fixup",
-        "icon": "$(sparkle)"
       },
       {
         "command": "cody.fixup.open",

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -504,7 +504,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 return null
             }
             case /^\/edit(\s)?/.test(text):
-                await vscode.commands.executeCommand('cody.fixup.new', { instruction: text })
+                await vscode.commands.executeCommand('cody.command.edit-code', { instruction: text }, 'sidebar')
                 return null
             default: {
                 if (!this.editor.getActiveTextEditor()?.filePath) {

--- a/vscode/src/code-actions/fixup.ts
+++ b/vscode/src/code-actions/fixup.ts
@@ -30,9 +30,10 @@ export class FixupCodeAction implements vscode.CodeActionProvider {
     private createCommandCodeAction(diagnostics: vscode.Diagnostic[], range: vscode.Range): vscode.CodeAction {
         const action = new vscode.CodeAction('Ask Cody to Fix', vscode.CodeActionKind.QuickFix)
         const instruction = this.getCodeActionInstruction(diagnostics)
+        const source = 'code-action'
         action.command = {
-            command: 'cody.fixup.new',
-            arguments: [{ instruction, range }],
+            command: 'cody.command.edit-code',
+            arguments: [{ instruction, range }, source],
             title: 'Ask Cody to Fix',
         }
         action.diagnostics = diagnostics

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -95,15 +95,22 @@ export class CommandRunner implements vscode.Disposable {
             return
         }
 
-        const range = this.command.slashCommand === '/doc' ? getDocCommandRange(doc, selection) : selection
+        const commandKey = this.command.slashCommand
+        const range = commandKey === '/doc' ? getDocCommandRange(doc, selection) : selection
         const instruction = insertMode ? addSelectionToPrompt(this.command.prompt, code) : this.command.prompt
-        await vscode.commands.executeCommand('cody.fixup.new', {
-            range,
-            instruction,
-            document: doc,
-            auto: true,
-            insertMode,
-        })
+        const source = this.command.type === 'default' ? commandKey.replace('/', '') : 'custom'
+
+        await vscode.commands.executeCommand(
+            'cody.command.edit-code',
+            {
+                range,
+                instruction,
+                document: doc,
+                auto: true,
+                insertMode,
+            },
+            source
+        )
     }
 
     /**

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -241,10 +241,15 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                     return await vscode.commands.executeCommand('cody.action.chat', input)
                 }
                 case selectedCommandID === menu_options.fix.slashCommand: {
+                    const source = 'menu'
                     if (userPrompt.trim()) {
-                        return await vscode.commands.executeCommand('cody.fixup.new', { instruction: userPrompt })
+                        return await vscode.commands.executeCommand(
+                            'cody.command.edit-code',
+                            { instruction: userPrompt },
+                            source
+                        )
                     }
-                    return await vscode.commands.executeCommand('cody.fixup.new')
+                    return await vscode.commands.executeCommand('cody.command.edit-code', {}, source)
                 }
             }
 


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C05AGQYD528/p1695733960910859

refactor: unify fixup and refactor commands & event names

Right now all the commands that uses the fixup recipe are logged under fixup. This PR adds the source to the event name and log all fixup event based on its source name, for example, if the command comes from 'editor' context menu:
<img width="862" alt="Screenshot 2023-09-26 at 2 42 53 PM" src="https://github.com/sourcegraph/cody/assets/68532117/aa4bbbef-01ab-4bf7-b993-eac5cc01fd6c">

- Unified 'cody.fixup.new' and 'cody.command.edit-code' commands into 'cody.command.edit-code'
- Updated references to command in package.json, MessageProvider.ts, and other files
- Updated fixup command to use new `edit-code` command

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
