### PR TITLE
Fixing the cody chat jump to the top on initiating a new chat

### DIFF
--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -202,7 +202,10 @@ export const Transcript: React.FunctionComponent<
 })
 
 function findLastIndex<T>(array: T[], predicate: (value: T) => boolean): number {
-    const arr = array.slice()
-    arr.reverse()
-    return arr.findIndex(predicate)
+    for (let i = array.length - 1; i >= 0; i--) {
+        if (predicate(array[i])) {
+            return i
+        }
+    }
+    return -1
 }


### PR DESCRIPTION
Fixing the Cody chat jump to the top on initiating a new chat

Solves [Issue Link](https://github.com/sourcegraph/cody/issues/1341)
The bug was first introduced in [PR #1224](https://github.com/sourcegraph/cody/pull/1224).
For a detailed discussion on resolving the original issue, see [Issue Link](https://github.com/sourcegraph/cody/issues/1191).

We can't remove the extra utility function because older versions of Node don't support it. This bug was surprising, as the utility function first creates a shallow copy before reversing the array. This still causes unintended side effects. Now, I've replaced it with a loop iterating from the end of the array, which resolves the issue. 

CC @dominiccooney @philipp-spiess 

## Test plan

<!-- Required. See [Sourcegraph Testing Principles](https://docs.sourcegraph.com/dev/background-information/testing_principles). -->
There is not functionality/logic change here and all the tests pass already.
I've tested the changes on my machine and they work as expected.