### PR TITLE
add event logging validation to inline test

### DIFF
--- a/vscode/test/e2e/inline-completion.test.ts
+++ b/vscode/test/e2e/inline-completion.test.ts
@@ -1,8 +1,19 @@
 import { expect, Page } from '@playwright/test'
 
+import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
+
 import { sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
+const expectedOrderedEvents = [
+    'CodyVSCodeExtension:completion:suggested',
+    'CodyVSCodeExtension:completion:accepted',
+    'CodyVSCodeExtension:completion:suggested',
+]
+
+test.beforeEach(() => {
+    resetLoggedEvents()
+})
 test('shows completion onboarding notice on first completion accept', async ({ page, sidebar }) => {
     const indexFile = page.getByRole('treeitem', { name: 'index.html' }).locator('a')
     const editor = page.locator('[id="workbench\\.parts\\.editor"]')
@@ -26,6 +37,7 @@ test('shows completion onboarding notice on first completion accept', async ({ p
     // Accept the completion and expect the text to be added and
     // the notice to be shown.
     await acceptInlineCompletion(page)
+    console.log('1')
     await expect(firstAcceptedCompletion).toBeVisible()
     await expect(notice).toBeVisible()
 
@@ -38,6 +50,7 @@ test('shows completion onboarding notice on first completion accept', async ({ p
     await acceptInlineCompletion(page)
     await expect(otherAcceptedCompletion).toBeVisible()
     await expect(notice).not.toBeVisible()
+    await expect.poll(() => loggedEvents.sort()).toEqual(expectedOrderedEvents.sort())
 })
 
 async function triggerInlineCompletionInBody(page: Page): Promise<void> {


### PR DESCRIPTION
Adds logging validation to`inline-completion.test.ts`, to ensure that the correct events are logged when inline completions occur. 

To note, for this test we sort the array of expectedEvents and loggedEvents when comparing because `CodyVSCodeExtension:completion:suggested` and `CodyVSCodeExtension:completion:accepted` events fire at the same time making this test flaky if we do not sort when comparing the arrays.
## Test plan
Tested locally running pnpm test:e2e
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
