### PR TITLE
Agent: fix Windows issues

### DIFF
--- a/agent/src/AgentTextDocument.ts
+++ b/agent/src/AgentTextDocument.ts
@@ -12,7 +12,7 @@ import * as vscode_shim from './vscode-shim'
 export class AgentTextDocument implements vscode.TextDocument {
     constructor(public readonly textDocument: TextDocument) {
         this.content = textDocument.content ?? ''
-        this.uri = vscode_shim.Uri.from({ scheme: 'file', path: textDocument.filePath })
+        this.uri = vscode.Uri.from({ scheme: 'file', path: textDocument.filePath })
         this.fileName = textDocument.filePath
         this.isUntitled = false
         this.languageId = getLanguageForFileName(this.fileName)

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -9,7 +9,7 @@ import * as vscode_shim from './vscode-shim'
 
 export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
     private readonly documents: Map<string, TextDocument> = new Map()
-    public workspaceRootUri: vscode_shim.Uri | undefined
+    public workspaceRootUri: vscode.Uri | undefined
     public activeDocumentFilePath: string | null = null
     public loadedDocument(document: TextDocument): TextDocument {
         const fromCache = this.documents.get(document.filePath)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -27,8 +27,11 @@ function initializeVscodeExtension(): void {
         environmentVariableCollection: {} as any,
         extension: {} as any,
         extensionMode: {} as any,
-        extensionPath: {} as any,
-        extensionUri: {} as any,
+        // Placeholder string values for extension path/uri. These are only used
+        // to resolve paths to icon in the UI. They need to have compatible
+        // types but don't have to point to a meaningful path/URI.
+        extensionPath: '__extensionPath_should_never_be_read_from',
+        extensionUri: vscode.Uri.from({ scheme: 'file', path: '__extensionUri__should_never_be_read_from' }),
         globalState: {
             keys: () => [],
             get: () => undefined,
@@ -77,8 +80,8 @@ export class Agent extends MessageHandler {
             )
             initializeVscodeExtension()
             this.workspace.workspaceRootUri = client.workspaceRootUri
-                ? vscode_shim.Uri.parse(client.workspaceRootUri)
-                : vscode_shim.Uri.from({ scheme: 'file', path: client.workspaceRootPath })
+                ? vscode.Uri.parse(client.workspaceRootUri)
+                : vscode.Uri.from({ scheme: 'file', path: client.workspaceRootPath })
 
             if (client.extensionConfiguration) {
                 this.setClient(client.extensionConfiguration)

--- a/agent/src/editor.ts
+++ b/agent/src/editor.ts
@@ -1,3 +1,5 @@
+import type * as vscode from 'vscode'
+
 import {
     ActiveTextEditor,
     ActiveTextEditorDiagnostic,
@@ -10,7 +12,6 @@ import {
 import { Agent } from './agent'
 import { DocumentOffsets } from './offsets'
 import { TextDocument } from './protocol'
-import * as vscode_shim from './vscode-shim'
 
 export class AgentEditor implements Editor {
     public controllers?: ActiveTextEditorViewControllers | undefined
@@ -27,7 +28,7 @@ export class AgentEditor implements Editor {
         return uri?.scheme === 'file' ? uri.fsPath : null
     }
 
-    public getWorkspaceRootUri(): vscode_shim.Uri | null {
+    public getWorkspaceRootUri(): vscode.Uri | null {
         return this.agent.workspace.workspaceRootUri ?? null
     }
 

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -41,7 +41,7 @@ describe.each([
             version: 'v1',
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
-            connectionConfiguration: {
+            extensionConfiguration: {
                 accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
                 serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
                 customHeaders: {},
@@ -61,7 +61,7 @@ describe.each([
             version: 'v1',
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
-            connectionConfiguration: {
+            extensionConfiguration: {
                 accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalid',
                 serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalid',
                 customHeaders: {},
@@ -75,7 +75,7 @@ describe.each([
             version: 'v1',
             workspaceRootUri: 'file:///path/to/foo',
             workspaceRootPath: '/path/to/foo',
-            connectionConfiguration: {
+            extensionConfiguration: {
                 accessToken: '',
                 serverEndpoint: 'https://sourcegraph.com/',
                 customHeaders: {},
@@ -96,7 +96,7 @@ describe.each([
     // Bundle the agent. When running `pnpm run test`, vitest doesn't re-run this step.
     execSync('pnpm run build')
 
-    const agentProcess = spawn('node', ['--inspect', path.join(__dirname, '../dist/index.js'), '--inspect'], {
+    const agentProcess = spawn('node', ['--inspect', path.join(__dirname, '..', 'dist', 'index.js'), '--inspect'], {
         stdio: 'pipe',
     })
 

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -152,7 +152,7 @@ export const onDidRenameFiles = new EventEmitter<vscode.FileRenameEvent>()
 export const onDidDeleteFiles = new EventEmitter<vscode.FileDeleteEvent>()
 
 export interface WorkspaceDocuments {
-    workspaceRootUri?: Uri
+    workspaceRootUri?: vscode.Uri
     openTextDocument: (filePath: string) => Promise<vscode.TextDocument>
 }
 let workspaceDocuments: WorkspaceDocuments | undefined

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -15,76 +15,10 @@ import type {
     Range as VSCodeRange,
 } from 'vscode'
 import type * as vscode_types from 'vscode'
-import { URI } from 'vscode-uri'
 
-export class Uri {
-    public static parse(value: string, strict?: boolean): Uri {
-        return Uri.from(URI.parse(value, strict).toJSON())
-    }
-    public static file(path: string): URI {
-        return Uri.from(URI.file(path).toJSON())
-    }
+import { Uri } from './vscode/uri'
 
-    public static joinPath(base: Uri, ...pathSegments: string[]): Uri {
-        return base.with({ path: [base.path, ...pathSegments].join('/') })
-    }
-
-    public static from(components: {
-        readonly scheme: string
-        readonly authority?: string
-        readonly path?: string
-        readonly query?: string
-        readonly fragment?: string
-    }): Uri {
-        const uri = URI.from(components)
-        return new Uri(uri.scheme, uri.authority, uri.path, uri.query, uri.fragment)
-    }
-
-    private uri: URI
-
-    private constructor(
-        public readonly scheme: string,
-        public readonly authority: string,
-        public readonly path: string,
-        public readonly query: string,
-        public readonly fragment: string
-    ) {
-        this.uri = URI.from({ scheme, authority, path, query, fragment })
-        this.fsPath = path // TODO
-    }
-
-    public readonly fsPath: string
-
-    public with(change: {
-        scheme?: string
-        authority?: string
-        path?: string
-        query?: string
-        fragment?: string
-    }): Uri {
-        return Uri.from({
-            scheme: change.scheme || this.scheme,
-            authority: change.authority || this.authority,
-            path: change.path || this.path,
-            query: change.query || this.query,
-            fragment: change.fragment || this.fragment,
-        })
-    }
-
-    public toString(skipEncoding?: boolean): string {
-        return this.uri.toString(skipEncoding)
-    }
-
-    public toJSON(): any {
-        return {
-            scheme: this.scheme,
-            authority: this.authority,
-            path: this.path,
-            query: this.query,
-            fragment: this.fragment,
-        }
-    }
-}
+export { Uri } from './vscode/uri'
 
 export class Disposable implements VSCodeDisposable {
     public static from(...disposableLikes: { dispose: () => any }[]): Disposable {
@@ -618,7 +552,7 @@ export const vsCodeMocks = {
         }),
         applyEdit: (edit: WorkspaceEdit) => true,
         save: () => true,
-        asRelativePath(path: string | URI) {
+        asRelativePath(path: string | Uri) {
             return path.toString()
         },
     },

--- a/vscode/src/testutils/vscode/AMDLoader.ts
+++ b/vscode/src/testutils/vscode/AMDLoader.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare namespace AMDLoader {
+    interface ILoaderPlugin {
+        load: (
+            pluginParam: string,
+            parentRequire: IRelativeRequire,
+            loadCallback: IPluginLoadCallback,
+            options: IConfigurationOptions
+        ) => void
+        write?: (pluginName: string, moduleName: string, write: IPluginWriteCallback) => void
+        writeFile?: (
+            pluginName: string,
+            moduleName: string,
+            req: IRelativeRequire,
+            write: IPluginWriteFileCallback,
+            config: IConfigurationOptions
+        ) => void
+        finishBuild?: (write: (filename: string, contents: string) => void) => void
+    }
+    interface IRelativeRequire {
+        (dependencies: string[], callback: Function, errorback?: (error: Error) => void): void
+        toUrl(id: string): string
+    }
+    interface IPluginLoadCallback {
+        (value: any): void
+        error(err: any): void
+    }
+    interface IConfigurationOptions {
+        isBuild: boolean | undefined
+        [key: string]: any
+    }
+    interface IPluginWriteCallback {
+        (contents: string): void
+        getEntryPoint(): string
+        asModule(moduleId: string, contents: string): void
+    }
+    interface IPluginWriteFileCallback {
+        (filename: string, contents: string): void
+        getEntryPoint(): string
+        asModule(moduleId: string, contents: string): void
+    }
+}

--- a/vscode/src/testutils/vscode/LICENSE.txt
+++ b/vscode/src/testutils/vscode/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 - present Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vscode/src/testutils/vscode/charCode.ts
+++ b/vscode/src/testutils/vscode/charCode.ts
@@ -1,0 +1,443 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Names from https://blog.codinghorror.com/ascii-pronunciation-rules-for-programmers/
+
+/**
+ * An inlined enum containing useful character codes (to be used with String.charCodeAt).
+ * Please leave the const keyword such that it gets inlined when compiled to JavaScript!
+ */
+export const enum CharCode {
+    Null = 0,
+    /**
+     * The `\b` character.
+     */
+    Backspace = 8,
+    /**
+     * The `\t` character.
+     */
+    Tab = 9,
+    /**
+     * The `\n` character.
+     */
+    LineFeed = 10,
+    /**
+     * The `\r` character.
+     */
+    CarriageReturn = 13,
+    Space = 32,
+    /**
+     * The `!` character.
+     */
+    ExclamationMark = 33,
+    /**
+     * The `"` character.
+     */
+    DoubleQuote = 34,
+    /**
+     * The `#` character.
+     */
+    Hash = 35,
+    /**
+     * The `$` character.
+     */
+    DollarSign = 36,
+    /**
+     * The `%` character.
+     */
+    PercentSign = 37,
+    /**
+     * The `&` character.
+     */
+    Ampersand = 38,
+    /**
+     * The `'` character.
+     */
+    SingleQuote = 39,
+    /**
+     * The `(` character.
+     */
+    OpenParen = 40,
+    /**
+     * The `)` character.
+     */
+    CloseParen = 41,
+    /**
+     * The `*` character.
+     */
+    Asterisk = 42,
+    /**
+     * The `+` character.
+     */
+    Plus = 43,
+    /**
+     * The `,` character.
+     */
+    Comma = 44,
+    /**
+     * The `-` character.
+     */
+    Dash = 45,
+    /**
+     * The `.` character.
+     */
+    Period = 46,
+    /**
+     * The `/` character.
+     */
+    Slash = 47,
+
+    Digit0 = 48,
+    Digit1 = 49,
+    Digit2 = 50,
+    Digit3 = 51,
+    Digit4 = 52,
+    Digit5 = 53,
+    Digit6 = 54,
+    Digit7 = 55,
+    Digit8 = 56,
+    Digit9 = 57,
+
+    /**
+     * The `:` character.
+     */
+    Colon = 58,
+    /**
+     * The `;` character.
+     */
+    Semicolon = 59,
+    /**
+     * The `<` character.
+     */
+    LessThan = 60,
+    /**
+     * The `=` character.
+     */
+    Equals = 61,
+    /**
+     * The `>` character.
+     */
+    GreaterThan = 62,
+    /**
+     * The `?` character.
+     */
+    QuestionMark = 63,
+    /**
+     * The `@` character.
+     */
+    AtSign = 64,
+
+    A = 65,
+    B = 66,
+    C = 67,
+    D = 68,
+    E = 69,
+    F = 70,
+    G = 71,
+    H = 72,
+    I = 73,
+    J = 74,
+    K = 75,
+    L = 76,
+    M = 77,
+    N = 78,
+    O = 79,
+    P = 80,
+    Q = 81,
+    R = 82,
+    S = 83,
+    T = 84,
+    U = 85,
+    V = 86,
+    W = 87,
+    X = 88,
+    Y = 89,
+    Z = 90,
+
+    /**
+     * The `[` character.
+     */
+    OpenSquareBracket = 91,
+    /**
+     * The `\` character.
+     */
+    Backslash = 92,
+    /**
+     * The `]` character.
+     */
+    CloseSquareBracket = 93,
+    /**
+     * The `^` character.
+     */
+    Caret = 94,
+    /**
+     * The `_` character.
+     */
+    Underline = 95,
+    /**
+     * The ``(`)`` character.
+     */
+    BackTick = 96,
+
+    a = 97,
+    b = 98,
+    c = 99,
+    d = 100,
+    e = 101,
+    f = 102,
+    g = 103,
+    h = 104,
+    i = 105,
+    j = 106,
+    k = 107,
+    l = 108,
+    m = 109,
+    n = 110,
+    o = 111,
+    p = 112,
+    q = 113,
+    r = 114,
+    s = 115,
+    t = 116,
+    u = 117,
+    v = 118,
+    w = 119,
+    x = 120,
+    y = 121,
+    z = 122,
+
+    /**
+     * The `{` character.
+     */
+    OpenCurlyBrace = 123,
+    /**
+     * The `|` character.
+     */
+    Pipe = 124,
+    /**
+     * The `}` character.
+     */
+    CloseCurlyBrace = 125,
+    /**
+     * The `~` character.
+     */
+    Tilde = 126,
+
+    U_Combining_Grave_Accent = 0x0300, //	U+0300	Combining Grave Accent
+    U_Combining_Acute_Accent = 0x0301, //	U+0301	Combining Acute Accent
+    U_Combining_Circumflex_Accent = 0x0302, //	U+0302	Combining Circumflex Accent
+    U_Combining_Tilde = 0x0303, //	U+0303	Combining Tilde
+    U_Combining_Macron = 0x0304, //	U+0304	Combining Macron
+    U_Combining_Overline = 0x0305, //	U+0305	Combining Overline
+    U_Combining_Breve = 0x0306, //	U+0306	Combining Breve
+    U_Combining_Dot_Above = 0x0307, //	U+0307	Combining Dot Above
+    U_Combining_Diaeresis = 0x0308, //	U+0308	Combining Diaeresis
+    U_Combining_Hook_Above = 0x0309, //	U+0309	Combining Hook Above
+    U_Combining_Ring_Above = 0x030a, //	U+030A	Combining Ring Above
+    U_Combining_Double_Acute_Accent = 0x030b, //	U+030B	Combining Double Acute Accent
+    U_Combining_Caron = 0x030c, //	U+030C	Combining Caron
+    U_Combining_Vertical_Line_Above = 0x030d, //	U+030D	Combining Vertical Line Above
+    U_Combining_Double_Vertical_Line_Above = 0x030e, //	U+030E	Combining Double Vertical Line Above
+    U_Combining_Double_Grave_Accent = 0x030f, //	U+030F	Combining Double Grave Accent
+    U_Combining_Candrabindu = 0x0310, //	U+0310	Combining Candrabindu
+    U_Combining_Inverted_Breve = 0x0311, //	U+0311	Combining Inverted Breve
+    U_Combining_Turned_Comma_Above = 0x0312, //	U+0312	Combining Turned Comma Above
+    U_Combining_Comma_Above = 0x0313, //	U+0313	Combining Comma Above
+    U_Combining_Reversed_Comma_Above = 0x0314, //	U+0314	Combining Reversed Comma Above
+    U_Combining_Comma_Above_Right = 0x0315, //	U+0315	Combining Comma Above Right
+    U_Combining_Grave_Accent_Below = 0x0316, //	U+0316	Combining Grave Accent Below
+    U_Combining_Acute_Accent_Below = 0x0317, //	U+0317	Combining Acute Accent Below
+    U_Combining_Left_Tack_Below = 0x0318, //	U+0318	Combining Left Tack Below
+    U_Combining_Right_Tack_Below = 0x0319, //	U+0319	Combining Right Tack Below
+    U_Combining_Left_Angle_Above = 0x031a, //	U+031A	Combining Left Angle Above
+    U_Combining_Horn = 0x031b, //	U+031B	Combining Horn
+    U_Combining_Left_Half_Ring_Below = 0x031c, //	U+031C	Combining Left Half Ring Below
+    U_Combining_Up_Tack_Below = 0x031d, //	U+031D	Combining Up Tack Below
+    U_Combining_Down_Tack_Below = 0x031e, //	U+031E	Combining Down Tack Below
+    U_Combining_Plus_Sign_Below = 0x031f, //	U+031F	Combining Plus Sign Below
+    U_Combining_Minus_Sign_Below = 0x0320, //	U+0320	Combining Minus Sign Below
+    U_Combining_Palatalized_Hook_Below = 0x0321, //	U+0321	Combining Palatalized Hook Below
+    U_Combining_Retroflex_Hook_Below = 0x0322, //	U+0322	Combining Retroflex Hook Below
+    U_Combining_Dot_Below = 0x0323, //	U+0323	Combining Dot Below
+    U_Combining_Diaeresis_Below = 0x0324, //	U+0324	Combining Diaeresis Below
+    U_Combining_Ring_Below = 0x0325, //	U+0325	Combining Ring Below
+    U_Combining_Comma_Below = 0x0326, //	U+0326	Combining Comma Below
+    U_Combining_Cedilla = 0x0327, //	U+0327	Combining Cedilla
+    U_Combining_Ogonek = 0x0328, //	U+0328	Combining Ogonek
+    U_Combining_Vertical_Line_Below = 0x0329, //	U+0329	Combining Vertical Line Below
+    U_Combining_Bridge_Below = 0x032a, //	U+032A	Combining Bridge Below
+    U_Combining_Inverted_Double_Arch_Below = 0x032b, //	U+032B	Combining Inverted Double Arch Below
+    U_Combining_Caron_Below = 0x032c, //	U+032C	Combining Caron Below
+    U_Combining_Circumflex_Accent_Below = 0x032d, //	U+032D	Combining Circumflex Accent Below
+    U_Combining_Breve_Below = 0x032e, //	U+032E	Combining Breve Below
+    U_Combining_Inverted_Breve_Below = 0x032f, //	U+032F	Combining Inverted Breve Below
+    U_Combining_Tilde_Below = 0x0330, //	U+0330	Combining Tilde Below
+    U_Combining_Macron_Below = 0x0331, //	U+0331	Combining Macron Below
+    U_Combining_Low_Line = 0x0332, //	U+0332	Combining Low Line
+    U_Combining_Double_Low_Line = 0x0333, //	U+0333	Combining Double Low Line
+    U_Combining_Tilde_Overlay = 0x0334, //	U+0334	Combining Tilde Overlay
+    U_Combining_Short_Stroke_Overlay = 0x0335, //	U+0335	Combining Short Stroke Overlay
+    U_Combining_Long_Stroke_Overlay = 0x0336, //	U+0336	Combining Long Stroke Overlay
+    U_Combining_Short_Solidus_Overlay = 0x0337, //	U+0337	Combining Short Solidus Overlay
+    U_Combining_Long_Solidus_Overlay = 0x0338, //	U+0338	Combining Long Solidus Overlay
+    U_Combining_Right_Half_Ring_Below = 0x0339, //	U+0339	Combining Right Half Ring Below
+    U_Combining_Inverted_Bridge_Below = 0x033a, //	U+033A	Combining Inverted Bridge Below
+    U_Combining_Square_Below = 0x033b, //	U+033B	Combining Square Below
+    U_Combining_Seagull_Below = 0x033c, //	U+033C	Combining Seagull Below
+    U_Combining_X_Above = 0x033d, //	U+033D	Combining X Above
+    U_Combining_Vertical_Tilde = 0x033e, //	U+033E	Combining Vertical Tilde
+    U_Combining_Double_Overline = 0x033f, //	U+033F	Combining Double Overline
+    U_Combining_Grave_Tone_Mark = 0x0340, //	U+0340	Combining Grave Tone Mark
+    U_Combining_Acute_Tone_Mark = 0x0341, //	U+0341	Combining Acute Tone Mark
+    U_Combining_Greek_Perispomeni = 0x0342, //	U+0342	Combining Greek Perispomeni
+    U_Combining_Greek_Koronis = 0x0343, //	U+0343	Combining Greek Koronis
+    U_Combining_Greek_Dialytika_Tonos = 0x0344, //	U+0344	Combining Greek Dialytika Tonos
+    U_Combining_Greek_Ypogegrammeni = 0x0345, //	U+0345	Combining Greek Ypogegrammeni
+    U_Combining_Bridge_Above = 0x0346, //	U+0346	Combining Bridge Above
+    U_Combining_Equals_Sign_Below = 0x0347, //	U+0347	Combining Equals Sign Below
+    U_Combining_Double_Vertical_Line_Below = 0x0348, //	U+0348	Combining Double Vertical Line Below
+    U_Combining_Left_Angle_Below = 0x0349, //	U+0349	Combining Left Angle Below
+    U_Combining_Not_Tilde_Above = 0x034a, //	U+034A	Combining Not Tilde Above
+    U_Combining_Homothetic_Above = 0x034b, //	U+034B	Combining Homothetic Above
+    U_Combining_Almost_Equal_To_Above = 0x034c, //	U+034C	Combining Almost Equal To Above
+    U_Combining_Left_Right_Arrow_Below = 0x034d, //	U+034D	Combining Left Right Arrow Below
+    U_Combining_Upwards_Arrow_Below = 0x034e, //	U+034E	Combining Upwards Arrow Below
+    U_Combining_Grapheme_Joiner = 0x034f, //	U+034F	Combining Grapheme Joiner
+    U_Combining_Right_Arrowhead_Above = 0x0350, //	U+0350	Combining Right Arrowhead Above
+    U_Combining_Left_Half_Ring_Above = 0x0351, //	U+0351	Combining Left Half Ring Above
+    U_Combining_Fermata = 0x0352, //	U+0352	Combining Fermata
+    U_Combining_X_Below = 0x0353, //	U+0353	Combining X Below
+    U_Combining_Left_Arrowhead_Below = 0x0354, //	U+0354	Combining Left Arrowhead Below
+    U_Combining_Right_Arrowhead_Below = 0x0355, //	U+0355	Combining Right Arrowhead Below
+    U_Combining_Right_Arrowhead_And_Up_Arrowhead_Below = 0x0356, //	U+0356	Combining Right Arrowhead And Up Arrowhead Below
+    U_Combining_Right_Half_Ring_Above = 0x0357, //	U+0357	Combining Right Half Ring Above
+    U_Combining_Dot_Above_Right = 0x0358, //	U+0358	Combining Dot Above Right
+    U_Combining_Asterisk_Below = 0x0359, //	U+0359	Combining Asterisk Below
+    U_Combining_Double_Ring_Below = 0x035a, //	U+035A	Combining Double Ring Below
+    U_Combining_Zigzag_Above = 0x035b, //	U+035B	Combining Zigzag Above
+    U_Combining_Double_Breve_Below = 0x035c, //	U+035C	Combining Double Breve Below
+    U_Combining_Double_Breve = 0x035d, //	U+035D	Combining Double Breve
+    U_Combining_Double_Macron = 0x035e, //	U+035E	Combining Double Macron
+    U_Combining_Double_Macron_Below = 0x035f, //	U+035F	Combining Double Macron Below
+    U_Combining_Double_Tilde = 0x0360, //	U+0360	Combining Double Tilde
+    U_Combining_Double_Inverted_Breve = 0x0361, //	U+0361	Combining Double Inverted Breve
+    U_Combining_Double_Rightwards_Arrow_Below = 0x0362, //	U+0362	Combining Double Rightwards Arrow Below
+    U_Combining_Latin_Small_Letter_A = 0x0363, //	U+0363	Combining Latin Small Letter A
+    U_Combining_Latin_Small_Letter_E = 0x0364, //	U+0364	Combining Latin Small Letter E
+    U_Combining_Latin_Small_Letter_I = 0x0365, //	U+0365	Combining Latin Small Letter I
+    U_Combining_Latin_Small_Letter_O = 0x0366, //	U+0366	Combining Latin Small Letter O
+    U_Combining_Latin_Small_Letter_U = 0x0367, //	U+0367	Combining Latin Small Letter U
+    U_Combining_Latin_Small_Letter_C = 0x0368, //	U+0368	Combining Latin Small Letter C
+    U_Combining_Latin_Small_Letter_D = 0x0369, //	U+0369	Combining Latin Small Letter D
+    U_Combining_Latin_Small_Letter_H = 0x036a, //	U+036A	Combining Latin Small Letter H
+    U_Combining_Latin_Small_Letter_M = 0x036b, //	U+036B	Combining Latin Small Letter M
+    U_Combining_Latin_Small_Letter_R = 0x036c, //	U+036C	Combining Latin Small Letter R
+    U_Combining_Latin_Small_Letter_T = 0x036d, //	U+036D	Combining Latin Small Letter T
+    U_Combining_Latin_Small_Letter_V = 0x036e, //	U+036E	Combining Latin Small Letter V
+    U_Combining_Latin_Small_Letter_X = 0x036f, //	U+036F	Combining Latin Small Letter X
+
+    /**
+     * Unicode Character 'LINE SEPARATOR' (U+2028)
+     * http://www.fileformat.info/info/unicode/char/2028/index.htm
+     */
+    LINE_SEPARATOR = 0x2028,
+    /**
+     * Unicode Character 'PARAGRAPH SEPARATOR' (U+2029)
+     * http://www.fileformat.info/info/unicode/char/2029/index.htm
+     */
+    PARAGRAPH_SEPARATOR = 0x2029,
+    /**
+     * Unicode Character 'NEXT LINE' (U+0085)
+     * http://www.fileformat.info/info/unicode/char/0085/index.htm
+     */
+    NEXT_LINE = 0x0085,
+
+    // http://www.fileformat.info/info/unicode/category/Sk/list.htm
+    U_CIRCUMFLEX = 0x005e, // U+005E	CIRCUMFLEX
+    U_GRAVE_ACCENT = 0x0060, // U+0060	GRAVE ACCENT
+    U_DIAERESIS = 0x00a8, // U+00A8	DIAERESIS
+    U_MACRON = 0x00af, // U+00AF	MACRON
+    U_ACUTE_ACCENT = 0x00b4, // U+00B4	ACUTE ACCENT
+    U_CEDILLA = 0x00b8, // U+00B8	CEDILLA
+    U_MODIFIER_LETTER_LEFT_ARROWHEAD = 0x02c2, // U+02C2	MODIFIER LETTER LEFT ARROWHEAD
+    U_MODIFIER_LETTER_RIGHT_ARROWHEAD = 0x02c3, // U+02C3	MODIFIER LETTER RIGHT ARROWHEAD
+    U_MODIFIER_LETTER_UP_ARROWHEAD = 0x02c4, // U+02C4	MODIFIER LETTER UP ARROWHEAD
+    U_MODIFIER_LETTER_DOWN_ARROWHEAD = 0x02c5, // U+02C5	MODIFIER LETTER DOWN ARROWHEAD
+    U_MODIFIER_LETTER_CENTRED_RIGHT_HALF_RING = 0x02d2, // U+02D2	MODIFIER LETTER CENTRED RIGHT HALF RING
+    U_MODIFIER_LETTER_CENTRED_LEFT_HALF_RING = 0x02d3, // U+02D3	MODIFIER LETTER CENTRED LEFT HALF RING
+    U_MODIFIER_LETTER_UP_TACK = 0x02d4, // U+02D4	MODIFIER LETTER UP TACK
+    U_MODIFIER_LETTER_DOWN_TACK = 0x02d5, // U+02D5	MODIFIER LETTER DOWN TACK
+    U_MODIFIER_LETTER_PLUS_SIGN = 0x02d6, // U+02D6	MODIFIER LETTER PLUS SIGN
+    U_MODIFIER_LETTER_MINUS_SIGN = 0x02d7, // U+02D7	MODIFIER LETTER MINUS SIGN
+    U_BREVE = 0x02d8, // U+02D8	BREVE
+    U_DOT_ABOVE = 0x02d9, // U+02D9	DOT ABOVE
+    U_RING_ABOVE = 0x02da, // U+02DA	RING ABOVE
+    U_OGONEK = 0x02db, // U+02DB	OGONEK
+    U_SMALL_TILDE = 0x02dc, // U+02DC	SMALL TILDE
+    U_DOUBLE_ACUTE_ACCENT = 0x02dd, // U+02DD	DOUBLE ACUTE ACCENT
+    U_MODIFIER_LETTER_RHOTIC_HOOK = 0x02de, // U+02DE	MODIFIER LETTER RHOTIC HOOK
+    U_MODIFIER_LETTER_CROSS_ACCENT = 0x02df, // U+02DF	MODIFIER LETTER CROSS ACCENT
+    U_MODIFIER_LETTER_EXTRA_HIGH_TONE_BAR = 0x02e5, // U+02E5	MODIFIER LETTER EXTRA-HIGH TONE BAR
+    U_MODIFIER_LETTER_HIGH_TONE_BAR = 0x02e6, // U+02E6	MODIFIER LETTER HIGH TONE BAR
+    U_MODIFIER_LETTER_MID_TONE_BAR = 0x02e7, // U+02E7	MODIFIER LETTER MID TONE BAR
+    U_MODIFIER_LETTER_LOW_TONE_BAR = 0x02e8, // U+02E8	MODIFIER LETTER LOW TONE BAR
+    U_MODIFIER_LETTER_EXTRA_LOW_TONE_BAR = 0x02e9, // U+02E9	MODIFIER LETTER EXTRA-LOW TONE BAR
+    U_MODIFIER_LETTER_YIN_DEPARTING_TONE_MARK = 0x02ea, // U+02EA	MODIFIER LETTER YIN DEPARTING TONE MARK
+    U_MODIFIER_LETTER_YANG_DEPARTING_TONE_MARK = 0x02eb, // U+02EB	MODIFIER LETTER YANG DEPARTING TONE MARK
+    U_MODIFIER_LETTER_UNASPIRATED = 0x02ed, // U+02ED	MODIFIER LETTER UNASPIRATED
+    U_MODIFIER_LETTER_LOW_DOWN_ARROWHEAD = 0x02ef, // U+02EF	MODIFIER LETTER LOW DOWN ARROWHEAD
+    U_MODIFIER_LETTER_LOW_UP_ARROWHEAD = 0x02f0, // U+02F0	MODIFIER LETTER LOW UP ARROWHEAD
+    U_MODIFIER_LETTER_LOW_LEFT_ARROWHEAD = 0x02f1, // U+02F1	MODIFIER LETTER LOW LEFT ARROWHEAD
+    U_MODIFIER_LETTER_LOW_RIGHT_ARROWHEAD = 0x02f2, // U+02F2	MODIFIER LETTER LOW RIGHT ARROWHEAD
+    U_MODIFIER_LETTER_LOW_RING = 0x02f3, // U+02F3	MODIFIER LETTER LOW RING
+    U_MODIFIER_LETTER_MIDDLE_GRAVE_ACCENT = 0x02f4, // U+02F4	MODIFIER LETTER MIDDLE GRAVE ACCENT
+    U_MODIFIER_LETTER_MIDDLE_DOUBLE_GRAVE_ACCENT = 0x02f5, // U+02F5	MODIFIER LETTER MIDDLE DOUBLE GRAVE ACCENT
+    U_MODIFIER_LETTER_MIDDLE_DOUBLE_ACUTE_ACCENT = 0x02f6, // U+02F6	MODIFIER LETTER MIDDLE DOUBLE ACUTE ACCENT
+    U_MODIFIER_LETTER_LOW_TILDE = 0x02f7, // U+02F7	MODIFIER LETTER LOW TILDE
+    U_MODIFIER_LETTER_RAISED_COLON = 0x02f8, // U+02F8	MODIFIER LETTER RAISED COLON
+    U_MODIFIER_LETTER_BEGIN_HIGH_TONE = 0x02f9, // U+02F9	MODIFIER LETTER BEGIN HIGH TONE
+    U_MODIFIER_LETTER_END_HIGH_TONE = 0x02fa, // U+02FA	MODIFIER LETTER END HIGH TONE
+    U_MODIFIER_LETTER_BEGIN_LOW_TONE = 0x02fb, // U+02FB	MODIFIER LETTER BEGIN LOW TONE
+    U_MODIFIER_LETTER_END_LOW_TONE = 0x02fc, // U+02FC	MODIFIER LETTER END LOW TONE
+    U_MODIFIER_LETTER_SHELF = 0x02fd, // U+02FD	MODIFIER LETTER SHELF
+    U_MODIFIER_LETTER_OPEN_SHELF = 0x02fe, // U+02FE	MODIFIER LETTER OPEN SHELF
+    U_MODIFIER_LETTER_LOW_LEFT_ARROW = 0x02ff, // U+02FF	MODIFIER LETTER LOW LEFT ARROW
+    U_GREEK_LOWER_NUMERAL_SIGN = 0x0375, // U+0375	GREEK LOWER NUMERAL SIGN
+    U_GREEK_TONOS = 0x0384, // U+0384	GREEK TONOS
+    U_GREEK_DIALYTIKA_TONOS = 0x0385, // U+0385	GREEK DIALYTIKA TONOS
+    U_GREEK_KORONIS = 0x1fbd, // U+1FBD	GREEK KORONIS
+    U_GREEK_PSILI = 0x1fbf, // U+1FBF	GREEK PSILI
+    U_GREEK_PERISPOMENI = 0x1fc0, // U+1FC0	GREEK PERISPOMENI
+    U_GREEK_DIALYTIKA_AND_PERISPOMENI = 0x1fc1, // U+1FC1	GREEK DIALYTIKA AND PERISPOMENI
+    U_GREEK_PSILI_AND_VARIA = 0x1fcd, // U+1FCD	GREEK PSILI AND VARIA
+    U_GREEK_PSILI_AND_OXIA = 0x1fce, // U+1FCE	GREEK PSILI AND OXIA
+    U_GREEK_PSILI_AND_PERISPOMENI = 0x1fcf, // U+1FCF	GREEK PSILI AND PERISPOMENI
+    U_GREEK_DASIA_AND_VARIA = 0x1fdd, // U+1FDD	GREEK DASIA AND VARIA
+    U_GREEK_DASIA_AND_OXIA = 0x1fde, // U+1FDE	GREEK DASIA AND OXIA
+    U_GREEK_DASIA_AND_PERISPOMENI = 0x1fdf, // U+1FDF	GREEK DASIA AND PERISPOMENI
+    U_GREEK_DIALYTIKA_AND_VARIA = 0x1fed, // U+1FED	GREEK DIALYTIKA AND VARIA
+    U_GREEK_DIALYTIKA_AND_OXIA = 0x1fee, // U+1FEE	GREEK DIALYTIKA AND OXIA
+    U_GREEK_VARIA = 0x1fef, // U+1FEF	GREEK VARIA
+    U_GREEK_OXIA = 0x1ffd, // U+1FFD	GREEK OXIA
+    U_GREEK_DASIA = 0x1ffe, // U+1FFE	GREEK DASIA
+
+    U_IDEOGRAPHIC_FULL_STOP = 0x3002, // U+3002	IDEOGRAPHIC FULL STOP
+    U_LEFT_CORNER_BRACKET = 0x300c, // U+300C	LEFT CORNER BRACKET
+    U_RIGHT_CORNER_BRACKET = 0x300d, // U+300D	RIGHT CORNER BRACKET
+    U_LEFT_BLACK_LENTICULAR_BRACKET = 0x3010, // U+3010	LEFT BLACK LENTICULAR BRACKET
+    U_RIGHT_BLACK_LENTICULAR_BRACKET = 0x3011, // U+3011	RIGHT BLACK LENTICULAR BRACKET
+
+    U_OVERLINE = 0x203e, // Unicode Character 'OVERLINE'
+
+    /**
+     * UTF-8 BOM
+     * Unicode Character 'ZERO WIDTH NO-BREAK SPACE' (U+FEFF)
+     * http://www.fileformat.info/info/unicode/char/feff/index.htm
+     */
+    UTF8_BOM = 65279,
+
+    U_FULLWIDTH_SEMICOLON = 0xff1b, // U+FF1B	FULLWIDTH SEMICOLON
+    U_FULLWIDTH_COMMA = 0xff0c, // U+FF0C	FULLWIDTH COMMA
+}

--- a/vscode/src/testutils/vscode/marshallingId.ts
+++ b/vscode/src/testutils/vscode/marshallingId.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const enum MarshalledId {
+    Uri = 1,
+    Regexp,
+    ScmResource,
+    ScmResourceGroup,
+    ScmProvider,
+    CommentController,
+    CommentThread,
+    CommentThreadReply,
+    CommentNode,
+    CommentThreadNode,
+    TimelineActionContext,
+    NotebookCellActionContext,
+    NotebookActionContext,
+    TestItemContext,
+    Date,
+}

--- a/vscode/src/testutils/vscode/nls.ts
+++ b/vscode/src/testutils/vscode/nls.ts
@@ -1,0 +1,263 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+let isPseudo =
+    typeof document !== 'undefined' && document.location && document.location.hash.indexOf('pseudo=true') >= 0
+const DEFAULT_TAG = 'i-default'
+
+interface INLSPluginConfig {
+    availableLanguages?: INLSPluginConfigAvailableLanguages
+    loadBundle?: BundleLoader
+    translationServiceUrl?: string
+}
+
+export interface INLSPluginConfigAvailableLanguages {
+    '*'?: string
+    [module: string]: string | undefined
+}
+
+interface BundleLoader {
+    (bundle: string, locale: string | null, cb: (err: Error, messages: string[] | IBundledStrings) => void): void
+}
+
+interface IBundledStrings {
+    [moduleId: string]: string[]
+}
+
+export interface ILocalizeInfo {
+    key: string
+    comment: string[]
+}
+
+interface ILocalizeFunc {
+    (info: ILocalizeInfo, message: string, ...args: (string | number | boolean | undefined | null)[]): string
+    (key: string, message: string, ...args: (string | number | boolean | undefined | null)[]): string
+}
+
+interface IBoundLocalizeFunc {
+    (idx: number, defaultValue: null): string
+}
+
+interface IConsumerAPI {
+    localize: ILocalizeFunc | IBoundLocalizeFunc
+    getConfiguredDefaultLocale(stringFromLocalizeCall: string): string | undefined
+}
+
+function _format(message: string, args: (string | number | boolean | undefined | null)[]): string {
+    let result: string
+
+    if (args.length === 0) {
+        result = message
+    } else {
+        result = message.replace(/\{(\d+)\}/g, (match, rest) => {
+            const index = rest[0]
+            const arg = args[index]
+            let result = match
+            if (typeof arg === 'string') {
+                result = arg
+            } else if (typeof arg === 'number' || typeof arg === 'boolean' || arg === void 0 || arg === null) {
+                result = String(arg)
+            }
+            return result
+        })
+    }
+
+    if (isPseudo) {
+        // FF3B and FF3D is the Unicode zenkaku representation for [ and ]
+        result = '\uFF3B' + result.replace(/[aouei]/g, '$&$&') + '\uFF3D'
+    }
+
+    return result
+}
+
+function findLanguageForModule(config: INLSPluginConfigAvailableLanguages, name: string) {
+    let result = config[name]
+    if (result) {
+        return result
+    }
+    result = config['*']
+    if (result) {
+        return result
+    }
+    return null
+}
+
+function endWithSlash(path: string): string {
+    if (path.charAt(path.length - 1) === '/') {
+        return path
+    }
+    return path + '/'
+}
+
+async function getMessagesFromTranslationsService(
+    translationServiceUrl: string,
+    language: string,
+    name: string
+): Promise<string[] | IBundledStrings> {
+    const url = endWithSlash(translationServiceUrl) + endWithSlash(language) + 'vscode/' + endWithSlash(name)
+    const res = await fetch(url)
+    if (res.ok) {
+        const messages = (await res.json()) as string[] | IBundledStrings
+        return messages
+    }
+    throw new Error(`${res.status} - ${res.statusText}`)
+}
+
+function createScopedLocalize(scope: string[]): IBoundLocalizeFunc {
+    return function (idx: number, defaultValue: null) {
+        const restArgs = Array.prototype.slice.call(arguments, 2)
+        return _format(scope[idx], restArgs)
+    }
+}
+
+/**
+ * Localize a message.
+ *
+ * `message` can contain `{n}` notation where it is replaced by the nth value in `...args`
+ * For example, `localize({ key: 'sayHello', comment: ['Welcomes user'] }, 'hello {0}', name)`
+ */
+export function localize(
+    info: ILocalizeInfo,
+    message: string,
+    ...args: (string | number | boolean | undefined | null)[]
+): string
+
+/**
+ * Localize a message.
+ *
+ * `message` can contain `{n}` notation where it is replaced by the nth value in `...args`
+ * For example, `localize('sayHello', 'hello {0}', name)`
+ */
+export function localize(
+    key: string,
+    message: string,
+    ...args: (string | number | boolean | undefined | null)[]
+): string
+
+export function localize(
+    data: ILocalizeInfo | string,
+    message: string,
+    ...args: (string | number | boolean | undefined | null)[]
+): string {
+    return _format(message, args)
+}
+
+/**
+ *
+ * @param stringFromLocalizeCall You must pass in a string that was returned from a `nls.localize()` call
+ * in order to ensure the loader plugin has been initialized before this function is called.
+ */
+export function getConfiguredDefaultLocale(stringFromLocalizeCall: string): string | undefined
+export function getConfiguredDefaultLocale(_: string): string | undefined {
+    // This returns undefined because this implementation isn't used and is overwritten by the loader
+    // when loaded.
+    return undefined
+}
+
+export function setPseudoTranslation(value: boolean) {
+    isPseudo = value
+}
+
+/**
+ * Invoked in a built product at run-time
+ */
+export function create(key: string, data: IBundledStrings & IConsumerAPI): IConsumerAPI {
+    return {
+        localize: createScopedLocalize(data[key]),
+        getConfiguredDefaultLocale: data.getConfiguredDefaultLocale ?? ((_: string) => undefined),
+    }
+}
+
+/**
+ * Invoked by the loader at run-time
+ */
+export function load(
+    name: string,
+    req: AMDLoader.IRelativeRequire,
+    load: AMDLoader.IPluginLoadCallback,
+    config: AMDLoader.IConfigurationOptions
+): void {
+    const pluginConfig: INLSPluginConfig = config['vs/nls'] ?? {}
+    if (!name || name.length === 0) {
+        return load({
+            localize: localize,
+            getConfiguredDefaultLocale: () => pluginConfig.availableLanguages?.['*'],
+        })
+    }
+    const language = pluginConfig.availableLanguages
+        ? findLanguageForModule(pluginConfig.availableLanguages, name)
+        : null
+    const useDefaultLanguage = language === null || language === DEFAULT_TAG
+    let suffix = '.nls'
+    if (!useDefaultLanguage) {
+        suffix = suffix + '.' + language
+    }
+    const messagesLoaded = (messages: string[] | IBundledStrings) => {
+        if (Array.isArray(messages)) {
+            ;(messages as any as IConsumerAPI).localize = createScopedLocalize(messages)
+        } else {
+            ;(messages as any as IConsumerAPI).localize = createScopedLocalize(messages[name])
+        }
+        ;(messages as any as IConsumerAPI).getConfiguredDefaultLocale = () => pluginConfig.availableLanguages?.['*']
+        load(messages)
+    }
+    if (typeof pluginConfig.loadBundle === 'function') {
+        ;(pluginConfig.loadBundle as BundleLoader)(name, language, (err: Error, messages) => {
+            // We have an error. Load the English default strings to not fail
+            if (err) {
+                req([name + '.nls'], messagesLoaded)
+            } else {
+                messagesLoaded(messages)
+            }
+        })
+    } else if (pluginConfig.translationServiceUrl && !useDefaultLanguage) {
+        ;(async () => {
+            try {
+                const messages = await getMessagesFromTranslationsService(
+                    pluginConfig.translationServiceUrl!,
+                    language,
+                    name
+                )
+                return messagesLoaded(messages)
+            } catch (err) {
+                // Language is already as generic as it gets, so require default messages
+                if (!language.includes('-')) {
+                    console.error(err)
+                    return req([name + '.nls'], messagesLoaded)
+                }
+                try {
+                    // Since there is a dash, the language configured is a specific sub-language of the same generic language.
+                    // Since we were unable to load the specific language, try to load the generic language. Ex. we failed to find a
+                    // Swiss German (de-CH), so try to load the generic German (de) messages instead.
+                    const genericLanguage = language.split('-')[0]
+                    const messages = await getMessagesFromTranslationsService(
+                        pluginConfig.translationServiceUrl!,
+                        genericLanguage,
+                        name
+                    )
+                    // We got some messages, so we configure the configuration to use the generic language for this session.
+                    pluginConfig.availableLanguages ??= {}
+                    pluginConfig.availableLanguages['*'] = genericLanguage
+                    return messagesLoaded(messages)
+                } catch (err) {
+                    console.error(err)
+                    return req([name + '.nls'], messagesLoaded)
+                }
+            }
+        })()
+    } else {
+        req([name + suffix], messagesLoaded, (err: Error) => {
+            if (suffix === '.nls') {
+                console.error('Failed trying to load default language strings', err)
+                return
+            }
+            console.error(
+                `Failed to load message bundle for language ${language}. Falling back to the default language:`,
+                err
+            )
+            req([name + '.nls'], messagesLoaded)
+        })
+    }
+}

--- a/vscode/src/testutils/vscode/path.ts
+++ b/vscode/src/testutils/vscode/path.ts
@@ -1,0 +1,1506 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// NOTE: VSCode's copy of nodejs path library to be usable in common (non-node) namespace
+// Copied from: https://github.com/nodejs/node/blob/v14.16.0/lib/path.js
+
+/**
+ * Copyright Joyent, Inc. and other Node contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+ * NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import * as process from 'process';
+
+const CHAR_UPPERCASE_A = 65;/* A */
+const CHAR_LOWERCASE_A = 97; /* a */
+const CHAR_UPPERCASE_Z = 90; /* Z */
+const CHAR_LOWERCASE_Z = 122; /* z */
+const CHAR_DOT = 46; /* . */
+const CHAR_FORWARD_SLASH = 47; /* / */
+const CHAR_BACKWARD_SLASH = 92; /* \ */
+const CHAR_COLON = 58; /* : */
+const CHAR_QUESTION_MARK = 63; /* ? */
+
+class ErrorInvalidArgType extends Error {
+	code: 'ERR_INVALID_ARG_TYPE';
+	constructor(name: string, expected: string, actual: unknown) {
+		// determiner: 'must be' or 'must not be'
+		let determiner;
+		if (typeof expected === 'string' && expected.indexOf('not ') === 0) {
+			determiner = 'must not be';
+			expected = expected.replace(/^not /, '');
+		} else {
+			determiner = 'must be';
+		}
+
+		const type = name.indexOf('.') !== -1 ? 'property' : 'argument';
+		let msg = `The "${name}" ${type} ${determiner} of type ${expected}`;
+
+		msg += `. Received type ${typeof actual}`;
+		super(msg);
+
+		this.code = 'ERR_INVALID_ARG_TYPE';
+	}
+}
+
+function validateString(value: string, name: string) {
+	if (typeof value !== 'string') {
+		throw new ErrorInvalidArgType(name, 'string', value);
+	}
+}
+
+function isPathSeparator(code: number | undefined) {
+	return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+}
+
+function isPosixPathSeparator(code: number | undefined) {
+	return code === CHAR_FORWARD_SLASH;
+}
+
+function isWindowsDeviceRoot(code: number) {
+	return (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
+		(code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z);
+}
+
+// Resolves . and .. elements in a path with directory names
+function normalizeString(path: string, allowAboveRoot: boolean, separator: string, isPathSeparator: (code?: number) => boolean) {
+	let res = '';
+	let lastSegmentLength = 0;
+	let lastSlash = -1;
+	let dots = 0;
+	let code = 0;
+	for (let i = 0; i <= path.length; ++i) {
+		if (i < path.length) {
+			code = path.charCodeAt(i);
+		}
+		else if (isPathSeparator(code)) {
+			break;
+		}
+		else {
+			code = CHAR_FORWARD_SLASH;
+		}
+
+		if (isPathSeparator(code)) {
+			if (lastSlash === i - 1 || dots === 1) {
+				// NOOP
+			} else if (dots === 2) {
+				if (res.length < 2 || lastSegmentLength !== 2 ||
+					res.charCodeAt(res.length - 1) !== CHAR_DOT ||
+					res.charCodeAt(res.length - 2) !== CHAR_DOT) {
+					if (res.length > 2) {
+						const lastSlashIndex = res.lastIndexOf(separator);
+						if (lastSlashIndex === -1) {
+							res = '';
+							lastSegmentLength = 0;
+						} else {
+							res = res.slice(0, lastSlashIndex);
+							lastSegmentLength = res.length - 1 - res.lastIndexOf(separator);
+						}
+						lastSlash = i;
+						dots = 0;
+						continue;
+					} else if (res.length !== 0) {
+						res = '';
+						lastSegmentLength = 0;
+						lastSlash = i;
+						dots = 0;
+						continue;
+					}
+				}
+				if (allowAboveRoot) {
+					res += res.length > 0 ? `${separator}..` : '..';
+					lastSegmentLength = 2;
+				}
+			} else {
+				if (res.length > 0) {
+					res += `${separator}${path.slice(lastSlash + 1, i)}`;
+				}
+				else {
+					res = path.slice(lastSlash + 1, i);
+				}
+				lastSegmentLength = i - lastSlash - 1;
+			}
+			lastSlash = i;
+			dots = 0;
+		} else if (code === CHAR_DOT && dots !== -1) {
+			++dots;
+		} else {
+			dots = -1;
+		}
+	}
+	return res;
+}
+
+function _format(sep: string, pathObject: ParsedPath) {
+	if (pathObject === null || typeof pathObject !== 'object') {
+		throw new ErrorInvalidArgType('pathObject', 'Object', pathObject);
+	}
+	const dir = pathObject.dir || pathObject.root;
+	const base = pathObject.base ||
+		`${pathObject.name || ''}${pathObject.ext || ''}`;
+	if (!dir) {
+		return base;
+	}
+	return dir === pathObject.root ? `${dir}${base}` : `${dir}${sep}${base}`;
+}
+
+export interface ParsedPath {
+	root: string;
+	dir: string;
+	base: string;
+	ext: string;
+	name: string;
+}
+
+export interface IPath {
+	normalize(path: string): string;
+	isAbsolute(path: string): boolean;
+	join(...paths: string[]): string;
+	resolve(...pathSegments: string[]): string;
+	relative(from: string, to: string): string;
+	dirname(path: string): string;
+	basename(path: string, ext?: string): string;
+	extname(path: string): string;
+	format(pathObject: ParsedPath): string;
+	parse(path: string): ParsedPath;
+	toNamespacedPath(path: string): string;
+	sep: '\\' | '/';
+	delimiter: string;
+	win32: IPath | null;
+	posix: IPath | null;
+}
+
+export const win32: IPath = {
+	// path.resolve([from ...], to)
+	resolve(...pathSegments: string[]): string {
+		let resolvedDevice = '';
+		let resolvedTail = '';
+		let resolvedAbsolute = false;
+
+		for (let i = pathSegments.length - 1; i >= -1; i--) {
+			let path;
+			if (i >= 0) {
+				path = pathSegments[i];
+				validateString(path, 'path');
+
+				// Skip empty entries
+				if (path.length === 0) {
+					continue;
+				}
+			} else if (resolvedDevice.length === 0) {
+				path = process.cwd();
+			} else {
+				// Windows has the concept of drive-specific current working
+				// directories. If we've resolved a drive letter but not yet an
+				// absolute path, get cwd for that drive, or the process cwd if
+				// the drive cwd is not available. We're sure the device is not
+				// a UNC path at this points, because UNC paths are always absolute.
+				path = process.env[`=${resolvedDevice}`] || process.cwd();
+
+				// Verify that a cwd was found and that it actually points
+				// to our drive. If not, default to the drive's root.
+				if (path === undefined ||
+					(path.slice(0, 2).toLowerCase() !== resolvedDevice.toLowerCase() &&
+						path.charCodeAt(2) === CHAR_BACKWARD_SLASH)) {
+					path = `${resolvedDevice}\\`;
+				}
+			}
+
+			const len = path.length;
+			let rootEnd = 0;
+			let device = '';
+			let isAbsolute = false;
+			const code = path.charCodeAt(0);
+
+			// Try to match a root
+			if (len === 1) {
+				if (isPathSeparator(code)) {
+					// `path` contains just a path separator
+					rootEnd = 1;
+					isAbsolute = true;
+				}
+			} else if (isPathSeparator(code)) {
+				// Possible UNC root
+
+				// If we started with a separator, we know we at least have an
+				// absolute path of some kind (UNC or otherwise)
+				isAbsolute = true;
+
+				if (isPathSeparator(path.charCodeAt(1))) {
+					// Matched double path separator at beginning
+					let j = 2;
+					let last = j;
+					// Match 1 or more non-path separators
+					while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+						j++;
+					}
+					if (j < len && j !== last) {
+						const firstPart = path.slice(last, j);
+						// Matched!
+						last = j;
+						// Match 1 or more path separators
+						while (j < len && isPathSeparator(path.charCodeAt(j))) {
+							j++;
+						}
+						if (j < len && j !== last) {
+							// Matched!
+							last = j;
+							// Match 1 or more non-path separators
+							while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+								j++;
+							}
+							if (j === len || j !== last) {
+								// We matched a UNC root
+								device = `\\\\${firstPart}\\${path.slice(last, j)}`;
+								rootEnd = j;
+							}
+						}
+					}
+				} else {
+					rootEnd = 1;
+				}
+			} else if (isWindowsDeviceRoot(code) &&
+				path.charCodeAt(1) === CHAR_COLON) {
+				// Possible device root
+				device = path.slice(0, 2);
+				rootEnd = 2;
+				if (len > 2 && isPathSeparator(path.charCodeAt(2))) {
+					// Treat separator following drive name as an absolute path
+					// indicator
+					isAbsolute = true;
+					rootEnd = 3;
+				}
+			}
+
+			if (device.length > 0) {
+				if (resolvedDevice.length > 0) {
+					if (device.toLowerCase() !== resolvedDevice.toLowerCase()) {
+						// This path points to another device so it is not applicable
+						continue;
+					}
+				} else {
+					resolvedDevice = device;
+				}
+			}
+
+			if (resolvedAbsolute) {
+				if (resolvedDevice.length > 0) {
+					break;
+				}
+			} else {
+				resolvedTail = `${path.slice(rootEnd)}\\${resolvedTail}`;
+				resolvedAbsolute = isAbsolute;
+				if (isAbsolute && resolvedDevice.length > 0) {
+					break;
+				}
+			}
+		}
+
+		// At this point the path should be resolved to a full absolute path,
+		// but handle relative paths to be safe (might happen when process.cwd()
+		// fails)
+
+		// Normalize the tail path
+		resolvedTail = normalizeString(resolvedTail, !resolvedAbsolute, '\\',
+			isPathSeparator);
+
+		return resolvedAbsolute ?
+			`${resolvedDevice}\\${resolvedTail}` :
+			`${resolvedDevice}${resolvedTail}` || '.';
+	},
+
+	normalize(path: string): string {
+		validateString(path, 'path');
+		const len = path.length;
+		if (len === 0) {
+			return '.';
+		}
+		let rootEnd = 0;
+		let device;
+		let isAbsolute = false;
+		const code = path.charCodeAt(0);
+
+		// Try to match a root
+		if (len === 1) {
+			// `path` contains just a single char, exit early to avoid
+			// unnecessary work
+			return isPosixPathSeparator(code) ? '\\' : path;
+		}
+		if (isPathSeparator(code)) {
+			// Possible UNC root
+
+			// If we started with a separator, we know we at least have an absolute
+			// path of some kind (UNC or otherwise)
+			isAbsolute = true;
+
+			if (isPathSeparator(path.charCodeAt(1))) {
+				// Matched double path separator at beginning
+				let j = 2;
+				let last = j;
+				// Match 1 or more non-path separators
+				while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+					j++;
+				}
+				if (j < len && j !== last) {
+					const firstPart = path.slice(last, j);
+					// Matched!
+					last = j;
+					// Match 1 or more path separators
+					while (j < len && isPathSeparator(path.charCodeAt(j))) {
+						j++;
+					}
+					if (j < len && j !== last) {
+						// Matched!
+						last = j;
+						// Match 1 or more non-path separators
+						while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+							j++;
+						}
+						if (j === len) {
+							// We matched a UNC root only
+							// Return the normalized version of the UNC root since there
+							// is nothing left to process
+							return `\\\\${firstPart}\\${path.slice(last)}\\`;
+						}
+						if (j !== last) {
+							// We matched a UNC root with leftovers
+							device = `\\\\${firstPart}\\${path.slice(last, j)}`;
+							rootEnd = j;
+						}
+					}
+				}
+			} else {
+				rootEnd = 1;
+			}
+		} else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+			// Possible device root
+			device = path.slice(0, 2);
+			rootEnd = 2;
+			if (len > 2 && isPathSeparator(path.charCodeAt(2))) {
+				// Treat separator following drive name as an absolute path
+				// indicator
+				isAbsolute = true;
+				rootEnd = 3;
+			}
+		}
+
+		let tail = rootEnd < len ?
+			normalizeString(path.slice(rootEnd), !isAbsolute, '\\', isPathSeparator) :
+			'';
+		if (tail.length === 0 && !isAbsolute) {
+			tail = '.';
+		}
+		if (tail.length > 0 && isPathSeparator(path.charCodeAt(len - 1))) {
+			tail += '\\';
+		}
+		if (device === undefined) {
+			return isAbsolute ? `\\${tail}` : tail;
+		}
+		return isAbsolute ? `${device}\\${tail}` : `${device}${tail}`;
+	},
+
+	isAbsolute(path: string): boolean {
+		validateString(path, 'path');
+		const len = path.length;
+		if (len === 0) {
+			return false;
+		}
+
+		const code = path.charCodeAt(0);
+		return isPathSeparator(code) ||
+			// Possible device root
+			(len > 2 &&
+				isWindowsDeviceRoot(code) &&
+				path.charCodeAt(1) === CHAR_COLON &&
+				isPathSeparator(path.charCodeAt(2)));
+	},
+
+	join(...paths: string[]): string {
+		if (paths.length === 0) {
+			return '.';
+		}
+
+		let joined;
+		let firstPart: string | undefined;
+		for (let i = 0; i < paths.length; ++i) {
+			const arg = paths[i];
+			validateString(arg, 'path');
+			if (arg.length > 0) {
+				if (joined === undefined) {
+					joined = firstPart = arg;
+				}
+				else {
+					joined += `\\${arg}`;
+				}
+			}
+		}
+
+		if (joined === undefined) {
+			return '.';
+		}
+
+		// Make sure that the joined path doesn't start with two slashes, because
+		// normalize() will mistake it for a UNC path then.
+		//
+		// This step is skipped when it is very clear that the user actually
+		// intended to point at a UNC path. This is assumed when the first
+		// non-empty string arguments starts with exactly two slashes followed by
+		// at least one more non-slash character.
+		//
+		// Note that for normalize() to treat a path as a UNC path it needs to
+		// have at least 2 components, so we don't filter for that here.
+		// This means that the user can use join to construct UNC paths from
+		// a server name and a share name; for example:
+		//   path.join('//server', 'share') -> '\\\\server\\share\\')
+		let needsReplace = true;
+		let slashCount = 0;
+		if (typeof firstPart === 'string' && isPathSeparator(firstPart.charCodeAt(0))) {
+			++slashCount;
+			const firstLen = firstPart.length;
+			if (firstLen > 1 && isPathSeparator(firstPart.charCodeAt(1))) {
+				++slashCount;
+				if (firstLen > 2) {
+					if (isPathSeparator(firstPart.charCodeAt(2))) {
+						++slashCount;
+					} else {
+						// We matched a UNC path in the first part
+						needsReplace = false;
+					}
+				}
+			}
+		}
+		if (needsReplace) {
+			// Find any more consecutive slashes we need to replace
+			while (slashCount < joined.length &&
+				isPathSeparator(joined.charCodeAt(slashCount))) {
+				slashCount++;
+			}
+
+			// Replace the slashes if needed
+			if (slashCount >= 2) {
+				joined = `\\${joined.slice(slashCount)}`;
+			}
+		}
+
+		return win32.normalize(joined);
+	},
+
+
+	// It will solve the relative path from `from` to `to`, for instance:
+	//  from = 'C:\\orandea\\test\\aaa'
+	//  to = 'C:\\orandea\\impl\\bbb'
+	// The output of the function should be: '..\\..\\impl\\bbb'
+	relative(from: string, to: string): string {
+		validateString(from, 'from');
+		validateString(to, 'to');
+
+		if (from === to) {
+			return '';
+		}
+
+		const fromOrig = win32.resolve(from);
+		const toOrig = win32.resolve(to);
+
+		if (fromOrig === toOrig) {
+			return '';
+		}
+
+		from = fromOrig.toLowerCase();
+		to = toOrig.toLowerCase();
+
+		if (from === to) {
+			return '';
+		}
+
+		// Trim any leading backslashes
+		let fromStart = 0;
+		while (fromStart < from.length &&
+			from.charCodeAt(fromStart) === CHAR_BACKWARD_SLASH) {
+			fromStart++;
+		}
+		// Trim trailing backslashes (applicable to UNC paths only)
+		let fromEnd = from.length;
+		while (fromEnd - 1 > fromStart &&
+			from.charCodeAt(fromEnd - 1) === CHAR_BACKWARD_SLASH) {
+			fromEnd--;
+		}
+		const fromLen = fromEnd - fromStart;
+
+		// Trim any leading backslashes
+		let toStart = 0;
+		while (toStart < to.length &&
+			to.charCodeAt(toStart) === CHAR_BACKWARD_SLASH) {
+			toStart++;
+		}
+		// Trim trailing backslashes (applicable to UNC paths only)
+		let toEnd = to.length;
+		while (toEnd - 1 > toStart &&
+			to.charCodeAt(toEnd - 1) === CHAR_BACKWARD_SLASH) {
+			toEnd--;
+		}
+		const toLen = toEnd - toStart;
+
+		// Compare paths to find the longest common path from root
+		const length = fromLen < toLen ? fromLen : toLen;
+		let lastCommonSep = -1;
+		let i = 0;
+		for (; i < length; i++) {
+			const fromCode = from.charCodeAt(fromStart + i);
+			if (fromCode !== to.charCodeAt(toStart + i)) {
+				break;
+			} else if (fromCode === CHAR_BACKWARD_SLASH) {
+				lastCommonSep = i;
+			}
+		}
+
+		// We found a mismatch before the first common path separator was seen, so
+		// return the original `to`.
+		if (i !== length) {
+			if (lastCommonSep === -1) {
+				return toOrig;
+			}
+		} else {
+			if (toLen > length) {
+				if (to.charCodeAt(toStart + i) === CHAR_BACKWARD_SLASH) {
+					// We get here if `from` is the exact base path for `to`.
+					// For example: from='C:\\foo\\bar'; to='C:\\foo\\bar\\baz'
+					return toOrig.slice(toStart + i + 1);
+				}
+				if (i === 2) {
+					// We get here if `from` is the device root.
+					// For example: from='C:\\'; to='C:\\foo'
+					return toOrig.slice(toStart + i);
+				}
+			}
+			if (fromLen > length) {
+				if (from.charCodeAt(fromStart + i) === CHAR_BACKWARD_SLASH) {
+					// We get here if `to` is the exact base path for `from`.
+					// For example: from='C:\\foo\\bar'; to='C:\\foo'
+					lastCommonSep = i;
+				} else if (i === 2) {
+					// We get here if `to` is the device root.
+					// For example: from='C:\\foo\\bar'; to='C:\\'
+					lastCommonSep = 3;
+				}
+			}
+			if (lastCommonSep === -1) {
+				lastCommonSep = 0;
+			}
+		}
+
+		let out = '';
+		// Generate the relative path based on the path difference between `to` and
+		// `from`
+		for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+			if (i === fromEnd || from.charCodeAt(i) === CHAR_BACKWARD_SLASH) {
+				out += out.length === 0 ? '..' : '\\..';
+			}
+		}
+
+		toStart += lastCommonSep;
+
+		// Lastly, append the rest of the destination (`to`) path that comes after
+		// the common path parts
+		if (out.length > 0) {
+			return `${out}${toOrig.slice(toStart, toEnd)}`;
+		}
+
+		if (toOrig.charCodeAt(toStart) === CHAR_BACKWARD_SLASH) {
+			++toStart;
+		}
+
+		return toOrig.slice(toStart, toEnd);
+	},
+
+	toNamespacedPath(path: string): string {
+		// Note: this will *probably* throw somewhere.
+		if (typeof path !== 'string') {
+			return path;
+		}
+
+		if (path.length === 0) {
+			return '';
+		}
+
+		const resolvedPath = win32.resolve(path);
+
+		if (resolvedPath.length <= 2) {
+			return path;
+		}
+
+		if (resolvedPath.charCodeAt(0) === CHAR_BACKWARD_SLASH) {
+			// Possible UNC root
+			if (resolvedPath.charCodeAt(1) === CHAR_BACKWARD_SLASH) {
+				const code = resolvedPath.charCodeAt(2);
+				if (code !== CHAR_QUESTION_MARK && code !== CHAR_DOT) {
+					// Matched non-long UNC root, convert the path to a long UNC path
+					return `\\\\?\\UNC\\${resolvedPath.slice(2)}`;
+				}
+			}
+		} else if (isWindowsDeviceRoot(resolvedPath.charCodeAt(0)) &&
+			resolvedPath.charCodeAt(1) === CHAR_COLON &&
+			resolvedPath.charCodeAt(2) === CHAR_BACKWARD_SLASH) {
+			// Matched device root, convert the path to a long UNC path
+			return `\\\\?\\${resolvedPath}`;
+		}
+
+		return path;
+	},
+
+	dirname(path: string): string {
+		validateString(path, 'path');
+		const len = path.length;
+		if (len === 0) {
+			return '.';
+		}
+		let rootEnd = -1;
+		let offset = 0;
+		const code = path.charCodeAt(0);
+
+		if (len === 1) {
+			// `path` contains just a path separator, exit early to avoid
+			// unnecessary work or a dot.
+			return isPathSeparator(code) ? path : '.';
+		}
+
+		// Try to match a root
+		if (isPathSeparator(code)) {
+			// Possible UNC root
+
+			rootEnd = offset = 1;
+
+			if (isPathSeparator(path.charCodeAt(1))) {
+				// Matched double path separator at beginning
+				let j = 2;
+				let last = j;
+				// Match 1 or more non-path separators
+				while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+					j++;
+				}
+				if (j < len && j !== last) {
+					// Matched!
+					last = j;
+					// Match 1 or more path separators
+					while (j < len && isPathSeparator(path.charCodeAt(j))) {
+						j++;
+					}
+					if (j < len && j !== last) {
+						// Matched!
+						last = j;
+						// Match 1 or more non-path separators
+						while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+							j++;
+						}
+						if (j === len) {
+							// We matched a UNC root only
+							return path;
+						}
+						if (j !== last) {
+							// We matched a UNC root with leftovers
+
+							// Offset by 1 to include the separator after the UNC root to
+							// treat it as a "normal root" on top of a (UNC) root
+							rootEnd = offset = j + 1;
+						}
+					}
+				}
+			}
+			// Possible device root
+		} else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+			rootEnd = len > 2 && isPathSeparator(path.charCodeAt(2)) ? 3 : 2;
+			offset = rootEnd;
+		}
+
+		let end = -1;
+		let matchedSlash = true;
+		for (let i = len - 1; i >= offset; --i) {
+			if (isPathSeparator(path.charCodeAt(i))) {
+				if (!matchedSlash) {
+					end = i;
+					break;
+				}
+			} else {
+				// We saw the first non-path separator
+				matchedSlash = false;
+			}
+		}
+
+		if (end === -1) {
+			if (rootEnd === -1) {
+				return '.';
+			}
+
+			end = rootEnd;
+		}
+		return path.slice(0, end);
+	},
+
+	basename(path: string, ext?: string): string {
+		if (ext !== undefined) {
+			validateString(ext, 'ext');
+		}
+		validateString(path, 'path');
+		let start = 0;
+		let end = -1;
+		let matchedSlash = true;
+		let i;
+
+		// Check for a drive letter prefix so as not to mistake the following
+		// path separator as an extra separator at the end of the path that can be
+		// disregarded
+		if (path.length >= 2 &&
+			isWindowsDeviceRoot(path.charCodeAt(0)) &&
+			path.charCodeAt(1) === CHAR_COLON) {
+			start = 2;
+		}
+
+		if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+			if (ext === path) {
+				return '';
+			}
+			let extIdx = ext.length - 1;
+			let firstNonSlashEnd = -1;
+			for (i = path.length - 1; i >= start; --i) {
+				const code = path.charCodeAt(i);
+				if (isPathSeparator(code)) {
+					// If we reached a path separator that was not part of a set of path
+					// separators at the end of the string, stop now
+					if (!matchedSlash) {
+						start = i + 1;
+						break;
+					}
+				} else {
+					if (firstNonSlashEnd === -1) {
+						// We saw the first non-path separator, remember this index in case
+						// we need it if the extension ends up not matching
+						matchedSlash = false;
+						firstNonSlashEnd = i + 1;
+					}
+					if (extIdx >= 0) {
+						// Try to match the explicit extension
+						if (code === ext.charCodeAt(extIdx)) {
+							if (--extIdx === -1) {
+								// We matched the extension, so mark this as the end of our path
+								// component
+								end = i;
+							}
+						} else {
+							// Extension does not match, so our result is the entire path
+							// component
+							extIdx = -1;
+							end = firstNonSlashEnd;
+						}
+					}
+				}
+			}
+
+			if (start === end) {
+				end = firstNonSlashEnd;
+			} else if (end === -1) {
+				end = path.length;
+			}
+			return path.slice(start, end);
+		}
+		for (i = path.length - 1; i >= start; --i) {
+			if (isPathSeparator(path.charCodeAt(i))) {
+				// If we reached a path separator that was not part of a set of path
+				// separators at the end of the string, stop now
+				if (!matchedSlash) {
+					start = i + 1;
+					break;
+				}
+			} else if (end === -1) {
+				// We saw the first non-path separator, mark this as the end of our
+				// path component
+				matchedSlash = false;
+				end = i + 1;
+			}
+		}
+
+		if (end === -1) {
+			return '';
+		}
+		return path.slice(start, end);
+	},
+
+	extname(path: string): string {
+		validateString(path, 'path');
+		let start = 0;
+		let startDot = -1;
+		let startPart = 0;
+		let end = -1;
+		let matchedSlash = true;
+		// Track the state of characters (if any) we see before our first dot and
+		// after any path separator we find
+		let preDotState = 0;
+
+		// Check for a drive letter prefix so as not to mistake the following
+		// path separator as an extra separator at the end of the path that can be
+		// disregarded
+
+		if (path.length >= 2 &&
+			path.charCodeAt(1) === CHAR_COLON &&
+			isWindowsDeviceRoot(path.charCodeAt(0))) {
+			start = startPart = 2;
+		}
+
+		for (let i = path.length - 1; i >= start; --i) {
+			const code = path.charCodeAt(i);
+			if (isPathSeparator(code)) {
+				// If we reached a path separator that was not part of a set of path
+				// separators at the end of the string, stop now
+				if (!matchedSlash) {
+					startPart = i + 1;
+					break;
+				}
+				continue;
+			}
+			if (end === -1) {
+				// We saw the first non-path separator, mark this as the end of our
+				// extension
+				matchedSlash = false;
+				end = i + 1;
+			}
+			if (code === CHAR_DOT) {
+				// If this is our first dot, mark it as the start of our extension
+				if (startDot === -1) {
+					startDot = i;
+				}
+				else if (preDotState !== 1) {
+					preDotState = 1;
+				}
+			} else if (startDot !== -1) {
+				// We saw a non-dot and non-path separator before our dot, so we should
+				// have a good chance at having a non-empty extension
+				preDotState = -1;
+			}
+		}
+
+		if (startDot === -1 ||
+			end === -1 ||
+			// We saw a non-dot character immediately before the dot
+			preDotState === 0 ||
+			// The (right-most) trimmed path component is exactly '..'
+			(preDotState === 1 &&
+				startDot === end - 1 &&
+				startDot === startPart + 1)) {
+			return '';
+		}
+		return path.slice(startDot, end);
+	},
+
+	format: _format.bind(null, '\\'),
+
+	parse(path) {
+		validateString(path, 'path');
+
+		const ret = { root: '', dir: '', base: '', ext: '', name: '' };
+		if (path.length === 0) {
+			return ret;
+		}
+
+		const len = path.length;
+		let rootEnd = 0;
+		let code = path.charCodeAt(0);
+
+		if (len === 1) {
+			if (isPathSeparator(code)) {
+				// `path` contains just a path separator, exit early to avoid
+				// unnecessary work
+				ret.root = ret.dir = path;
+				return ret;
+			}
+			ret.base = ret.name = path;
+			return ret;
+		}
+		// Try to match a root
+		if (isPathSeparator(code)) {
+			// Possible UNC root
+
+			rootEnd = 1;
+			if (isPathSeparator(path.charCodeAt(1))) {
+				// Matched double path separator at beginning
+				let j = 2;
+				let last = j;
+				// Match 1 or more non-path separators
+				while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+					j++;
+				}
+				if (j < len && j !== last) {
+					// Matched!
+					last = j;
+					// Match 1 or more path separators
+					while (j < len && isPathSeparator(path.charCodeAt(j))) {
+						j++;
+					}
+					if (j < len && j !== last) {
+						// Matched!
+						last = j;
+						// Match 1 or more non-path separators
+						while (j < len && !isPathSeparator(path.charCodeAt(j))) {
+							j++;
+						}
+						if (j === len) {
+							// We matched a UNC root only
+							rootEnd = j;
+						} else if (j !== last) {
+							// We matched a UNC root with leftovers
+							rootEnd = j + 1;
+						}
+					}
+				}
+			}
+		} else if (isWindowsDeviceRoot(code) && path.charCodeAt(1) === CHAR_COLON) {
+			// Possible device root
+			if (len <= 2) {
+				// `path` contains just a drive root, exit early to avoid
+				// unnecessary work
+				ret.root = ret.dir = path;
+				return ret;
+			}
+			rootEnd = 2;
+			if (isPathSeparator(path.charCodeAt(2))) {
+				if (len === 3) {
+					// `path` contains just a drive root, exit early to avoid
+					// unnecessary work
+					ret.root = ret.dir = path;
+					return ret;
+				}
+				rootEnd = 3;
+			}
+		}
+		if (rootEnd > 0) {
+			ret.root = path.slice(0, rootEnd);
+		}
+
+		let startDot = -1;
+		let startPart = rootEnd;
+		let end = -1;
+		let matchedSlash = true;
+		let i = path.length - 1;
+
+		// Track the state of characters (if any) we see before our first dot and
+		// after any path separator we find
+		let preDotState = 0;
+
+		// Get non-dir info
+		for (; i >= rootEnd; --i) {
+			code = path.charCodeAt(i);
+			if (isPathSeparator(code)) {
+				// If we reached a path separator that was not part of a set of path
+				// separators at the end of the string, stop now
+				if (!matchedSlash) {
+					startPart = i + 1;
+					break;
+				}
+				continue;
+			}
+			if (end === -1) {
+				// We saw the first non-path separator, mark this as the end of our
+				// extension
+				matchedSlash = false;
+				end = i + 1;
+			}
+			if (code === CHAR_DOT) {
+				// If this is our first dot, mark it as the start of our extension
+				if (startDot === -1) {
+					startDot = i;
+				} else if (preDotState !== 1) {
+					preDotState = 1;
+				}
+			} else if (startDot !== -1) {
+				// We saw a non-dot and non-path separator before our dot, so we should
+				// have a good chance at having a non-empty extension
+				preDotState = -1;
+			}
+		}
+
+		if (end !== -1) {
+			if (startDot === -1 ||
+				// We saw a non-dot character immediately before the dot
+				preDotState === 0 ||
+				// The (right-most) trimmed path component is exactly '..'
+				(preDotState === 1 &&
+					startDot === end - 1 &&
+					startDot === startPart + 1)) {
+				ret.base = ret.name = path.slice(startPart, end);
+			} else {
+				ret.name = path.slice(startPart, startDot);
+				ret.base = path.slice(startPart, end);
+				ret.ext = path.slice(startDot, end);
+			}
+		}
+
+		// If the directory is the root, use the entire root as the `dir` including
+		// the trailing slash if any (`C:\abc` -> `C:\`). Otherwise, strip out the
+		// trailing slash (`C:\abc\def` -> `C:\abc`).
+		if (startPart > 0 && startPart !== rootEnd) {
+			ret.dir = path.slice(0, startPart - 1);
+		} else {
+			ret.dir = ret.root;
+		}
+
+		return ret;
+	},
+
+	sep: '\\',
+	delimiter: ';',
+	win32: null,
+	posix: null
+};
+
+export const posix: IPath = {
+	// path.resolve([from ...], to)
+	resolve(...pathSegments: string[]): string {
+		let resolvedPath = '';
+		let resolvedAbsolute = false;
+
+		for (let i = pathSegments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
+			const path = i >= 0 ? pathSegments[i] : process.cwd();
+
+			validateString(path, 'path');
+
+			// Skip empty entries
+			if (path.length === 0) {
+				continue;
+			}
+
+			resolvedPath = `${path}/${resolvedPath}`;
+			resolvedAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+		}
+
+		// At this point the path should be resolved to a full absolute path, but
+		// handle relative paths to be safe (might happen when process.cwd() fails)
+
+		// Normalize the path
+		resolvedPath = normalizeString(resolvedPath, !resolvedAbsolute, '/',
+			isPosixPathSeparator);
+
+		if (resolvedAbsolute) {
+			return `/${resolvedPath}`;
+		}
+		return resolvedPath.length > 0 ? resolvedPath : '.';
+	},
+
+	normalize(path: string): string {
+		validateString(path, 'path');
+
+		if (path.length === 0) {
+			return '.';
+		}
+
+		const isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+		const trailingSeparator =
+			path.charCodeAt(path.length - 1) === CHAR_FORWARD_SLASH;
+
+		// Normalize the path
+		path = normalizeString(path, !isAbsolute, '/', isPosixPathSeparator);
+
+		if (path.length === 0) {
+			if (isAbsolute) {
+				return '/';
+			}
+			return trailingSeparator ? './' : '.';
+		}
+		if (trailingSeparator) {
+			path += '/';
+		}
+
+		return isAbsolute ? `/${path}` : path;
+	},
+
+	isAbsolute(path: string): boolean {
+		validateString(path, 'path');
+		return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+	},
+
+	join(...paths: string[]): string {
+		if (paths.length === 0) {
+			return '.';
+		}
+		let joined;
+		for (let i = 0; i < paths.length; ++i) {
+			const arg = paths[i];
+			validateString(arg, 'path');
+			if (arg.length > 0) {
+				if (joined === undefined) {
+					joined = arg;
+				} else {
+					joined += `/${arg}`;
+				}
+			}
+		}
+		if (joined === undefined) {
+			return '.';
+		}
+		return posix.normalize(joined);
+	},
+
+	relative(from: string, to: string): string {
+		validateString(from, 'from');
+		validateString(to, 'to');
+
+		if (from === to) {
+			return '';
+		}
+
+		// Trim leading forward slashes.
+		from = posix.resolve(from);
+		to = posix.resolve(to);
+
+		if (from === to) {
+			return '';
+		}
+
+		const fromStart = 1;
+		const fromEnd = from.length;
+		const fromLen = fromEnd - fromStart;
+		const toStart = 1;
+		const toLen = to.length - toStart;
+
+		// Compare paths to find the longest common path from root
+		const length = (fromLen < toLen ? fromLen : toLen);
+		let lastCommonSep = -1;
+		let i = 0;
+		for (; i < length; i++) {
+			const fromCode = from.charCodeAt(fromStart + i);
+			if (fromCode !== to.charCodeAt(toStart + i)) {
+				break;
+			} else if (fromCode === CHAR_FORWARD_SLASH) {
+				lastCommonSep = i;
+			}
+		}
+		if (i === length) {
+			if (toLen > length) {
+				if (to.charCodeAt(toStart + i) === CHAR_FORWARD_SLASH) {
+					// We get here if `from` is the exact base path for `to`.
+					// For example: from='/foo/bar'; to='/foo/bar/baz'
+					return to.slice(toStart + i + 1);
+				}
+				if (i === 0) {
+					// We get here if `from` is the root
+					// For example: from='/'; to='/foo'
+					return to.slice(toStart + i);
+				}
+			} else if (fromLen > length) {
+				if (from.charCodeAt(fromStart + i) === CHAR_FORWARD_SLASH) {
+					// We get here if `to` is the exact base path for `from`.
+					// For example: from='/foo/bar/baz'; to='/foo/bar'
+					lastCommonSep = i;
+				} else if (i === 0) {
+					// We get here if `to` is the root.
+					// For example: from='/foo/bar'; to='/'
+					lastCommonSep = 0;
+				}
+			}
+		}
+
+		let out = '';
+		// Generate the relative path based on the path difference between `to`
+		// and `from`.
+		for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
+			if (i === fromEnd || from.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+				out += out.length === 0 ? '..' : '/..';
+			}
+		}
+
+		// Lastly, append the rest of the destination (`to`) path that comes after
+		// the common path parts.
+		return `${out}${to.slice(toStart + lastCommonSep)}`;
+	},
+
+	toNamespacedPath(path: string): string {
+		// Non-op on posix systems
+		return path;
+	},
+
+	dirname(path: string): string {
+		validateString(path, 'path');
+		if (path.length === 0) {
+			return '.';
+		}
+		const hasRoot = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+		let end = -1;
+		let matchedSlash = true;
+		for (let i = path.length - 1; i >= 1; --i) {
+			if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+				if (!matchedSlash) {
+					end = i;
+					break;
+				}
+			} else {
+				// We saw the first non-path separator
+				matchedSlash = false;
+			}
+		}
+
+		if (end === -1) {
+			return hasRoot ? '/' : '.';
+		}
+		if (hasRoot && end === 1) {
+			return '//';
+		}
+		return path.slice(0, end);
+	},
+
+	basename(path: string, ext?: string): string {
+		if (ext !== undefined) {
+			validateString(ext, 'ext');
+		}
+		validateString(path, 'path');
+
+		let start = 0;
+		let end = -1;
+		let matchedSlash = true;
+		let i;
+
+		if (ext !== undefined && ext.length > 0 && ext.length <= path.length) {
+			if (ext === path) {
+				return '';
+			}
+			let extIdx = ext.length - 1;
+			let firstNonSlashEnd = -1;
+			for (i = path.length - 1; i >= 0; --i) {
+				const code = path.charCodeAt(i);
+				if (code === CHAR_FORWARD_SLASH) {
+					// If we reached a path separator that was not part of a set of path
+					// separators at the end of the string, stop now
+					if (!matchedSlash) {
+						start = i + 1;
+						break;
+					}
+				} else {
+					if (firstNonSlashEnd === -1) {
+						// We saw the first non-path separator, remember this index in case
+						// we need it if the extension ends up not matching
+						matchedSlash = false;
+						firstNonSlashEnd = i + 1;
+					}
+					if (extIdx >= 0) {
+						// Try to match the explicit extension
+						if (code === ext.charCodeAt(extIdx)) {
+							if (--extIdx === -1) {
+								// We matched the extension, so mark this as the end of our path
+								// component
+								end = i;
+							}
+						} else {
+							// Extension does not match, so our result is the entire path
+							// component
+							extIdx = -1;
+							end = firstNonSlashEnd;
+						}
+					}
+				}
+			}
+
+			if (start === end) {
+				end = firstNonSlashEnd;
+			} else if (end === -1) {
+				end = path.length;
+			}
+			return path.slice(start, end);
+		}
+		for (i = path.length - 1; i >= 0; --i) {
+			if (path.charCodeAt(i) === CHAR_FORWARD_SLASH) {
+				// If we reached a path separator that was not part of a set of path
+				// separators at the end of the string, stop now
+				if (!matchedSlash) {
+					start = i + 1;
+					break;
+				}
+			} else if (end === -1) {
+				// We saw the first non-path separator, mark this as the end of our
+				// path component
+				matchedSlash = false;
+				end = i + 1;
+			}
+		}
+
+		if (end === -1) {
+			return '';
+		}
+		return path.slice(start, end);
+	},
+
+	extname(path: string): string {
+		validateString(path, 'path');
+		let startDot = -1;
+		let startPart = 0;
+		let end = -1;
+		let matchedSlash = true;
+		// Track the state of characters (if any) we see before our first dot and
+		// after any path separator we find
+		let preDotState = 0;
+		for (let i = path.length - 1; i >= 0; --i) {
+			const code = path.charCodeAt(i);
+			if (code === CHAR_FORWARD_SLASH) {
+				// If we reached a path separator that was not part of a set of path
+				// separators at the end of the string, stop now
+				if (!matchedSlash) {
+					startPart = i + 1;
+					break;
+				}
+				continue;
+			}
+			if (end === -1) {
+				// We saw the first non-path separator, mark this as the end of our
+				// extension
+				matchedSlash = false;
+				end = i + 1;
+			}
+			if (code === CHAR_DOT) {
+				// If this is our first dot, mark it as the start of our extension
+				if (startDot === -1) {
+					startDot = i;
+				}
+				else if (preDotState !== 1) {
+					preDotState = 1;
+				}
+			} else if (startDot !== -1) {
+				// We saw a non-dot and non-path separator before our dot, so we should
+				// have a good chance at having a non-empty extension
+				preDotState = -1;
+			}
+		}
+
+		if (startDot === -1 ||
+			end === -1 ||
+			// We saw a non-dot character immediately before the dot
+			preDotState === 0 ||
+			// The (right-most) trimmed path component is exactly '..'
+			(preDotState === 1 &&
+				startDot === end - 1 &&
+				startDot === startPart + 1)) {
+			return '';
+		}
+		return path.slice(startDot, end);
+	},
+
+	format: _format.bind(null, '/'),
+
+	parse(path: string): ParsedPath {
+		validateString(path, 'path');
+
+		const ret = { root: '', dir: '', base: '', ext: '', name: '' };
+		if (path.length === 0) {
+			return ret;
+		}
+		const isAbsolute = path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+		let start;
+		if (isAbsolute) {
+			ret.root = '/';
+			start = 1;
+		} else {
+			start = 0;
+		}
+		let startDot = -1;
+		let startPart = 0;
+		let end = -1;
+		let matchedSlash = true;
+		let i = path.length - 1;
+
+		// Track the state of characters (if any) we see before our first dot and
+		// after any path separator we find
+		let preDotState = 0;
+
+		// Get non-dir info
+		for (; i >= start; --i) {
+			const code = path.charCodeAt(i);
+			if (code === CHAR_FORWARD_SLASH) {
+				// If we reached a path separator that was not part of a set of path
+				// separators at the end of the string, stop now
+				if (!matchedSlash) {
+					startPart = i + 1;
+					break;
+				}
+				continue;
+			}
+			if (end === -1) {
+				// We saw the first non-path separator, mark this as the end of our
+				// extension
+				matchedSlash = false;
+				end = i + 1;
+			}
+			if (code === CHAR_DOT) {
+				// If this is our first dot, mark it as the start of our extension
+				if (startDot === -1) {
+					startDot = i;
+				} else if (preDotState !== 1) {
+					preDotState = 1;
+				}
+			} else if (startDot !== -1) {
+				// We saw a non-dot and non-path separator before our dot, so we should
+				// have a good chance at having a non-empty extension
+				preDotState = -1;
+			}
+		}
+
+		if (end !== -1) {
+			const start = startPart === 0 && isAbsolute ? 1 : startPart;
+			if (startDot === -1 ||
+				// We saw a non-dot character immediately before the dot
+				preDotState === 0 ||
+				// The (right-most) trimmed path component is exactly '..'
+				(preDotState === 1 &&
+					startDot === end - 1 &&
+					startDot === startPart + 1)) {
+				ret.base = ret.name = path.slice(start, end);
+			} else {
+				ret.name = path.slice(start, startDot);
+				ret.base = path.slice(start, end);
+				ret.ext = path.slice(startDot, end);
+			}
+		}
+
+		if (startPart > 0) {
+			ret.dir = path.slice(0, startPart - 1);
+		} else if (isAbsolute) {
+			ret.dir = '/';
+		}
+
+		return ret;
+	},
+
+	sep: '/',
+	delimiter: ':',
+	win32: null,
+	posix: null
+};
+
+posix.win32 = win32.win32 = win32;
+posix.posix = win32.posix = posix;
+
+export const normalize = (process.platform === 'win32' ? win32.normalize : posix.normalize);
+export const isAbsolute = (process.platform === 'win32' ? win32.isAbsolute : posix.isAbsolute);
+export const join = (process.platform === 'win32' ? win32.join : posix.join);
+export const resolve = (process.platform === 'win32' ? win32.resolve : posix.resolve);
+export const relative = (process.platform === 'win32' ? win32.relative : posix.relative);
+export const dirname = (process.platform === 'win32' ? win32.dirname : posix.dirname);
+export const basename = (process.platform === 'win32' ? win32.basename : posix.basename);
+export const extname = (process.platform === 'win32' ? win32.extname : posix.extname);
+export const format = (process.platform === 'win32' ? win32.format : posix.format);
+export const parse = (process.platform === 'win32' ? win32.parse : posix.parse);
+export const toNamespacedPath = (process.platform === 'win32' ? win32.toNamespacedPath : posix.toNamespacedPath);
+export const sep = (process.platform === 'win32' ? win32.sep : posix.sep);
+export const delimiter = (process.platform === 'win32' ? win32.delimiter : posix.delimiter);

--- a/vscode/src/testutils/vscode/platform.ts
+++ b/vscode/src/testutils/vscode/platform.ts
@@ -1,0 +1,284 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as nls from './nls'
+
+export const LANGUAGE_DEFAULT = 'en'
+
+let _isWindows = false
+let _isMacintosh = false
+let _isLinux = false
+let _isLinuxSnap = false
+let _isNative = false
+let _isWeb = false
+let _isElectron = false
+let _isIOS = false
+let _isCI = false
+let _isMobile = false
+let _locale: string | undefined = undefined
+let _language: string = LANGUAGE_DEFAULT
+let _translationsConfigFile: string | undefined = undefined
+let _userAgent: string | undefined = undefined
+
+interface NLSConfig {
+    locale: string
+    availableLanguages: { [key: string]: string }
+    _translationsConfigFile: string
+}
+
+export interface IProcessEnvironment {
+    [key: string]: string | undefined
+}
+
+/**
+ * This interface is intentionally not identical to node.js
+ * process because it also works in sandboxed environments
+ * where the process object is implemented differently. We
+ * define the properties here that we need for `platform`
+ * to work and nothing else.
+ */
+export interface INodeProcess {
+    platform: string
+    arch: string
+    env: IProcessEnvironment
+    versions?: {
+        electron?: string
+    }
+    type?: string
+    cwd: () => string
+}
+
+declare const process: INodeProcess
+declare const global: unknown
+declare const self: unknown
+
+export const globals: any = typeof self === 'object' ? self : typeof global === 'object' ? global : {}
+
+let nodeProcess: INodeProcess | undefined = undefined
+if (typeof globals.vscode !== 'undefined' && typeof globals.vscode.process !== 'undefined') {
+    // Native environment (sandboxed)
+    nodeProcess = globals.vscode.process
+} else if (typeof process !== 'undefined') {
+    // Native environment (non-sandboxed)
+    nodeProcess = process
+}
+
+const isElectronProcess = typeof nodeProcess?.versions?.electron === 'string'
+const isElectronRenderer = isElectronProcess && nodeProcess?.type === 'renderer'
+
+interface INavigator {
+    userAgent: string
+    maxTouchPoints?: number
+}
+declare const navigator: INavigator
+
+// Web environment
+if (typeof navigator === 'object' && !isElectronRenderer) {
+    _userAgent = navigator.userAgent
+    _isWindows = _userAgent.indexOf('Windows') >= 0
+    _isMacintosh = _userAgent.indexOf('Macintosh') >= 0
+    _isIOS =
+        (_userAgent.indexOf('Macintosh') >= 0 ||
+            _userAgent.indexOf('iPad') >= 0 ||
+            _userAgent.indexOf('iPhone') >= 0) &&
+        !!navigator.maxTouchPoints &&
+        navigator.maxTouchPoints > 0
+    _isLinux = _userAgent.indexOf('Linux') >= 0
+    _isMobile = _userAgent?.indexOf('Mobi') >= 0
+    _isWeb = true
+
+    const configuredLocale = nls.getConfiguredDefaultLocale(
+        // This call _must_ be done in the file that calls `nls.getConfiguredDefaultLocale`
+        // to ensure that the NLS AMD Loader plugin has been loaded and configured.
+        // This is because the loader plugin decides what the default locale is based on
+        // how it's able to resolve the strings.
+        nls.localize({ key: 'ensureLoaderPluginIsLoaded', comment: ['{Locked}'] }, '_')
+    )
+
+    _locale = configuredLocale || LANGUAGE_DEFAULT
+
+    _language = _locale
+}
+
+// Native environment
+else if (typeof nodeProcess === 'object') {
+    _isWindows = nodeProcess.platform === 'win32'
+    _isMacintosh = nodeProcess.platform === 'darwin'
+    _isLinux = nodeProcess.platform === 'linux'
+    _isLinuxSnap = _isLinux && !!nodeProcess.env['SNAP'] && !!nodeProcess.env['SNAP_REVISION']
+    _isElectron = isElectronProcess
+    _isCI = !!nodeProcess.env['CI'] || !!nodeProcess.env['BUILD_ARTIFACTSTAGINGDIRECTORY']
+    _locale = LANGUAGE_DEFAULT
+    _language = LANGUAGE_DEFAULT
+    const rawNlsConfig = nodeProcess.env['VSCODE_NLS_CONFIG']
+    if (rawNlsConfig) {
+        try {
+            const nlsConfig: NLSConfig = JSON.parse(rawNlsConfig)
+            const resolved = nlsConfig.availableLanguages['*']
+            _locale = nlsConfig.locale
+            // VSCode's default language is 'en'
+            _language = resolved ? resolved : LANGUAGE_DEFAULT
+            _translationsConfigFile = nlsConfig._translationsConfigFile
+        } catch (e) {}
+    }
+    _isNative = true
+}
+
+// Unknown environment
+else {
+    console.error('Unable to resolve platform.')
+}
+
+export const enum Platform {
+    Web,
+    Mac,
+    Linux,
+    Windows,
+}
+export function PlatformToString(platform: Platform) {
+    switch (platform) {
+        case Platform.Web:
+            return 'Web'
+        case Platform.Mac:
+            return 'Mac'
+        case Platform.Linux:
+            return 'Linux'
+        case Platform.Windows:
+            return 'Windows'
+    }
+}
+
+let _platform: Platform = Platform.Web
+if (_isMacintosh) {
+    _platform = Platform.Mac
+} else if (_isWindows) {
+    _platform = Platform.Windows
+} else if (_isLinux) {
+    _platform = Platform.Linux
+}
+
+export const isWindows = _isWindows
+export const isMacintosh = _isMacintosh
+export const isLinux = _isLinux
+export const isLinuxSnap = _isLinuxSnap
+export const isNative = _isNative
+export const isElectron = _isElectron
+export const isWeb = _isWeb
+export const isWebWorker = _isWeb && typeof globals.importScripts === 'function'
+export const isIOS = _isIOS
+export const isMobile = _isMobile
+/**
+ * Whether we run inside a CI environment, such as
+ * GH actions or Azure Pipelines.
+ */
+export const isCI = _isCI
+export const platform = _platform
+export const userAgent = _userAgent
+
+/**
+ * The language used for the user interface. The format of
+ * the string is all lower case (e.g. zh-tw for Traditional
+ * Chinese)
+ */
+export const language = _language
+
+export namespace Language {
+    export function value(): string {
+        return language
+    }
+
+    export function isDefaultVariant(): boolean {
+        if (language.length === 2) {
+            return language === 'en'
+        } else if (language.length >= 3) {
+            return language[0] === 'e' && language[1] === 'n' && language[2] === '-'
+        } else {
+            return false
+        }
+    }
+
+    export function isDefault(): boolean {
+        return language === 'en'
+    }
+}
+
+/**
+ * The OS locale or the locale specified by --locale. The format of
+ * the string is all lower case (e.g. zh-tw for Traditional
+ * Chinese). The UI is not necessarily shown in the provided locale.
+ */
+export const locale = _locale
+
+/**
+ * The translations that are available through language packs.
+ */
+export const translationsConfigFile = _translationsConfigFile
+
+export const setTimeout0IsFaster = typeof globals.postMessage === 'function' && !globals.importScripts
+
+/**
+ * See https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#:~:text=than%204%2C%20then-,set%20timeout%20to%204,-.
+ *
+ * Works similarly to `setTimeout(0)` but doesn't suffer from the 4ms artificial delay
+ * that browsers set when the nesting level is > 5.
+ */
+export const setTimeout0 = (() => {
+    if (setTimeout0IsFaster) {
+        interface IQueueElement {
+            id: number
+            callback: () => void
+        }
+        const pending: IQueueElement[] = []
+        globals.addEventListener('message', (e: MessageEvent) => {
+            if (e.data && e.data.vscodeScheduleAsyncWork) {
+                for (let i = 0, len = pending.length; i < len; i++) {
+                    const candidate = pending[i]
+                    if (candidate.id === e.data.vscodeScheduleAsyncWork) {
+                        pending.splice(i, 1)
+                        candidate.callback()
+                        return
+                    }
+                }
+            }
+        })
+        let lastId = 0
+        return (callback: () => void) => {
+            const myId = ++lastId
+            pending.push({
+                id: myId,
+                callback: callback,
+            })
+            globals.postMessage({ vscodeScheduleAsyncWork: myId }, '*')
+        }
+    }
+    return (callback: () => void) => setTimeout(callback)
+})()
+
+export const enum OperatingSystem {
+    Windows = 1,
+    Macintosh = 2,
+    Linux = 3,
+}
+export const OS =
+    _isMacintosh || _isIOS ? OperatingSystem.Macintosh : _isWindows ? OperatingSystem.Windows : OperatingSystem.Linux
+
+let _isLittleEndian = true
+let _isLittleEndianComputed = false
+export function isLittleEndian(): boolean {
+    if (!_isLittleEndianComputed) {
+        _isLittleEndianComputed = true
+        const test = new Uint8Array(2)
+        test[0] = 1
+        test[1] = 2
+        const view = new Uint16Array(test.buffer)
+        _isLittleEndian = view[0] === (2 << 8) + 1
+    }
+    return _isLittleEndian
+}
+
+export const isChrome = !!(userAgent && userAgent.indexOf('Chrome') >= 0)
+export const isFirefox = !!(userAgent && userAgent.indexOf('Firefox') >= 0)
+export const isSafari = !!(!isChrome && userAgent && userAgent.indexOf('Safari') >= 0)
+export const isEdge = !!(userAgent && userAgent.indexOf('Edg/') >= 0)
+export const isAndroid = !!(userAgent && userAgent.indexOf('Android') >= 0)

--- a/vscode/src/testutils/vscode/readme.md
+++ b/vscode/src/testutils/vscode/readme.md
@@ -1,0 +1,5 @@
+# Copied code from VS Code
+
+The code in this directory is copy-pasted from the
+[microsoft/vscode](https://github.com/microsoft/vscode) repository. The
+original code is MIT licenced per [LICENSE.txt](./LICENSE.txt).

--- a/vscode/src/testutils/vscode/uri.ts
+++ b/vscode/src/testutils/vscode/uri.ts
@@ -1,0 +1,730 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CharCode } from './charCode'
+import { MarshalledId } from './marshallingId'
+import * as paths from './path'
+import { isWindows } from './platform'
+
+const _schemePattern = /^\w[\w\d+.-]*$/
+const _singleSlashStart = /^\//
+const _doubleSlashStart = /^\/\//
+
+function _validateUri(ret: URI, _strict?: boolean): void {
+    // scheme, must be set
+    if (!ret.scheme && _strict) {
+        throw new Error(
+            `[UriError]: Scheme is missing: {scheme: "", authority: "${ret.authority}", path: "${ret.path}", query: "${ret.query}", fragment: "${ret.fragment}"}`
+        )
+    }
+
+    // scheme, https://tools.ietf.org/html/rfc3986#section-3.1
+    // ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    if (ret.scheme && !_schemePattern.test(ret.scheme)) {
+        throw new Error('[UriError]: Scheme contains illegal characters.')
+    }
+
+    // path, http://tools.ietf.org/html/rfc3986#section-3.3
+    // If a URI contains an authority component, then the path component
+    // must either be empty or begin with a slash ("/") character.  If a URI
+    // does not contain an authority component, then the path cannot begin
+    // with two slash characters ("//").
+    if (ret.path) {
+        if (ret.authority) {
+            if (!_singleSlashStart.test(ret.path)) {
+                throw new Error(
+                    '[UriError]: If a URI contains an authority component, then the path component must either be empty or begin with a slash ("/") character'
+                )
+            }
+        } else {
+            if (_doubleSlashStart.test(ret.path)) {
+                throw new Error(
+                    '[UriError]: If a URI does not contain an authority component, then the path cannot begin with two slash characters ("//")'
+                )
+            }
+        }
+    }
+}
+
+// for a while we allowed uris *without* schemes and this is the migration
+// for them, e.g. an uri without scheme and without strict-mode warns and falls
+// back to the file-scheme. that should cause the least carnage and still be a
+// clear warning
+function _schemeFix(scheme: string, _strict: boolean): string {
+    if (!scheme && !_strict) {
+        return 'file'
+    }
+    return scheme
+}
+
+// implements a bit of https://tools.ietf.org/html/rfc3986#section-5
+function _referenceResolution(scheme: string, path: string): string {
+    // the slash-character is our 'default base' as we don't
+    // support constructing URIs relative to other URIs. This
+    // also means that we alter and potentially break paths.
+    // see https://tools.ietf.org/html/rfc3986#section-5.1.4
+    switch (scheme) {
+        case 'https':
+        case 'http':
+        case 'file':
+            if (!path) {
+                path = _slash
+            } else if (path[0] !== _slash) {
+                path = _slash + path
+            }
+            break
+    }
+    return path
+}
+
+const _empty = ''
+const _slash = '/'
+const _regexp = /^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/
+
+/**
+ * Uniform Resource Identifier (URI) http://tools.ietf.org/html/rfc3986.
+ * This class is a simple parser which creates the basic component parts
+ * (http://tools.ietf.org/html/rfc3986#section-3) with minimal validation
+ * and encoding.
+ *
+ * ```txt
+ *       foo://example.com:8042/over/there?name=ferret#nose
+ *       \_/   \______________/\_________/ \_________/ \__/
+ *        |           |            |            |        |
+ *     scheme     authority       path        query   fragment
+ *        |   _____________________|__
+ *       / \ /                        \
+ *       urn:example:animal:ferret:nose
+ * ```
+ */
+export class URI implements UriComponents {
+    static isUri(thing: any): thing is URI {
+        if (thing instanceof URI) {
+            return true
+        }
+        if (!thing) {
+            return false
+        }
+        return (
+            typeof (<URI>thing).authority === 'string' &&
+            typeof (<URI>thing).fragment === 'string' &&
+            typeof (<URI>thing).path === 'string' &&
+            typeof (<URI>thing).query === 'string' &&
+            typeof (<URI>thing).scheme === 'string' &&
+            typeof (<URI>thing).fsPath === 'string' &&
+            typeof (<URI>thing).with === 'function' &&
+            typeof (<URI>thing).toString === 'function'
+        )
+    }
+
+    /**
+     * scheme is the 'http' part of 'http://www.example.com/some/path?query#fragment'.
+     * The part before the first colon.
+     */
+    readonly scheme: string
+
+    /**
+     * authority is the 'www.example.com' part of 'http://www.example.com/some/path?query#fragment'.
+     * The part between the first double slashes and the next slash.
+     */
+    readonly authority: string
+
+    /**
+     * path is the '/some/path' part of 'http://www.example.com/some/path?query#fragment'.
+     */
+    readonly path: string
+
+    /**
+     * query is the 'query' part of 'http://www.example.com/some/path?query#fragment'.
+     */
+    readonly query: string
+
+    /**
+     * fragment is the 'fragment' part of 'http://www.example.com/some/path?query#fragment'.
+     */
+    readonly fragment: string
+
+    /**
+     * @internal
+     */
+    protected constructor(
+        scheme: string,
+        authority?: string,
+        path?: string,
+        query?: string,
+        fragment?: string,
+        _strict?: boolean
+    )
+
+    /**
+     * @internal
+     */
+    protected constructor(components: UriComponents)
+
+    /**
+     * @internal
+     */
+    protected constructor(
+        schemeOrData: string | UriComponents,
+        authority?: string,
+        path?: string,
+        query?: string,
+        fragment?: string,
+        _strict: boolean = false
+    ) {
+        if (typeof schemeOrData === 'object') {
+            this.scheme = schemeOrData.scheme || _empty
+            this.authority = schemeOrData.authority || _empty
+            this.path = schemeOrData.path || _empty
+            this.query = schemeOrData.query || _empty
+            this.fragment = schemeOrData.fragment || _empty
+            // no validation because it's this URI
+            // that creates uri components.
+            // _validateUri(this);
+        } else {
+            this.scheme = _schemeFix(schemeOrData, _strict)
+            this.authority = authority || _empty
+            this.path = _referenceResolution(this.scheme, path || _empty)
+            this.query = query || _empty
+            this.fragment = fragment || _empty
+
+            _validateUri(this, _strict)
+        }
+    }
+
+    // ---- filesystem path -----------------------
+
+    /**
+	 * Returns a string representing the corresponding file system path of this URI.
+	 * Will handle UNC paths, normalizes windows drive letters to lower-case, and uses the
+	 * platform specific path separator.
+	 *
+	 * * Will *not* validate the path for invalid characters and semantics.
+	 * * Will *not* look at the scheme of this URI.
+	 * * The result shall *not* be used for display purposes but for accessing a file on disk.
+	 *
+	 *
+	 * The *difference* to `URI#path` is the use of the platform specific separator and the handling
+	 * of UNC paths. See the below sample of a file-uri with an authority (UNC path).
+	 *
+	 * ```ts
+		const u = URI.parse('file://server/c$/folder/file.txt')
+		u.authority === 'server'
+		u.path === '/shares/c$/file.txt'
+		u.fsPath === '\\server\c$\folder\file.txt'
+	```
+	 *
+	 * Using `URI#path` to read a file (using fs-apis) would not be enough because parts of the path,
+	 * namely the server name, would be missing. Therefore `URI#fsPath` exists - it's sugar to ease working
+	 * with URIs that represent files on disk (`file` scheme).
+	 */
+    get fsPath(): string {
+        // if (this.scheme !== 'file') {
+        // 	console.warn(`[UriError] calling fsPath with scheme ${this.scheme}`);
+        // }
+        return uriToFsPath(this, false)
+    }
+
+    // ---- modify to new -------------------------
+
+    with(change: {
+        scheme?: string
+        authority?: string | null
+        path?: string | null
+        query?: string | null
+        fragment?: string | null
+    }): URI {
+        if (!change) {
+            return this
+        }
+
+        let { scheme, authority, path, query, fragment } = change
+        if (scheme === undefined) {
+            scheme = this.scheme
+        } else if (scheme === null) {
+            scheme = _empty
+        }
+        if (authority === undefined) {
+            authority = this.authority
+        } else if (authority === null) {
+            authority = _empty
+        }
+        if (path === undefined) {
+            path = this.path
+        } else if (path === null) {
+            path = _empty
+        }
+        if (query === undefined) {
+            query = this.query
+        } else if (query === null) {
+            query = _empty
+        }
+        if (fragment === undefined) {
+            fragment = this.fragment
+        } else if (fragment === null) {
+            fragment = _empty
+        }
+
+        if (
+            scheme === this.scheme &&
+            authority === this.authority &&
+            path === this.path &&
+            query === this.query &&
+            fragment === this.fragment
+        ) {
+            return this
+        }
+
+        return new Uri(scheme, authority, path, query, fragment)
+    }
+
+    // ---- parse & validate ------------------------
+
+    /**
+     * Creates a new URI from a string, e.g. `http://www.example.com/some/path`,
+     * `file:///usr/home`, or `scheme:with/path`.
+     *
+     * @param value A string which represents an URI (see `URI#toString`).
+     */
+    static parse(value: string, _strict: boolean = false): URI {
+        const match = _regexp.exec(value)
+        if (!match) {
+            return new Uri(_empty, _empty, _empty, _empty, _empty)
+        }
+        return new Uri(
+            match[2] || _empty,
+            percentDecode(match[4] || _empty),
+            percentDecode(match[5] || _empty),
+            percentDecode(match[7] || _empty),
+            percentDecode(match[9] || _empty),
+            _strict
+        )
+    }
+
+    /**
+	 * Creates a new URI from a file system path, e.g. `c:\my\files`,
+	 * `/usr/home`, or `\\server\share\some\path`.
+	 *
+	 * The *difference* between `URI#parse` and `URI#file` is that the latter treats the argument
+	 * as path, not as stringified-uri. E.g. `URI.file(path)` is **not the same as**
+	 * `URI.parse('file://' + path)` because the path might contain characters that are
+	 * interpreted (# and ?). See the following sample:
+	 * ```ts
+	const good = URI.file('/coding/c#/project1');
+	good.scheme === 'file';
+	good.path === '/coding/c#/project1';
+	good.fragment === '';
+	const bad = URI.parse('file://' + '/coding/c#/project1');
+	bad.scheme === 'file';
+	bad.path === '/coding/c'; // path is now broken
+	bad.fragment === '/project1';
+	```
+	 *
+	 * @param path A file system path (see `URI#fsPath`)
+	 */
+    static file(path: string): URI {
+        let authority = _empty
+
+        // normalize to fwd-slashes on windows,
+        // on other systems bwd-slashes are valid
+        // filename character, eg /f\oo/ba\r.txt
+        if (isWindows) {
+            path = path.replace(/\\/g, _slash)
+        }
+
+        // check for authority as used in UNC shares
+        // or use the path as given
+        if (path[0] === _slash && path[1] === _slash) {
+            const idx = path.indexOf(_slash, 2)
+            if (idx === -1) {
+                authority = path.substring(2)
+                path = _slash
+            } else {
+                authority = path.substring(2, idx)
+                path = path.substring(idx) || _slash
+            }
+        }
+
+        return new Uri('file', authority, path, _empty, _empty)
+    }
+
+    static from(components: {
+        scheme: string
+        authority?: string
+        path?: string
+        query?: string
+        fragment?: string
+    }): URI {
+        const result = new Uri(
+            components.scheme,
+            components.authority,
+            components.path,
+            components.query,
+            components.fragment
+        )
+        _validateUri(result, true)
+        return result
+    }
+
+    /**
+     * Join a URI path with path fragments and normalizes the resulting path.
+     *
+     * @param uri The input URI.
+     * @param pathFragment The path fragment to add to the URI path.
+     * @returns The resulting URI.
+     */
+    static joinPath(uri: URI, ...pathFragment: string[]): URI {
+        if (!uri.path) {
+            throw new Error(`[UriError]: cannot call joinPath on URI without path`)
+        }
+        let newPath: string
+        if (isWindows && uri.scheme === 'file') {
+            newPath = URI.file(paths.win32.join(uriToFsPath(uri, true), ...pathFragment)).path
+        } else {
+            newPath = paths.posix.join(uri.path, ...pathFragment)
+        }
+        return uri.with({ path: newPath })
+    }
+
+    // ---- printing/externalize ---------------------------
+
+    /**
+     * Creates a string representation for this URI. It's guaranteed that calling
+     * `URI.parse` with the result of this function creates an URI which is equal
+     * to this URI.
+     *
+     * * The result shall *not* be used for display purposes but for externalization or transport.
+     * * The result will be encoded using the percentage encoding and encoding happens mostly
+     * ignore the scheme-specific encoding rules.
+     *
+     * @param skipEncoding Do not encode the result, default is `false`
+     */
+    toString(skipEncoding: boolean = false): string {
+        return _asFormatted(this, skipEncoding)
+    }
+
+    toJSON(): UriComponents {
+        return this
+    }
+
+    static revive(data: UriComponents | URI): URI
+    static revive(data: UriComponents | URI | undefined): URI | undefined
+    static revive(data: UriComponents | URI | null): URI | null
+    static revive(data: UriComponents | URI | undefined | null): URI | undefined | null
+    static revive(data: UriComponents | URI | undefined | null): URI | undefined | null {
+        if (!data) {
+            return data
+        } else if (data instanceof URI) {
+            return data
+        } else {
+            const result = new Uri(data)
+            result._formatted = (<UriState>data).external
+            result._fsPath = (<UriState>data)._sep === _pathSepMarker ? (<UriState>data).fsPath : null
+            return result
+        }
+    }
+}
+
+export interface UriComponents {
+    scheme: string
+    authority: string
+    path: string
+    query: string
+    fragment: string
+}
+
+interface UriState extends UriComponents {
+    $mid: MarshalledId.Uri
+    external: string
+    fsPath: string
+    _sep: 1 | undefined
+}
+
+const _pathSepMarker = isWindows ? 1 : undefined
+
+// This class exists so that URI is compatible with vscode.Uri (API).
+export class Uri extends URI {
+    _formatted: string | null = null
+    _fsPath: string | null = null
+
+    override get fsPath(): string {
+        if (!this._fsPath) {
+            this._fsPath = uriToFsPath(this, false)
+        }
+        return this._fsPath
+    }
+
+    override toString(skipEncoding: boolean = false): string {
+        if (!skipEncoding) {
+            if (!this._formatted) {
+                this._formatted = _asFormatted(this, false)
+            }
+            return this._formatted
+        } else {
+            // we don't cache that
+            return _asFormatted(this, true)
+        }
+    }
+
+    override toJSON(): UriComponents {
+        const res = <UriState>{
+            $mid: MarshalledId.Uri,
+        }
+        // cached state
+        if (this._fsPath) {
+            res.fsPath = this._fsPath
+            res._sep = _pathSepMarker
+        }
+        if (this._formatted) {
+            res.external = this._formatted
+        }
+        // uri components
+        if (this.path) {
+            res.path = this.path
+        }
+        if (this.scheme) {
+            res.scheme = this.scheme
+        }
+        if (this.authority) {
+            res.authority = this.authority
+        }
+        if (this.query) {
+            res.query = this.query
+        }
+        if (this.fragment) {
+            res.fragment = this.fragment
+        }
+        return res
+    }
+}
+
+// reserved characters: https://tools.ietf.org/html/rfc3986#section-2.2
+const encodeTable: { [ch: number]: string } = {
+    [CharCode.Colon]: '%3A', // gen-delims
+    [CharCode.Slash]: '%2F',
+    [CharCode.QuestionMark]: '%3F',
+    [CharCode.Hash]: '%23',
+    [CharCode.OpenSquareBracket]: '%5B',
+    [CharCode.CloseSquareBracket]: '%5D',
+    [CharCode.AtSign]: '%40',
+
+    [CharCode.ExclamationMark]: '%21', // sub-delims
+    [CharCode.DollarSign]: '%24',
+    [CharCode.Ampersand]: '%26',
+    [CharCode.SingleQuote]: '%27',
+    [CharCode.OpenParen]: '%28',
+    [CharCode.CloseParen]: '%29',
+    [CharCode.Asterisk]: '%2A',
+    [CharCode.Plus]: '%2B',
+    [CharCode.Comma]: '%2C',
+    [CharCode.Semicolon]: '%3B',
+    [CharCode.Equals]: '%3D',
+
+    [CharCode.Space]: '%20',
+}
+
+function encodeURIComponentFast(uriComponent: string, allowSlash: boolean): string {
+    let res: string | undefined = undefined
+    let nativeEncodePos = -1
+
+    for (let pos = 0; pos < uriComponent.length; pos++) {
+        const code = uriComponent.charCodeAt(pos)
+
+        // unreserved characters: https://tools.ietf.org/html/rfc3986#section-2.3
+        if (
+            (code >= CharCode.a && code <= CharCode.z) ||
+            (code >= CharCode.A && code <= CharCode.Z) ||
+            (code >= CharCode.Digit0 && code <= CharCode.Digit9) ||
+            code === CharCode.Dash ||
+            code === CharCode.Period ||
+            code === CharCode.Underline ||
+            code === CharCode.Tilde ||
+            (allowSlash && code === CharCode.Slash)
+        ) {
+            // check if we are delaying native encode
+            if (nativeEncodePos !== -1) {
+                res += encodeURIComponent(uriComponent.substring(nativeEncodePos, pos))
+                nativeEncodePos = -1
+            }
+            // check if we write into a new string (by default we try to return the param)
+            if (res !== undefined) {
+                res += uriComponent.charAt(pos)
+            }
+        } else {
+            // encoding needed, we need to allocate a new string
+            if (res === undefined) {
+                res = uriComponent.substr(0, pos)
+            }
+
+            // check with default table first
+            const escaped = encodeTable[code]
+            if (escaped !== undefined) {
+                // check if we are delaying native encode
+                if (nativeEncodePos !== -1) {
+                    res += encodeURIComponent(uriComponent.substring(nativeEncodePos, pos))
+                    nativeEncodePos = -1
+                }
+
+                // append escaped variant to result
+                res += escaped
+            } else if (nativeEncodePos === -1) {
+                // use native encode only when needed
+                nativeEncodePos = pos
+            }
+        }
+    }
+
+    if (nativeEncodePos !== -1) {
+        res += encodeURIComponent(uriComponent.substring(nativeEncodePos))
+    }
+
+    return res !== undefined ? res : uriComponent
+}
+
+function encodeURIComponentMinimal(path: string): string {
+    let res: string | undefined = undefined
+    for (let pos = 0; pos < path.length; pos++) {
+        const code = path.charCodeAt(pos)
+        if (code === CharCode.Hash || code === CharCode.QuestionMark) {
+            if (res === undefined) {
+                res = path.substr(0, pos)
+            }
+            res += encodeTable[code]
+        } else {
+            if (res !== undefined) {
+                res += path[pos]
+            }
+        }
+    }
+    return res !== undefined ? res : path
+}
+
+/**
+ * Compute `fsPath` for the given uri
+ */
+export function uriToFsPath(uri: URI, keepDriveLetterCasing: boolean): string {
+    let value: string
+    if (uri.authority && uri.path.length > 1 && uri.scheme === 'file') {
+        // unc path: file://shares/c$/far/boo
+        value = `//${uri.authority}${uri.path}`
+    } else if (
+        uri.path.charCodeAt(0) === CharCode.Slash &&
+        ((uri.path.charCodeAt(1) >= CharCode.A && uri.path.charCodeAt(1) <= CharCode.Z) ||
+            (uri.path.charCodeAt(1) >= CharCode.a && uri.path.charCodeAt(1) <= CharCode.z)) &&
+        uri.path.charCodeAt(2) === CharCode.Colon
+    ) {
+        if (!keepDriveLetterCasing) {
+            // windows drive letter: file:///c:/far/boo
+            value = uri.path[1].toLowerCase() + uri.path.substr(2)
+        } else {
+            value = uri.path.substr(1)
+        }
+    } else {
+        // other path
+        value = uri.path
+    }
+    if (isWindows) {
+        value = value.replace(/\//g, '\\')
+    }
+    return value
+}
+
+/**
+ * Create the external version of a uri
+ */
+function _asFormatted(uri: URI, skipEncoding: boolean): string {
+    const encoder = !skipEncoding ? encodeURIComponentFast : encodeURIComponentMinimal
+
+    let res = ''
+    let { scheme, authority, path, query, fragment } = uri
+    if (scheme) {
+        res += scheme
+        res += ':'
+    }
+    if (authority || scheme === 'file') {
+        res += _slash
+        res += _slash
+    }
+    if (authority) {
+        let idx = authority.indexOf('@')
+        if (idx !== -1) {
+            // <user>@<auth>
+            const userinfo = authority.substr(0, idx)
+            authority = authority.substr(idx + 1)
+            idx = userinfo.indexOf(':')
+            if (idx === -1) {
+                res += encoder(userinfo, false)
+            } else {
+                // <user>:<pass>@<auth>
+                res += encoder(userinfo.substr(0, idx), false)
+                res += ':'
+                res += encoder(userinfo.substr(idx + 1), false)
+            }
+            res += '@'
+        }
+        authority = authority.toLowerCase()
+        idx = authority.indexOf(':')
+        if (idx === -1) {
+            res += encoder(authority, false)
+        } else {
+            // <auth>:<port>
+            res += encoder(authority.substr(0, idx), false)
+            res += authority.substr(idx)
+        }
+    }
+    if (path) {
+        // lower-case windows drive letters in /C:/fff or C:/fff
+        if (path.length >= 3 && path.charCodeAt(0) === CharCode.Slash && path.charCodeAt(2) === CharCode.Colon) {
+            const code = path.charCodeAt(1)
+            if (code >= CharCode.A && code <= CharCode.Z) {
+                path = `/${String.fromCharCode(code + 32)}:${path.substr(3)}` // "/c:".length === 3
+            }
+        } else if (path.length >= 2 && path.charCodeAt(1) === CharCode.Colon) {
+            const code = path.charCodeAt(0)
+            if (code >= CharCode.A && code <= CharCode.Z) {
+                path = `${String.fromCharCode(code + 32)}:${path.substr(2)}` // "/c:".length === 3
+            }
+        }
+        // encode the rest of the path
+        res += encoder(path, true)
+    }
+    if (query) {
+        res += '?'
+        res += encoder(query, false)
+    }
+    if (fragment) {
+        res += '#'
+        res += !skipEncoding ? encodeURIComponentFast(fragment, false) : fragment
+    }
+    return res
+}
+
+// --- decode
+
+function decodeURIComponentGraceful(str: string): string {
+    try {
+        return decodeURIComponent(str)
+    } catch {
+        if (str.length > 3) {
+            return str.substr(0, 3) + decodeURIComponentGraceful(str.substr(3))
+        } else {
+            return str
+        }
+    }
+}
+
+const _rEncodedAsHex = /(%[0-9A-Za-z][0-9A-Za-z])+/g
+
+function percentDecode(str: string): string {
+    if (!str.match(_rEncodedAsHex)) {
+        return str
+    }
+    return str.replace(_rEncodedAsHex, match => decodeURIComponentGraceful(match))
+}
+
+/**
+ * Mapped-type that replaces all occurrences of URI with UriComponents
+ */
+export type UriDto<T> = { [K in keyof T]: T[K] extends URI ? UriComponents : UriDto<T[K]> }


### PR DESCRIPTION
Previously, autocomplete wasn't working on Windows for the JetBrains plugin. The changes in this PR fix the problem. I manually verified the fix by running a Windows instance on GCP and setting up IntelliJ via Remote Desktop.

To summarize the diff:

- `vscode.ExtensionContext.extensionPath` was previously an empty object `{}` instead of a `string`.
- `vscode.ExtensionContext.extensionUri` was previously an empty object `{}` instead of a `vscode.Uri`.
- `vscode.Uri.fsPath` didn't work on Windows because it used the URI `path`. This PR fixes the problem by inlining `vscode.Uri` implementation from microsoft/vscode under a new MIT-licensed directory.


## Test plan

- Make sure `src login` is configured
  - `VITEST_ONLY=NotConfigured pnpm run test agent/src/index.test.ts` to verify agent tests are still passing
- `./gradlew clean buildPlugin` in JetBrains plugin
  - Install plugin on Windows computer
  - Confirm completions work as expected
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
