### PR TITLE
Autocomplete: Enable completeSuggestWidgetSelection by default

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -25,7 +25,7 @@ export interface Configuration {
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedModel: string | null
     autocompleteAdvancedAccessToken: string | null
-    autocompleteExperimentalCompleteSuggestWidgetSelection?: boolean
+    autocompleteCompleteSuggestWidgetSelection?: boolean
     autocompleteExperimentalSyntacticPostProcessing?: boolean
     autocompleteExperimentalGraphContext?: boolean
     isRunningInsideAgent?: boolean

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -16,7 +16,6 @@ export enum FeatureFlag {
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-default-llama-code-13b',
     CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',
     CodyAutocompleteMinimumLatency = 'cody-autocomplete-minimum-latency',
-    CodyAutocompleteCompleteSuggestWidgetSelection = 'cody-autocomplete-complete-suggest-widget-selection',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - New `mode` field in the Custom Commands config file enables a command to be configured on how the prompt should be run by Cody. Currently supports `inline` (run command prompt in inline chat), `edit` (run command prompt on selected code for refactoring purpose), and `insert` (run command prompt on selected code where Cody's response will be inserted on top of the selected code) modes. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
 - Experimentally added `smart selection` which removes the need to manually highlight code before running the `/doc` and `/test` commands. [pull/1116](https://github.com/sourcegraph/cody/pull/1116)
 - Show a notice on first autocomplete. [pull/1071](https://github.com/sourcegraph/cody/pull/1071)
+- Autocomplete now takes the currently selected item in the suggest widget into account. This behavior can be disabled by setting `cody.autocomplete.suggestWidgetSelection` to `false`.
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -921,9 +921,9 @@
           "default": true,
           "markdownDescription": "Enables the use of embeddings as code completions context."
         },
-        "cody.autocomplete.experimental.completeSuggestWidgetSelection": {
+        "cody.autocomplete.completeSuggestWidgetSelection": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Autocomplete based on the currently selection in the suggest widget. Requires the VS Code user setting `editor.inlineSuggest.suppressSuggestions` set to true and will change it to true in user settings if it is not true."
         },
         "cody.autocomplete.experimental.syntacticPostProcessing": {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -53,10 +53,9 @@ export async function createInlineCompletionItemProvider({
 
     const disposables: vscode.Disposable[] = []
 
-    const [providerConfig, graphContextFlag, completeSuggestWidgetSelectionFlag] = await Promise.all([
+    const [providerConfig, graphContextFlag] = await Promise.all([
         createProviderConfig(config, client, featureFlagProvider, authProvider.getAuthStatus().configOverwrites),
         featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteGraphContext),
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteCompleteSuggestWidgetSelection),
     ])
     if (providerConfig) {
         const history = new VSCodeDocumentHistory()
@@ -71,8 +70,7 @@ export async function createInlineCompletionItemProvider({
             statusBar,
             getCodebaseContext: () => contextProvider.context,
             graphContextFetcher: sectionObserver,
-            completeSuggestWidgetSelection:
-                config.autocompleteExperimentalCompleteSuggestWidgetSelection || completeSuggestWidgetSelectionFlag,
+            completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
             featureFlagProvider,
             triggerNotice,
         })

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -132,6 +132,9 @@ export enum TriggerKind {
 
     /** Completion was triggered manually by the user invoking the keyboard shortcut. **/
     Manual = 'Manual',
+
+    /** When the user uses the suggest widget to cycle through different completions. */
+    SuggestWidget = 'SuggestWidget',
 }
 
 export async function getInlineCompletions(params: InlineCompletionsParams): Promise<InlineCompletionsResult | null> {
@@ -177,7 +180,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         setIsLoading,
         abortSignal,
         tracer,
-        completeSuggestWidgetSelection = false,
+        completeSuggestWidgetSelection = true,
         handleDidAcceptCompletionItem,
         handleDidPartiallyAcceptCompletionItem,
     } = params

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -54,7 +54,7 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
         superArgs?: Partial<ConstructorParameters<typeof InlineCompletionItemProvider>[0]>
     ) {
         super({
-            completeSuggestWidgetSelection: false,
+            completeSuggestWidgetSelection: true,
             // Most of these are just passed directly to `getInlineCompletions`, which we've mocked, so
             // we can just make them `null`.
             //
@@ -386,7 +386,7 @@ describe('InlineCompletionItemProvider', () => {
                 source: InlineCompletionsResultSource.Network,
             })
 
-            const provider = new MockableInlineCompletionItemProvider(fn, { completeSuggestWidgetSelection: true })
+            const provider = new MockableInlineCompletionItemProvider(fn)
             const items = await provider.provideInlineCompletionItems(document, position, {
                 triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
                 selectedCompletionInfo: { text: 'log', range: new vsCodeMocks.Range(1, 12, 1, 13) },
@@ -423,7 +423,7 @@ describe('InlineCompletionItemProvider', () => {
                 source: InlineCompletionsResultSource.Network,
             })
 
-            const provider = new MockableInlineCompletionItemProvider(fn, { completeSuggestWidgetSelection: true })
+            const provider = new MockableInlineCompletionItemProvider(fn)
 
             // Ignore the first call, it will not use the selected completion info
             await provider.provideInlineCompletionItems(document, position, {
@@ -490,7 +490,7 @@ describe('InlineCompletionItemProvider', () => {
                 source: InlineCompletionsResultSource.Network,
             })
 
-            const provider = new MockableInlineCompletionItemProvider(fn, { completeSuggestWidgetSelection: true })
+            const provider = new MockableInlineCompletionItemProvider(fn)
             const items = await provider.provideInlineCompletionItems(document, position, {
                 triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
                 selectedCompletionInfo: { text: 'dir', range: new vsCodeMocks.Range(1, 12, 1, 13) },

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -533,10 +533,12 @@ function isCompletionVisible(
     //   popup into account when generating completions as we do with the
     //   completeSuggestWidgetSelection flag
     //
-    // - When no completions contains characters in the current line that are
-    //   not in the current line suffix. Since VS Code will try to merge
-    //   completion with the suffix, we have to do a per-character diff to test
-    //   this.
+    // - When no completion contains all characters that are in the suffix of
+    //   the current line. This happens because we extend the insert range of
+    //   the completion to the whole line and any characters that are in the
+    //   suffix that would be overwritten, will need to be part of the inserted
+    //   completion (the VS Code UI does not allow character deletion). To test
+    //   for this, we have to do a per-character diff.
     const isAborted = abortSignal ? abortSignal.aborted : false
     const isMatchingPopupItem = completeSuggestWidgetSelection
         ? true

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -128,22 +128,18 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         this.lastCompletionRequest = completionRequest
 
         const start = performance.now()
-        // We start the request early so that we have a high chance of getting a response before we
-        // need it.
-        const minimumLatencyFlagsPromise = this.config.featureFlagProvider.evaluateFeatureFlag(
-            FeatureFlag.CodyAutocompleteMinimumLatency
-        )
+
+        // We start feature flag requests early so that we have a high chance of getting a response
+        // before we need it.
+        const [isIncreasedDebounceTimeEnabledPromise, minimumLatencyFlagsPromise] = [
+            this.config.featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled
+            ),
+            this.config.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteMinimumLatency),
+        ]
 
         const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
         const graphContextFetcher = this.config.graphContextFetcher ?? undefined
-
-        const triggerKind =
-            this.lastManualCompletionTimestamp && this.lastManualCompletionTimestamp > Date.now() - 500
-                ? TriggerKind.Manual
-                : context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic
-                ? TriggerKind.Automatic
-                : TriggerKind.Hover
-        this.lastManualCompletionTimestamp = null
 
         let stopLoading: () => void | undefined
         const setIsLoading = (isLoading: boolean): void => {
@@ -179,6 +175,16 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             takeSuggestWidgetSelectionIntoAccount = true
         }
 
+        const triggerKind =
+            this.lastManualCompletionTimestamp && this.lastManualCompletionTimestamp > Date.now() - 500
+                ? TriggerKind.Manual
+                : context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic
+                ? TriggerKind.Automatic
+                : takeSuggestWidgetSelectionIntoAccount
+                ? TriggerKind.SuggestWidget
+                : TriggerKind.Hover
+        this.lastManualCompletionTimestamp = null
+
         const docContext = getCurrentDocContext({
             document,
             position,
@@ -189,9 +195,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,
         })
 
-        const isIncreasedDebounceTimeEnabled = await this.config.featureFlagProvider.evaluateFeatureFlag(
-            FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled
-        )
+        const isIncreasedDebounceTimeEnabled = await isIncreasedDebounceTimeEnabledPromise
+
         try {
             const result = await this.getInlineCompletions({
                 document,
@@ -241,12 +246,12 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 this.handleUnwantedCompletionItem(getRequestParamsFromLastCandidate(document, this.lastCandidate))
             }
 
-            //  Unless the result is from the last candidate, we may want to apply the minimum
-            //  latency so that we don't show a result before the user has paused typing for a brief
-            //  moment.
+            // Unless the result is from the last candidate, we may want to apply the minimum
+            // latency so that we don't show a result before the user has paused typing for a brief
+            // moment.
             if (result.source !== InlineCompletionsResultSource.LastCandidate) {
                 const minimumLatencyFlag = await Promise.resolve(minimumLatencyFlagsPromise)
-                if (minimumLatencyFlag) {
+                if (triggerKind === TriggerKind.Automatic && minimumLatencyFlag) {
                     const minimumLatency = getLatency(this.config.providerConfig.identifier, document.languageId)
 
                     const delta = performance.now() - start
@@ -254,8 +259,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                         await new Promise(resolve => setTimeout(resolve, minimumLatency - delta))
                     }
 
-                    //  Avoid any further work if the completion is invalidated during the the
-                    //  minimum duration pause
+                    // Avoid any further work if the completion is invalidated during the the
+                    // minimum duration pause
                     if (abortController.signal.aborted) {
                         return null
                     }
@@ -272,7 +277,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 takeSuggestWidgetSelectionIntoAccount
             )
 
-            //  A completion that won't be visible in VS Code will not be returned and not be logged.
+            // A completion that won't be visible in VS Code will not be returned and not be logged.
             if (
                 !isCompletionVisible(
                     items,
@@ -284,16 +289,16 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     abortController.signal
                 )
             ) {
-                //  Returning null will clear any existing suggestions, thus we need to reset the
-                //  last candidate.
+                // Returning null will clear any existing suggestions, thus we need to reset the
+                // last candidate.
                 this.lastCandidate = undefined
                 return null
             }
 
-            //  Since we now know that the completion is going to be visible in the UI, we save the
-            //  completion as the last candidate (that is shown as ghost text in the editor) so that
-            //  we can reuse it if the user types in such a way that it is still valid (such as by
-            //  typing `ab` if the ghost text suggests `abcd`).
+            // Since we now know that the completion is going to be visible in the UI, we save the
+            // completion as the last candidate (that is shown as ghost text in the editor) so that
+            // we can reuse it if the user types in such a way that it is still valid (such as by
+            // typing `ab` if the ghost text suggests `abcd`).
             if (result.source !== InlineCompletionsResultSource.LastCandidate) {
                 const candidate: LastInlineCompletionCandidate = {
                     uri: document.uri,
@@ -311,7 +316,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 CompletionLogger.noResponse(result.logId)
             }
 
-            //  return `CompletionEvent` telemetry data to the agent command `autocomplete/execute`.
+            // return `CompletionEvent` telemetry data to the agent command `autocomplete/execute`.
             const completionResult: AutocompleteResult = {
                 items,
                 completionEvent: CompletionLogger.getCompletionEvent(result.logId),
@@ -330,11 +335,11 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         request: RequestParams
     ): void {
         resetLatency()
-        //  When a completion is accepted, the lastCandidate should be cleared. This makes sure the
-        //  log id is never reused if the completion is accepted.
+        // When a completion is accepted, the lastCandidate should be cleared. This makes sure the
+        // log id is never reused if the completion is accepted.
         this.clearLastCandidate()
 
-        //  Remove the completion from the network cache
+        // Remove the completion from the network cache
         this.requestManager.removeFromCache(request)
 
         if (this.config.triggerNotice) {
@@ -407,21 +412,21 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             const currentLinePrefix = document.getText(currentLine.range.with({ end: position }))
             let insertText = completion.insertText
 
-            //  Append any eventual inline completion context item to the prefix if
-            //  completeSuggestWidgetSelection is enabled.
+            // Append any eventual inline completion context item to the prefix if
+            // completeSuggestWidgetSelection is enabled.
             if (takeSuggestWidgetSelectionIntoAccount && context.selectedCompletionInfo) {
                 const { range, text } = context.selectedCompletionInfo
                 insertText = text.slice(position.character - range.start.character) + insertText
             }
 
-            //  Return the completion from the start of the current line (instead of starting at the
-            //  given position). This avoids UI jitter in VS Code; when typing or deleting individual
-            //  characters, VS Code reuses the existing completion while it waits for the new one to
-            //  come in.
+            // Return the completion from the start of the current line (instead of starting at the
+            // given position). This avoids UI jitter in VS Code; when typing or deleting individual
+            // characters, VS Code reuses the existing completion while it waits for the new one to
+            // come in.
             const start = currentLine.range.start
 
-            //  The completion will always exclude the same line suffix, so it has to overwrite the
-            //  current same line suffix and reach to the end of the line.
+            // The completion will always exclude the same line suffix, so it has to overwrite the
+            // current same line suffix and reach to the end of the line.
             const end = currentLine.range.end
 
             return new vscode.InlineCompletionItem(currentLinePrefix + insertText, new vscode.Range(start, end), {
@@ -468,25 +473,25 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             return
         }
 
-        //  TODO(philipp-spiess): Bring back this code once we have fewer uncaught errors
+        // TODO(philipp-spiess): Bring back this code once we have fewer uncaught errors
         //
-        //  c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1693471486690459
+        // c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1693471486690459
         //
-        //  const now = Date.now()
-        //  if (
-        //     this.reportedErrorMessages.has(error.message) &&
-        //     this.reportedErrorMessages.get(error.message)! + ONE_HOUR >= now
-        //  ) {
-        //     return
-        //  }
-        //  this.reportedErrorMessages.set(error.message, now)
-        //  this.config.statusBar.addError({
-        //     title: 'Cody Autocomplete Encountered an Unexpected Error',
-        //     description: error.message,
-        //     onSelect: () => {
-        //         outputChannel.show()
-        //     },
-        //  })
+        // const now = Date.now()
+        // if (
+        //    this.reportedErrorMessages.has(error.message) &&
+        //    this.reportedErrorMessages.get(error.message)! + ONE_HOUR >= now
+        // ) {
+        //    return
+        // }
+        // this.reportedErrorMessages.set(error.message, now)
+        // this.config.statusBar.addError({
+        //    title: 'Cody Autocomplete Encountered an Unexpected Error',
+        //    description: error.message,
+        //    onSelect: () => {
+        //        outputChannel.show()
+        //    },
+        // })
     }
 }
 
@@ -494,8 +499,8 @@ let globalInvocationSequenceForTracer = 0
 
 /**
  * Creates a tracer for a single invocation of
- * {@link CodyCompletionItemProvider.provideInlineCompletionItems} that accumulates all of the data
- * for that invocation.
+ * {@link InlineCompletionItemProvider.provideInlineCompletionItems} that accumulates all of the
+ * data for that invocation.
  */
 function createTracerForInvocation(tracer: ProvideInlineCompletionItemsTracer): InlineCompletionsParams['tracer'] {
     let data: ProvideInlineCompletionsItemTraceData = { invocationSequence: ++globalInvocationSequenceForTracer }
@@ -514,13 +519,13 @@ function isCompletionVisible(
     completeSuggestWidgetSelection: boolean,
     abortSignal: AbortSignal | undefined
 ): boolean {
-    //  There are these cases when a completion is being returned here but won't
-    //  be displayed by VS Code.
+    // There are these cases when a completion is being returned here but won't
+    // be displayed by VS Code.
     //
-    //  - When the abort signal was already triggered and a new completion
+    // - When the abort signal was already triggered and a new completion
     //   request was stared.
     //
-    //  - When the VS Code completion popup is open and we suggest a completion
+    // - When the VS Code completion popup is open and we suggest a completion
     //   that does not match the currently selected completion. For now we make
     //   sure to not log these completions as displayed.
     //
@@ -528,7 +533,7 @@ function isCompletionVisible(
     //   popup into account when generating completions as we do with the
     //   completeSuggestWidgetSelection flag
     //
-    //  - When no completions contains characters in the current line that are
+    // - When no completions contains characters in the current line that are
     //   not in the current line suffix. Since VS Code will try to merge
     //   completion with the suffix, we have to do a per-character diff to test
     //   this.
@@ -542,12 +547,12 @@ function isCompletionVisible(
     return isVisible
 }
 
-//  Check if the current text in the editor overlaps with the currently selected
-//  item in the completion widget.
+// Check if the current text in the editor overlaps with the currently selected
+// item in the completion widget.
 //
-//  If it won't VS Code will never show an inline completions.
+// If it won't VS Code will never show an inline completions.
 //
-//  Here's an example of how to trigger this case:
+// Here's an example of how to trigger this case:
 //
 //  1. Type the text `console.l` in a TypeScript file.
 //  2. Use the arrow keys to navigate to a suggested method that start with a
@@ -569,10 +574,10 @@ function currentEditorContentMatchesPopupItem(
     return true
 }
 
-//  Checks if the currently selected completion widget item overlaps with the
-//  proposed completion.
+// Checks if the currently selected completion widget item overlaps with the
+// proposed completion.
 //
-//  VS Code won't show a completion if it won't.
+// VS Code won't show a completion if it won't.
 function completionMatchesPopupItem(
     completions: vscode.InlineCompletionItem[],
     position: vscode.Position,
@@ -590,9 +595,9 @@ function completionMatchesPopupItem(
                 return true
             }
 
-            //  To ensure a good experience, the VS Code insertion might have the range start at the
-            //  beginning of the line. When this happens, the insertText needs to be adjusted to only
-            //  contain the insertion after the current position.
+            // To ensure a good experience, the VS Code insertion might have the range start at the
+            // beginning of the line. When this happens, the insertText needs to be adjusted to only
+            // contain the insertion after the current position.
             const offset = position.character - (visibleCompletion.range?.start.character ?? position.character)
             const correctInsertText = insertText.slice(offset)
             if (!(currentText + correctInsertText).startsWith(selectedText)) {

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -33,7 +33,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocompleteAdvancedServerEndpoint: null,
     autocompleteAdvancedModel: null,
     autocompleteAdvancedAccessToken: null,
-    autocompleteExperimentalCompleteSuggestWidgetSelection: false,
+    autocompleteCompleteSuggestWidgetSelection: false,
     autocompleteExperimentalSyntacticPostProcessing: false,
     autocompleteExperimentalGraphContext: false,
 }

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -44,11 +44,11 @@ export interface RequestManagerResult {
 export class RequestManager {
     private cache = new RequestCache()
     private readonly inflightRequests: Set<InflightRequest> = new Set()
-    private completeSuggestWidgetSelection = false
+    private completeSuggestWidgetSelection = true
 
     constructor(
-        { completeSuggestWidgetSelection = false }: { completeSuggestWidgetSelection: boolean } = {
-            completeSuggestWidgetSelection: false,
+        { completeSuggestWidgetSelection = true }: { completeSuggestWidgetSelection: boolean } = {
+            completeSuggestWidgetSelection: true,
         }
     ) {
         this.completeSuggestWidgetSelection = completeSuggestWidgetSelection

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -35,7 +35,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedServerEndpoint: null,
             autocompleteAdvancedModel: null,
             autocompleteAdvancedAccessToken: null,
-            autocompleteExperimentalCompleteSuggestWidgetSelection: false,
+            autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: false,
         })
@@ -98,7 +98,7 @@ describe('getConfiguration', () => {
                         return 'foobar'
                     case 'cody.autocomplete.advanced.embeddings':
                         return false
-                    case 'cody.autocomplete.experimental.completeSuggestWidgetSelection':
+                    case 'cody.autocomplete.completeSuggestWidgetSelection':
                         return false
                     case 'cody.autocomplete.experimental.syntacticPostProcessing':
                         return true
@@ -139,7 +139,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedServerEndpoint: 'https://example.com/llm',
             autocompleteAdvancedModel: 'starcoder-32b',
             autocompleteAdvancedAccessToken: 'foobar',
-            autocompleteExperimentalCompleteSuggestWidgetSelection: false,
+            autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: true,
         })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -65,9 +65,9 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         ),
         autocompleteAdvancedModel: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedModel, null),
         autocompleteAdvancedAccessToken: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedAccessToken, null),
-        autocompleteExperimentalCompleteSuggestWidgetSelection: config.get(
-            CONFIG_KEY.autocompleteExperimentalCompleteSuggestWidgetSelection,
-            false
+        autocompleteCompleteSuggestWidgetSelection: config.get(
+            CONFIG_KEY.autocompleteCompleteSuggestWidgetSelection,
+            true
         ),
         autocompleteExperimentalSyntacticPostProcessing: config.get(
             CONFIG_KEY.autocompleteExperimentalSyntacticPostProcessing,


### PR DESCRIPTION
This ships completeSuggestWidgetSelection by default but keeps a VS Code config option to turn of the behavior in case people are not happy with the config overwrite. 

This also improves the behavior slightly:

- Introduces a new `triggerKind` `SuggestWidget` so we detect if a completion was triggered because the user cycles through the suggest widget
- Based on this new `triggerKind`, ensure that no latency is used. A user selecting an option is a strong sign that they want to continue code in this direction so we should treat this more like a manual invocation and not like the automatic one.

## Test plan
- Start VS Code in dev mode
- Type `console.` and wait for the dropdown
- Select `dir(` from the dropdown and observe a fast completion like this:
    <img width="644" alt="Screenshot 2023-10-02 at 13 21 44" src="https://github.com/sourcegraph/cody/assets/458591/77dce4f8-44f1-4931-a3c2-153d4ee409ea">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
