### PR TITLE
Agent: replace console.info with debug logs

### DIFF
--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -319,8 +319,10 @@ async function getCodebaseContext(
     // Find an embeddings client
     const embeddingsSearch = await EmbeddingsDetector.newEmbeddingsSearchClient(embeddingsClientCandidates, codebase)
     if (isError(embeddingsSearch)) {
-        const infoMessage = `Cody could not find embeddings for '${codebase}' on your Sourcegraph instance.\n`
-        console.info(infoMessage)
+        logDebug(
+            'ContextProvider:getCodebaseContext',
+            `Cody could not find embeddings for '${codebase}' on your Sourcegraph instance`
+        )
         return null
     }
 

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -14,7 +14,7 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { CodeCompletionsClient, createClient as createCodeCompletionsClint } from './completions/client'
 import { PlatformContext } from './extension.common'
-import { logger } from './log'
+import { logDebug, logger } from './log'
 import { getRerankWithLog } from './logged-rerank'
 
 interface ExternalServices {
@@ -61,10 +61,11 @@ export async function configureExternalServices(
 
     const repoId = initialConfig.codebase ? await client.getRepoId(initialConfig.codebase) : null
     if (isError(repoId)) {
-        const infoMessage =
+        logDebug(
+            'external-services:configureExternalServices',
             `Cody could not find the '${initialConfig.codebase}' repository on your Sourcegraph instance.\n` +
-            'Please check that the repository exists. You can override the repository with the "cody.codebase" setting.'
-        console.info(infoMessage)
+                'Please check that the repository exists. You can override the repository with the "cody.codebase" setting.'
+        )
     }
     const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
 


### PR DESCRIPTION
The console.info messages with \n were causing an error 
```
java.lang.IllegalStateException: Missing header Content-Length in input
```
replaced with the debug logger 
## Test plan
`./gradlew -PforceAgentBuild=true :runIDE`
Open a repo that does not have embeddings
ensure no error occurs.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
