### PR TITLE
add doc behind feature flag

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,15 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Executed the `/doc` command now automatically adds the documentation directly above your selected code in your editor, instead of shown in chat. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
 - New `mode` field in the Custom Commands config file enables a command to be configured on how the prompt should be run by Cody. Currently supports `inline` (run command prompt in inline chat), `edit` (run command prompt on selected code for refactoring purpose), and `insert` (run command prompt on selected code where Cody's response will be inserted on top of the selected code) modes. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
 - Experimentally added `smart selection` which removes the need to manually highlight code before running the `/doc` and `/test` commands. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+
+### Fixed
+
+### Changed
+
+## [0.12.3]
+
+### Added
+
 - New "Save Code to File.." button on code blocks. [pull/1119](https://github.com/sourcegraph/cody/pull/1119)
 - Add situation-based latency for unwanted autocomplete suggestions. [pull/1202](https://github.com/sourcegraph/cody/pull/1202)
 - Add logging for partially accepting completions. [pull/1214](https://github.com/sourcegraph/cody/pull/1214)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,18 +8,6 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
-- Executed the `/doc` command now automatically adds the documentation directly above your selected code in your editor, instead of shown in chat. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
-- New `mode` field in the Custom Commands config file enables a command to be configured on how the prompt should be run by Cody. Currently supports `inline` (run command prompt in inline chat), `edit` (run command prompt on selected code for refactoring purpose), and `insert` (run command prompt on selected code where Cody's response will be inserted on top of the selected code) modes. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
-- Experimentally added `smart selection` which removes the need to manually highlight code before running the `/doc` and `/test` commands. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
-
-### Fixed
-
-### Changed
-
-## [0.12.3]
-
-### Added
-
 - New "Save Code to File.." button on code blocks. [pull/1119](https://github.com/sourcegraph/cody/pull/1119)
 - Add situation-based latency for unwanted autocomplete suggestions. [pull/1202](https://github.com/sourcegraph/cody/pull/1202)
 - Add logging for partially accepting completions. [pull/1214](https://github.com/sourcegraph/cody/pull/1214)

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -6,6 +6,8 @@ import { getCursorFoldingRange } from '../editor/utils'
 import { logDebug } from '../log'
 import { telemetryService } from '../services/telemetry'
 
+const release = false
+
 /**
  * CommandRunner class implements disposable interface.
  * Manages executing a Cody command and optional fixup.
@@ -58,7 +60,7 @@ export class CommandRunner implements vscode.Disposable {
         }
 
         // Run fixup if this is a edit command
-        const insertMode = command.mode === 'insert'
+        const insertMode = command.mode === 'insert' && release
         const fixupMode = command.mode === 'edit' || instruction?.startsWith('/edit ')
         this.isFixupRequest = isFixupRequest || fixupMode || insertMode
         if (this.isFixupRequest) {
@@ -139,8 +141,8 @@ export class CommandRunner implements vscode.Disposable {
                 range,
                 instruction,
                 document: doc,
-                auto: true,
-                insertMode,
+                auto: release,
+                insertMode: release,
             },
             source
         )

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -108,7 +108,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      */
     private async createCodyCommand(command: CodyPrompt, input = ''): Promise<string> {
         const commandKey = command.slashCommand
-        const defaultEditCommands = new Set(['/edit', '/fix', '/doc'])
+        const defaultEditCommands = new Set(['/edit', '/fix'])
         const isFixupRequest = defaultEditCommands.has(commandKey) || command.prompt.startsWith('/edit')
 
         logDebug('CommandsController:createCodyCommand:creating', commandKey)

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -19,6 +19,8 @@ import { InlineController } from '../services/InlineController'
 import { EditorCodeLenses } from './EditorCodeLenses'
 import { getCursorFoldingRange } from './utils'
 
+const release = false
+
 export class VSCodeEditor implements Editor<InlineController, FixupController, CommandsController> {
     constructor(
         public readonly controllers: ActiveTextEditorViewControllers<
@@ -134,6 +136,9 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
      * @returns The smart selection for the active editor, or null if none can be determined.
      */
     public async getActiveTextEditorSmartSelection(): Promise<ActiveTextEditorSelection | null> {
+        if (!release) {
+            return this.getActiveTextEditorSelection()
+        }
         const activeEditor = this.getActiveTextEditorInstance()
         if (!activeEditor) {
             return null


### PR DESCRIPTION
Put /doc behind a temporary flag (hard coded) until the next release. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try the /doc command, smart selection will not work and you will have to highlight code before running the /doc command