### PR TITLE
change: /doc scroll on invisible range only

### DIFF
--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -213,17 +213,21 @@ function getDocCommandRange(
 
     // move the current selection to the defined selection in the text editor document
     if (editor) {
-        // reveal the range of the selection minus 5 lines
-        editor?.revealRange(
-            selection.with({
-                start:
-                    selection.start.line > 5
-                        ? selection.start.with({ line: selection.start.line - 5 })
-                        : selection.start,
-                end: selection.end,
-            }),
-            vscode.TextEditorRevealType.InCenter
-        )
+        const visibleRange = editor.visibleRanges
+        // reveal the range of the selection minus 5 lines if visibleRange doesn't contain the selection
+        if (!visibleRange.some(range => range.contains(selection))) {
+            // reveal the range of the selection minus 5 lines
+            editor?.revealRange(
+                selection.with({
+                    start:
+                        selection.start.line > 5
+                            ? selection.start.with({ line: selection.start.line - 5 })
+                            : selection.start,
+                    end: selection.end,
+                }),
+                vscode.TextEditorRevealType.InCenter
+            )
+        }
     }
 
     return new vscode.Selection(pos, pos)

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -217,16 +217,7 @@ function getDocCommandRange(
         // reveal the range of the selection minus 5 lines if visibleRange doesn't contain the selection
         if (!visibleRange.some(range => range.contains(selection))) {
             // reveal the range of the selection minus 5 lines
-            editor?.revealRange(
-                selection.with({
-                    start:
-                        selection.start.line > 5
-                            ? selection.start.with({ line: selection.start.line - 5 })
-                            : selection.start,
-                    end: selection.end,
-                }),
-                vscode.TextEditorRevealType.InCenter
-            )
+            editor?.revealRange(selection, vscode.TextEditorRevealType.InCenter)
         }
     }
 


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1695902300751599?thread_ts=1695733768.715559&cid=C05AGQYD528

fix: check if selection is visible before revealing range

Only reveal the selection range if it is not already visible. This avoids unnecessarily revealing the range and disrupting the user's view if the selection is already on screen.

- Get the visible ranges from the editor
- Check if selection is contained in visible ranges
- Only reveal selection if not visible

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

#### Before 

https://github.com/sourcegraph/cody/assets/68532117/6dbd9f96-4e40-46ab-8e0f-498bfd1a844f

#### After

Won't scroll to range if it's already visible 
