### PR TITLE
Agent: disable tree-sitter setting

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -135,8 +135,8 @@ describe.each([
     })
 
     it('returns non-empty autocomplete', async () => {
-        const filePath = '/path/to/foo/file.js'
-        const content = 'function sum(a, b) {\n    \n}'
+        const filePath = '/path/to/foo/file.ts'
+        const content = 'function sum(a: number, b: number) {\n    \n}'
         client.notify('textDocument/didOpen', {
             filePath,
             content,
@@ -144,8 +144,8 @@ describe.each([
         })
         const completions = await client.request('autocomplete/execute', {
             filePath,
-            position: { line: 1, character: 4 },
-            triggerKind: 'Automatic',
+            position: { line: 1, character: 3 },
+            triggerKind: 'Invoke',
         })
         assert(completions.items.length > 0)
     })
@@ -178,9 +178,9 @@ describe.each([
     it('executing a recipe sends chat/updateMessageInProgress notifications', () => streamingChatMessages, 100)
 
     it('allows us to cancel chat', async () => {
-        setTimeout(() => client.notify('$/cancelRequest', { id: client.id - 1 }), 200)
+        setTimeout(() => client.notify('$/cancelRequest', { id: client.id - 1 }), 300)
         await client.executeRecipe('chat-question', 'How do I implement sum?')
-    }, 500)
+    }, 600)
 
     afterAll(async () => {
         await client.shutdownAndExit()

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -129,6 +129,9 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.debug ?? false
             case 'cody.debug.verbose':
                 return connectionConfig?.verboseDebug ?? false
+            case 'cody.autocomplete.experimental.syntacticPostProcessing':
+                // False because we don't embed WASM with the agent yet.
+                return false
             case 'cody.codebase':
                 return connectionConfig?.codebase
             default:
@@ -336,6 +339,7 @@ export function completionProvider(): Promise<InlineCompletionItemProvider> {
 }
 
 const _languages: Partial<typeof vscode.languages> = {
+    getLanguages: () => Promise.resolve([]),
     registerCodeActionsProvider: () => emptyDisposable,
     registerCodeLensProvider: () => emptyDisposable,
     registerInlineCompletionItemProvider: (_selector, provider) => {


### PR DESCRIPTION
Previously, the agent was crashing because it was failing to load WASM modules for tree-sitter. This PR fixes the problem by disabling the setting for tree-sitter post-processing. The autocomplete e2e test was updated to use TypeScript since our tree-sitter experiments are mostly focused on TypeScript for now.


## Test plan

- `cd agent/`
- `src login`
- `VITEST_ONLY=NotConfigured pnpm run test src/index.test.ts`

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
