### PR TITLE
VS Code: Release 0.12.4

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,14 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.12.4]
+
+### Added
+
 - New "Save Code to File.." button on code blocks. [pull/1119](https://github.com/sourcegraph/cody/pull/1119)
 - Add logging for partially accepting completions. [pull/1214](https://github.com/sourcegraph/cody/pull/1214)
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Releasing 0.12.4 from `main` in preparation for the big release.

## Test plan

Version and change log change

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
