### PR TITLE
Auth symf after login

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -113,7 +113,6 @@ const register = async (
     const symfRunner = platform.createSymfRunner?.(context, initialConfig.accessToken)
     if (symfRunner) {
         authProvider.addChangeListener(async (authStatus: AuthStatus) => {
-            console.log('# authStatus', authStatus, authStatus.authenticated, authStatus.isLoggedIn)
             if (authStatus.isLoggedIn) {
                 symfRunner.setAuthToken(await getAccessToken())
             } else {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -10,7 +10,7 @@ import { ContextProvider } from './chat/ContextProvider'
 import { FixupManager } from './chat/FixupViewProvider'
 import { InlineChatViewManager } from './chat/InlineChatViewProvider'
 import { MessageProviderOptions } from './chat/MessageProvider'
-import { CODY_FEEDBACK_URL } from './chat/protocol'
+import { AuthStatus, CODY_FEEDBACK_URL } from './chat/protocol'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './completions/tree-sitter/parse-tree-cache'
 import { getConfiguration, getFullConfig } from './configuration'
@@ -25,7 +25,7 @@ import { GuardrailsProvider } from './services/GuardrailsProvider'
 import { Comment, InlineController } from './services/InlineController'
 import { LocalAppSetupPublisher } from './services/LocalAppSetupPublisher'
 import { localStorage } from './services/LocalStorageProvider'
-import { CODY_ACCESS_TOKEN_SECRET, secretStorage, VSCodeSecretStorage } from './services/SecretStorageProvider'
+import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, secretStorage, VSCodeSecretStorage } from './services/SecretStorageProvider'
 import { createStatusBar } from './services/StatusBar'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { TestSupport } from './test-support'
@@ -107,7 +107,20 @@ const register = async (
         disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
     }
 
+    const authProvider = new AuthProvider(initialConfig)
+    await authProvider.init()
+
     const symfRunner = platform.createSymfRunner?.(context, initialConfig.accessToken)
+    if (symfRunner) {
+        authProvider.addChangeListener(async (authStatus: AuthStatus) => {
+            console.log('# authStatus', authStatus, authStatus.authenticated, authStatus.isLoggedIn)
+            if (authStatus.isLoggedIn) {
+                symfRunner.setAuthToken(await getAccessToken())
+            } else {
+                symfRunner.setAuthToken(null)
+            }
+        })
+    }
 
     const {
         featureFlagProvider,
@@ -118,9 +131,6 @@ const register = async (
         guardrails,
         onConfigurationChange: externalServicesOnDidConfigurationChange,
     } = await configureExternalServices(initialConfig, rgPath, symfRunner, editor, platform)
-
-    const authProvider = new AuthProvider(initialConfig)
-    await authProvider.init()
 
     const contextProvider = new ContextProvider(
         initialConfig,
@@ -441,7 +451,7 @@ const register = async (
             if (config.isRunningInsideAgent) {
                 throw new Error(
                     'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
-                        'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
+                    'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
                 )
             }
             return


### PR DESCRIPTION
This fixes the following bug:
- User is logged out
- User logs in
- We don't propagate the auth token to SymfRunner, so it doesn't make it to `/symf`, which uses it to query claude-instant for query expansion

## Test plan

- Verify the bug behavior on `main`
- Check out this branch and log out
- Log back in and verify `/symf [query]` works