### PR TITLE
Autocomplete: add a feature flag for syntactic triggers

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -28,7 +28,6 @@ export interface Configuration {
     autocompleteAdvancedAccessToken: string | null
     autocompleteCompleteSuggestWidgetSelection?: boolean
     autocompleteExperimentalSyntacticPostProcessing?: boolean
-    autocompleteExperimentalSyntacticTriggers?: boolean
     autocompleteExperimentalGraphContext?: boolean
     isRunningInsideAgent?: boolean
 }

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -16,6 +16,7 @@ export enum FeatureFlag {
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-default-llama-code-13b',
     CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',
     CodyAutocompleteMinimumLatency = 'cody-autocomplete-minimum-latency',
+    CodyAutocompleteSyntacticTriggers = 'cody-autocomplete-syntactic-triggers',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -935,11 +935,6 @@
           "default": true,
           "markdownDescription": "Rank autocomplete results with tree-sitter."
         },
-        "cody.autocomplete.experimental.syntacticTriggers": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Use tree-sitter to choose between multiline and singleline modes."
-        },
         "cody.autocomplete.experimental.graphContext": {
           "type": "boolean",
           "default": false,

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -69,7 +69,6 @@ export async function createInlineCompletionItemProvider({
             getCodebaseContext: () => contextProvider.context,
             graphContextFetcher: sectionObserver,
             completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
-            syntacticTriggers: config.autocompleteExperimentalSyntacticTriggers,
             triggerNotice,
         })
 

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -40,7 +40,6 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocompleteAdvancedAccessToken: null,
     autocompleteCompleteSuggestWidgetSelection: false,
     autocompleteExperimentalSyntacticPostProcessing: false,
-    autocompleteExperimentalSyntacticTriggers: false,
     autocompleteExperimentalGraphContext: false,
 }
 

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -41,7 +41,6 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteExperimentalSyntacticPostProcessing: true,
-            autocompleteExperimentalSyntacticTriggers: false,
             autocompleteExperimentalGraphContext: false,
         })
     })
@@ -107,8 +106,6 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.experimental.syntacticPostProcessing':
                         return true
-                    case 'cody.autocomplete.experimental.syntacticTriggers':
-                        return false
                     case 'cody.autocomplete.experimental.graphContext':
                         return true
                     case 'cody.advanced.agent.running':
@@ -152,7 +149,6 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
-            autocompleteExperimentalSyntacticTriggers: false,
             autocompleteExperimentalGraphContext: true,
         })
     })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -77,10 +77,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
             CONFIG_KEY.autocompleteExperimentalSyntacticPostProcessing,
             true
         ),
-        autocompleteExperimentalSyntacticTriggers: config.get(
-            CONFIG_KEY.autocompleteExperimentalSyntacticTriggers,
-            false
-        ),
         autocompleteExperimentalGraphContext: config.get<boolean>(
             CONFIG_KEY.autocompleteExperimentalGraphContext,
             false


### PR DESCRIPTION
## Context 

- Adds a feature flag for syntactic triggers based on tree-sitter queries.
- Follow-up for https://github.com/sourcegraph/cody/pull/1259
- Part of https://github.com/sourcegraph/cody/issues/1157

## Test plan

CI
