### PR TITLE
Agent: mirror runtime behavior for `instanceof URI`

### DIFF
--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -1,8 +1,9 @@
 import assert from 'assert'
 import * as path from 'path'
 
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
+import { URI } from 'vscode-uri'
 
 describe('vscode-shim', () => {
     describe('vscode.Uri', () => {
@@ -30,7 +31,14 @@ describe('vscode-shim', () => {
         })
 
         it('instanceof can be used', () => {
+            class Qux {}
+
             assert.ok(vscode.Uri.parse('http://example.org/one/two') instanceof vscode.Uri)
+            expect(new Qux() instanceof vscode.Uri).toBe(false)
+
+            expect(vscode.Uri.parse('http://example.org/one/two') instanceof Qux).toBe(false)
+
+            expect(vscode.Uri.parse('http://example.org/one/two') instanceof URI).toBe(false)
         })
     })
 })

--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -31,6 +31,7 @@ describe('vscode-shim', () => {
         })
 
         it('instanceof can be used', () => {
+            // eslint-disable-next-line @typescript-eslint/no-extraneous-class
             class Qux {}
 
             assert.ok(vscode.Uri.parse('http://example.org/one/two') instanceof vscode.Uri)

--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -30,6 +30,10 @@ describe('vscode-shim', () => {
             assert.equal(vscode.Uri.file('a.txt').fsPath, `${path.sep}a.txt`)
         })
 
+        it('with is available', () => {
+            assert.equal(vscode.Uri.file('a.txt').with({ path: 'b.txt' }).path, `${path.sep}b.txt`)
+        })
+
         it('instanceof can be used', () => {
             // eslint-disable-next-line @typescript-eslint/no-extraneous-class
             class Qux {}
@@ -40,6 +44,8 @@ describe('vscode-shim', () => {
             expect(vscode.Uri.parse('http://example.org/one/two') instanceof Qux).toBe(false)
 
             expect(vscode.Uri.parse('http://example.org/one/two') instanceof URI).toBe(false)
+            expect(vscode.Uri.file('a.txt').with({ path: 'b.txt' }) instanceof vscode.Uri).toBe(true)
+            expect(vscode.Uri.file('a.txt').with({ path: 'b.txt' }) instanceof URI).toBe(false)
         })
     })
 })

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -15,26 +15,10 @@ import type {
     Range as VSCodeRange,
 } from 'vscode'
 import type * as vscode_types from 'vscode'
-import { URI, Utils as UriUtils } from 'vscode-uri'
 
