### PR TITLE
Simplified Onboarding: Pick up the app token if available after sign-in

### DIFF
--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -39,6 +39,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         const localAppWatcher = new LocalAppWatcher()
         this.disposables.push(localAppWatcher)
         this.disposables.push(localAppWatcher.onChange(appWatcher => this.appWatcherChanged(appWatcher)))
+        this.disposables.push(localAppWatcher.onTokenFileChange(tokenFile => this.tokenFileChanged(tokenFile)))
     }
 
     private async onDidReceiveMessage(message: WebviewMessage): Promise<void> {
@@ -181,6 +182,12 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     private appWatcherChanged(appWatcher: LocalAppWatcher): void {
         void this.webview?.postMessage({ type: 'app-state', isInstalled: appWatcher.isInstalled })
         void this.simplifiedOnboardingReloadEmbeddingsState()
+    }
+
+    private tokenFileChanged(file: vscode.Uri): void {
+        void this.authProvider.appDetector
+            .tryFetchAppJson(file)
+            .then(() => this.simplifiedOnboardingReloadEmbeddingsState())
     }
 
     private async onHumanMessageSubmitted(text: string, submitType: 'user' | 'suggestion' | 'example'): Promise<void> {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -317,11 +317,11 @@ async function getCodebaseContext(
     }
 
     // Find an embeddings client
-    const embeddingsSearch = await EmbeddingsDetector.newEmbeddingsSearchClient(embeddingsClientCandidates, codebase)
+    let embeddingsSearch = await EmbeddingsDetector.newEmbeddingsSearchClient(embeddingsClientCandidates, codebase)
     if (isError(embeddingsSearch)) {
         const infoMessage = `Cody could not find embeddings for '${codebase}' on your Sourcegraph instance.\n`
         console.info(infoMessage)
-        return null
+        embeddingsSearch = undefined
     }
 
     return new CodebaseContext(

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -94,7 +94,17 @@ export class LocalAppDetector implements vscode.Disposable {
         if (!this.tokenFsPath || this.localEnv.hasAppJson) {
             return
         }
-        const appJson = await loadAppJson(this.tokenFsPath)
+        await this.tryFetchAppJson(this.tokenFsPath)
+    }
+
+    // Check if `uri` has the an app token. This skips the checks for an
+    // existing token and will forcibly load new tokens.
+    //
+    // This is a stop-gap so LocalAppWatcher/simplified onboarding can force
+    // LocalAppDetector and downstream to pick up an app token even after the
+    // user has logged in to dotcom.
+    public async tryFetchAppJson(uri: vscode.Uri): Promise<void> {
+        const appJson = await loadAppJson(uri)
         if (!appJson) {
             return
         }

--- a/vscode/src/services/LocalAppDetector.ts
+++ b/vscode/src/services/LocalAppDetector.ts
@@ -80,7 +80,7 @@ export class LocalAppDetector implements vscode.Disposable {
         if (this.localEnv.isAppInstalled || !this.appFsPaths) {
             return
         }
-        if (await Promise.any(this.appFsPaths.map(file => pathExists(file)))) {
+        if (await Promise.any(this.appFsPaths.map(file => pathExists(vscode.Uri.file(file))))) {
             this.localEnv.isAppInstalled = true
             this.appFsPaths = []
             await this.found('app')
@@ -158,16 +158,16 @@ export class LocalAppDetector implements vscode.Disposable {
 }
 
 // Utility functions
-async function pathExists(path: string): Promise<boolean> {
+export async function pathExists(uri: vscode.Uri): Promise<boolean> {
     try {
-        await vscode.workspace.fs.stat(vscode.Uri.file(path))
+        await vscode.workspace.fs.stat(uri)
         return true
     } catch {
         return false
     }
 }
 
-function expandHomeDir(path: string, homeDir: string | null): string {
+export function expandHomeDir(path: string, homeDir: string | null | undefined): string {
     if (homeDir && path.startsWith('~/')) {
         return path.replace('~', homeDir)
     }


### PR DESCRIPTION
LocalAppDetector stops monitoring app once the user has signed in. Simplified Onboarding needs to pick up the app token, even if the user has logged into dotcom, so that we can use app for local embeddings. This makes simplified onboarding's LocalAppWatcher ping the LocalAppDetector to retrieve the app token, if it detects a change in the app.json file, even after the user has logged in.

Part of #632.

## Test plan

0. Open Cody App, add a repo, and add embeddings for a private local repository which has a remote.
1. Quit Cody App if it is running. Open Keychain and delete any vscodesourcegraph.cody-ai tokens. Delete ~/Library/Application Support/com.sourcegraph.cody/app.json . This means VScode will not have a cached app token. (Some uncertainty around where VScode stores secrets across versions. You can set a breakpoint in the extension LocalAppWatcher and run `secretStorage.deleteToken(LOCAL_APP_URL.href)` to clear the token. Alternatively, logging into App and signing out should also clear that token.)
2. Run VScode, edit User Settings JSON and add `"testing.simplified-onboarding": true`. Restart VScode.
3. Log into dotcom using GitHub, etc. if necessary.
4. Open the repository from step 0, open a file from the repository, click on the chat input status indicator. You should see a pop-up to open app.
5. Open app and wait up to 20 seconds. Chat input status indicator should flip to having a checkmark indicating VScode has detected app is running, picked up the token from app.json, and found app has embeddings for the repository.
6. Close app and wait up to 20 seconds. The chat input status indicator should flip to red/open app popup.