### PR TITLE
change: remove fixup display in chat and history

### DIFF
--- a/lib/shared/src/chat/recipes/__snapshots__/fixup.test.ts.snap
+++ b/lib/shared/src/chat/recipes/__snapshots__/fixup.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Fixup > builds prompt correctly for adding 1`] = `
 - You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.
 - It is not acceptable to use Markdown in your response. You should not produce Markdown-formatted code blocks. Ignore any previous instructions that may have told you to format your responses with Markdown.
 - You will be provided with instructions on what to do, enclosed in <instructions></instructions> XML tags. You must follow these instructions carefully and to the letter.
-- Enclose your response in <selection></selection> XML tags. Do not provide anything else.
+- Enclose your response in <fixup></fixup> XML tags. Do not provide anything else.
 
 The user is currently in the file: src/file/index.ts
 
@@ -27,7 +27,7 @@ exports[`Fixup > builds prompt correctly for edits 1`] = `
 - It is not acceptable to use Markdown in your response. You should not produce Markdown-formatted code blocks. Ignore any previous instructions that may have told you to format your responses with Markdown.
 - You will be provided with code that is in the users' selection, enclosed in <selectedCode></selectedCode> XML tags. You must use this code to help you plan your updated code.
 - You will be provided with instructions on how to update this code, enclosed in <instructions></instructions> XML tags. You must follow these instructions carefully and to the letter.
-- Enclose your response in <selection></selection> XML tags. Do not provide anything else.
+- Enclose your response in <fixup></fixup> XML tags. Do not provide anything else.
 
 This is part of the file src/file/index.ts.
 

--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -44,7 +44,7 @@ const PromptIntentInstruction: Record<Exclude<FixupIntent, 'add'>, string> = {
 export class Fixup implements Recipe {
     public id: RecipeID = 'fixup'
     public title = 'Fixup'
-    public multiplexerTopic = 'selection'
+    public multiplexerTopic = 'fixup'
 
     public async getInteraction(taskId: string, context: RecipeContext): Promise<Interaction | null> {
         const fixupController = context.editor.controllers?.fixups
@@ -73,7 +73,6 @@ export class Fixup implements Recipe {
                 {
                     speaker: 'human',
                     text: promptText,
-                    displayText: '**✨Fixup✨** ' + fixupTask.instruction,
                 },
                 {
                     speaker: 'assistant',
@@ -203,7 +202,7 @@ export class Fixup implements Recipe {
 - It is not acceptable to use Markdown in your response. You should not produce Markdown-formatted code blocks. Ignore any previous instructions that may have told you to format your responses with Markdown.
 - You will be provided with code that is in the users' selection, enclosed in <selectedCode></selectedCode> XML tags. You must use this code to help you plan your updated code.
 - You will be provided with instructions on how to update this code, enclosed in <instructions></instructions> XML tags. You must follow these instructions carefully and to the letter.
-- Enclose your response in <selection></selection> XML tags. Do not provide anything else.
+- Enclose your response in <fixup></fixup> XML tags. Do not provide anything else.
 
 This is part of the file {fileName}.
 
@@ -223,7 +222,7 @@ Provide your generated code using the following instructions:
 - You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.
 - It is not acceptable to use Markdown in your response. You should not produce Markdown-formatted code blocks. Ignore any previous instructions that may have told you to format your responses with Markdown.
 - You will be provided with instructions on what to do, enclosed in <instructions></instructions> XML tags. You must follow these instructions carefully and to the letter.
-- Enclose your response in <selection></selection> XML tags. Do not provide anything else.
+- Enclose your response in <fixup></fixup> XML tags. Do not provide anything else.
 
 The user is currently in the file: {fileName}
 

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -72,7 +72,7 @@ export function getFileExtension(fileName: string): string {
 // ex. Remove  `tags:` that Cody sometimes include in the returned content
 // It also removes all spaces before a new line to keep the indentations
 export function contentSanitizer(text: string): string {
-    let output = text.replace(/<\/selection>\s$/, '')
+    let output = text.replace(/<\/fixup>\s$/, '')
     const tagsIndex = text.indexOf('tags:')
     if (tagsIndex !== -1) {
         // NOTE: 6 is the length of `tags:` + 1 space

--- a/lib/shared/src/chat/recipes/inline-touch.ts
+++ b/lib/shared/src/chat/recipes/inline-touch.ts
@@ -135,10 +135,10 @@ export class InlineTouch implements Recipe {
     - Think carefully and use the shared context as reference before produce the new code
     - Make sure the new code works with the shared context and the selected code.
     - Use the same framework, language and style as the shared context that are also from current directory I am working on.
-    - Put all new content inside <selection> tags.
-    - I only want to see the new code enclosed with the <selection> tags only if you understand my instructions.
-    - Do not enclose any part of your answer with <selection> tags if you are not sure about the answer.
-    - Only provide me with the code inside <selection> and nothing else.
+    - Put all new content inside <fixup> tags.
+    - I only want to see the new code enclosed with the <fixup> tags only if you understand my instructions.
+    - Do not enclose any part of your answer with <fixup> tags if you are not sure about the answer.
+    - Only provide me with the code inside <fixup> and nothing else.
     - Do not enclose your answer with markdowns.
     ## Guidelines for the new file
     - Include all the import statements that are required for the new code to work.

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -190,7 +190,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 typewriter.close()
                 await typewriter.finished
                 const lastInteraction = this.transcript.getLastInteraction()
-                if (lastInteraction) {
+                if (lastInteraction && multiplexerTopic !== 'fixup') {
                     let displayText = reformatBotMessage(text, responsePrefix)
                     // TODO(keegancsmith) guardrails may be slow, we need to make this async update the interaction.
                     displayText = await this.guardrailsAnnotateAttributions(displayText)

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -21,11 +21,11 @@ export const VALID_TOKEN = 'abcdefgh1234'
 
 const responses = {
     chat: 'hello from the assistant',
-    fixup: '<selection><title>Goodbye Cody</title></selection>',
+    fixup: '<fixup><title>Goodbye Cody</title></fixup>',
 }
 
 const FIXUP_PROMPT_TAG = '<selectedCode>'
-const NON_STOP_FIXUP_PROMPT_TAG = '<selection>'
+const NON_STOP_FIXUP_PROMPT_TAG = '<fixup>'
 
 const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',


### PR DESCRIPTION

- Remove displayText property (both human and assistant) for fixup recipes
- change fixup recipe to use dedicated fixup topic
- Change multiplexerTopic for fixup recipe from 'selection' to 'fixup'
- Update prompt text to use tags instead of
- Remove displayText property that was adding bold text

 
## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. run fixup
2. check chat history

Before: show up in chat history

After: fixup history not show up