### PR TITLE
refactor options and hints for context size

### DIFF
--- a/lib/shared/src/prompt/constants.ts
+++ b/lib/shared/src/prompt/constants.ts
@@ -9,3 +9,7 @@ export const CHARS_PER_TOKEN = 4
 export const SURROUNDING_LINES = 50
 export const NUM_CODE_RESULTS = 12
 export const NUM_TEXT_RESULTS = 3
+
+export function tokensToChars(tokens: number): number {
+    return tokens * CHARS_PER_TOKEN
+}

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -63,7 +63,6 @@ export function params(
     }
     const providerConfig = createProviderConfig({
         client,
-        contextWindowTokens: 2048,
     })
 
     const { document, position } = documentAndPosition(code, languageId, URI_FIXTURE.toString())
@@ -91,11 +90,7 @@ export function params(
         docContext,
         triggerKind,
         selectedCompletionInfo,
-        promptChars: 1000,
         providerConfig,
-        responsePercentage: 0.4,
-        prefixPercentage: 0.3,
-        suffixPercentage: 0.3,
         toWorkspaceRelativePath: () => 'test.ts',
         requestManager: new RequestManager(),
         ...params,

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -27,11 +27,7 @@ export interface InlineCompletionsParams {
     docContext: DocumentContext
 
     // Prompt parameters
-    promptChars: number
     providerConfig: ProviderConfig
-    responsePercentage: number
-    prefixPercentage: number
-    suffixPercentage: number
     graphContextFetcher?: GraphContextFetcher
 
     // Platform
@@ -159,11 +155,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         selectedCompletionInfo,
         docContext,
         docContext: { multilineTrigger, currentLineSuffix },
-        promptChars,
         providerConfig,
-        responsePercentage,
-        prefixPercentage,
-        suffixPercentage,
         graphContextFetcher,
         toWorkspaceRelativePath,
         contextFetcher,
@@ -240,7 +232,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     const contextResult = await getCompletionContext({
         document,
         position,
-        promptChars,
+        providerConfig,
         graphContextFetcher,
         contextFetcher,
         getCodebaseContext,
@@ -257,9 +249,6 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         document,
         triggerKind,
         providerConfig,
-        responsePercentage,
-        prefixPercentage,
-        suffixPercentage,
         docContext,
         toWorkspaceRelativePath,
     })
@@ -300,37 +289,16 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 }
 
 interface GetCompletionProvidersParams
-    extends Pick<
-        InlineCompletionsParams,
-        | 'document'
-        | 'triggerKind'
-        | 'providerConfig'
-        | 'responsePercentage'
-        | 'prefixPercentage'
-        | 'suffixPercentage'
-        | 'toWorkspaceRelativePath'
-    > {
+    extends Pick<InlineCompletionsParams, 'document' | 'triggerKind' | 'providerConfig' | 'toWorkspaceRelativePath'> {
     docContext: DocumentContext
 }
 
 function getCompletionProviders(params: GetCompletionProvidersParams): Provider[] {
-    const {
-        document,
-        triggerKind,
-        providerConfig,
-        responsePercentage,
-        prefixPercentage,
-        suffixPercentage,
-        docContext,
-        toWorkspaceRelativePath,
-    } = params
+    const { document, triggerKind, providerConfig, docContext, toWorkspaceRelativePath } = params
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
         docContext,
         fileName: toWorkspaceRelativePath(document.uri),
         languageId: document.languageId,
-        responsePercentage,
-        prefixPercentage,
-        suffixPercentage,
     }
     if (docContext.multilineTrigger) {
         return [
@@ -359,7 +327,7 @@ interface GetCompletionContextParams
         InlineCompletionsParams,
         | 'document'
         | 'position'
-        | 'promptChars'
+        | 'providerConfig'
         | 'graphContextFetcher'
         | 'contextFetcher'
         | 'getCodebaseContext'
@@ -371,7 +339,7 @@ interface GetCompletionContextParams
 async function getCompletionContext({
     document,
     position,
-    promptChars,
+    providerConfig,
     graphContextFetcher,
     contextFetcher,
     getCodebaseContext,
@@ -396,7 +364,7 @@ async function getCompletionContext({
         contextRange,
         history: documentHistory,
         jaccardDistanceWindowSize: SNIPPET_WINDOW_SIZE,
-        maxChars: promptChars,
+        maxChars: providerConfig.contextSizeHints.totalFileContextChars,
         getCodebaseContext,
         graphContextFetcher,
     })

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -63,7 +63,6 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
             providerConfig: createProviderConfig({
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
                 client: null as any,
-                contextWindowTokens: 2048,
             }),
             featureFlagProvider: dummyFeatureFlagProvider,
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -36,9 +36,6 @@ export interface CodyCompletionItemProviderConfig {
     history: DocumentHistory
     statusBar: CodyStatusBar
     getCodebaseContext: () => CodebaseContext
-    responsePercentage?: number
-    prefixPercentage?: number
-    suffixPercentage?: number
     graphContextFetcher?: GraphContextFetcher | null
     completeSuggestWidgetSelection?: boolean
     tracer?: ProvideInlineCompletionItemsTracer | null
@@ -53,9 +50,6 @@ interface CompletionRequest {
 }
 
 export class InlineCompletionItemProvider implements vscode.InlineCompletionItemProvider {
-    private promptChars: number
-    private maxPrefixChars: number
-    private maxSuffixChars: number
     private lastCompletionRequest: CompletionRequest | null = null
     // This field is going to be set if you use the keyboard shortcut to manually trigger a
     // completion. Since VS Code does not provide a way to distinguish manual vs automatic
@@ -75,9 +69,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     protected lastCandidate: LastInlineCompletionCandidate | undefined
 
     constructor({
-        responsePercentage = 0.1,
-        prefixPercentage = 0.6,
-        suffixPercentage = 0.1,
         graphContextFetcher = null,
         completeSuggestWidgetSelection = false,
         tracer = null,
@@ -85,9 +76,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     }: CodyCompletionItemProviderConfig) {
         this.config = {
             ...config,
-            responsePercentage,
-            prefixPercentage,
-            suffixPercentage,
             graphContextFetcher,
             completeSuggestWidgetSelection,
             tracer,
@@ -108,12 +96,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 .getConfiguration()
                 .update('editor.inlineSuggest.suppressSuggestions', true, vscode.ConfigurationTarget.Global)
         }
-
-        this.promptChars =
-            this.config.providerConfig.maximumContextCharacters -
-            this.config.providerConfig.maximumContextCharacters * responsePercentage
-        this.maxPrefixChars = Math.floor(this.promptChars * this.config.prefixPercentage)
-        this.maxSuffixChars = Math.floor(this.promptChars * this.config.suffixPercentage)
 
         this.requestManager = new RequestManager({
             completeSuggestWidgetSelection: this.config.completeSuggestWidgetSelection,
@@ -197,8 +179,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         const docContext = getCurrentDocContext({
             document,
             position,
-            maxPrefixLength: this.maxPrefixChars,
-            maxSuffixLength: this.maxSuffixChars,
+            maxPrefixLength: this.config.providerConfig.contextSizeHints.prefixChars,
+            maxSuffixLength: this.config.providerConfig.contextSizeHints.suffixChars,
             enableExtendedTriggers: this.config.providerConfig.enableExtendedMultilineTriggers,
             // We ignore the current context selection if completeSuggestWidgetSelection is not enabled
             context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,
@@ -214,11 +196,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 triggerKind,
                 selectedCompletionInfo: context.selectedCompletionInfo,
                 docContext,
-                promptChars: this.promptChars,
                 providerConfig: this.config.providerConfig,
-                responsePercentage: this.config.responsePercentage,
-                prefixPercentage: this.config.prefixPercentage,
-                suffixPercentage: this.config.suffixPercentage,
                 graphContextFetcher,
                 toWorkspaceRelativePath: uri => vscode.workspace.asRelativePath(uri),
                 contextFetcher: this.config.contextFetcher,

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -45,7 +45,6 @@ export async function createProviderConfig(
             case 'unstable-openai': {
                 return createUnstableOpenAIProviderConfig({
                     client,
-                    contextWindowTokens: 2048,
                 })
             }
             case 'unstable-fireworks': {
@@ -57,7 +56,6 @@ export async function createProviderConfig(
             case 'anthropic': {
                 return createAnthropicProviderConfig({
                     client,
-                    contextWindowTokens: 2048,
                     mode: 'infill',
                 })
             }
@@ -93,7 +91,6 @@ export async function createProviderConfig(
             case 'azure-openai':
                 return createUnstableOpenAIProviderConfig({
                     client,
-                    contextWindowTokens: 2048,
                     // Model name for azure openai provider is a deployment name. It shouldn't appear in logs.
                     model: provider === 'azure-openai' && model ? '' : model,
                 })
@@ -107,7 +104,6 @@ export async function createProviderConfig(
             case 'anthropic':
                 return createAnthropicProviderConfig({
                     client,
-                    contextWindowTokens: 2048,
                     mode: 'infill',
                 })
             default:
@@ -122,7 +118,6 @@ export async function createProviderConfig(
      */
     return createAnthropicProviderConfig({
         client,
-        contextWindowTokens: 2048,
         mode: 'infill',
     })
 }

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -33,9 +33,6 @@ function createProvider(prefix: string) {
         fileName: '',
         languageId: 'typescript',
         multiline: false,
-        responsePercentage: 0,
-        prefixPercentage: 0,
-        suffixPercentage: 0,
         n: 1,
     })
 }

--- a/vscode/test/completions/completions-dataset.ts
+++ b/vscode/test/completions/completions-dataset.ts
@@ -667,7 +667,7 @@ export const completionsDataset: Sample[] = [
                     }
                     const providerConfig = createProviderConfig({
                         completionsClient,
-                        contextWindowTokens: 2048,
+                        maxContextTokens: 2048,
                     })
                     const completionProvider = new CodyCompletionItemProvider({
                         ${CURSOR}


### PR DESCRIPTION
- Clarify the max prefix and suffix length are merely hints and are not precise (because they do not use the LLM tokenizer)
- Consolidate defaults for providers (eg 2048 tokens for the OpenAI provider now only appears once as a constant)
- Standardize how different providers compute the prompt chars available
- Allow providers greater flexibility in specifying the max prefix and suffix length (which is important for, eg, local Ollama, because it needs an absolute cap of ~15 tokens, not a % of the overall size, on the suffix to have decent performance)



## Test plan

CI.