-/**
- * A proxy for the vscode-uri URI class as a replacement for the VS Code
- * URI class.
- *
- * For methods that don't exist on vscode-uri.URI, vscode-uri.Utils will be
- * used since that's where static methods like joinPath() are.
- */
-export const Uri = new Proxy(URI, {
-    get(obj, prop) {
-        if (prop in obj) {
-            return (obj as any)[prop]
-        }
-        if (prop in UriUtils) {
-            return (UriUtils as any)[prop]
-        }
-        return undefined
-    },
-})
+import { Uri } from './uri'
+
+export { Uri } from './uri'
 
 export class Disposable implements VSCodeDisposable {
     public static from(...disposableLikes: { dispose: () => any }[]): Disposable {

--- a/vscode/src/testutils/uri.ts
+++ b/vscode/src/testutils/uri.ts
@@ -18,7 +18,7 @@ import { UriComponents } from 'vscode-uri/lib/umd/uri'
  * We tried copy-pasting the full implementation of `vscode.Uri` into this
  * repository but it required adding >3k lines of code with minor that we have
  * to keep up-to-date and maintain. https://github.com/sourcegraph/cody/pull/1264
-
+ 
  * We tried using `Proxy` to avoid having to reimplement all APIs but this
  * solution didn't faithfully reproduce the behavior of `instanceof` checks.
  * https://github.com/sourcegraph/cody/pull/1335
@@ -59,26 +59,26 @@ export class Uri {
         }
     }
 
-    get scheme() {
+    public get scheme(): string {
         return this.uri.scheme
     }
 
-    get authority() {
+    public get authority(): string {
         return this.uri.authority
     }
-    get path() {
+    public get path(): string {
         return this.uri.path
     }
 
-    get query() {
+    public get query(): string {
         return this.uri.query
     }
 
-    get fragment() {
+    public get fragment(): string {
         return this.uri.fragment
     }
 
-    get fsPath() {
+    public get fsPath(): string {
         return this.uri.fsPath
     }
 

--- a/vscode/src/testutils/uri.ts
+++ b/vscode/src/testutils/uri.ts
@@ -1,6 +1,31 @@
 import { URI, Utils } from 'vscode-uri'
 import { UriComponents } from 'vscode-uri/lib/umd/uri'
 
+/**
+ *
+ * This `Uri` class is a reimplemenation of `vscode.Uri` that is backed by
+ * vscode-uri. The reason we reimplement `vscode.Uri` instead of using URI
+ * directly in mocks is that we want full runtime fidelity with `vscode.Uri`. If
+ * we use URI directly then we end up with minor runtime differences. For
+ * example:
+ *
+ * - vscode.Uri.parse(..) instanceof URI // Should be false
+ * - vscode.Uri.joinPath(..)             // Does not exist in URI
+ *
+ * We opened an issue about adding `joinPath` as a static function, which got
+ * closed as wontfix https://github.com/microsoft/vscode/issues/194615
+ *
+ * We tried copy-pasting the full implementation of `vscode.Uri` into this
+ * repository but it required adding >3k lines of code with minor that we have
+ * to keep up-to-date and maintain. https://github.com/sourcegraph/cody/pull/1264
+
+ * We tried using `Proxy` to avoid having to reimplement all APIs but this
+ * solution didn't faithfully reproduce the behavior of `instanceof` checks.
+ * https://github.com/sourcegraph/cody/pull/1335
+ *
+ * See agent/src/vscode-shim.test.ts for tests that assert that this class
+ * is compatible with `vscode.Uri`.
+ */
 export class Uri {
     public static parse(value: string, strict?: boolean): Uri {
         return new Uri(URI.parse(value, strict))

--- a/vscode/src/testutils/uri.ts
+++ b/vscode/src/testutils/uri.ts
@@ -1,0 +1,89 @@
+import { URI, Utils } from 'vscode-uri'
+import { UriComponents } from 'vscode-uri/lib/umd/uri'
+
+export class Uri {
+    public static parse(value: string, strict?: boolean): Uri {
+        return new Uri(URI.parse(value, strict))
+    }
+
+    public static file(path: string): URI {
+        return new Uri(URI.file(path))
+    }
+
+    public static joinPath(base: Uri, ...pathSegments: string[]): Uri {
+        return new Uri(Utils.joinPath(base.uri, ...pathSegments))
+    }
+
+    public static from(components: {
+        readonly scheme: string
+        readonly authority?: string
+        readonly path?: string
+        readonly query?: string
+        readonly fragment?: string
+    }): Uri {
+        return new Uri(URI.from(components))
+    }
+
+    private uri: URI
+
+    private constructor(componentsOrUri: UriComponents | URI) {
+        if (componentsOrUri instanceof URI) {
+            this.uri = componentsOrUri
+        } else {
+            this.uri = URI.from(componentsOrUri)
+        }
+    }
+
+    get scheme() {
+        return this.uri.scheme
+    }
+
+    get authority() {
+        return this.uri.authority
+    }
+    get path() {
+        return this.uri.path
+    }
+
+    get query() {
+        return this.uri.query
+    }
+
+    get fragment() {
+        return this.uri.fragment
+    }
+
+    get fsPath() {
+        return this.uri.fsPath
+    }
+
+    public with(change: {
+        scheme?: string
+        authority?: string
+        path?: string
+        query?: string
+        fragment?: string
+    }): Uri {
+        return Uri.from({
+            scheme: change.scheme || this.scheme,
+            authority: change.authority || this.authority,
+            path: change.path || this.path,
+            query: change.query || this.query,
+            fragment: change.fragment || this.fragment,
+        })
+    }
+
+    public toString(skipEncoding?: boolean): string {
+        return this.uri.toString(skipEncoding)
+    }
+
+    public toJSON(): any {
+        return {
+            scheme: this.scheme,
+            authority: this.authority,
+            path: this.path,
+            query: this.query,
+            fragment: this.fragment,
+        }
+    }
+}


### PR DESCRIPTION
Previously, `vscode.Uri.parse(...) instanceof URI` returned true with vscode-shim and false in VS Code itself. This PR fixes the problem by creating a wrapper `Uri` classes that implemements the same API as `vscode.Uri` but delegates all underlying logic to vscode-uri `URI`.


## Test plan

See updated tests.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
