### PR TITLE
Only show "Ask Cody Inline" context menu item when signed in

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Removeed chat and chat history created by edit and doc commands. [pull/1220](https://github.com/sourcegraph/cody/pull/1220)
+- Only show "Ask Cody Inline" context menu item when signed in. [pull/1281](https://github.com/sourcegraph/cody/pull/1281)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,7 +17,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Removeed chat and chat history created by edit and doc commands. [pull/1220](https://github.com/sourcegraph/cody/pull/1220)
+- Remove chat and chat history created by edit and doc commands. [pull/1220](https://github.com/sourcegraph/cody/pull/1220)
 - Only show "Ask Cody Inline" context menu item when signed in. [pull/1281](https://github.com/sourcegraph/cody/pull/1281)
 
 ### Changed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -623,6 +623,7 @@
         },
         {
           "command": "cody.inline.new",
+          "when": "cody.activated",
           "group": "ask"
         }
       ],


### PR DESCRIPTION
Fixes the "Ask Cody Inline" context menu incorrectly showing for logged out users.

| Before | After |
| - | - |
|  <img width="462" alt="Screenshot 2023-10-03 at 12 03 13 pm" src="https://github.com/sourcegraph/cody/assets/153/dfd8b860-c8eb-47e0-98e2-ceb71a79e62f"> | <img width="355" alt="Screenshot 2023-10-03 at 12 04 08 pm" src="https://github.com/sourcegraph/cody/assets/153/589f18fa-8c84-46cb-af2b-63215ac9f458"> |

Part of #1275

## Test plan

- While logged out, right clicked on code, verified menu item no longer there