### PR TITLE
Increase simplified onboarding experiment rollout to 100%

### DIFF
--- a/vscode/src/services/OnboardingExperiment.ts
+++ b/vscode/src/services/OnboardingExperiment.ts
@@ -9,7 +9,7 @@ import { localStorage } from './LocalStorageProvider'
 
 // The fraction of users to allocate to the simplified onboarding treatment.
 // This should be between 0 (no users) and 1 (all users).
-const SIMPLIFIED_ARM_ALLOCATION = 0.5
+const SIMPLIFIED_ARM_ALLOCATION = 1
 
 const ONBOARDING_EXPERIMENT_STORAGE_KEY = 'experiment.onboarding'
 


### PR DESCRIPTION
There are still users in the control arm of the experiment. This does not remove the control arm, it just changes the rollout to direct all new users into the treatment arm of the experiment.

## Test plan

This has already shipped to half of users, this just increases the rollout.