### PR TITLE
Autocomplete: Add bookkeeping to reuse completion IDs over multiple suggestions

### DIFF
--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -78,9 +78,12 @@ export async function createInlineCompletionItemProvider({
             vscode.commands.registerCommand('cody.autocomplete.manual-trigger', () =>
                 completionsProvider.manuallyTriggerCompletion()
             ),
-            vscode.commands.registerCommand('cody.autocomplete.inline.accepted', ({ codyLogId, codyCompletion }) => {
-                completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyCompletion)
-            }),
+            vscode.commands.registerCommand(
+                'cody.autocomplete.inline.accepted',
+                ({ codyLogId, codyCompletion, codyRequest }) => {
+                    completionsProvider.handleDidAcceptCompletionItem(codyLogId, codyCompletion, codyRequest)
+                }
+            ),
             vscode.languages.registerInlineCompletionItemProvider(
                 [{ scheme: 'file', language: '*' }, { notebookType: '*' }],
                 completionsProvider

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vitest } from 'vitest'
 import { range } from '../../testutils/textDocument'
 import { getCurrentDocContext } from '../get-current-doc-context'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from '../get-inline-completions'
+import { SuggestionID } from '../logger'
 import { documentAndPosition } from '../test-helpers'
 
 import { getInlineCompletions, params, V } from './helpers'
@@ -27,7 +28,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             lastTriggerPosition: position,
             lastTriggerSelectedInfoItem,
             result: {
-                logId: '1',
+                logId: '1' as SuggestionID,
                 source: InlineCompletionsResultSource.Network,
                 items: Array.isArray(insertText) ? insertText.map(insertText => ({ insertText })) : [{ insertText }],
             },

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -11,6 +11,7 @@ import { vsCodeMocks } from '../testutils/mocks'
 import { getInlineCompletions, InlineCompletionsResultSource } from './get-inline-completions'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
 import * as CompletionLogger from './logger'
+import { SuggestionID } from './logger'
 import { createProviderConfig } from './providers/anthropic'
 import { documentAndPosition } from './test-helpers'
 import { InlineCompletionItem } from './types'
@@ -78,7 +79,7 @@ describe('InlineCompletionItemProvider', () => {
     it('returns results that span the whole line', async () => {
         const { document, position } = documentAndPosition('const foo = █', 'typescript')
         const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-            logId: '1',
+            logId: '1' as SuggestionID,
             items: [{ insertText: 'test', range: new vsCodeMocks.Range(position, position) }],
             source: InlineCompletionsResultSource.Network,
         })
@@ -116,7 +117,7 @@ describe('InlineCompletionItemProvider', () => {
 
         const item: InlineCompletionItem = { insertText: 'test', range: new vsCodeMocks.Range(position, position) }
         const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-            logId: '1',
+            logId: '1' as SuggestionID,
             items: [item],
             source: InlineCompletionsResultSource.Network,
         })
@@ -197,7 +198,7 @@ describe('InlineCompletionItemProvider', () => {
 
             const { document, position } = documentAndPosition('const foo = █', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: 'bar', range: new vsCodeMocks.Range(position, position) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -228,7 +229,7 @@ describe('InlineCompletionItemProvider', () => {
             const fn = vi.fn(getInlineCompletions).mockImplementation(() => {
                 cancel()
                 return Promise.resolve({
-                    logId: '1',
+                    logId: '1' as SuggestionID,
                     items: [{ insertText: 'bar', range: new vsCodeMocks.Range(position, position) }],
                     source: InlineCompletionsResultSource.Network,
                 })
@@ -245,7 +246,7 @@ describe('InlineCompletionItemProvider', () => {
 
             const { document, position } = documentAndPosition('console.█', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: 'log()', range: new vsCodeMocks.Range(position, position) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -264,7 +265,7 @@ describe('InlineCompletionItemProvider', () => {
 
             const { document, position } = documentAndPosition('const a = [1, █];', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: '2] ;', range: new vsCodeMocks.Range(position, position) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -283,7 +284,7 @@ describe('InlineCompletionItemProvider', () => {
                 'typescript'
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: '2] ;', range: new vsCodeMocks.Range(position, position) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -299,7 +300,7 @@ describe('InlineCompletionItemProvider', () => {
 
             const { document, position } = documentAndPosition('const a = [1, █)(123);', 'typescript')
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: '2];', range: new vsCodeMocks.Range(position, position) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -323,7 +324,7 @@ describe('InlineCompletionItemProvider', () => {
                 'typescript'
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: "('hello world!')", range: new vsCodeMocks.Range(1, 12, 1, 13) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -360,7 +361,7 @@ describe('InlineCompletionItemProvider', () => {
                 'typescript'
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: "('hello world!')", range: new vsCodeMocks.Range(1, 12, 1, 13) }],
                 source: InlineCompletionsResultSource.Network,
             })
@@ -427,7 +428,7 @@ describe('InlineCompletionItemProvider', () => {
                 'typescript'
             )
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
-                logId: '1',
+                logId: '1' as SuggestionID,
                 items: [{ insertText: 'dir', range: new vsCodeMocks.Range(position, position) }],
                 source: InlineCompletionsResultSource.Network,
             })

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -602,6 +602,7 @@ function completionMatchesSuffix(completions: vscode.InlineCompletionItem[], doc
         }
         const insertion = completion.insertText
         let j = 0
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
         for (let i = 0; i < insertion.length; i++) {
             if (insertion[i] === suffix[j]) {
                 j++

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import { telemetryService } from '../services/telemetry'
+
+import { getCurrentDocContext } from './get-current-doc-context'
+import { InlineCompletionsResultSource, TriggerKind } from './get-inline-completions'
+import * as CompletionLogger from './logger'
+import { RequestParams } from './request-manager'
+import { documentAndPosition } from './test-helpers'
+
+const defaultArgs = {
+    multiline: false,
+    triggerKind: TriggerKind.Automatic,
+    providerIdentifier: 'bfl',
+    providerModel: 'blazing-fast-llm',
+    languageId: 'typescript',
+}
+
+const { document, position } = documentAndPosition('const foo = █')
+const defaultRequestParams: RequestParams = {
+    document,
+    position,
+    docContext: getCurrentDocContext({
+        document,
+        position,
+        maxPrefixLength: 100,
+        maxSuffixLength: 100,
+        enableExtendedTriggers: true,
+    }),
+    selectedCompletionInfo: undefined,
+}
+
+describe('logger', () => {
+    let logSpy: MockInstance
+    beforeEach(() => {
+        logSpy = vi.spyOn(telemetryService, 'log')
+    })
+    afterEach(() => {
+        CompletionLogger.reset_testOnly()
+    })
+
+    it('logs a suggestion life cycle', () => {
+        const item = { insertText: 'foo' }
+        const id = CompletionLogger.create(defaultArgs)
+
+        expect(id).toBeDefined()
+        expect(typeof id).toBe('string')
+
+        CompletionLogger.start(id)
+        CompletionLogger.networkRequestStarted(id, { duration: 0.1337 })
+        CompletionLogger.loaded(id, defaultRequestParams, [item])
+        CompletionLogger.suggested(id, InlineCompletionsResultSource.Network, item)
+        CompletionLogger.accept(id, item)
+
+        const shared = {
+            id: expect.any(String),
+            languageId: 'typescript',
+            lineCount: 1,
+            source: 'Network',
+            triggerKind: 'Automatic',
+            type: 'inline',
+
+            multiline: false,
+            multilineMode: null,
+            otherCompletionProviderEnabled: false,
+            providerIdentifier: 'bfl',
+            providerModel: 'blazing-fast-llm',
+            charCount: 3,
+            contextSummary: {
+                duration: 0.1337,
+            },
+            items: [
+                {
+                    charCount: 3,
+                    lineCount: 1,
+                    lineTruncatedCount: undefined,
+                    nodeTypes: undefined,
+                    parseErrorCount: undefined,
+                    truncatedWith: undefined,
+                },
+            ],
+        }
+
+        expect(logSpy).toHaveBeenCalledWith('CodyVSCodeExtension:completion:suggested', {
+            ...shared,
+            accepted: true,
+            completionsStartedSinceLastSuggestion: 1,
+            displayDuration: expect.any(Number),
+            read: true,
+            latency: expect.any(Number),
+        })
+
+        expect(logSpy).toHaveBeenCalledWith('CodyVSCodeExtension:completion:accepted', {
+            ...shared,
+            acceptedItem: {
+                charCount: 3,
+                lineCount: 1,
+                lineTruncatedCount: undefined,
+                nodeTypes: undefined,
+                parseErrorCount: undefined,
+                truncatedWith: undefined,
+            },
+        })
+    })
+
+    it.only('reuses the completion ID for the same completion', () => {
+        const item = { insertText: 'foo' }
+
+        const id1 = CompletionLogger.create(defaultArgs)
+        CompletionLogger.start(id1)
+        CompletionLogger.networkRequestStarted(id1, { duration: 0 })
+        CompletionLogger.loaded(id1, defaultRequestParams, [item])
+        CompletionLogger.suggested(id1, InlineCompletionsResultSource.Network, item)
+
+        const loggerItem = CompletionLogger.getCompletionEvent(id1)
+        const completionId = loggerItem?.params.id
+        expect(completionId).toBeDefined()
+
+        const id2 = CompletionLogger.create(defaultArgs)
+        CompletionLogger.start(id2)
+        CompletionLogger.networkRequestStarted(id2, { duration: 0 })
+        CompletionLogger.loaded(id2, defaultRequestParams, [item])
+        CompletionLogger.suggested(id2, InlineCompletionsResultSource.Cache, item)
+        CompletionLogger.accept(id2, item)
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'CodyVSCodeExtension:completion:suggested',
+            expect.objectContaining({
+                id: loggerItem?.params.id,
+                source: 'Network',
+            })
+        )
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'CodyVSCodeExtension:completion:suggested',
+            expect.objectContaining({
+                id: loggerItem?.params.id,
+                source: 'Cache',
+            })
+        )
+        expect(logSpy).toHaveBeenCalledWith(
+            'CodyVSCodeExtension:completion:suggested',
+            expect.objectContaining({
+                id: loggerItem?.params.id,
+            })
+        )
+
+        // After accepting the completion, the ID won't be reused a third time
+        const id3 = CompletionLogger.create(defaultArgs)
+        CompletionLogger.start(id3)
+        CompletionLogger.networkRequestStarted(id3, { duration: 0 })
+        CompletionLogger.loaded(id3, defaultRequestParams, [item])
+        CompletionLogger.suggested(id3, InlineCompletionsResultSource.Cache, item)
+
+        const loggerItem3 = CompletionLogger.getCompletionEvent(id3)
+        expect(loggerItem3?.params.id).not.toBe(completionId)
+    })
+})

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -121,7 +121,7 @@ describe('logger', () => {
         CompletionLogger.accept(id2, item)
 
         const loggerItem2 = CompletionLogger.getCompletionEvent(id2)
-        expect(loggerItem2?.params.id).not.toBe(completionId)
+        expect(loggerItem2?.params.id).toBe(completionId)
 
         expect(logSpy).toHaveBeenCalledWith(
             'CodyVSCodeExtension:completion:suggested',

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -42,8 +42,6 @@ describe('logger', () => {
     it('logs a suggestion life cycle', () => {
         const item = { insertText: 'foo' }
         const id = CompletionLogger.create(defaultArgs)
-
-        expect(id).toBeDefined()
         expect(typeof id).toBe('string')
 
         CompletionLogger.start(id)

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -59,7 +59,6 @@ describe('logger', () => {
             source: 'Network',
             triggerKind: 'Automatic',
             type: 'inline',
-
             multiline: false,
             multilineMode: null,
             otherCompletionProviderEnabled: false,
@@ -103,7 +102,7 @@ describe('logger', () => {
         })
     })
 
-    it.only('reuses the completion ID for the same completion', () => {
+    it('reuses the completion ID for the same completion', () => {
         const item = { insertText: 'foo' }
 
         const id1 = CompletionLogger.create(defaultArgs)
@@ -122,6 +121,9 @@ describe('logger', () => {
         CompletionLogger.loaded(id2, defaultRequestParams, [item])
         CompletionLogger.suggested(id2, InlineCompletionsResultSource.Cache, item)
         CompletionLogger.accept(id2, item)
+
+        const loggerItem2 = CompletionLogger.getCompletionEvent(id2)
+        expect(loggerItem2?.params.id).not.toBe(completionId)
 
         expect(logSpy).toHaveBeenCalledWith(
             'CodyVSCodeExtension:completion:suggested',

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -10,13 +10,25 @@ import { telemetryService } from '../services/telemetry'
 
 import { ContextSummary } from './context/context'
 import { InlineCompletionsResultSource, TriggerKind } from './get-inline-completions'
+import { RequestParams } from './request-manager'
 import * as statistics from './statistics'
 import { InlineCompletionItemWithAnalytics } from './text-processing/process-inline-completions'
 import { lines } from './text-processing/utils'
 import { InlineCompletionItem } from './types'
 
+// A completion ID is a unique identifier for a specific completion text displayed at a specific
+// point in the document. A single completion can be suggested multiple times.
+type CompletionID = string & { _opaque: typeof CompletionID }
+declare const CompletionID: unique symbol
+
+// A suggestion DI is a unique identifier for a suggestion lifecycle.
+export type SuggestionID = string & { _opaque: typeof SuggestionID }
+declare const SuggestionID: unique symbol
+
 export interface CompletionEvent {
+    id: SuggestionID
     params: {
+        id: CompletionID | null
         type: 'inline'
         multiline: boolean
         multilineMode: null | 'block'
@@ -26,7 +38,6 @@ export interface CompletionEvent {
         languageId: string
         contextSummary?: ContextSummary
         source?: InlineCompletionsResultSource
-        id: string
         lineCount?: number
         charCount?: number
     }
@@ -81,8 +92,26 @@ interface CompletionItemInfo extends ItemPostProcessingInfo {
 
 const READ_TIMEOUT_MS = 750
 
-const displayedCompletions = new LRUCache<string, CompletionEvent>({
-    max: 100, // Maximum number of completions that we are keeping track of
+// Maintain a cache of active suggestion lifecycle
+const activeSuggestions = new LRUCache<SuggestionID, CompletionEvent>({
+    max: 20,
+})
+
+// Maintain a history of the last n displayed completions and their generated completion IDs. This
+// allows us to reuse the completion ID across multiple suggestions.
+const recentCompletions = new LRUCache<string, CompletionID>({
+    max: 20,
+})
+function getRecentCompletionsKey(params: RequestParams, completion: string): string {
+    return `${params.docContext.prefix}█${completion}█${params.docContext.nextNonEmptyLine}`
+}
+
+// On our analytics dashboards, we apply a distinct count on the completion ID to count unique
+// completions as suggested. Since we don't have want to maintain a list of all completion IDs in
+// the client, we instead retain the last few completion IDs that were marked as suggested to
+// prevent local over counting.
+const completionIdsMarkedAsSuggested = new LRUCache<CompletionID, true>({
+    max: 50,
 })
 
 let completionsStartedSinceLastSuggestion = 0
@@ -91,17 +120,18 @@ export function logCompletionEvent(name: string, params?: TelemetryEventProperti
     telemetryService.log(`CodyVSCodeExtension:completion:${name}`, params)
 }
 
-export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMode' | 'type' | 'id'>): string {
-    const id = uuid.v4()
+export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMode' | 'type' | 'id'>): SuggestionID {
+    const id = uuid.v4() as SuggestionID
     const params: CompletionEvent['params'] = {
         ...inputParams,
         type: 'inline',
         // @deprecated: We only keep the legacy name for backward compatibility in analytics
         multilineMode: inputParams.multiline ? 'block' : null,
-        id,
+        id: null,
     }
 
-    displayedCompletions.set(id, {
+    activeSuggestions.set(id, {
+        id,
         params,
         startedAt: performance.now(),
         networkRequestStartedAt: null,
@@ -117,27 +147,33 @@ export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMo
     return id
 }
 
-export function start(id: string): void {
-    const event = displayedCompletions.get(id)
+export function start(id: SuggestionID): void {
+    const event = activeSuggestions.get(id)
     if (event && !event.startLoggedAt) {
         event.startLoggedAt = performance.now()
         completionsStartedSinceLastSuggestion++
     }
 }
 
-export function networkRequestStarted(id: string, contextSummary: ContextSummary | undefined): void {
-    const event = displayedCompletions.get(id)
+export function networkRequestStarted(id: SuggestionID, contextSummary: ContextSummary | undefined): void {
+    const event = activeSuggestions.get(id)
     if (event && !event.networkRequestStartedAt) {
         event.networkRequestStartedAt = performance.now()
         event.params.contextSummary = contextSummary
     }
 }
 
-export function loaded(id: string, items: InlineCompletionItemWithAnalytics[]): void {
-    const event = displayedCompletions.get(id)
+export function loaded(id: SuggestionID, params: RequestParams, items: InlineCompletionItemWithAnalytics[]): void {
+    const event = activeSuggestions.get(id)
     if (!event) {
         return
     }
+
+    // Check if we already have a completion id for the loaded completion item
+    const key = items.length > 0 ? getRecentCompletionsKey(params, items[0].insertText) : ''
+    const completionId: CompletionID = recentCompletions.get(key) ?? (uuid.v4() as CompletionID)
+    recentCompletions.set(key, completionId)
+    event.params.id = completionId
 
     if (!event.loadedAt) {
         event.loadedAt = performance.now()
@@ -154,10 +190,19 @@ export function loaded(id: string, items: InlineCompletionItemWithAnalytics[]): 
 //
 // For statistics logging we start a timeout matching the READ_TIMEOUT_MS so we can increment the
 // suggested completion count as soon as we count it as such.
-export function suggested(id: string, source: InlineCompletionsResultSource, completion: InlineCompletionItem): void {
-    const event = displayedCompletions.get(id)
+export function suggested(
+    id: SuggestionID,
+    source: InlineCompletionsResultSource,
+    completion: InlineCompletionItem
+): void {
+    const event = activeSuggestions.get(id)
     if (!event) {
         return
+    }
+
+    const completionId = event.params.id
+    if (!completionId) {
+        throw new Error('Completion ID not set, make sure to call loaded() first')
     }
 
     if (!event.suggestedAt) {
@@ -168,23 +213,27 @@ export function suggested(id: string, source: InlineCompletionsResultSource, com
         event.suggestedAt = performance.now()
 
         setTimeout(() => {
-            const event = displayedCompletions.get(id)
+            const event = activeSuggestions.get(id)
             if (!event) {
                 return
             }
 
+            // We can assume that this completion will be marked as `read: true` because
+            // READ_TIMEOUT_MS has passed without the completion being logged yet.
             if (event.suggestedAt && !event.suggestionAnalyticsLoggedAt && !event.suggestionLoggedAt) {
-                // We can assume that this completion will be marked as `read: true` because
-                // READ_TIMEOUT_MS has passed without the completion being logged yet.
+                if (completionIdsMarkedAsSuggested.has(completionId)) {
+                    return
+                }
                 statistics.logSuggested()
+                completionIdsMarkedAsSuggested.set(completionId, true)
                 event.suggestionAnalyticsLoggedAt = performance.now()
             }
         }, READ_TIMEOUT_MS)
     }
 }
 
-export function accept(id: string, completion: InlineCompletionItem): void {
-    const completionEvent = displayedCompletions.get(id)
+export function accept(id: SuggestionID, completion: InlineCompletionItem): void {
+    const completionEvent = activeSuggestions.get(id)
     if (!completionEvent || completionEvent.acceptedAt) {
         // Log a debug event, this case should not happen in production
         logCompletionEvent('acceptedUntrackedCompletion')
@@ -216,6 +265,23 @@ export function accept(id: string, completion: InlineCompletionItem): void {
         logCompletionEvent('unexpectedAlreadySuggested')
     }
 
+    if (!completionEvent.params.id) {
+        throw new Error('Completion ID not set, make sure to call loaded() first')
+    }
+
+    // Ensure the CompletionID is never reused by removing it from the recent completions cache
+    let key: string | null = null
+    // eslint-disable-next-line ban/ban
+    recentCompletions.forEach((v, k) => {
+        if (v === completionEvent.params.id) {
+            key = k
+        }
+    })
+
+    if (key) {
+        recentCompletions.delete(key)
+    }
+
     completionEvent.acceptedAt = performance.now()
 
     logSuggestionEvents()
@@ -226,8 +292,8 @@ export function accept(id: string, completion: InlineCompletionItem): void {
     statistics.logAccepted()
 }
 
-export function partiallyAccept(id: string, completion: InlineCompletionItem, acceptedLength: number): void {
-    const completionEvent = displayedCompletions.get(id)
+export function partiallyAccept(id: SuggestionID, completion: InlineCompletionItem, acceptedLength: number): void {
+    const completionEvent = activeSuggestions.get(id)
     // Only log partial acceptances if the completion was not yet fully accepted
     if (!completionEvent || completionEvent.acceptedAt) {
         return
@@ -240,12 +306,12 @@ export function partiallyAccept(id: string, completion: InlineCompletionItem, ac
     })
 }
 
-export function getCompletionEvent(id: string): CompletionEvent | undefined {
-    return displayedCompletions.get(id)
+export function getCompletionEvent(id: SuggestionID): CompletionEvent | undefined {
+    return activeSuggestions.get(id)
 }
 
-export function noResponse(id: string): void {
-    const completionEvent = displayedCompletions.get(id)
+export function noResponse(id: SuggestionID): void {
+    const completionEvent = activeSuggestions.get(id)
     logCompletionEvent('noResponse', completionEvent?.params ?? {})
 }
 
@@ -253,15 +319,16 @@ export function noResponse(id: string): void {
  * This callback should be triggered whenever VS Code tries to highlight a new completion and it's
  * used to measure how long previous completions were visible.
  */
-export function clear(): void {
+export function flushActiveSuggestions(): void {
     logSuggestionEvents()
 }
 
 function logSuggestionEvents(): void {
     const now = performance.now()
     // eslint-disable-next-line ban/ban
-    displayedCompletions.forEach(completionEvent => {
+    activeSuggestions.forEach(completionEvent => {
         const {
+            params,
             loadedAt,
             suggestedAt,
             suggestionLoggedAt,
@@ -273,7 +340,7 @@ function logSuggestionEvents(): void {
 
         // Only log suggestion events that were already shown to the user and
         // have not been logged yet.
-        if (!loadedAt || !startLoggedAt || !suggestedAt || suggestionLoggedAt) {
+        if (!loadedAt || !startLoggedAt || !suggestedAt || suggestionLoggedAt || !params.id) {
             return
         }
         completionEvent.suggestionLoggedAt = now
@@ -286,8 +353,9 @@ function logSuggestionEvents(): void {
 
         if (!suggestionAnalyticsLoggedAt) {
             completionEvent.suggestionAnalyticsLoggedAt = now
-            if (read) {
+            if (read && !completionIdsMarkedAsSuggested.has(params.id)) {
                 statistics.logSuggested()
+                completionIdsMarkedAsSuggested.set(params.id, true)
             }
         }
 
@@ -306,6 +374,14 @@ function logSuggestionEvents(): void {
     // Completions are kept in the LRU cache for longer. This is because they
     // can still become visible if e.g. they are served from the cache and we
     // need to retain the ability to mark them as seen
+}
+
+// Restores the logger's internals to a pristine state§
+export function reset_testOnly(): void {
+    activeSuggestions.clear()
+    completionIdsMarkedAsSuggested.clear()
+    recentCompletions.clear()
+    completionsStartedSinceLastSuggestion = 0
 }
 
 function lineAndCharCount({ insertText }: InlineCompletionItem): { lineCount: number; charCount: number } {

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 
 import { DocumentContext } from './get-current-doc-context'
 import { InlineCompletionsResultSource, LastInlineCompletionCandidate } from './get-inline-completions'
-import { logCompletionEvent } from './logger'
+import { logCompletionEvent, SuggestionID } from './logger'
 import { CompletionProviderTracer, Provider } from './providers/provider'
 import { reuseLastCandidate } from './reuse-last-candidate'
 import {
@@ -101,9 +101,10 @@ export class RequestManager {
         return request.promise
     }
 
-    // Remove unwanted suggestions from the cache
-    public removeUnwanted(params: RequestParams): void {
+    public removeFromCache(params: RequestParams): void {
+        console.log(this.cache)
         this.cache.delete(params)
+        console.log(this.cache)
     }
 
     /**
@@ -121,7 +122,7 @@ export class RequestManager {
             lastTriggerDocContext: docContext,
             lastTriggerSelectedInfoItem: selectedCompletionInfo?.text,
             result: {
-                logId: '',
+                logId: '' as SuggestionID,
                 source: InlineCompletionsResultSource.Network,
                 items,
             },


### PR DESCRIPTION
This PR will add a new book keeping for completion IDs. These are different from the existing suggestion IDs in that:

- Suggestion IDs are used for one suggestion life cycle: One time a completion is rendered on the screen
- Completion IDs are used to identify a specific completion that is printed in a specific document location

The new change makes it so that we will log multiple completions events with the same id. This will help us identify how useful the current cache behavior is.

## Test plan

https://github.com/sourcegraph/cody/assets/458591/5e6604f8-e4a3-4b38-ab5c-16776677d265



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
