### PR TITLE
fix: remove params from logError verbose logging

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Removed invalid variable from logs that stopped rate-limit errors from displaying properly. [pull/1205](https://github.com/sourcegraph/cody/pull/1205)
+
 ### Changed
 
 - Moved "Insert at Cursor" and "Copy" buttons to the bottom of code blocks, and no longer just show on hover. [pull/1119](https://github.com/sourcegraph/cody/pull/1119)

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -135,7 +135,7 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
         const error = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
 
         params.tracer?.({ error: error.toString() })
-        logError('getInlineCompletions:error', error.message, error.stack, { verbose: { params, error } })
+        logError('getInlineCompletions:error', error.message, error.stack, { verbose: { error } })
         CompletionLogger.logError(error)
 
         if (isAbortError(error)) {


### PR DESCRIPTION
fix: remove params from logError verbose logging

(Discovered and fixed by @philipp-spiess 🙇‍♀️  ) This PR removed the params object from the verbose logging in logError inside getInlineCompletions.

This avoids logging potentially sensitive information from the params as well as invoking the windowActivity proposal API that breaks the extension from displaying the rate limit error properly:  

<img width="634" alt="Screenshot 2023-09-27 at 9 29 42 AM" src="https://github.com/sourcegraph/cody/assets/68532117/9e23819c-d9ca-4eda-8db0-9170c48a0101">

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

#### After

Reset after 26 year 🥲 

<img width="1404" alt="Screenshot 2023-09-27 at 10 22 54 AM" src="https://github.com/sourcegraph/cody/assets/68532117/c477eb9d-f268-44c7-99c3-b79c0c98795b">

