### PR TITLE
fix: set display text for typewriter

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -172,7 +172,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         const typewriter = new Typewriter({
             update: content => {
                 const displayText = reformatBotMessage(content, responsePrefix)
-                this.transcript.addAssistantResponse(displayText)
+                this.transcript.addAssistantResponse(content, displayText)
                 this.sendTranscript()
             },
             close: () => {},
@@ -194,7 +194,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     let displayText = reformatBotMessage(text, responsePrefix)
                     // TODO(keegancsmith) guardrails may be slow, we need to make this async update the interaction.
                     displayText = await this.guardrailsAnnotateAttributions(displayText)
-                    this.transcript.addAssistantResponse(text || '', displayText)
+                    this.transcript.addAssistantResponse(text, displayText)
                 }
                 await this.onCompletionEnd()
                 // Count code generated from response


### PR DESCRIPTION
follow up on https://github.com/sourcegraph/cody/pull/1220

Right now we are not streaming assistant response as we are not setting display text in typewriter for assistant response because of the change in 1220.

This PR should fix the issue

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. run /test command on selected code
2. before the change, you will not see the response until cody has finished the response
3. when building from this branch, you should see the response from cody streaming in chat view