### PR TITLE
Code Action: Allow enabling/disabling and improve ranking of explain

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -13,8 +13,9 @@ export interface Configuration {
     customHeaders: Record<string, string>
     chatPreInstruction: string
     autocomplete: boolean
-    experimentalChatPredictions: boolean
     inlineChat: boolean
+    codeActions: boolean
+    experimentalChatPredictions: boolean
     experimentalCommandLenses: boolean
     experimentalEditorTitleCommandIcon: boolean
     experimentalGuardrails: boolean

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -845,7 +845,7 @@
           "order": 11,
           "title": "Cody Code Actions",
           "type": "boolean",
-          "markdownDescription": "Enable Cody to fix or explain errors and warnings, directly in your code.",
+          "markdownDescription": "Enable Cody fix and explain options in the Quick Fix menu",
           "default": true
         },
         "cody.experimental.symf.path": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -841,6 +841,13 @@
             "Answer all my questions in Spanish."
           ]
         },
+        "cody.codeActions.enabled": {
+          "order": 11,
+          "title": "Cody Code Actions",
+          "type": "boolean",
+          "markdownDescription": "Enables displaying code fix and explain suggestions alongside errors and warnings directly in the editor.",
+          "default": true
+        },
         "cody.experimental.symf.path": {
           "order": 99,
           "type": "string",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -845,7 +845,7 @@
           "order": 11,
           "title": "Cody Code Actions",
           "type": "boolean",
-          "markdownDescription": "Enables displaying code fix and explain suggestions alongside errors and warnings directly in the editor.",
+          "markdownDescription": "Enables displaying fix and explain suggestions alongside errors and warnings found in your code.",
           "default": true
         },
         "cody.experimental.symf.path": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -845,7 +845,7 @@
           "order": 11,
           "title": "Cody Code Actions",
           "type": "boolean",
