### PR TITLE
fix: add enablement for inline chat in context menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Removed invalid variable from logs that stopped rate-limit errors from displaying properly. [pull/1205](https://github.com/sourcegraph/cody/pull/1205)
+- Disable `Ask Cody Inline` in Cody Context Menu when `cody.InlineChat.enabled` is set to false. [pull/1209](https://github.com/sourcegraph/cody/pull/1209)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -374,7 +374,7 @@
         "title": "Ask Cody Inline",
         "category": "Cody Inline Chat",
         "when": "cody.activated && config.cody.inlineChat.enabled",
-        "enablement": "editorFocus"
+        "enablement": "editorFocus && config.cody.inlineChat.enabled"
       },
       {
         "command": "cody.guardrails.debug",
@@ -474,7 +474,8 @@
         "command": "cody.inline.new",
         "key": "ctrl+shift+c",
         "mac": "cmd+shift+c",
-        "when": "cody.activated && editorFocus && config.cody.inlineChat.enabled"
+        "when": "cody.activated && editorFocus && config.cody.inlineChat.enabled",
+        "enablement": "config.cody.inlineChat.enabled"
       },
       {
         "command": "cody.action.commands.menu",


### PR DESCRIPTION
Currently, the `Ask Cody Inline`  would show up but not working when `Inline Chat` is disabled.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. disable inline chat
2. check your cody context menu
3. `Ask Cody Inline` should be disabled

<img width="839" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/aa5ea656-743a-455b-8c33-e72368470e2a">
