### PR TITLE
Remove .com from enterprise login options

### DIFF
--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -110,11 +110,6 @@ export const LoginMenuOptionItems = [
         totalSteps: 2,
     },
     {
-        id: 'dotcom',
-        label: 'Sign in to Sourcegraph.com',
-        totalSteps: 0,
-    },
-    {
         id: 'token',
         label: 'Sign in with URL and Access Token',
         totalSteps: 2,


### PR DESCRIPTION
Now we have the new login options, it doesn't make sense to have sourcegraph.com in the quickpick items, so this removes it. 

| Before | After |
| - | - |
| <img width="886" alt="Screenshot 2023-10-03 at 12 30 02 pm" src="https://github.com/sourcegraph/cody/assets/153/702a0154-d071-4815-bff2-4707716f0b3d"> | <img width="886" alt="Screenshot 2023-10-03 at 12 29 44 pm" src="https://github.com/sourcegraph/cody/assets/153/33b3439d-d816-4468-a41b-d89ec19638aa"> |

In the future, it would be good to provide a "Sign in to sourcegraph.com with Access Token" option (currently you have to use "recently used" to achieve that).

Fixes #1280

No changelog necessary

## Test plan

- While logged out, click "Sign in to Enterprise Instance" and review quickpick items