### PR TITLE
revert pull/1248

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,10 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Executed the `/doc` command now automatically adds the documentation directly above your selected code in your editor, instead of shown in chat. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+- New `mode` field in the Custom Commands config file enables a command to be configured on how the prompt should be run by Cody. Currently supports `inline` (run command prompt in inline chat), `edit` (run command prompt on selected code for refactoring purpose), and `insert` (run command prompt on selected code where Cody's response will be inserted on top of the selected code) modes. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+- Experimentally added `smart selection` which removes the need to manually highlight code before running the `/doc` and `/test` commands. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
+
 ### Fixed
 
 ### Changed

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -6,8 +6,6 @@ import { getCursorFoldingRange } from '../editor/utils'
 import { logDebug } from '../log'
 import { telemetryService } from '../services/telemetry'
 
-const release = false
-
 /**
  * CommandRunner class implements disposable interface.
  * Manages executing a Cody command and optional fixup.
@@ -60,7 +58,7 @@ export class CommandRunner implements vscode.Disposable {
         }
 
         // Run fixup if this is a edit command
-        const insertMode = command.mode === 'insert' && release
+        const insertMode = command.mode === 'insert'
         const fixupMode = command.mode === 'edit' || instruction?.startsWith('/edit ')
         this.isFixupRequest = isFixupRequest || fixupMode || insertMode
         if (this.isFixupRequest) {
@@ -141,8 +139,8 @@ export class CommandRunner implements vscode.Disposable {
                 range,
                 instruction,
                 document: doc,
-                auto: release,
-                insertMode: release,
+                auto: true,
+                insertMode,
             },
             source
         )

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -108,7 +108,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      */
     private async createCodyCommand(command: CodyPrompt, input = ''): Promise<string> {
         const commandKey = command.slashCommand
-        const defaultEditCommands = new Set(['/edit', '/fix'])
+        const defaultEditCommands = new Set(['/edit', '/fix', '/doc'])
         const isFixupRequest = defaultEditCommands.has(commandKey) || command.prompt.startsWith('/edit')
 
         logDebug('CommandsController:createCodyCommand:creating', commandKey)

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -19,8 +19,6 @@ import { InlineController } from '../services/InlineController'
 import { EditorCodeLenses } from './EditorCodeLenses'
 import { getCursorFoldingRange } from './utils'
 
-const release = false
-
 export class VSCodeEditor implements Editor<InlineController, FixupController, CommandsController> {
     constructor(
         public readonly controllers: ActiveTextEditorViewControllers<
@@ -136,9 +134,6 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
      * @returns The smart selection for the active editor, or null if none can be determined.
      */
     public async getActiveTextEditorSmartSelection(): Promise<ActiveTextEditorSelection | null> {
-        if (!release) {
-            return this.getActiveTextEditorSelection()
-        }
         const activeEditor = this.getActiveTextEditorInstance()
         if (!activeEditor) {
             return null


### PR DESCRIPTION
revert https://github.com/sourcegraph/cody/pull/1248 for next release

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

revert https://github.com/sourcegraph/cody/pull/1248