### PR TITLE
Agent: make chat client respect NODE_TLS_REJECT_UNAUTHORIZED

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -29,7 +29,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     ...this.config.customHeaders,
                 },
                 // So we can send requests to the Sourcegraph local development instance, which has an incompatible cert.
-                rejectUnauthorized: !this.config.debugEnable,
+                rejectUnauthorized: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0' && !this.config.debugEnable,
             },
             (res: http.IncomingMessage) => {
                 if (res.statusCode === undefined) {


### PR DESCRIPTION
The JetBrains extension has a setting to allow untrusted certs, however requests to the chat client set this option directly on the request.  This adds a check of the environment variable set by the extension if it wishes to accept untrusted certs.

## Test plan
`sg start`
`./gradlew -PforceAgentBuild=true :runIDE`
connect to the local instance `https://sourcegraph.test:3443`
verify I can chat successfully



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
