### PR TITLE
Autocomplete: Persist completion ids in network cache

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -33,7 +33,7 @@ describe('[getInlineCompletions] common', () => {
                 )
             )
         ).toEqual<V>({
-            items: [{ insertText: 'if (true) {' }],
+            items: [expect.objectContaining({ insertText: 'if (true) {' })],
             source: InlineCompletionsResultSource.Network,
         }))
 
@@ -45,7 +45,7 @@ describe('[getInlineCompletions] common', () => {
                 })
             )
         ).toEqual<V>({
-            items: [{ insertText: 'rt()' }],
+            items: [expect.objectContaining({ insertText: 'rt()' })],
             source: InlineCompletionsResultSource.Network,
         }))
 
@@ -57,7 +57,7 @@ describe('[getInlineCompletions] common', () => {
                 abortSignal: abortController.signal,
             })
         ).toEqual<V>({
-            items: [{ insertText: '1337' }],
+            items: [expect.objectContaining({ insertText: '1337' })],
             source: InlineCompletionsResultSource.Network,
         })
     })

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -5,6 +5,7 @@ import { range } from '../../testutils/textDocument'
 import { getCurrentDocContext } from '../get-current-doc-context'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from '../get-inline-completions'
 import { documentAndPosition } from '../test-helpers'
+import { createCompletion } from '../utils'
 
 import { getInlineCompletions, params, V } from './helpers'
 
@@ -28,7 +29,9 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             lastTriggerSelectedInfoItem,
             result: {
                 logId: '1',
-                items: Array.isArray(insertText) ? insertText.map(insertText => ({ insertText })) : [{ insertText }],
+                items: Array.isArray(insertText)
+                    ? insertText.map(insertText => createCompletion(insertText))
+                    : [createCompletion(insertText)],
             },
             lastTriggerDocContext: lastDocContext,
         }
