### PR TITLE
feat: add command argument parsing

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -531,7 +531,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     await this.addCustomInteraction('Command failed. Please open a file and try again.', text)
                     return null
                 }
-                const commandRunnerID = await this.editor.controllers.command?.addCommand(text)
+                // Split the text into two part, first part contains the command and the second part contains the arguments
+                // e.g. /add-command foo -c bar => ['/add-command', 'foo -c bar']
+                const [command, ...args] = text.split(' ')
+                const commandRunnerID = await this.editor.controllers.command?.addCommand(command, args?.join(' '))
                 if (!commandRunnerID) {
                     return null
                 }

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -26,7 +26,7 @@ export class CommandRunner implements vscode.Disposable {
 
     constructor(
         private command: CodyPrompt,
-        public instruction?: string,
+        public instruction?: string, // additional instruction to add to end of prompt
         private isFixupRequest?: boolean
     ) {
         // use commandKey to identify default command in telemetry
@@ -43,13 +43,17 @@ export class CommandRunner implements vscode.Disposable {
 
         logDebug('CommandRunner:init', this.kind)
 
-        // Commands only work in active editor / workspace unless context specifies otherwise
+        // Commands only work in active editor / workspace unless context is set to none
         this.editor = vscode.window.activeTextEditor || undefined
-        if (!this.editor || command.context?.none) {
+        if (!this.editor && !command.context?.none) {
             const errorMsg = 'Failed to create command: No active text editor found.'
             logDebug('CommandRunner:int:fail', errorMsg)
             void vscode.window.showErrorMessage(errorMsg)
             return
+        }
+
+        if (instruction) {
+            this.command.prompt = `${command.prompt} ${instruction}`
         }
 
         if (command.mode === 'inline') {

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -19,6 +19,7 @@ import {
     showcommandTypeQuickPick,
     showRemoveConfirmationInput,
 } from './utils/menu'
+import { extractCommandArgs } from './utils/process_input'
 
 /**
  * Manage commands built with prompts from CustomPromptsStore and PromptsProvider
@@ -113,8 +114,13 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
         logDebug('CommandsController:createCodyCommand:creating', commandKey)
 
+        const [instruction, commandArg] = extractCommandArgs(input)
+        if (commandArg && command.context?.command) {
+            command.context.command = [command.context?.command, commandArg].join(' ')
+        }
+
         // Start the command runner
-        const codyCommand = new CommandRunner(command, input, isFixupRequest)
+        const codyCommand = new CommandRunner(command, instruction, isFixupRequest)
         this.commandRunners.set(codyCommand.id, codyCommand)
         this.lastUsedCommands.add(command.slashCommand)
 

--- a/vscode/src/custom-prompts/utils/process_input.test.ts
+++ b/vscode/src/custom-prompts/utils/process_input.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractCommandArgs } from './process_input'
+
+describe('extractCommandArgs', () => {
+    it('splits input on -c', () => {
+        const [command, args] = extractCommandArgs('foo -c bar')
+        expect(command).toBe('foo')
+        expect(args).toBe('bar')
+    })
+
+    it('trims whitespace from split strings', () => {
+        const [command, args] = extractCommandArgs('  foo   -c   bar  ')
+        expect(command).toBe('foo')
+        expect(args).toBe('bar')
+    })
+
+    it('returns command strings only if no -c', () => {
+        const [command, args] = extractCommandArgs('foo')
+        expect(command).toBe('foo')
+        expect(args).toBe('')
+    })
+
+    it('returns empty strings if input undefined', () => {
+        const [command, args] = extractCommandArgs(undefined)
+        expect(command).toBe('')
+        expect(args).toBe('')
+    })
+
+    it('returns empty strings if no input', () => {
+        const [command, args] = extractCommandArgs()
+        expect(command).toBe('')
+        expect(args).toBe('')
+    })
+
+    it('returns input as command if no -c', () => {
+        const [command, args] = extractCommandArgs('foo')
+        expect(command).toBe('foo')
+        expect(args).toBe('')
+    })
+
+    it('splits on first instance of -c', () => {
+        const [command, args] = extractCommandArgs('foo -c bar -c baz')
+        expect(command).toBe('foo -c bar')
+        expect(args).toBe('baz')
+    })
+})

--- a/vscode/src/custom-prompts/utils/process_input.ts
+++ b/vscode/src/custom-prompts/utils/process_input.ts
@@ -1,0 +1,24 @@
+export const flags = ['-c']
+/**
+ * Splits input string into command and arguments strings.
+ *
+ * Looks for '-c' in input string to split into command and arguments.
+ * Returns array with command string (trimmed) and arguments string (trimmed).
+ *
+ * If no '-c' split or input is undefined, returns empty strings.
+ */
+export function extractCommandArgs(input?: string): [string, string] {
+    if (input) {
+        const splitInput = input.split('-c')
+        if (splitInput.length > 1) {
+            // Gets last element as args string
+            // example: ['foo', '-c', 'bar', '-c', 'baz'] -> 'baz'
+            // Then, join splitInput again but remove the last element if it's '-c'
+            // example: ['foo', '-c', 'bar', '-c'] -> ['foo', '-c', 'bar']
+            const args = splitInput.at(-1) || ''
+            // Joins all but last element as command string
+            return [splitInput.slice(0, -1).join('-c').trim(), args.trim()]
+        }
+    }
+    return [input || '', '']
+}


### PR DESCRIPTION
feat: add command argument parsing

- Split command text into command name and arguments
- Pass arguments to CommandRunner constructor 
- Append instruction text to command prompt

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Added unit test, commands are currently covered by e2e and integration tests