### PR TITLE
Agent: Add a script and VScode launch configuration for debugging agent

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,7 @@
       "name": "Attach to Node (Agent)",
       "port": 9229,
       "request": "attach",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "type": "node"
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,15 @@
   "version": "0.1.0",
   "configurations": [
     {
+      "name": "Attach to Node (Agent)",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node"
+    },
+    {
       "name": "Launch VS Code Extension (Desktop)",
       "type": "extensionHost",
       "request": "launch",

--- a/agent/debug.sh
+++ b/agent/debug.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "${0%/*}"
+CODY_AGENT_TRACE_PATH=/tmp/cody.log pnpm exec node --inspect-brk dist/index.js
+


### PR DESCRIPTION
## Test plan

1. `agent/debug.sh`
2. In VScode, Debug tab, switch the run configuration to agent, hit play.

VScode should be debugging agent, with sourcemaps, etc. stopped at the first line of the first file.