### PR TITLE
Autocomplete: Remove outdated embeddings config

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -923,13 +923,7 @@
             "llama-code-13b",
             "llama-code-13b-instruct"
           ],
-          "markdownDescription": "Overwrite the default model used for code autocompletion inference. This is only supported with the `unstable-fireworks` provider"
-        },
-        "cody.autocomplete.advanced.embeddings": {
-          "order": 99,
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enables the use of embeddings as code completions context."
+          "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `unstable-fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
           "type": "boolean",

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -102,8 +102,6 @@ describe('getConfiguration', () => {
                         return 'starcoder-32b'
                     case 'cody.autocomplete.advanced.accessToken':
                         return 'foobar'
-                    case 'cody.autocomplete.advanced.embeddings':
-                        return false
                     case 'cody.autocomplete.completeSuggestWidgetSelection':
                         return false
                     case 'cody.autocomplete.experimental.syntacticPostProcessing':


### PR DESCRIPTION
Leftover from removing the embeddings context from Autocomplete

## Test plan

👀 

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
