### PR TITLE
Fix unit tests on Windows + enable on bots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure everything is checked out using \n even on Windows, because some test
+# code and snapshots assume this.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu]
-        node: [16, 20]
+        runner: [ubuntu, windows, macos]
+        # Run on the most recently supported version of node for all bots.
+        node: [20]
+        include:
+          # Additionally, run the oldest supported version on Ubuntu. We don't
+          # need to run this on all platforms as we're only verifying we don't
+          # call any APIs not available in this version.
+          - runner: ubuntu
+            node: 16 # Supported by VS Code 1.81 (July 2023).
     runs-on: ${{ matrix.runner }}-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,6 +53,19 @@
       "preLaunchTask": "Build VS Code Extension (Web)",
       "outFiles": ["${workspaceFolder}/vscode/dist/**/*.js"],
       "args": ["--extensionDevelopmentPath=${workspaceRoot}/vscode", "--extensionDevelopmentKind=web"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Current File with vitest",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      // ${relativeFile} will guarantee the "current" file, but fileBaseNameNoExtension
+      // can be convenient because running with a file like "graph-section-observer.ts"
+      // (the implementation, not the test) will run the correct tests.
+      "args": ["run", "${fileBasenameNoExtension}"],
+      "smartStep": true
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,8 @@
   },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -31,7 +31,7 @@ describe('vscode-shim', () => {
         })
 
         it('with is available', () => {
-            assert.equal(vscode.Uri.file('a.txt').with({ path: 'b.txt' }).path, `${path.sep}b.txt`)
+            assert.equal(vscode.Uri.file('a.txt').with({ path: 'b.txt' }).path, '/b.txt')
         })
 
         it('instanceof can be used', () => {

--- a/vscode/src/completions/context/lsp-light-graph-cache.test.ts
+++ b/vscode/src/completions/context/lsp-light-graph-cache.test.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import { Position } from '../../testutils/mocks'
-import { range } from '../../testutils/textDocument'
+import { range, withPosixPaths } from '../../testutils/textDocument'
 import { document } from '../test-helpers'
 
 import { LspLightGraphCache } from './lsp-light-graph-cache'
@@ -128,7 +128,7 @@ describe('LSPLightGraphCache', () => {
 
         getGraphContextFromRange.mockClear()
 
-        expect(await cache.getContextAtPosition(testDocuments.document1, new Position(1, 0), 100))
+        expect(withPosixPaths(await cache.getContextAtPosition(testDocuments.document1, new Position(1, 0), 100)))
             .toMatchInlineSnapshot(`
           [
             {
@@ -168,7 +168,7 @@ describe('LSPLightGraphCache', () => {
             contentChanges: [],
         })
 
-        expect(await cache.getContextAtPosition(testDocuments.document1, new Position(1, 0), 100))
+        expect(withPosixPaths(await cache.getContextAtPosition(testDocuments.document1, new Position(1, 0), 100)))
             .toMatchInlineSnapshot(`
           [
             {

--- a/vscode/src/completions/context/section-observer.test.ts
+++ b/vscode/src/completions/context/section-observer.test.ts
@@ -221,7 +221,7 @@ describe('GraphSectionObserver', () => {
 
             expect(context[0]).toEqual({
                 content: 'foo\nbar\nfoo',
-                fileName: '/document2.ts',
+                fileName: document2Uri.fsPath,
             })
         })
 

--- a/vscode/src/completions/context/section-observer.ts
+++ b/vscode/src/completions/context/section-observer.ts
@@ -144,12 +144,15 @@ export class SectionObserver implements vscode.Disposable {
     }
 
     /**
-     * A pretty way to print th e current state of all cached sections
+     * A pretty way to print the current state of all cached sections
+     *
+     * Printed paths are always in posix format (forwards slashes) even on windows
+     * for consistency.
      */
     public debugPrint(selectedDocument?: vscode.TextDocument, selections?: readonly vscode.Selection[]): string {
         const lines: string[] = []
         this.activeDocuments.forEach(document => {
-            lines.push(path.normalize(vscode.workspace.asRelativePath(document.uri)))
+            lines.push(path.posix.normalize(vscode.workspace.asRelativePath(document.uri)))
             for (const section of document.sections) {
                 const isSelected =
                     selectedDocument?.uri.toString() === document.uri.toString() &&
@@ -169,12 +172,9 @@ export class SectionObserver implements vscode.Disposable {
             for (let i = 0; i < lastSections.length; i++) {
                 const section = lastSections[i]
                 const isLast = i === lastSections.length - 1
+                const filePath = path.posix.normalize(vscode.workspace.asRelativePath(section.location.uri))
 
-                lines.push(
-                    `  ${isLast ? '└' : '├'} ${path.normalize(vscode.workspace.asRelativePath(section.location.uri))} ${
-                        section.fuzzyName ?? 'unknown'
-                    }`
-                )
+                lines.push(`  ${isLast ? '└' : '├'} ${filePath} ${section.fuzzyName ?? 'unknown'}`)
             }
         }
 

--- a/vscode/src/graph/lsp/graph.test.ts
+++ b/vscode/src/graph/lsp/graph.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'vitest'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
+import { testFilePath } from '../../testutils/textDocument'
+
 import {
     extractDefinitionContexts,
     extractRelevantDocumentSymbolRanges,
@@ -9,6 +11,7 @@ import {
     gatherDefinitions,
 } from './graph'
 
+const testFile1Uri = URI.file(testFilePath('test-1.test'))
 const testFile1 = `
 import fmt
 
@@ -31,6 +34,7 @@ class bar {
 // end of file
 `
 
+const testFile2Uri = URI.file(testFilePath('test-2.test'))
 const testFile2 = `
 import foo
 import bar
@@ -41,6 +45,7 @@ const bazbar = new bar()
 // end of file
 `
 
+const testFile3Uri = URI.file(testFilePath('test-3.test'))
 const testFile3 = `
 import foo
 import bar
@@ -56,7 +61,7 @@ func bonk() => { return new bar().Bar(new foo().Foo(), baz.Foo()) }
 
 describe('extractRelevantDocumentSymbolRanges', () => {
     test('returns all document symbol ranges by default', async () => {
-        const uri = URI.file('/test-1.test')
+        const uri = testFile1Uri
         const ranges = await extractRelevantDocumentSymbolRanges([{ uri }], () =>
             Promise.resolve([
                 new vscode.Range(2, 0, 8, 1), // foo
@@ -71,7 +76,7 @@ describe('extractRelevantDocumentSymbolRanges', () => {
     })
 
     test('returns partial document symbol ranges with selection range', async () => {
-        const uri = URI.file('/test-1.test')
+        const uri = testFile1Uri
         const ranges = await extractRelevantDocumentSymbolRanges([{ uri, range: new vscode.Range(4, 3, 5, 5) }], () =>
             Promise.resolve([
                 new vscode.Range(2, 0, 8, 1), // foo
@@ -87,7 +92,7 @@ describe('extractRelevantDocumentSymbolRanges', () => {
 
 describe('gatherDefinitions', () => {
     test('returns definitions referencing multiple files', async () => {
-        const uri = URI.parse('/test-3.test')
+        const uri = testFile3Uri
         const selections = [
             {
                 uri,
@@ -104,19 +109,19 @@ describe('gatherDefinitions', () => {
         const getDefinitions = async (uri: URI, position: vscode.Position): Promise<vscode.Location[]> => {
             switch (position.character) {
                 case 6:
-                    return [{ uri: URI.file('/test-3.test'), range: new vscode.Range(7, 5, 7, 7) }]
+                    return [{ uri: testFile3Uri, range: new vscode.Range(7, 5, 7, 7) }]
                 case 29: // bar
-                    return [{ uri: URI.file('/test-1.test'), range: new vscode.Range(10, 6, 10, 9) }]
+                    return [{ uri: testFile1Uri, range: new vscode.Range(10, 6, 10, 9) }]
                 case 35: // Bar
-                    return [{ uri: URI.file('/test-1.test'), range: new vscode.Range(11, 6, 11, 9) }]
+                    return [{ uri: testFile1Uri, range: new vscode.Range(11, 6, 11, 9) }]
                 case 43: // foo
-                    return [{ uri: URI.file('/test-1.test'), range: new vscode.Range(2, 6, 2, 9) }]
+                    return [{ uri: testFile1Uri, range: new vscode.Range(2, 6, 2, 9) }]
                 case 49: // Foo
-                    return [{ uri: URI.file('/test-1.test'), range: new vscode.Range(3, 6, 3, 9) }]
+                    return [{ uri: testFile1Uri, range: new vscode.Range(3, 6, 3, 9) }]
                 case 56: // baz
-                    return [{ uri: URI.file('/test-2.test'), range: new vscode.Range(3, 6, 3, 8) }]
+                    return [{ uri: testFile2Uri, range: new vscode.Range(3, 6, 3, 8) }]
                 case 60: // Foo
-                    return [{ uri: URI.file('/test-1.test'), range: new vscode.Range(3, 6, 3, 9) }]
+                    return [{ uri: testFile1Uri, range: new vscode.Range(3, 6, 3, 9) }]
             }
 
             return []
@@ -149,50 +154,40 @@ describe('gatherDefinitions', () => {
             // { symbolName: 'here', locations: [] },
 
             // Definitions within input selection are pruned
-            // { symbolName: 'bonk', locations: [{ uri: URI.file('/test-3.test'), range: new vscode.Range(7, 5, 7, 7) }] },
+            // { symbolName: 'bonk', locations: [{ uri: testFile3Uri, range: new vscode.Range(7, 5, 7, 7) }] },
 
             {
                 symbolName: 'bar',
                 hover: [],
-                definitionLocations: [
-                    { uri: URI.file('/test-1.test').toString(), range: new vscode.Range(10, 6, 10, 9) },
-                ],
+                definitionLocations: [{ uri: testFile1Uri.toString(), range: new vscode.Range(10, 6, 10, 9) }],
                 typeDefinitionLocations: [],
                 implementationLocations: [],
             },
             {
                 symbolName: 'Bar',
                 hover: [],
-                definitionLocations: [
-                    { uri: URI.file('/test-1.test').toString(), range: new vscode.Range(11, 6, 11, 9) },
-                ],
+                definitionLocations: [{ uri: testFile1Uri.toString(), range: new vscode.Range(11, 6, 11, 9) }],
                 typeDefinitionLocations: [],
                 implementationLocations: [],
             },
             {
                 symbolName: 'foo',
                 hover: [],
-                definitionLocations: [
-                    { uri: URI.file('/test-1.test').toString(), range: new vscode.Range(2, 6, 2, 9) },
-                ],
+                definitionLocations: [{ uri: testFile1Uri.toString(), range: new vscode.Range(2, 6, 2, 9) }],
                 typeDefinitionLocations: [],
                 implementationLocations: [],
             },
             {
                 symbolName: 'Foo',
                 hover: [],
-                definitionLocations: [
-                    { uri: URI.file('/test-1.test').toString(), range: new vscode.Range(3, 6, 3, 9) },
-                ],
+                definitionLocations: [{ uri: testFile1Uri.toString(), range: new vscode.Range(3, 6, 3, 9) }],
                 typeDefinitionLocations: [],
                 implementationLocations: [],
             },
             {
                 symbolName: 'baz',
                 hover: [],
-                definitionLocations: [
-                    { uri: URI.file('/test-2.test').toString(), range: new vscode.Range(3, 6, 3, 8) },
-                ],
+                definitionLocations: [{ uri: testFile2Uri.toString(), range: new vscode.Range(3, 6, 3, 8) }],
                 typeDefinitionLocations: [],
                 implementationLocations: [],
             },
@@ -201,7 +196,7 @@ describe('gatherDefinitions', () => {
             // {
             //     symbolName: 'Foo',
             //     hover: [],
-            //     locations: [{ uri: URI.file('/test-1.test'), range: new vscode.Range(3, 6, 3, 9) }],
+            //     locations: [{ uri: testFile1Uri, range: new vscode.Range(3, 6, 3, 9) }],
             // },
         ])
     })
@@ -214,43 +209,43 @@ describe('extractDefinitionContexts', () => {
                 {
                     symbolName: 'foo',
                     hover: [],
-                    location: { uri: URI.file('/test-1.test'), range: new vscode.Range(2, 6, 2, 9) },
+                    location: { uri: testFile1Uri, range: new vscode.Range(2, 6, 2, 9) },
                 },
                 {
                     symbolName: 'bar',
                     hover: [],
-                    location: { uri: URI.file('/test-1.test'), range: new vscode.Range(10, 6, 10, 9) },
+                    location: { uri: testFile1Uri, range: new vscode.Range(10, 6, 10, 9) },
                 },
                 {
                     symbolName: 'baz',
                     hover: [],
-                    location: { uri: URI.file('/test-2.test'), range: new vscode.Range(3, 6, 3, 8) },
+                    location: { uri: testFile2Uri, range: new vscode.Range(3, 6, 3, 8) },
                 },
                 {
                     symbolName: 'bonk',
                     hover: [],
-                    location: { uri: URI.file('/test-3.test'), range: new vscode.Range(7, 5, 7, 7) },
+                    location: { uri: testFile3Uri, range: new vscode.Range(7, 5, 7, 7) },
                 },
             ],
             new Map<string, string[]>([
-                ['/test-1.test', testFile1.split('\n').slice(1)], // foo, bar
-                ['/test-2.test', testFile2.split('\n').slice(1)], // baz
-                ['/test-3.test', testFile3.split('\n').slice(1)], // bonk
+                [testFile1Uri.fsPath, testFile1.split('\n').slice(1)], // foo, bar
+                [testFile2Uri.fsPath, testFile2.split('\n').slice(1)], // baz
+                [testFile3Uri.fsPath, testFile3.split('\n').slice(1)], // bonk
             ]),
             (uri: URI): Promise<vscode.Range[]> => {
                 switch (uri.fsPath) {
-                    case '/test-1.test':
+                    case testFile1Uri.fsPath:
                         return Promise.resolve([
                             new vscode.Range(2, 0, 8, 1), // foo
                             new vscode.Range(10, 0, 16, 1), // bar
                         ])
 
-                    case '/test-2.test':
+                    case testFile2Uri.fsPath:
                         return Promise.resolve([
                             new vscode.Range(3, 0, 3, 20), // baz
                         ])
 
-                    case '/test-3.test':
+                    case testFile3Uri.fsPath:
                         return Promise.resolve([
                             new vscode.Range(4, 0, 7, 67), // bonk
                         ])
@@ -263,7 +258,7 @@ describe('extractDefinitionContexts', () => {
         expect(contexts).toEqual([
             {
                 symbol: { fuzzyName: 'foo' },
-                filePath: '/test-1.test',
+                filePath: testFile1Uri.fsPath,
                 hoverText: [],
                 definitionSnippet:
                     'class foo {\n\tfunc Foo() {\n\t\tconst a = 3\n\t\tconst b = 4\n\t\treturn a + b\n\t}\n}',
@@ -271,7 +266,7 @@ describe('extractDefinitionContexts', () => {
             },
             {
                 symbol: { fuzzyName: 'bar' },
-                filePath: '/test-1.test',
+                filePath: testFile1Uri.fsPath,
                 hoverText: [],
                 definitionSnippet:
                     'class bar {\n\tfunc Bar(x, y) {\n\t\tconst a = 3\n\t\tconst b = 4\n\t\treturn (a * b) + (x * y)\n\t}\n}',
@@ -279,14 +274,14 @@ describe('extractDefinitionContexts', () => {
             },
             {
                 symbol: { fuzzyName: 'baz' },
-                filePath: '/test-2.test',
+                filePath: testFile2Uri.fsPath,
                 hoverText: [],
                 definitionSnippet: 'const baz = new foo()',
                 range: { startLine: 3, startCharacter: 6, endLine: 3, endCharacter: 8 },
             },
             {
                 symbol: { fuzzyName: 'bonk' },
-                filePath: '/test-3.test',
+                filePath: testFile3Uri.fsPath,
                 hoverText: [],
                 definitionSnippet:
                     '/**\n * Some docstring here.\n */\nfunc bonk() => { return new bar().Bar(new foo().Foo(), baz.Foo()) }',

--- a/vscode/src/testutils/textDocument.ts
+++ b/vscode/src/testutils/textDocument.ts
@@ -1,3 +1,5 @@
+import * as path from 'path'
+
 import type { EndOfLine, Position, Range, TextLine, TextDocument as VSCodeTextDocument } from 'vscode'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
@@ -55,4 +57,38 @@ function createTextLine(text: string, range: Range): TextLine {
 
 export function range(startLine: number, startCharacter: number, endLine?: number, endCharacter?: number): Range {
     return new vsCodeMocks.Range(startLine, startCharacter, endLine || startLine, endCharacter || 0)
+}
+
+/**
+ * Builds a platform-aware absolute path for a filename.
+ *
+ * For POSIX platforms, returns `/file`, for windows returns
+ * 'C:\file'.
+ *
+ * @param name The name/relative path of the file. Always in POSIX format.
+ */
+export function testFilePath(name: string): string {
+    // `path === path.win32` does not appear to work, even though win32 says
+    // "Same as parent object on windows" ☹️
+    const filePath = path.sep === path.win32.sep ? `C:\\${name}` : `/${name}`
+
+    return path.normalize(filePath)
+}
+
+/**
+ * A helper to convert paths on objects to posix form so that test snapshots can always use
+ * forward slashes and work on Windows.
+ *
+ * @param obj the object (or array of objects) to fix paths on
+ * @returns obj
+ */
+export function withPosixPaths<T extends object>(obj: T): T {
+    if ('fileName' in obj && typeof obj.fileName === 'string') {
+        obj.fileName = obj.fileName.replaceAll('\\', '/')
+    } else if (Array.isArray(obj)) {
+        for (const objItem of obj) {
+            withPosixPaths(objItem)
+        }
+    }
+    return obj
 }


### PR DESCRIPTION
(Re-do of https://github.com/sourcegraph/cody/pull/1150 because all the bots won't run on forks)

I don't know how sound all of these changes are, but they fix the failing tests I have on Windows.

1. Use platform-correct paths (drive letters + backslashes on Windows) in tests and debug printing
  Previously lots of code assumed posix-style paths then had mismatches on windows because of slash direction
2. Replace fake Uri class with vscode-uri
  As part of doing (1), I found that `vscode.Uri` was missing. While adding it, I realised there was a mock `Uri` implementation (presumably to avoid importing `vscode` where it won't be available), however the `vscode-uri` package (which does not depend on VS Code) was also already imported, so I removed the fake `Uri` class and just used this. This required updating a bunch of places (`Uri` => `URI`) and I don't know if there are other implications of doing this, but I think it's better.
3. Add launch config to run current test file under debugger
  Makes it easy to debug tests (or run without debugging for the current file) without having to use the terminal
4. Use prettier when editing JSON files like `.vscode/settings.json` and `.vscode/launch.json` (these already seemed to be formatted using Prettier, but it wasn't set explicitly so the formatting gets messed up if you didn't have Prettier as default formatter)

## Test plan

Tested using `pnpm test:unit`.