@@ -43,7 +46,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                 params('\nconst x = 1█', [], { lastCandidate: lastCandidate('\n█', 'const x = 123') })
             )
         ).toEqual<V>({
-            items: [{ insertText: '23' }],
+            items: [expect.objectContaining({ insertText: '23' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
@@ -51,7 +54,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         // The user types ` `, sees ghost text ` x`, then types ` `. The original completion
         // should still display.
         expect(await getInlineCompletions(params('  █', [], { lastCandidate: lastCandidate(' █', ' x') }))).toEqual<V>({
-            items: [{ insertText: 'x' }],
+            items: [expect.objectContaining({ insertText: 'x' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
@@ -59,7 +62,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         // The user sees ghost text `  x`, then types `  `. The original completion should still
         // display.
         expect(await getInlineCompletions(params('  █', [], { lastCandidate: lastCandidate('█', '  x') }))).toEqual<V>({
-            items: [{ insertText: 'x' }],
+            items: [expect.objectContaining({ insertText: 'x' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
@@ -68,7 +71,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         // completion should be reused.
         expect(await getInlineCompletions(params(' █', [], { lastCandidate: lastCandidate('█', 'x = 1') }))).toEqual<V>(
             {
-                items: [{ insertText: 'x = 1' }],
+                items: [expect.objectContaining({ insertText: 'x = 1' })],
                 source: InlineCompletionsResultSource.LastCandidate,
             }
         ))
@@ -80,7 +83,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         expect(
             await getInlineCompletions(params('const x█', [], { lastCandidate: lastCandidate('const x█', ' = 123') }))
         ).toEqual<V>({
-            items: [{ insertText: ' = 123' }],
+            items: [expect.objectContaining({ insertText: ' = 123' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
@@ -172,7 +175,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                 })
             )
         ).toEqual<V>({
-            items: [{ insertText: 'i xyz")' }],
+            items: [expect.objectContaining({ insertText: 'i xyz")' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
@@ -183,7 +186,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             // The user types on a new line `\t\t`, sees ghost text `const x = 1`, then
             // deletes one `\t`. The same ghost text should still be displayed.
             expect(await getInlineCompletions(params('\t█', [], { lastCandidate: candidate }))).toEqual<V>({
-                items: [{ insertText: '\tconst x = 1' }],
+                items: [expect.objectContaining({ insertText: '\tconst x = 1' })],
                 source: InlineCompletionsResultSource.LastCandidate,
             }))
 
@@ -192,7 +195,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             // all leading whitespace (both `\t\t`). The same ghost text should still be
             // displayed.
             expect(await getInlineCompletions(params('█', [], { lastCandidate: candidate }))).toEqual<V>({
-                items: [{ insertText: '\t\tconst x = 1' }],
+                items: [expect.objectContaining({ insertText: '\t\tconst x = 1' })],
                 source: InlineCompletionsResultSource.LastCandidate,
             }))
 
@@ -225,7 +228,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         // The user types ``, sees ghost text `x\ny`, then types ` ` (space). The original
         // completion should be reused.
         expect(await getInlineCompletions(params('x█', [], { lastCandidate: lastCandidate('█', 'x\ny') }))).toEqual<V>({
-            items: [{ insertText: '\ny' }],
+            items: [expect.objectContaining({ insertText: '\ny' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
@@ -233,7 +236,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         // The user types ``, sees ghost text `x\ny`, then types ` `. The original completion
         // should be reused.
         expect(await getInlineCompletions(params(' █', [], { lastCandidate: lastCandidate('█', 'x\ny') }))).toEqual<V>({
-            items: [{ insertText: 'x\ny' }],
+            items: [expect.objectContaining({ insertText: 'x\ny' })],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 

--- a/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
@@ -13,13 +13,13 @@ describe('[getInlineCompletions] post-processing', () => {
                 params('const isLocalHost = window.location.host█', [completion`├ === 'localhost'┤`])
             )
         ).toEqual<V>({
-            items: [{ insertText: " === 'localhost'" }],
+            items: [expect.objectContaining({ insertText: " === 'localhost'" })],
             source: InlineCompletionsResultSource.Network,
         }))
 
     it('collapses leading whitespace when prefix has trailing whitespace', async () =>
         expect(await getInlineCompletions(params('const x = █', [completion`├${T}1337┤`]))).toEqual<V>({
-            items: [{ insertText: '1337' }],
+            items: [expect.objectContaining({ insertText: '1337' })],
             source: InlineCompletionsResultSource.Network,
         }))
 
@@ -32,7 +32,7 @@ describe('[getInlineCompletions] post-processing', () => {
             [completion`├-  foo┤`, 'foo'],
         ])('fixes %s to %s', async (completion, expected) =>
             expect(await getInlineCompletions(params('█', [completion]))).toEqual<V>({
-                items: [{ insertText: expected }],
+                items: [expect.objectContaining({ insertText: expected })],
                 source: InlineCompletionsResultSource.Network,
             })
         )
@@ -41,7 +41,7 @@ describe('[getInlineCompletions] post-processing', () => {
     describe('odd indentation', () => {
         it('filters out odd indentation in single-line completions', async () =>
             expect(await getInlineCompletions(params('const foo = █', [completion`├ 1337┤`]))).toEqual<V>({
-                items: [{ insertText: '1337' }],
+                items: [expect.objectContaining({ insertText: '1337' })],
                 source: InlineCompletionsResultSource.Network,
             }))
     })

--- a/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import { InlineCompletionsResultSource } from '../get-inline-completions'
 import { completion, nextTick } from '../test-helpers'
+import { createCompletion } from '../utils'
 
 import { getInlineCompletions, params, V } from './helpers'
 
@@ -21,7 +22,7 @@ describe('[getInlineCompletions] streaming', () => {
                 abortSignal: abortController.signal,
             })
         ).toEqual<V>({
-            items: [{ insertText: '1337' }],
+            items: [expect.objectContaining({ insertText: '1337' })],
             source: InlineCompletionsResultSource.Network,
         })
     })
@@ -43,7 +44,7 @@ describe('[getInlineCompletions] streaming', () => {
                 abortSignal: abortController.signal,
             })
         ).toEqual<V>({
-            items: [{ insertText: '1337' }],
+            items: [expect.objectContaining({ insertText: '1337' })],
             source: InlineCompletionsResultSource.Network,
         })
     })
@@ -130,7 +131,7 @@ describe('[getInlineCompletions] streaming', () => {
                 abortSignal: abortController.signal,
             })
         ).toEqual<V>({
-            items: [{ insertText: 'const a = new Array()' }],
+            items: [expect.objectContaining({ insertText: 'const a = new Array()' })],
             source: InlineCompletionsResultSource.Network,
         })
     })

--- a/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
@@ -13,13 +13,13 @@ describe('[getInlineCompletions] triggers', () => {
     describe('singleline', () => {
         it('after whitespace', async () =>
             expect(await getInlineCompletions(params('foo = █', [completion`bar`]))).toEqual<V>({
-                items: [{ insertText: 'bar' }],
+                items: [expect.objectContaining({ insertText: 'bar' })],
                 source: InlineCompletionsResultSource.Network,
             }))
 
         it('end of word', async () =>
             expect(await getInlineCompletions(params('foo█', [completion`()`]))).toEqual<V>({
-                items: [{ insertText: '()' }],
+                items: [expect.objectContaining({ insertText: '()' })],
                 source: InlineCompletionsResultSource.Network,
             }))
 

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -80,7 +80,7 @@ describe('InlineCompletionItemProvider', () => {
         const { document, position } = documentAndPosition('const foo = █', 'typescript')
         const fn = vi.fn(getInlineCompletions).mockResolvedValue({
             logId: '1',
-            items: [{ insertText: 'test', range: new vsCodeMocks.Range(position, position) }],
+            items: [{ id: 'fake', insertText: 'test', range: new vsCodeMocks.Range(position, position) }],
             source: InlineCompletionsResultSource.Network,
         })
         const provider = new MockableInlineCompletionItemProvider(fn)
@@ -115,7 +115,11 @@ describe('InlineCompletionItemProvider', () => {
             'typescript'
         )
 
-        const item: InlineCompletionItem = { insertText: 'test', range: new vsCodeMocks.Range(position, position) }
+        const item: InlineCompletionItem = {
+            id: 'fake-id',
+            insertText: 'test',
+            range: new vsCodeMocks.Range(position, position),
+        }
         const fn = vi.fn(getInlineCompletions).mockResolvedValue({
             logId: '1',
             items: [item],
@@ -152,8 +156,8 @@ describe('InlineCompletionItemProvider', () => {
               "prefix": "const foo = ",
               "prevNonEmptyLine": "",
               "suffix": "
-console.log(1)
-console.log(2)",
+          console.log(1)
+          console.log(2)",
             },
             "lastTriggerPosition": Position {
               "character": 12,
@@ -163,6 +167,7 @@ console.log(2)",
             "result": {
               "items": [
                 {
+                  "id": "fake-id",
                   "insertText": "test",
                   "range": Range {
                     "end": Position {
@@ -198,7 +203,9 @@ console.log(2)",
             const { document, position } = documentAndPosition('const foo = █', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: 'bar', range: new vsCodeMocks.Range(position, position) }],
+                items: [
+                    { id: expect.any(String), insertText: 'bar', range: new vsCodeMocks.Range(position, position) },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -229,7 +236,9 @@ console.log(2)",
                 cancel()
                 return Promise.resolve({
                     logId: '1',
-                    items: [{ insertText: 'bar', range: new vsCodeMocks.Range(position, position) }],
+                    items: [
+                        { id: expect.any(String), insertText: 'bar', range: new vsCodeMocks.Range(position, position) },
+                    ],
                     source: InlineCompletionsResultSource.Network,
                 })
             })
@@ -246,7 +255,9 @@ console.log(2)",
             const { document, position } = documentAndPosition('console.█', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: 'log()', range: new vsCodeMocks.Range(position, position) }],
+                items: [
+                    { id: expect.any(String), insertText: 'log()', range: new vsCodeMocks.Range(position, position) },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -265,7 +276,9 @@ console.log(2)",
             const { document, position } = documentAndPosition('const a = [1, █];', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: '2] ;', range: new vsCodeMocks.Range(position, position) }],
+                items: [
+                    { id: expect.any(String), insertText: '2] ;', range: new vsCodeMocks.Range(position, position) },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -284,7 +297,9 @@ console.log(2)",
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: '2] ;', range: new vsCodeMocks.Range(position, position) }],
+                items: [
+                    { id: expect.any(String), insertText: '2] ;', range: new vsCodeMocks.Range(position, position) },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -300,7 +315,9 @@ console.log(2)",
             const { document, position } = documentAndPosition('const a = [1, █)(123);', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: '2];', range: new vsCodeMocks.Range(position, position) }],
+                items: [
+                    { id: expect.any(String), insertText: '2];', range: new vsCodeMocks.Range(position, position) },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -324,7 +341,13 @@ console.log(2)",
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: "('hello world!')", range: new vsCodeMocks.Range(1, 12, 1, 13) }],
+                items: [
+                    {
+                        id: expect.any(String),
+                        insertText: "('hello world!')",
+                        range: new vsCodeMocks.Range(1, 12, 1, 13),
+                    },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -361,7 +384,13 @@ console.log(2)",
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: "('hello world!')", range: new vsCodeMocks.Range(1, 12, 1, 13) }],
+                items: [
+                    {
+                        id: expect.any(String),
+                        insertText: "('hello world!')",
+                        range: new vsCodeMocks.Range(1, 12, 1, 13),
+                    },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 
@@ -428,7 +457,9 @@ console.log(2)",
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1',
-                items: [{ insertText: 'dir', range: new vsCodeMocks.Range(position, position) }],
+                items: [
+                    { id: expect.any(String), insertText: 'dir', range: new vsCodeMocks.Range(position, position) },
+                ],
                 source: InlineCompletionsResultSource.Network,
             })
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -57,7 +57,7 @@ export interface CompletionEvent {
     items: CompletionItemInfo[]
 }
 
-export interface ItemPostProcesssingInfo {
+export interface ItemPostProcessingInfo {
     // Number of ERROR nodes found in the completion insert text after pasting
     // it into the document and parsing this range with tree-sitter.
     parseErrorCount?: number
@@ -74,7 +74,7 @@ export interface ItemPostProcesssingInfo {
     }
 }
 
-interface CompletionItemInfo extends ItemPostProcesssingInfo {
+interface CompletionItemInfo extends ItemPostProcessingInfo {
     lineCount: number
     charCount: number
 }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -20,7 +20,7 @@ import {
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
 import { Completion, ContextSnippet } from '../types'
-import { forkSignal, messagesToText } from '../utils'
+import { createCompletion, forkSignal, messagesToText } from '../utils'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
 
@@ -165,15 +165,7 @@ export class AnthropicProvider extends Provider {
             })
         )
 
-        const ret = responses.map(resp => [
-            {
-                prefix: this.options.docContext.prefix,
-                content: resp.completion,
-                stopReason: resp.stopReason,
-            },
-        ])
-
-        const completions = ret.flat()
+        const completions = responses.map(resp => createCompletion(resp.completion, resp.stopReason))
         tracer?.result({ rawResponses: responses, completions })
 
         return completions

--- a/vscode/src/completions/providers/unstable-codegen.ts
+++ b/vscode/src/completions/providers/unstable-codegen.ts
@@ -3,6 +3,7 @@ import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/error
 import { fetch } from '../../fetch'
 import { logger } from '../../log'
 import { Completion, ContextSnippet } from '../types'
+import { createCompletion } from '../utils'
 
 import { Provider, ProviderConfig, ProviderOptions } from './provider'
 
@@ -60,7 +61,7 @@ export class UnstableCodeGenProvider extends Provider {
             const completions: string[] = data.completions.map(c => postProcess(c.completion))
             log?.onComplete(completions)
 
-            return completions.map(content => ({ content }))
+            return completions.map(content => createCompletion(content))
         } catch (error: any) {
             if (!isAbortError(error)) {
                 log?.onError(error)

--- a/vscode/src/completions/providers/unstable-fireworks.ts
+++ b/vscode/src/completions/providers/unstable-fireworks.ts
@@ -8,7 +8,7 @@ import { getLanguageConfig } from '../language'
 import { canUsePartialCompletion } from '../streaming'
 import { formatSymbolContextRelationship } from '../text-processing'
 import { Completion, ContextSnippet } from '../types'
-import { forkSignal } from '../utils'
+import { createCompletion, forkSignal } from '../utils'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
 
@@ -163,15 +163,7 @@ export class UnstableFireworksProvider extends Provider {
             })
         )
 
-        const ret = responses.map(resp => [
-            {
-                prefix: this.options.docContext.prefix,
-                content: resp.completion,
-                stopReason: resp.stopReason,
-            },
-        ])
-
-        const completions = ret.flat()
+        const completions = responses.map(resp => createCompletion(resp.completion, resp.stopReason))
         tracer?.result({ rawResponses: responses, completions })
 
         return completions

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -7,7 +7,7 @@ import { CodeCompletionsClient } from '../client'
 import { canUsePartialCompletion } from '../streaming'
 import { getHeadAndTail } from '../text-processing'
 import { Completion, ContextSnippet } from '../types'
-import { forkSignal } from '../utils'
+import { createCompletion, forkSignal } from '../utils'
 
 import { CompletionProviderTracer, Provider, ProviderConfig, ProviderOptions } from './provider'
 
@@ -89,15 +89,7 @@ export class UnstableOpenAIProvider extends Provider {
             })
         )
 
-        const ret = responses.map(resp => [
-            {
-                prefix: this.options.docContext.prefix,
-                content: resp.completion,
-                stopReason: resp.stopReason,
-            },
-        ])
-
-        const completions = ret.flat()
+        const completions = responses.map(resp => createCompletion(resp.completion, resp.stopReason))
         tracer?.result({ rawResponses: responses, completions })
 
         return completions

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -5,6 +5,7 @@ import { Provider } from './providers/provider'
 import { RequestManager, RequestManagerResult, RequestParams } from './request-manager'
 import { documentAndPosition } from './test-helpers'
 import { Completion } from './types'
+import { createCompletion } from './utils'
 
 class MockProvider extends Provider {
     public didFinishNetworkRequest = false
@@ -13,7 +14,7 @@ class MockProvider extends Provider {
 
     public resolveRequest(completions: string[]): void {
         this.didFinishNetworkRequest = true
-        this.resolve(completions.map(content => ({ content })))
+        this.resolve(completions.map(c => createCompletion(c)))
     }
 
     public generateCompletions(abortSignal: AbortSignal): Promise<Completion[]> {

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -74,10 +74,7 @@ export class RequestManager {
             .then(res => res.flat())
             .then(completions =>
                 // Shared post-processing logic
-                processInlineCompletions(
-                    completions.map(item => ({ insertText: item.content })),
-                    params
-                )
+                processInlineCompletions(completions, params)
             )
             .then(processedCompletions => {
                 // Cache even if the request was aborted or already fulfilled.
@@ -115,6 +112,8 @@ export class RequestManager {
         items: InlineCompletionItemWithAnalytics[]
     ): void {
         const { document, position, docContext, selectedCompletionInfo } = resolvedRequest.params
+
+        // Create a fake last candidate, as if this completion came from the last trigger
         const lastCandidate: LastInlineCompletionCandidate = {
             uri: document.uri,
             lastTriggerPosition: position,
@@ -183,7 +182,7 @@ class RequestCache {
     private cache = new LRUCache<string, InlineCompletionItemWithAnalytics[]>({ max: 50 })
 
     private toCacheKey(key: RequestParams): string {
-        return `${key.docContext.prefix}█${key.docContext.nextNonEmptyLine}`
+        return `${key.docContext.prefix}█${key.docContext.suffix}`
     }
 
     public get(key: RequestParams): InlineCompletionItemWithAnalytics[] | undefined {

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -56,12 +56,15 @@ export function reuseLastCandidate({
             const isTypingAsSuggested =
                 lastCompletion.startsWith(currentLinePrefix) && position.isAfterOrEqual(lastTriggerPosition)
             if (isTypingAsSuggested) {
-                return { insertText: lastCompletion.slice(currentLinePrefix.length) }
+                return { id: item.id, insertText: lastCompletion.slice(currentLinePrefix.length) }
             }
 
             // Allow reuse if only the indentation (leading whitespace) has changed.
             if (isIndentationChange) {
-                return { insertText: lastTriggerCurrentLinePrefix.slice(currentLinePrefix.length) + item.insertText }
+                return {
+                    id: item.id,
+                    insertText: lastTriggerCurrentLinePrefix.slice(currentLinePrefix.length) + item.insertText,
+                }
             }
 
             return undefined

--- a/vscode/src/completions/test-helpers.ts
+++ b/vscode/src/completions/test-helpers.ts
@@ -95,3 +95,7 @@ export function formatCaptures(captures: QueryCapture[]): FormattedCapture[] {
 export async function nextTick(): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 0))
 }
+
+export function withoutId<T>({ id, ...t }: { id: string } & T): T {
+    return t as T
+}

--- a/vscode/src/completions/text-processing.test.ts
+++ b/vscode/src/completions/text-processing.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, test } from 'vitest'
 
 import {
     CLOSING_CODE_TAG,
-    collapseDuplicativeWhitespace,
+    collapseDuplicateWhitespace,
     extractFromCodeBlock,
     OPENING_CODE_TAG,
     trimEndOnLastLineIfWhitespaceOnly,
@@ -40,18 +40,18 @@ describe('trimLeadingWhitespaceUntilNewline', () => {
     test('preserves carriage returns', () => expect(trimLeadingWhitespaceUntilNewline('\t\r\n  a')).toBe('\r\n  a'))
 })
 
-describe('collapseDuplicativeWhitespace', () => {
-    test('trims space', () => expect(collapseDuplicativeWhitespace('x = ', ' 7')).toBe('7'))
+describe('collapseDuplicateWhitespace', () => {
+    test('trims space', () => expect(collapseDuplicateWhitespace('x = ', ' 7')).toBe('7'))
     test('trims identical duplicative whitespace chars', () =>
-        expect(collapseDuplicativeWhitespace('x =\t ', '\t 7')).toBe('7'))
+        expect(collapseDuplicateWhitespace('x =\t ', '\t 7')).toBe('7'))
     test('trims non-identical duplicative whitespace chars', () =>
-        expect(collapseDuplicativeWhitespace('x =\t ', '  7')).toBe('7'))
+        expect(collapseDuplicateWhitespace('x =\t ', '  7')).toBe('7'))
     test('trims more whitespace chars from completion than in prefix', () => {
-        expect(collapseDuplicativeWhitespace('x = ', '  7')).toBe('7')
-        expect(collapseDuplicativeWhitespace('x = ', '\t 7')).toBe('7')
+        expect(collapseDuplicateWhitespace('x = ', '  7')).toBe('7')
+        expect(collapseDuplicateWhitespace('x = ', '\t 7')).toBe('7')
     })
     test('does not trim newlines', () => {
-        expect(collapseDuplicativeWhitespace('x = ', '\n7')).toBe('\n7')
+        expect(collapseDuplicateWhitespace('x = ', '\n7')).toBe('\n7')
     })
 })
 

--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -4,15 +4,16 @@ import Parser from 'web-tree-sitter'
 
 import { range } from '../../testutils/textDocument'
 import { getCurrentDocContext } from '../get-current-doc-context'
-import { documentAndPosition, initTreeSitterParser } from '../test-helpers'
+import { documentAndPosition, initTreeSitterParser, withoutId } from '../test-helpers'
 import { updateParseTreeCache } from '../tree-sitter/parse-tree-cache'
 import { InlineCompletionItem } from '../types'
+import { createCompletion } from '../utils'
 
 import { adjustRangeToOverwriteOverlappingCharacters, processInlineCompletions } from './process-inline-completions'
 
 describe('adjustRangeToOverwriteOverlappingCharacters', () => {
     test('no adjustment at end of line', () => {
-        const item: InlineCompletionItem = { insertText: 'array) {' }
+        const item = createCompletion('array) {')
         const { position } = documentAndPosition('function sort(█')
         expect(
             adjustRangeToOverwriteOverlappingCharacters(item, {
@@ -23,7 +24,7 @@ describe('adjustRangeToOverwriteOverlappingCharacters', () => {
     })
 
     test('handles non-empty currentLineSuffix', () => {
-        const item: InlineCompletionItem = { insertText: 'array) {' }
+        const item = createCompletion('array) {')
         const { position } = documentAndPosition('function sort(█)')
         expect(
             adjustRangeToOverwriteOverlappingCharacters(item, {
@@ -37,7 +38,7 @@ describe('adjustRangeToOverwriteOverlappingCharacters', () => {
     })
 
     test('handles whitespace in currentLineSuffix', () => {
-        const item: InlineCompletionItem = { insertText: 'array) {' }
+        const item = createCompletion('array) {')
         const { position } = documentAndPosition('function sort(█)')
         expect(
             adjustRangeToOverwriteOverlappingCharacters(item, {
@@ -71,7 +72,7 @@ describe('process completion item', () => {
         updateParseTreeCache(document, parser)
 
         return processInlineCompletions(
-            completionSnippets.map(s => ({ insertText: s })),
+            completionSnippets.map(s => createCompletion(s)),
             {
                 document,
                 position,
@@ -104,7 +105,7 @@ describe('process completion item', () => {
             ['array) {\nreturn array.sort()\n} function two() {}', 'array) new\n']
         )
 
-        expect(completions).toMatchInlineSnapshot(`
+        expect(completions.map(withoutId)).toMatchInlineSnapshot(`
           [
             {
               "insertText": "array) {",
@@ -125,6 +126,7 @@ describe('process completion item', () => {
                   "line": 5,
                 },
               },
+              "stopReason": undefined,
             },
             {
               "insertText": "array) new",
@@ -145,6 +147,7 @@ describe('process completion item', () => {
                   "line": 5,
                 },
               },
+              "stopReason": undefined,
             },
           ]
         `)
@@ -171,7 +174,7 @@ describe('process completion item', () => {
             ]
         )
 
-        expect(completions).toMatchInlineSnapshot(`
+        expect(completions.map(withoutId)).toMatchInlineSnapshot(`
           [
             {
               "insertText": "console.log('one')
@@ -186,6 +189,7 @@ describe('process completion item', () => {
                 "parent": "statement_block",
               },
               "parseErrorCount": 0,
+              "stopReason": undefined,
               "truncatedWith": "tree-sitter",
             },
           ]

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -3,7 +3,7 @@ import { Position, TextDocument } from 'vscode'
 import { dedupeWith } from '@sourcegraph/cody-shared/src/common'
 
 import { DocumentContext } from '../get-current-doc-context'
-import { ItemPostProcesssingInfo } from '../logger'
+import { ItemPostProcessingInfo } from '../logger'
 import { astGetters } from '../tree-sitter/ast-getters'
 import { getDocumentQuerySDK } from '../tree-sitter/queries'
 import { InlineCompletionItem } from '../types'
@@ -11,7 +11,7 @@ import { InlineCompletionItem } from '../types'
 import { dropParserFields, parseCompletion, ParsedCompletion } from './parse-completion'
 import { truncateMultilineCompletion } from './truncate-multiline-completion'
 import { truncateParsedCompletion } from './truncate-parsed-completion'
-import { collapseDuplicativeWhitespace, removeTrailingWhitespace, trimUntilSuffix } from './utils'
+import { collapseDuplicateWhitespace, removeTrailingWhitespace, trimUntilSuffix } from './utils'
 
 export interface ProcessInlineCompletionsParams {
     document: TextDocument
@@ -19,7 +19,7 @@ export interface ProcessInlineCompletionsParams {
     docContext: DocumentContext
 }
 
-export interface InlineCompletionItemWithAnalytics extends ItemPostProcesssingInfo, InlineCompletionItem {}
+export interface InlineCompletionItemWithAnalytics extends ItemPostProcessingInfo, InlineCompletionItem {}
 
 /**
  * This function implements post-processing logic that is applied regardless of
@@ -114,7 +114,7 @@ export function processItem(params: ProcessItemParams): InlineCompletionItemWith
     }
 
     insertText = trimUntilSuffix(insertText, prefix, suffix, document.languageId)
-    insertText = collapseDuplicativeWhitespace(prefix, insertText)
+    insertText = collapseDuplicateWhitespace(prefix, insertText)
 
     // Trim start and end of the completion to remove all trailing whitespace.
     insertText = insertText.trimEnd()
@@ -171,3 +171,5 @@ function removeLowQualityCompletions(completions: InlineCompletionItem[]): Inlin
             .filter(c => c.insertText.trim().length > 1)
     )
 }
+
+// Filter

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -223,7 +223,7 @@ export function trimLeadingWhitespaceUntilNewline(str: string): string {
  *
  * Language-specific customizations are needed here to get greater accuracy.
  */
-export function collapseDuplicativeWhitespace(prefix: string, completion: string): string {
+export function collapseDuplicateWhitespace(prefix: string, completion: string): string {
     if (prefix.endsWith(' ') || prefix.endsWith('\t')) {
         completion = completion.replace(/^[\t ]+/, '')
     }

--- a/vscode/src/completions/types.ts
+++ b/vscode/src/completions/types.ts
@@ -3,7 +3,8 @@ import { Range } from 'vscode-languageserver-textdocument'
 import { HoverContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
 export interface Completion {
-    content: string
+    id: string
+    insertText: string
     stopReason?: string
 }
 
@@ -11,12 +12,14 @@ export interface Completion {
  * @see vscode.InlineCompletionItem
  */
 export interface InlineCompletionItem {
+    id: string
     insertText: string
+
     /**
-     * The range to replace.
-     * Must begin and end on the same line.
+     * The range to replace. Must begin and end on the same line.
      *
-     * Prefer replacements over insertions to provide a better experience when the user deletes typed text.
+     * Prefer replacements over insertions to provide a better experience when the user deletes
+     * typed text.
      */
     range?: Range
 }

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -1,6 +1,9 @@
 import * as anthropic from '@anthropic-ai/sdk'
+import * as uuid from 'uuid'
 
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
+
+import { Completion } from './types'
 
 export function messagesToText(messages: Message[]): string {
     return messages
@@ -66,5 +69,13 @@ export function createSubscriber<T>(): Subscriber<T> {
     return {
         subscribe,
         notify,
+    }
+}
+
+export function createCompletion(insertText: string, stopReason?: string): Completion {
+    return {
+        id: uuid.v4(),
+        insertText,
+        stopReason,
     }
 }


### PR DESCRIPTION
This is getting a rewrite tomorrow

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
