### PR TITLE
JetBrains: expose graphql query getRepoId in protocol

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -247,6 +247,15 @@ export class Agent extends MessageHandler {
             return typeof result === 'string' ? result : null
         })
 
+        this.registerRequest('graphql/getRepoId', async ({ repoName }) => {
+            const client = await this.client
+            const result = await client?.graphqlClient.getRepoId(repoName)
+            if (result instanceof Error) {
+                console.error('getRepoId', result)
+            }
+            return typeof result === 'string' ? result : null
+        })
+
         this.registerNotification('autocomplete/clearLastCandidate', async () => {
             const provider = await vscode_shim.completionProvider()
             if (!provider) {

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -41,6 +41,7 @@ export type Requests = {
     'graphql/logEvent': [event, null]
 
     'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
+    'graphql/getRepoId': [{ repoName: string }, string | null]
 
     // ================
     // Server -> Client


### PR DESCRIPTION
This PR exposes the grapqhl query getRepoId in protocol so we can distinguish in the plugins whether the repo is not found at all or whether it has no embeddings

## Test plan
- JetBrains plugin uses this query, so you can test it there in different PR -> https://github.com/sourcegraph/sourcegraph/pull/57128

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
