### PR TITLE
/symf: remove direct anthropic dependency, pass sourcegraph token

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -20,8 +20,6 @@ export interface Configuration {
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
     experimentalLocalSymbols: boolean
-    experimentalSymfPath: string
-    experimentalSymfAnthropicKey: string
     autocompleteAdvancedProvider: 'anthropic' | 'unstable-codegen' | 'unstable-fireworks' | 'unstable-openai' | null
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedModel: string | null

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -24,6 +24,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Increased the token limit for the selection Cody uses for the `/edit` command. [pull/1139](https://github.com/sourcegraph/cody/pull/1139)
 - Autocomplete now supports infilling through the customized `claude-instant-infill` model created for Anthropic Claude Instant by default. [pull/1164](https://github.com/sourcegraph/cody/pull/1164)
 - Improves interop with the VS Code suggest widget when using the `completeSuggestWidgetSelection` feature flag. [pull/1158](https://github.com/sourcegraph/cody/pull/1158)
+- Removes the need to set an Anthropic API key for the `/symf` command. The `symf` binary is now automatically downloaded. [pull/1207](https://github.com/sourcegraph/cody/pull/1207)
 
 ## [0.12.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -847,12 +847,6 @@
           "markdownDescription": "Path to symf binary",
           "default": ""
         },
-        "cody.experimental.symf.anthropicKey": {
-          "order": 99,
-          "type": "string",
-          "markdownDescription": "API key for Anthropic",
-          "default": ""
-        },
         "cody.debug.enable": {
           "order": 99,
           "type": "boolean",

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -24,8 +24,6 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     inlineChat: true,
     isRunningInsideAgent: false,
     experimentalNonStop: false,
-    experimentalSymfAnthropicKey: '',
-    experimentalSymfPath: 'symf',
     debugEnable: false,
     debugVerbose: false,
     debugFilter: null,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -26,8 +26,6 @@ describe('getConfiguration', () => {
             inlineChat: true,
             isRunningInsideAgent: false,
             experimentalNonStop: false,
-            experimentalSymfAnthropicKey: '',
-            experimentalSymfPath: 'symf',
             debugEnable: false,
             debugVerbose: false,
             debugFilter: null,
@@ -75,8 +73,6 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.localSymbols':
                         return true
-                    case 'cody.experimental.symf.anthropicKey':
-                        return 'anthropic_secret_key'
                     case 'cody.experimental.symf.path':
                         return '/usr/local/bin/symf'
                     case 'cody.debug.enable':
@@ -131,8 +127,6 @@ describe('getConfiguration', () => {
             inlineChat: true,
             isRunningInsideAgent: false,
             experimentalNonStop: true,
-            experimentalSymfAnthropicKey: 'anthropic_secret_key',
-            experimentalSymfPath: '/usr/local/bin/symf',
             debugEnable: true,
             debugVerbose: true,
             debugFilter: /.*/,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -58,8 +58,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
         experimentalEditorTitleCommandIcon: config.get(CONFIG_KEY.experimentalEditorTitleCommandIcon, false),
         autocompleteAdvancedProvider: config.get(CONFIG_KEY.autocompleteAdvancedProvider, null),
-        experimentalSymfPath: config.get<string>(CONFIG_KEY.experimentalSymfPath, 'symf'),
-        experimentalSymfAnthropicKey: config.get<string>(CONFIG_KEY.experimentalSymfAnthropicKey, ''),
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,
             null

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -16,7 +16,7 @@ const symfVersion = 'v0.0.0'
 export async function getSymfPath(context: vscode.ExtensionContext): Promise<string | null> {
     // If user-specified symf path is set, use that
     const config = vscode.workspace.getConfiguration()
-    const userSymfPath = config.get<string>('experimentalSymfPath')
+    const userSymfPath = config.get<string>('cody.experimental.symf.path')
     if (userSymfPath) {
         logDebug('symf', `using user symf: ${userSymfPath}`)
         return userSymfPath

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode'
 
 import { logDebug } from '../log'
 
-const symfVersion = 'v0.0.0'
+const symfVersion = 'v0.0.1'
 
 /**
  * Get the path to `symf`. If the symf binary is not found, download it.

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -65,7 +65,7 @@ export async function getSymfPath(context: vscode.ExtensionContext): Promise<str
         )
         void removeOldSymfBinaries(symfContainingDir, symfFilename)
     } catch (error) {
-        vscode.window.showErrorMessage(`Failed to download symf: ${error}`)
+        void vscode.window.showErrorMessage(`Failed to download symf: ${error}`)
         return null
     }
 

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -29,9 +29,13 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
 
     constructor(
         private context: vscode.ExtensionContext,
-        private anthropicKey: string
+        private authToken: string | null
     ) {
         this.indexRoot = path.join(os.homedir(), '.cody-symf')
+    }
+
+    public setAuthToken(authToken: string | null): void {
+        this.authToken = authToken
     }
 
     /**
@@ -57,6 +61,11 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
      * Returns the list of results from symf
      */
     public async getResults(query: string, scopeDir: string): Promise<Result[]> {
+        const accessToken = this.authToken
+        if (!accessToken) {
+            throw new Error('SymfRunner.getResults: No access token')
+        }
+
         const indexDir = await this.ensureIndexFor(scopeDir)
         const symfPath = await getSymfPath(this.context)
         if (!symfPath) {
@@ -68,7 +77,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
                 ['--index-root', indexDir, 'query', '--scopes', scopeDir, '--fmt', 'json', '--natural', query],
                 {
                     env: {
-                        ANTHROPIC_API_KEY: this.anthropicKey,
+                        SOURCEGRAPH_TOKEN: accessToken,
                         HOME: process.env.HOME,
                     },
                     maxBuffer: 1024 * 1024 * 1024,
@@ -194,7 +203,7 @@ function handleSymfError(error: unknown): void {
     if (errorString.includes('ENOENT')) {
         errorMessage = `symf binary not found. You should ensure you have (1) installed symf (\`go install github.com/sourcegraph/symf/cmd/symf@latest\`) and (2) set the "cody.experimental.symf.path" value in the VS Code settings. ${error}`
     } else if (errorString.includes('401')) {
-        errorMessage = `symf: Unauthorized. Is "cody.experimental.symf.anthropicKey" set correctly in setttings? ${error}`
+        errorMessage = `symf: Unauthorized. Is Cody signed in? ${error}`
     } else {
         errorMessage = `symf index creation failed: ${error}`
     }

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -201,7 +201,7 @@ function handleSymfError(error: unknown): void {
     const errorString = `${error}`
     let errorMessage: string
     if (errorString.includes('ENOENT')) {
-        errorMessage = `symf binary not found. You should ensure you have (1) installed symf (\`go install github.com/sourcegraph/symf/cmd/symf@latest\`) and (2) set the "cody.experimental.symf.path" value in the VS Code settings. ${error}`
+        errorMessage = "symf binary not found. Do you have \"cody.experimental.symf.path\" set and is it valid?"
     } else if (errorString.includes('401')) {
         errorMessage = `symf: Unauthorized. Is Cody signed in? ${error}`
     } else {

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -214,7 +214,7 @@ function handleSymfError(error: unknown): void {
     const errorString = `${error}`
     let errorMessage: string
     if (errorString.includes('ENOENT')) {
-        errorMessage = "symf binary not found. Do you have \"cody.experimental.symf.path\" set and is it valid?"
+        errorMessage = 'symf binary not found. Do you have "cody.experimental.symf.path" set and is it valid?'
     } else if (errorString.includes('401')) {
         errorMessage = `symf: Unauthorized. Is Cody signed in? ${error}`
     } else {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -107,7 +107,7 @@ const register = async (
         disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
     }
 
-    const symfRunner = platform.createSymfRunner?.(context, config.experimentalSymfAnthropicKey)
+    const symfRunner = platform.createSymfRunner?.(context, initialConfig.accessToken)
 
     const {
         featureFlagProvider,
@@ -497,6 +497,7 @@ const register = async (
             externalServicesOnDidConfigurationChange(newConfig)
             void createOrUpdateEventLogger(newConfig, isExtensionModeDevOrTest)
             platform.onConfigurationChange?.(newConfig)
+            symfRunner?.setAuthToken(newConfig.accessToken)
         },
     }
 }


### PR DESCRIPTION
Previously, `symf` talked directly to the Anthropic API. Now, it goes through a Sourcegraph instance to access the LLM. This PR updates Cody to pass the Sourcegraph auth token to `symf` and removes the old code for setting an Anthropic API token.

## Test plan

Test locally:
- Check out the main branch
- Remove any `cody.experimental.symf.anthropicKey` in your settings.
- Try running `/symf [query]`. You should see an error indicating that `symf` is unauthorized.

- Check out this branch and run the extension
- In the sidebar, run `/symf [query]`, where query is either a keyword search or a natural language question
  - You should observe a pop-up indicating a new version of `symf` (v0.0.1) is being downloaded
- You should see successful search results