### PR TITLE
Agent: reject promise on completions exception

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -220,7 +220,7 @@ export class Agent extends MessageHandler {
                 return { items, completionEvent: (result as any)?.completionEvent }
             } catch (error) {
                 console.log('autocomplete failed', error)
-                return { items: [] }
+                return Promise.reject(error)
             }
         })
 


### PR DESCRIPTION
Previously, Cody Agent would return no empty items array and no further indication that an error occurred. On the JetBrains side I want to update the status icon when certain errors are encountered, such as 401

## Test plan

Confirmed output is as expected:
```
-> {
    "jsonrpc": "2.0",
    "id": "15",
    "error": {
        "code": -32603,
        "message": "Request to https://sourcegraph.com/.api/completions/code failed with 401: Unauthorized",
        "data": "{\"error\":{\"status\":401},\"stack\":\"\\nError: Request to https://sourcegraph.com/.api/completions/code failed with 401: Unauthorized\\n    at Object.complete (/snapshot/dist/agent.js)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\\n    at async /snapshot/dist/agent.js\"}"
    }
}
```
