### PR TITLE
update expectedEvents in E2E tests

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -25,7 +25,12 @@ import { GuardrailsProvider } from './services/GuardrailsProvider'
 import { Comment, InlineController } from './services/InlineController'
 import { LocalAppSetupPublisher } from './services/LocalAppSetupPublisher'
 import { localStorage } from './services/LocalStorageProvider'
-import { CODY_ACCESS_TOKEN_SECRET, getAccessToken, secretStorage, VSCodeSecretStorage } from './services/SecretStorageProvider'
+import {
+    CODY_ACCESS_TOKEN_SECRET,
+    getAccessToken,
+    secretStorage,
+    VSCodeSecretStorage,
+} from './services/SecretStorageProvider'
 import { createStatusBar } from './services/StatusBar'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { TestSupport } from './test-support'
@@ -450,7 +455,7 @@ const register = async (
             if (config.isRunningInsideAgent) {
                 throw new Error(
                     'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
-                    'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
+                        'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
                 )
             }
             return

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -1,11 +1,10 @@
 import { expect } from '@playwright/test'
 
-import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
+import { resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarSignin } from './common'
 import { test } from './helpers'
 
-const expectedOrderedEvents = ['CodyVSCodeExtension:chat:submitted']
 test.beforeEach(() => {
     resetLoggedEvents()
 })
@@ -21,5 +20,4 @@ test('open the Custom Commands in sidebar and add new user recipe', async ({ pag
     await page.locator('a').filter({ hasText: 'New Custom Command...' }).click()
     await page.keyboard.type(recipeName)
     await page.keyboard.press('Enter')
-    await expect.poll(() => loggedEvents).toEqual(expectedOrderedEvents)
 })

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -8,7 +8,7 @@ import { test } from './helpers'
 const DECORATION_SELECTOR = 'div.view-overlays[role="presentation"] div[class*="TextEditorDecorationType"]'
 
 const expectedOrderedEvents = [
-    'CodyVSCodeExtension:fixup:created',
+    'CodyVSCodeExtension:command:edit:executed',
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',

--- a/vscode/test/e2e/inline-assist.test.ts
+++ b/vscode/test/e2e/inline-assist.test.ts
@@ -6,7 +6,7 @@ import { sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
 const expectedOrderedEvents = [
-    'CodyVSCodeExtension:fixup:created',
+    'CodyVSCodeExtension:command:edit:executed',
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -6,7 +6,7 @@ import { sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
 const expectedOrderedEvents = [
-    'CodyVSCodeExtension:fixup:created',
+    'CodyVSCodeExtension:command:edit:executed',
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',


### PR DESCRIPTION
Update expectedEvents within the E2E tests. There have been changes made to the events logged and the e2e tests need to be updated.

## Test plan
tested using `pnpm test:e2e`
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
