### PR TITLE
VS Code: singleton graphql client and feature flag provider

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -31,7 +31,7 @@ describe('FeatureFlagProvider', () => {
         expect(apiClient.evaluateFeatureFlag).not.toHaveBeenCalled()
     })
 
-    it('loads all evaluated feature flag on startup', async () => {
+    it('loads all evaluated feature flag on `syncAuthStatus`', async () => {
         const apiClient = {
             isDotCom: () => true,
             getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
@@ -41,6 +41,7 @@ describe('FeatureFlagProvider', () => {
         }
 
         const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
+        provider.syncAuthStatus()
 
         // Wait for the async initialization
         await nextTick()
@@ -101,6 +102,7 @@ describe('FeatureFlagProvider', () => {
             }
 
             const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
+            provider.syncAuthStatus()
 
             // Wait for the async initialization
             await nextTick()

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-void */
-import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
+import { graphqlClient, SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 import { isError } from '../utils'
 
 export enum FeatureFlag {
@@ -24,9 +24,7 @@ export class FeatureFlagProvider {
     private featureFlags: Record<string, boolean> = {}
     private lastUpdated = 0
 
-    constructor(private apiClient: SourcegraphGraphQLAPIClient) {
-        void this.refreshFeatureFlags()
-    }
+    constructor(private apiClient: SourcegraphGraphQLAPIClient) {}
 
     private getFromCache(flagName: FeatureFlag): boolean | undefined {
         const now = Date.now()
@@ -67,3 +65,5 @@ export class FeatureFlagProvider {
         this.lastUpdated = Date.now()
     }
 }
+
+export const featureFlagProvider = new FeatureFlagProvider(graphqlClient)

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -1,5 +1,4 @@
 import { ConfigurationWithAccessToken } from '../../configuration'
-import { FeatureFlagProvider } from '../../experimentation/FeatureFlagProvider'
 
 import { CompletionCallbacks, CompletionParameters, CompletionResponse, Event } from './types'
 
@@ -26,7 +25,6 @@ export abstract class SourcegraphCompletionsClient {
 
     constructor(
         protected config: CompletionsClientConfig,
-        protected featureFlagProvider?: FeatureFlagProvider,
         protected logger?: CompletionLogger
     ) {}
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -212,10 +212,28 @@ export function setUserAgent(newUseragent: string): void {
 
 export class SourcegraphGraphQLAPIClient {
     private dotcomUrl = DOTCOM_URL
-    constructor(private config: GraphQLAPIClientConfig) {}
+
+    /**
+     * Should be set on extension activation via `localStorage.onConfigurationChange(config)`
+     * Done to avoid passing the graphql client around as a parameter and instead
+     * access it as a singleton via the module import.
+     */
+    private _config: GraphQLAPIClientConfig | null = null
+
+    private get config(): GraphQLAPIClientConfig {
+        if (!this._config) {
+            throw new Error('GraphQLAPIClientConfig is not set')
+        }
+
+        return this._config
+    }
+
+    constructor(config: GraphQLAPIClientConfig | null = null) {
+        this._config = config
+    }
 
     public onConfigurationChange(newConfig: GraphQLAPIClientConfig): void {
-        this.config = newConfig
+        this._config = newConfig
     }
 
     public isDotCom(): boolean {
@@ -578,6 +596,12 @@ export class SourcegraphGraphQLAPIClient {
             .catch(error => new Error(`error fetching Testing Sourcegraph API: ${error} (${url})`))
     }
 }
+
+/**
+ * Singleton instance of the graphql client.
+ * Should be configured on the extension activation via `graphqlClient.onConfigurationChange(config)`.
+ */
+export const graphqlClient = new SourcegraphGraphQLAPIClient()
 
 function verifyResponseCode(response: Response): Response {
     if (!response.ok) {

--- a/lib/shared/src/sourcegraph-api/graphql/index.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/index.ts
@@ -1,2 +1,2 @@
 export type { EmbeddingsSearchResults } from './client'
-export { SourcegraphGraphQLAPIClient } from './client'
+export { SourcegraphGraphQLAPIClient, graphqlClient } from './client'

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -1,4 +1,4 @@
-import { FeatureFlag, type FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import type {
     CompletionLogger,
     CompletionsClientConfig,
@@ -30,11 +30,7 @@ export interface CodeCompletionsClient {
 /**
  * Access the code completion LLM APIs via a Sourcegraph server instance.
  */
-export function createClient(
-    config: CompletionsClientConfig,
-    featureFlagProvider?: FeatureFlagProvider,
-    logger?: CompletionLogger
-): CodeCompletionsClient {
+export function createClient(config: CompletionsClientConfig, logger?: CompletionLogger): CodeCompletionsClient {
     function getCodeCompletionsEndpoint(): string {
         return new URL('/.api/completions/code', config.serverEndpoint).href
     }
@@ -43,7 +39,7 @@ export function createClient(
         async complete(params, onPartialResponse, signal): Promise<CompletionResponse> {
             const log = logger?.startCompletion(params)
 
-            const tracingFlagEnabled = await featureFlagProvider?.evaluateFeatureFlag(
+            const tracingFlagEnabled = await featureFlagProvider.evaluateFeatureFlag(
                 FeatureFlag.CodyAutocompleteTracing
             )
 

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
 import { ContextProvider } from '../chat/ContextProvider'
 import { logDebug } from '../log'
@@ -20,7 +20,6 @@ interface InlineCompletionItemProviderArgs {
     client: CodeCompletionsClient
     statusBar: CodyStatusBar
     contextProvider: ContextProvider
-    featureFlagProvider: FeatureFlagProvider
     authProvider: AuthProvider
     triggerNotice: ((notice: { key: string }) => void) | null
 }
@@ -30,7 +29,6 @@ export async function createInlineCompletionItemProvider({
     client,
     statusBar,
     contextProvider,
-    featureFlagProvider,
     authProvider,
     triggerNotice,
 }: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
@@ -54,8 +52,8 @@ export async function createInlineCompletionItemProvider({
     const disposables: vscode.Disposable[] = []
 
     const [providerConfig, graphContextFlag] = await Promise.all([
-        createProviderConfig(config, client, featureFlagProvider, authProvider.getAuthStatus().configOverwrites),
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteGraphContext),
+        createProviderConfig(config, client, authProvider.getAuthStatus().configOverwrites),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteGraphContext),
     ])
     if (providerConfig) {
         const history = new VSCodeDocumentHistory()
@@ -71,7 +69,6 @@ export async function createInlineCompletionItemProvider({
             getCodebaseContext: () => contextProvider.context,
             graphContextFetcher: sectionObserver,
             completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
-            featureFlagProvider,
             triggerNotice,
         })
 

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -2,9 +2,9 @@ import dedent from 'dedent'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
 
-import { FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { GraphQLAPIClientConfig } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 import { localStorage } from '../services/LocalStorageProvider'
 import { vsCodeMocks } from '../testutils/mocks'
@@ -40,13 +40,7 @@ const DUMMY_CONTEXT: vscode.InlineCompletionContext = {
     triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
 }
 
-const dummyFeatureFlagProvider = new FeatureFlagProvider(
-    new SourcegraphGraphQLAPIClient({
-        accessToken: 'access-token',
-        serverEndpoint: 'https://sourcegraph.com',
-        customHeaders: {},
-    })
-)
+graphqlClient.onConfigurationChange({} as unknown as GraphQLAPIClientConfig)
 
 class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider {
     constructor(
@@ -68,7 +62,6 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
                 client: null as any,
             }),
-            featureFlagProvider: dummyFeatureFlagProvider,
             triggerNotice: null,
 
             ...superArgs,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -2,7 +2,7 @@ import { formatDistance } from 'date-fns'
 import * as vscode from 'vscode'
 
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
-import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { logDebug } from '../log'
@@ -42,7 +42,6 @@ export interface CodyCompletionItemProviderConfig {
     completeSuggestWidgetSelection?: boolean
     tracer?: ProvideInlineCompletionItemsTracer | null
     contextFetcher?: (options: GetContextOptions) => Promise<GetContextResult>
-    featureFlagProvider: FeatureFlagProvider
     triggerNotice: ((notice: { key: string }) => void) | null
 }
 
@@ -137,10 +136,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         // We start feature flag requests early so that we have a high chance of getting a response
         // before we need it.
         const [isIncreasedDebounceTimeEnabledPromise, minimumLatencyFlagsPromise] = [
-            this.config.featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled
-            ),
-            this.config.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteMinimumLatency),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteMinimumLatency),
         ]
 
         const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import {
+    CodyLLMSiteConfiguration,
+    GraphQLAPIClientConfig,
+    graphqlClient,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 import { CodeCompletionsClient } from '../client'
 
@@ -49,6 +53,8 @@ const dummyCodeCompletionsClient: CodeCompletionsClient = {
     onConfigurationChange: () => undefined,
 }
 
+graphqlClient.onConfigurationChange({} as unknown as GraphQLAPIClientConfig)
+
 describe('createProviderConfig', () => {
     describe('if completions provider fields are defined in VSCode settings', () => {
         it('returns null if completions provider is not supported', async () => {
@@ -57,7 +63,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedProvider: 'nasa-ai' as Configuration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider).toBeNull()
@@ -71,7 +76,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedProvider: null as Configuration['autocompleteAdvancedProvider'],
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider?.identifier).toBe('anthropic')
@@ -85,7 +89,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedServerEndpoint: 'https://unstable-codegen.com',
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider?.identifier).toBe('codegen')
@@ -96,7 +99,6 @@ describe('createProviderConfig', () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({ autocompleteAdvancedProvider: 'unstable-codegen' }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider).toBeNull()
@@ -109,7 +111,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedModel: 'starcoder-3b',
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider?.identifier).toBe('fireworks')
@@ -120,7 +121,6 @@ describe('createProviderConfig', () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({ autocompleteAdvancedProvider: 'unstable-fireworks' }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider?.identifier).toBe('fireworks')
@@ -134,7 +134,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedModel: 'hello-world',
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider?.identifier).toBe('unstable-openai')
@@ -148,7 +147,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedModel: 'hello-world',
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 {}
             )
             expect(provider?.identifier).toBe('anthropic')
@@ -162,7 +160,6 @@ describe('createProviderConfig', () => {
                     autocompleteAdvancedServerEndpoint: 'https://unstable-codegen.com',
                 }),
                 dummyCodeCompletionsClient,
-                undefined,
                 { provider: 'azure-open-ai', completionModel: 'gpt-35-turbo-test' }
             )
             expect(provider?.identifier).toBe('codegen')
@@ -256,7 +253,6 @@ describe('createProviderConfig', () => {
                     const provider = await createProviderConfig(
                         getVSCodeSettings(),
                         dummyCodeCompletionsClient,
-                        undefined,
                         codyLLMConfig
                     )
                     if (expected === null) {
@@ -271,7 +267,7 @@ describe('createProviderConfig', () => {
     })
 
     it('returns anthropic provider config if no completions provider specified in VSCode settings or site config', async () => {
-        const provider = await createProviderConfig(getVSCodeSettings(), dummyCodeCompletionsClient, undefined, {})
+        const provider = await createProviderConfig(getVSCodeSettings(), dummyCodeCompletionsClient, {})
         expect(provider?.identifier).toBe('anthropic')
         expect(provider?.model).toBe('claude-instant-infill')
     })

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -1,5 +1,5 @@
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 import { logError } from '../../log'
@@ -17,15 +17,13 @@ import { createProviderConfig as createUnstableOpenAIProviderConfig } from './un
 export async function createProviderConfig(
     config: Configuration,
     client: CodeCompletionsClient,
-    featureFlagProvider?: FeatureFlagProvider,
     codyLLMSiteConfig?: CodyLLMSiteConfiguration
 ): Promise<ProviderConfig | null> {
     /**
      * Look for the autocomplete provider in VSCode settings and return matching provider config.
      */
     const providerAndModelFromVSCodeConfig = await resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
-        config.autocompleteAdvancedProvider,
-        featureFlagProvider
+        config.autocompleteAdvancedProvider
     )
     if (providerAndModelFromVSCodeConfig) {
         const { provider, model } = providerAndModelFromVSCodeConfig
@@ -123,19 +121,18 @@ export async function createProviderConfig(
 }
 
 async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
-    configuredProvider: string | null,
-    featureFlagProvider?: FeatureFlagProvider
+    configuredProvider: string | null
 ): Promise<{ provider: string; model?: UnstableFireworksOptions['model'] } | null> {
     if (configuredProvider) {
         return { provider: configuredProvider }
     }
 
     const [starCoder7b, starCoder16b, starCoderHybrid, llamaCode7b, llamaCode13b] = await Promise.all([
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
-        featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
     ])
 
     if (starCoder7b || starCoder16b || starCoderHybrid || llamaCode7b || llamaCode13b) {

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -3,13 +3,12 @@ import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
-import { FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
 import { SourcegraphGuardrailsClient } from '@sourcegraph/cody-shared/src/guardrails/client'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/intent-detector/client'
 import { IndexedKeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
-import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { CodeCompletionsClient, createClient as createCodeCompletionsClint } from './completions/client'
@@ -23,7 +22,6 @@ interface ExternalServices {
     chatClient: ChatClient
     codeCompletionsClient: CodeCompletionsClient
     guardrails: Guardrails
-    featureFlagProvider: FeatureFlagProvider
 
     /** Update configuration for all of the services in this interface. */
     onConfigurationChange: (newConfig: ExternalServicesConfiguration) => void
@@ -54,12 +52,10 @@ export async function configureExternalServices(
     >
 ): Promise<ExternalServices> {
     const sentryService = platform.createSentryService?.(initialConfig)
-    const client = new SourcegraphGraphQLAPIClient(initialConfig)
-    const featureFlagProvider = new FeatureFlagProvider(client)
-    const completionsClient = platform.createCompletionsClient(initialConfig, featureFlagProvider, logger)
-    const codeCompletionsClient = createCodeCompletionsClint(initialConfig, featureFlagProvider, logger)
+    const completionsClient = platform.createCompletionsClient(initialConfig, logger)
+    const codeCompletionsClient = createCodeCompletionsClint(initialConfig, logger)
 
-    const repoId = initialConfig.codebase ? await client.getRepoId(initialConfig.codebase) : null
+    const repoId = initialConfig.codebase ? await graphqlClient.getRepoId(initialConfig.codebase) : null
     if (isError(repoId)) {
         logDebug(
             'external-services:configureExternalServices',
@@ -67,7 +63,8 @@ export async function configureExternalServices(
                 'Please check that the repository exists. You can override the repository with the "cody.codebase" setting.'
         )
     }
-    const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
+    const embeddingsSearch =
+        repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId) : null
 
     const chatClient = new ChatClient(completionsClient)
     const codebaseContext = new CodebaseContext(
@@ -82,18 +79,16 @@ export async function configureExternalServices(
         getRerankWithLog(chatClient)
     )
 
-    const guardrails = new SourcegraphGuardrailsClient(client)
+    const guardrails = new SourcegraphGuardrailsClient(graphqlClient)
 
     return {
-        intentDetector: new SourcegraphIntentDetectorClient(client, completionsClient),
-        featureFlagProvider,
+        intentDetector: new SourcegraphIntentDetectorClient(graphqlClient, completionsClient),
         codebaseContext,
         chatClient,
         codeCompletionsClient,
         guardrails,
         onConfigurationChange: newConfig => {
             sentryService?.onConfigurationChange(newConfig)
-            client.onConfigurationChange(newConfig)
             completionsClient.onConfigurationChange(newConfig)
             codeCompletionsClient.onConfigurationChange(newConfig)
             codebaseContext.onConfigurationChange(newConfig)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -3,7 +3,9 @@ import * as vscode from 'vscode'
 import { commandRegex } from '@sourcegraph/cody-shared/src/chat/recipes/helpers'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
+import { featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
+import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
 import { ChatViewProvider } from './chat/ChatViewProvider'
 import { ContextProvider } from './chat/ContextProvider'
@@ -126,8 +128,10 @@ const register = async (
         })
     }
 
+    graphqlClient.onConfigurationChange(initialConfig)
+    void featureFlagProvider.syncAuthStatus()
+
     const {
-        featureFlagProvider,
         intentDetector,
         codebaseContext: initialCodebaseContext,
         chatClient,
@@ -472,7 +476,6 @@ const register = async (
             client: codeCompletionsClient,
             statusBar,
             contextProvider,
-            featureFlagProvider,
             authProvider,
             triggerNotice: notice => sidebarChatProvider.triggerNotice(notice),
         })
@@ -513,6 +516,7 @@ const register = async (
     return {
         disposable: vscode.Disposable.from(...disposables),
         onConfigurationChange: newConfig => {
+            graphqlClient.onConfigurationChange(newConfig)
             contextProvider.onConfigurationChange(newConfig)
             externalServicesOnDidConfigurationChange(newConfig)
             void createOrUpdateEventLogger(newConfig, isExtensionModeDevOrTest)

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -8,9 +8,8 @@ import * as vscode from 'vscode'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { NoopEditor } from '@sourcegraph/cody-shared/src/editor'
-import { FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
-import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
 import { GetContextResult } from '../../src/completions/context/context'
 import { VSCodeDocumentHistory } from '../../src/completions/context/history'
@@ -30,14 +29,6 @@ import { findSubstringPosition } from './utils'
 
 let didLogConfig = false
 let providerConfig: ProviderConfig | null
-
-const dummyFeatureFlagProvider = new FeatureFlagProvider(
-    new SourcegraphGraphQLAPIClient({
-        accessToken: 'access-token',
-        serverEndpoint: 'https://sourcegraph.com',
-        customHeaders: {},
-    })
-)
 
 initializeNetworkAgent()
 
@@ -64,6 +55,7 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
         throw new Error('`cody.autocomplete` is not true!')
     }
 
+    graphqlClient.onConfigurationChange(initialConfig)
     const { codeCompletionsClient, codebaseContext } = await configureExternalServices(
         initialConfig,
         'rg',
@@ -89,7 +81,6 @@ async function initCompletionsProvider(context: GetContextResult): Promise<Inlin
         history,
         getCodebaseContext: () => codebaseContext,
         contextFetcher: () => Promise.resolve(context),
-        featureFlagProvider: dummyFeatureFlagProvider,
         triggerNotice: null,
     })
 


### PR DESCRIPTION
## Context

- Makes graphql client and feature flag provider singletons to avoid passing them around as parameters.
- Continue the migration to the singleton module-level exports. Related work: https://github.com/sourcegraph/cody/pull/876 and https://github.com/sourcegraph/cody/pull/912
- No functional changes.

## Test plan

CI and verified that `pnpm generate:completions` still works.
