### PR TITLE
VScode: Show Cody on first install

### DIFF
--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -20,6 +20,8 @@ export const showSetupNotification = async (config: ConfigurationWithAccessToken
 
     if (localStorage.get('extension.hasActivatedPreviously') !== 'true') {
         // User is on first activation, so has only just installed Cody.
+        // Show Cody so that they can get started.
+        await vscode.commands.executeCommand('cody.focus')
         return
     }
 


### PR DESCRIPTION
In user testing, we found that after installing Cody from the extension marketplace, people scroll through the extension marketplace page trying to log in to Cody. Instead, open the Cody sidebar the first time the extension activates.

Fixes #1298 

## Test plan

This creates an environment similar to a fresh install:

```
# Create a workspace folder
mkdir /tmp/project

# Create a separate profile
code-insiders --user-data-dir=/tmp/test-plan --profile test-plan /tmp/project
```

Now build and install the extension in that profile:

```
# Build the extension
cd vscode
CODY_RELEASE_TYPE=stable pnpm release:dry-run

# Install the extension
code-insiders --user-data-dir=/tmp/test-plan --profile test-plan /tmp/project --install-extension dist/cody.vsix

# Run VScode with the extension
code-insiders --user-data-dir=/tmp/test-plan --profile test-plan /tmp/project
```

Observe that the Cody sidebar panel is visible.

Select the file explorer panel—or any non-Cody panel—in the sidebar and restart VScode (either run the same command again, or Cmd-Shift-P *Reload Window*.)

Observe that the Cody sidebar panel does not pop open.

Clean up: Run code-insiders, Code Insiders, Settings, Profiles, Delete Profile..., check Test Plan, delete it.