### PR TITLE
Agent: Add a way to trigger "manual" autocompletions

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -194,10 +194,16 @@ export class Agent extends MessageHandler {
             const textDocument = new AgentTextDocument(document)
 
             try {
+                if (params.triggerKind === 'Invoke') {
+                    await provider.manuallyTriggerCompletion()
+                }
                 const result = await provider.provideInlineCompletionItems(
                     textDocument,
                     new vscode.Position(params.position.line, params.position.character),
-                    { triggerKind: vscode.InlineCompletionTriggerKind.Automatic, selectedCompletionInfo: undefined },
+                    {
+                        triggerKind: vscode.InlineCompletionTriggerKind[params.triggerKind || 'Automatic'],
+                        selectedCompletionInfo: undefined,
+                    },
                     token
                 )
                 const items: AutocompleteItem[] =

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -145,7 +145,7 @@ describe.each([
         const completions = await client.request('autocomplete/execute', {
             filePath,
             position: { line: 1, character: 4 },
-	    triggerKind: 'Automatic',
+            triggerKind: 'Automatic',
         })
         assert(completions.items.length > 0)
     })

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -145,6 +145,7 @@ describe.each([
         const completions = await client.request('autocomplete/execute', {
             filePath,
             position: { line: 1, character: 4 },
+	    triggerKind: 'Automatic',
         })
         assert(completions.items.length > 0)
     })

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -108,6 +108,9 @@ export interface CancelParams {
 export interface AutocompleteParams {
     filePath: string
     position: Position
+    // Defaults to 'Automatic' for autocompletions which were not explicitly
+    // triggered.
+    triggerKind?: 'Automatic' | 'Invoke'
 }
 
 export interface AutocompleteResult {

--- a/cli/src/commands/complete/command.ts
+++ b/cli/src/commands/complete/command.ts
@@ -97,6 +97,7 @@ async function codyAgentComplete({
     return client.request('autocomplete/execute', {
         filePath,
         position,
+        triggerKind: 'Invoke',
     })
 }
 


### PR DESCRIPTION
VScode has a couple of kinds of autocompletions ("Invoke", "Automatic") which Cody splits into three: Manually triggered ones, hovers, and automatic ones. Adds an optional field, `triggerKind` to `autocomplete/execute` which specifies one of the VScode kinds. Additionally, makes the completion provider do a "manual" completion when`triggerKind` is "Invoke".

## Test plan

Tested manually by adding triggerKind to cody-emacs and triggering an autocomplete with `C-c c`