### PR TITLE
Agent: don't default provider to anthropic so detection logic can run

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -116,7 +116,7 @@ const configuration: vscode.WorkspaceConfiguration = {
             case 'cody.autocomplete.enabled':
                 return true
             case 'cody.autocomplete.advanced.provider':
-                return connectionConfig?.autocompleteAdvancedProvider ?? 'anthropic'
+                return connectionConfig?.autocompleteAdvancedProvider ?? null
             case 'cody.autocomplete.advanced.serverEndpoint':
                 return connectionConfig?.autocompleteAdvancedServerEndpoint ?? null
             case 'cody.autocomplete.advanced.model':


### PR DESCRIPTION
The VS Code extension now has logic that checks the connected instance's configuration to determine which autocomplete provider should be used.  Removing the default to allow this logic to run.
## Test plan
`sg start` instance configured with azure-openai
`./gradlew -PforceAgentBuild=true :runIDE`
`connect Cody to local instance`
verifed autocomplete works and is served by azure

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
