### PR TITLE
update: refine instruction and define tag names for infill prompt

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Removed invalid variable from logs that stopped rate-limit errors from displaying properly. [pull/1205](https://github.com/sourcegraph/cody/pull/1205)
 - Disable `Ask Cody Inline` in Cody Context Menu when `cody.InlineChat.enabled` is set to false. [pull/1209](https://github.com/sourcegraph/cody/pull/1209)
+- Fixed a bug where the `claude-instant-infill` model was returning unhelpful suggestions. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ### Changed
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -84,7 +84,7 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the ${OPENING_CODE_TAG} XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside the tags precisely and nothing else, without duplicating existing implementations.\nHere is the code:\n${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
+                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the ${OPENING_CODE_TAG} XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose ONLY the completed code and nothing else inside the tags precisely without duplicating existing implementations: ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}\n<---end of file--->`,
             },
             {
                 speaker: 'assistant',
@@ -246,3 +246,4 @@ export function createProviderConfig(anthropicOptions: AnthropicOptions): Provid
         model: 'claude-instant-infill',
     }
 }
+

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -76,7 +76,7 @@ export class AnthropicProvider extends Provider {
         const prefixMessagesWithInfill: Message[] = [
             {
                 speaker: 'human',
-                text: `You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags. You only response with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.`,
+                text: `You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags. You only response with code that works and fits seamlessly with surrounding code if any or use best practice.`,
             },
             {
                 speaker: 'assistant',
@@ -84,8 +84,7 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations.
-                Here is the code: ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
+                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the ${OPENING_CODE_TAG} XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside the tags precisely and nothing else, without duplicating existing implementations.\nHere is the code:\n${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
             },
             {
                 speaker: 'assistant',


### PR DESCRIPTION
Update the text prompt sent to the Anthropic model to clarify that it should only complete code inside the XML tags

still investigating to confirm if this is the cause*

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before

Step to reproduce: type something in the last line in your document, you should see unhelpful response from the LLM:

<img width="1360" alt="Screenshot 2023-09-27 at 4 45 11 PM" src="https://github.com/sourcegraph/cody/assets/68532117/9d9f654c-f8be-4343-9217-8b092c1dd73f">

### After

<img width="989" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/ac411e98-0c31-4275-b24c-145acac2c45a">
