### PR TITLE
Autocomplete: add `stopReason` to completion events

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -1,0 +1,73 @@
+import { omit } from 'lodash'
+import * as uuid from 'uuid'
+import { describe, expect, it, vi } from 'vitest'
+
+import * as CompletionLogger from '../logger'
+import { initTreeSitterParser } from '../test-helpers'
+
+import { getInlineCompletions, params } from './helpers'
+
+describe('[getInlineCompletions] completion event', () => {
+    it('fills all the expected fields on `CompletionLogger.loaded` calls', async () => {
+        await initTreeSitterParser()
+        vi.spyOn(uuid, 'v4').mockImplementation(() => 'stable-uuid')
+        const spy = vi.spyOn(CompletionLogger, 'loaded')
+
+        await getInlineCompletions(
+            params('function foo() {█', [
+                {
+                    completion: 'console.log(bar)\nreturn false}',
+                    stopReason: 'unit-test',
+                },
+            ])
+        )
+
+        // Get `suggestionId` from `CompletionLogger.loaded` call.
+        const suggestionId: CompletionLogger.SuggestionID = spy.mock.calls[0][0]
+        const completionEvent = CompletionLogger.getCompletionEvent(suggestionId!)
+
+        const eventWithoutTimestamps = omit(completionEvent, [
+            'acceptedAt',
+            'loadedAt',
+            'networkRequestStartedAt',
+            'startLoggedAt',
+            'startedAt',
+            'suggestedAt',
+            'suggestionAnalyticsLoggedAt',
+            'suggestionLoggedAt',
+        ])
+
+        expect(eventWithoutTimestamps).toMatchInlineSnapshot(`
+          {
+            "id": "stable-uuid",
+            "items": [
+              {
+                "charCount": 30,
+                "lineCount": 2,
+                "lineTruncatedCount": 0,
+                "nodeTypes": {
+                  "atCursor": "{",
+                  "grandparent": "function_declaration",
+                  "greatGrandparent": "program",
+                  "parent": "statement_block",
+                },
+                "parseErrorCount": 0,
+                "stopReason": "unit-test",
+                "truncatedWith": "tree-sitter",
+              },
+            ],
+            "params": {
+              "contextSummary": undefined,
+              "id": "stable-uuid",
+              "languageId": "typescript",
+              "multiline": true,
+              "multilineMode": "block",
+              "providerIdentifier": "anthropic",
+              "providerModel": "claude-instant-infill",
+              "triggerKind": "Automatic",
+              "type": "inline",
+            },
+          }
+        `)
+    })
+})

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -107,7 +107,10 @@ export async function getInlineCompletions(
     const result = await _getInlineCompletions(...args)
     if (result) {
         const { logId: _discard, ...rest } = result
-        return rest
+        return {
+            ...rest,
+            items: result.items.map(({ stopReason: discard, ...item }) => item),
+        }
     }
     return result
 }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -88,6 +88,7 @@ export interface ItemPostProcessingInfo {
 interface CompletionItemInfo extends ItemPostProcessingInfo {
     lineCount: number
     charCount: number
+    stopReason?: string
 }
 
 const READ_TIMEOUT_MS = 750
@@ -442,6 +443,7 @@ function completionItemToItemInfo(item: InlineCompletionItemWithAnalytics): Comp
     return {
         lineCount,
         charCount,
+        stopReason: item.stopReason,
         parseErrorCount: item.parseErrorCount,
         lineTruncatedCount: item.lineTruncatedCount,
         truncatedWith: item.truncatedWith,

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -74,10 +74,7 @@ export class RequestManager {
             .then(res => res.flat())
             .then(completions =>
                 // Shared post-processing logic
-                processInlineCompletions(
-                    completions.map(item => ({ insertText: item.content })),
-                    params
-                )
+                processInlineCompletions(completions, params)
             )
             .then(processedCompletions => {
                 // Cache even if the request was aborted or already fulfilled.

--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -71,7 +71,7 @@ describe('process completion item', () => {
         updateParseTreeCache(document, parser)
 
         return processInlineCompletions(
-            completionSnippets.map(s => ({ insertText: s })),
+            completionSnippets.map(s => ({ content: s, stopReason: 'unknown' })),
             {
                 document,
                 position,
@@ -125,6 +125,7 @@ describe('process completion item', () => {
                   "line": 5,
                 },
               },
+              "stopReason": "unknown",
             },
             {
               "insertText": "array) new",
@@ -145,6 +146,7 @@ describe('process completion item', () => {
                   "line": 5,
                 },
               },
+              "stopReason": "unknown",
             },
           ]
         `)
@@ -186,6 +188,7 @@ describe('process completion item', () => {
                 "parent": "statement_block",
               },
               "parseErrorCount": 0,
+              "stopReason": "unknown",
               "truncatedWith": "tree-sitter",
             },
           ]

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -6,7 +6,7 @@ import { DocumentContext } from '../get-current-doc-context'
 import { ItemPostProcessingInfo } from '../logger'
 import { astGetters } from '../tree-sitter/ast-getters'
 import { getDocumentQuerySDK } from '../tree-sitter/queries'
-import { InlineCompletionItem } from '../types'
+import { Completion, InlineCompletionItem } from '../types'
 
 import { dropParserFields, parseCompletion, ParsedCompletion } from './parse-completion'
 import { truncateMultilineCompletion } from './truncate-multiline-completion'
@@ -19,21 +19,23 @@ export interface ProcessInlineCompletionsParams {
     docContext: DocumentContext
 }
 
-export interface InlineCompletionItemWithAnalytics extends ItemPostProcessingInfo, InlineCompletionItem {}
+export interface InlineCompletionItemWithAnalytics extends ItemPostProcessingInfo, InlineCompletionItem {
+    stopReason?: string
+}
 
 /**
  * This function implements post-processing logic that is applied regardless of
  * which provider is chosen.
  */
 export function processInlineCompletions(
-    items: InlineCompletionItem[],
+    items: Completion[],
     params: ProcessInlineCompletionsParams
 ): InlineCompletionItemWithAnalytics[] {
     // Shared post-processing logic
-    const processedCompletions = items.map(item => processItem({ ...params, completion: item }))
+    const completionItems = items.map(item => processCompletion({ ...params, completion: item }))
 
     // Remove low quality results
-    const visibleResults = removeLowQualityCompletions(processedCompletions)
+    const visibleResults = removeLowQualityCompletions(completionItems)
 
     // Remove duplicate results
     const uniqueResults = dedupeWith(visibleResults, 'insertText')
@@ -45,25 +47,30 @@ export function processInlineCompletions(
 }
 
 interface ProcessItemParams {
-    completion: InlineCompletionItem
+    completion: Completion
     document: TextDocument
     position: Position
     docContext: DocumentContext
 }
 
-export function processItem(params: ProcessItemParams): InlineCompletionItemWithAnalytics & ParsedCompletion {
+function processCompletion(params: ProcessItemParams): InlineCompletionItemWithAnalytics & ParsedCompletion {
     const { completion, document, position, docContext } = params
     const { prefix, suffix, currentLineSuffix, multilineTrigger } = docContext
 
-    if (typeof completion.insertText !== 'string') {
+    if (typeof completion.content !== 'string') {
         throw new TypeError('SnippetText not supported')
     }
 
-    if (completion.insertText.length === 0) {
-        return completion
+    const completionItem: InlineCompletionItemWithAnalytics = {
+        insertText: completion.content,
+        stopReason: completion.stopReason,
     }
 
-    const adjusted = adjustRangeToOverwriteOverlappingCharacters(completion, { position, currentLineSuffix })
+    if (completionItem.insertText.length === 0) {
+        return completionItem
+    }
+
+    const adjusted = adjustRangeToOverwriteOverlappingCharacters(completionItem, { position, currentLineSuffix })
     const parsed: InlineCompletionItemWithAnalytics & ParsedCompletion = parseCompletion({
         completion: adjusted,
         document,


### PR DESCRIPTION
## Context

- Adds unit tests for the `CompletionEvent` shape to automatically check if all the desired fields are filled with values.
- Add `stopReason` to `CompletionEvent.items[number]` so that we can understand if it's common for multiline completions to be truncated because of the token limit.

## Test plan

Unit tests + CI.