-          "markdownDescription": "Enables displaying fix and explain suggestions alongside errors and warnings found in your code.",
+          "markdownDescription": "Enable Cody to fix or explain errors and warnings, directly in your code.",
           "default": true
         },
         "cody.experimental.symf.path": {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -43,6 +43,7 @@ export type Config = Pick<
     | 'experimentalCommandLenses'
     | 'experimentalEditorTitleCommandIcon'
     | 'experimentalLocalSymbols'
+    | 'inlineChat'
 >
 
 export enum ContextEvent {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -37,6 +37,7 @@ export type Config = Pick<
     | 'customHeaders'
     | 'accessToken'
     | 'useContext'
+    | 'codeActions'
     | 'experimentalChatPredictions'
     | 'experimentalGuardrails'
     | 'experimentalCommandLenses'

--- a/vscode/src/chat/FixupViewProvider.ts
+++ b/vscode/src/chat/FixupViewProvider.ts
@@ -11,17 +11,33 @@ import { MessageProvider, MessageProviderOptions } from './MessageProvider'
 export class FixupManager implements vscode.Disposable {
     private fixupProviders = new Map<FixupTask, FixupProvider>()
     private messageProviderOptions: MessageProviderOptions
-    private disposables: vscode.Disposable[] = []
+    private configurationChangeListener: vscode.Disposable
+    private codeActionProvider: vscode.Disposable | null = null
 
     constructor(options: MessageProviderOptions) {
         this.messageProviderOptions = options
-        if (options.contextProvider.config.codeActions) {
-            this.disposables.push(
-                vscode.languages.registerCodeActionsProvider('*', new FixupCodeAction(), {
-                    providedCodeActionKinds: FixupCodeAction.providedCodeActionKinds,
-                })
-            )
+        this.configureCodeAction(options.contextProvider.config.codeActions)
+        this.configurationChangeListener = options.contextProvider.configurationChangeEvent.event(() => {
+            this.configureCodeAction(options.contextProvider.config.codeActions)
+        })
+    }
+
+    private configureCodeAction(enabled: boolean): void {
+        // Disable the code action provider if currently enabled
+        if (!enabled) {
+            this.codeActionProvider?.dispose()
+            this.codeActionProvider = null
+            return
         }
+
+        // Code action provider already exists, skip re-registering
+        if (this.codeActionProvider) {
+            return
+        }
+
+        this.codeActionProvider = vscode.languages.registerCodeActionsProvider('*', new FixupCodeAction(), {
+            providedCodeActionKinds: FixupCodeAction.providedCodeActionKinds,
+        })
     }
 
     public getProviderForTask(task: FixupTask): FixupProvider {
@@ -45,10 +61,9 @@ export class FixupManager implements vscode.Disposable {
     }
 
     public dispose(): void {
-        for (const disposable of this.disposables) {
-            disposable.dispose()
-        }
-        this.disposables = []
+        this.configurationChangeListener.dispose()
+        this.codeActionProvider?.dispose()
+        this.codeActionProvider = null
     }
 }
 

--- a/vscode/src/chat/FixupViewProvider.ts
+++ b/vscode/src/chat/FixupViewProvider.ts
@@ -15,11 +15,13 @@ export class FixupManager implements vscode.Disposable {
 
     constructor(options: MessageProviderOptions) {
         this.messageProviderOptions = options
-        this.disposables.push(
-            vscode.languages.registerCodeActionsProvider('*', new FixupCodeAction(), {
-                providedCodeActionKinds: FixupCodeAction.providedCodeActionKinds,
-            })
-        )
+        if (options.contextProvider.config.codeActions) {
+            this.disposables.push(
+                vscode.languages.registerCodeActionsProvider('*', new FixupCodeAction(), {
+                    providedCodeActionKinds: FixupCodeAction.providedCodeActionKinds,
+                })
+            )
+        }
     }
 
     public getProviderForTask(task: FixupTask): FixupProvider {

--- a/vscode/src/chat/InlineChatViewProvider.ts
+++ b/vscode/src/chat/InlineChatViewProvider.ts
@@ -13,11 +13,13 @@ export class InlineChatViewManager implements vscode.Disposable {
 
     constructor(options: MessageProviderOptions) {
         this.messageProviderOptions = options
-        this.disposables.push(
-            vscode.languages.registerCodeActionsProvider('*', new ExplainCodeAction(), {
-                providedCodeActionKinds: ExplainCodeAction.providedCodeActionKinds,
-            })
-        )
+        if (options.contextProvider.config.codeActions) {
+            this.disposables.push(
+                vscode.languages.registerCodeActionsProvider('*', new ExplainCodeAction(), {
+                    providedCodeActionKinds: ExplainCodeAction.providedCodeActionKinds,
+                })
+            )
+        }
     }
 
     public getProviderForThread(thread: vscode.CommentThread): InlineChatViewProvider {

--- a/vscode/src/code-actions/explain.ts
+++ b/vscode/src/code-actions/explain.ts
@@ -27,6 +27,7 @@ export class ExplainCodeAction implements vscode.CodeActionProvider {
             arguments: [instruction, range],
             title: 'Ask Cody to Explain',
         }
+        action.diagnostics = diagnostics
         return action
     }
 

--- a/vscode/src/code-actions/explain.ts
+++ b/vscode/src/code-actions/explain.ts
@@ -2,6 +2,11 @@ import * as vscode from 'vscode'
 
 export class ExplainCodeAction implements vscode.CodeActionProvider {
     public static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix]
+    private command: string
+
+    constructor(inline: boolean) {
+        this.command = inline ? 'cody.inline.add' : 'cody.action.chat'
+    }
 
     public provideCodeActions(
         document: vscode.TextDocument,
@@ -23,7 +28,7 @@ export class ExplainCodeAction implements vscode.CodeActionProvider {
         const action = new vscode.CodeAction('Ask Cody to Explain', vscode.CodeActionKind.QuickFix)
         const instruction = this.getCodeActionInstruction(diagnostics)
         action.command = {
-            command: 'cody.inline.add',
+            command: this.command,
             arguments: [instruction, range],
             title: 'Ask Cody to Explain',
         }

--- a/vscode/src/code-actions/fixup.ts
+++ b/vscode/src/code-actions/fixup.ts
@@ -36,7 +36,6 @@ export class FixupCodeAction implements vscode.CodeActionProvider {
             title: 'Ask Cody to Fix',
         }
         action.diagnostics = diagnostics
-        action.isPreferred = true
         return action
     }
 

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -22,6 +22,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     experimentalGuardrails: false,
     experimentalLocalSymbols: false,
     inlineChat: true,
+    codeActions: true,
     isRunningInsideAgent: false,
     experimentalNonStop: false,
     experimentalSymfAnthropicKey: '',

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -24,6 +24,7 @@ describe('getConfiguration', () => {
             experimentalGuardrails: false,
             experimentalLocalSymbols: false,
             inlineChat: true,
+            codeActions: true,
             isRunningInsideAgent: false,
             experimentalNonStop: false,
             experimentalSymfAnthropicKey: '',
@@ -71,6 +72,8 @@ describe('getConfiguration', () => {
                     case 'cody.experimental.guardrails':
                         return true
                     case 'cody.inlineChat.enabled':
+                        return true
+                    case 'cody.codeActions.enabled':
                         return true
                     case 'cody.experimental.nonStop':
                         return true
@@ -130,6 +133,7 @@ describe('getConfiguration', () => {
             experimentalGuardrails: true,
             experimentalLocalSymbols: true,
             inlineChat: true,
+            codeActions: true,
             isRunningInsideAgent: false,
             experimentalNonStop: true,
             experimentalSymfAnthropicKey: 'anthropic_secret_key',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -51,6 +51,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         autocomplete: config.get(CONFIG_KEY.autocompleteEnabled, true),
         experimentalChatPredictions: config.get(CONFIG_KEY.experimentalChatPredictions, isTesting),
         inlineChat: config.get(CONFIG_KEY.inlineChatEnabled, true),
+        codeActions: config.get(CONFIG_KEY.codeActionsEnabled, true),
         chatPreInstruction: config.get(CONFIG_KEY.chatPreInstruction),
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
         experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),

--- a/vscode/src/logged-rerank.ts
+++ b/vscode/src/logged-rerank.ts
@@ -15,7 +15,7 @@ export function getRerankWithLog(
 
     const reranker = new LLMReranker(chatClient)
     return async (userQuery: string, results: ContextResult[]): Promise<ContextResult[]> => {
-        const start = performance.noew()
+        const start = performance.now()
         const rerankedResults = await reranker.rerank(userQuery, results)
         const duration = performance.now() - start
         logDebug('Reranker:rerank', JSON.stringify({ duration }))

--- a/vscode/src/logged-rerank.ts
+++ b/vscode/src/logged-rerank.ts
@@ -15,7 +15,7 @@ export function getRerankWithLog(
 
     const reranker = new LLMReranker(chatClient)
     return async (userQuery: string, results: ContextResult[]): Promise<ContextResult[]> => {
-        const start = performance.now()
+        const start = performance.noew()
         const rerankedResults = await reranker.rerank(userQuery, results)
         const duration = performance.now() - start
         logDebug('Reranker:rerank', JSON.stringify({ duration }))

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -101,6 +101,14 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.inlineChat
                 ),
                 createFeatureToggle(
+                    'Code Actions',
+                    undefined,
+                    'Enable Cody to fix or explain errors and warnings, directly in your code.',
+                    'cody.codeActions.enabled',
+                    c => c.codeActions,
+                    true
+                ),
+                createFeatureToggle(
                     'Chat Suggestions',
                     'Experimental',
                     'Enable automatically suggested chat questions',

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -105,8 +105,7 @@ export function createStatusBar(): CodyStatusBar {
                     undefined,
                     'Enable Cody to fix or explain errors and warnings, directly in your code.',
                     'cody.codeActions.enabled',
-                    c => c.codeActions,
-                    true
+                    c => c.codeActions
                 ),
                 createFeatureToggle(
                     'Chat Suggestions',

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -103,7 +103,7 @@ export function createStatusBar(): CodyStatusBar {
                 createFeatureToggle(
                     'Code Actions',
                     undefined,
-                    'Enable Cody to fix or explain errors and warnings, directly in your code.',
+                    'Enable Cody fix and explain options in the Quick Fix menu',
                     'cody.codeActions.enabled',
                     c => c.codeActions
                 ),


### PR DESCRIPTION
## Description

- Group the fix and explain actions
- Allow enabling/disabling the actions all together

Enabled:
<img width="572" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/0a97402c-a216-4c24-bbb0-bdd86bc2ad9b">

Disabled:
<img width="672" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/907a9ec6-7b00-4fc1-83d9-88f991b9cfbc">

Interface:
<img width="665" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/68c6b572-a217-4e08-bd77-c34a71f01198">


## Test plan

Tested locally, enabling and disabling through interface and manually in VS Code settings

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
