### PR TITLE
fix: preamble leak for anthropic

### DIFF
--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -85,8 +85,7 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations.
-                Here is the code: ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}`,
+                text: `Below is the code from file path ${this.options.fileName}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: ${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix} \n<--End of code-->`,
             },
             {
                 speaker: 'assistant',


### PR DESCRIPTION
Fix issues that cause the preamble to leak for anthropic by ending the code snippets with `\n<--End of code-->` to make sure Claude instant knows where the code ends, instead of having the code snippets end with a new line that confused Claude and makes it think the code was not completed and should be continued from there.

#### Before

![Screenshot 2023-10-02 at 3 27 09 PM](https://github.com/sourcegraph/cody/assets/68532117/6c9f9319-279e-47da-bea8-3e6046eac31e)

#### After

![Screenshot 2023-10-02 at 3 28 30 PM](https://github.com/sourcegraph/cody/assets/68532117/d6adb3ca-f41b-4da2-a077-0920c206d5de)

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. build Cody from this branch
2. Go to `line 213` of [vscode/webviews/Chat.tsx](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/webviews/Chat.tsx?L213) in your editor
3. Instead of seeing `Human: ` as a suggestion, Cody should not suggest anything here.