### PR TITLE
fix: remove HTML escaping in inline chat markdown

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -389,6 +389,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Fixed HTML escaping in inline chat markdown.
+
 ### Changed
 
 ## [0.4.1]

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -389,7 +389,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Fixed HTML escaping in inline chat markdown.
+- Fixed HTML escaping in inline chat markdown. [pull/1349](https://github.com/sourcegraph/sourcegraph/pull/1349)
 
 ### Changed
 

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -609,18 +609,10 @@ export class Comment implements vscode.Comment {
     }
 
     /**
-     * Naive Html Escape, only does brackets for now, but works well enough to get tags showing up in inline
-     * comments that make reference to them.
-     */
-    private naiveHtmlEscape(text: string): string {
-        return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
-    }
-
-    /**
      * Turns string into Markdown string
      */
     private markdown(text: string): vscode.MarkdownString {
-        const markdownText = new vscode.MarkdownString(this.naiveHtmlEscape(text))
+        const markdownText = new vscode.MarkdownString(text)
         markdownText.isTrusted = true
         markdownText.supportHtml = true
         return markdownText

--- a/vscode/test/e2e/inline-chat.test.ts
+++ b/vscode/test/e2e/inline-chat.test.ts
@@ -1,0 +1,43 @@
+import { expect } from '@playwright/test'
+
+import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
+
+import { sidebarExplorer, sidebarSignin } from './common'
+import { test } from './helpers'
+
+const expectedOrderedEvents = [
+    'CodyVSCodeExtension:keywordContext:searchDuration',
+    'CodyVSCodeExtension:recipe:inline-chat:executed',
+    'CodyVSCodeExtension:chatResponse:noCode',
+]
+
+test.beforeEach(() => {
+    resetLoggedEvents()
+})
+test('start a fixup job from inline chat with valid auth', async ({ page, sidebar }) => {
+    // Sign into Cody
+    await sidebarSignin(page, sidebar)
+
+    // Open the Explorer view from the sidebar
+    await sidebarExplorer(page).click()
+
+    // Open the index.html file from the tree view
+    await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
+
+    // Click on line number 6 to open the comment thread
+    await page.locator('.comment-diff-added').nth(5).hover()
+    await page.locator('.comment-diff-added').nth(5).click()
+
+    // After opening the comment thread, we need to wait for the editor to load
+    await page.waitForSelector('.monaco-editor')
+    await page.waitForSelector('.monaco-text-button')
+
+    // Type in the question with the '<' and '>' to check for regression
+    await page.keyboard.type('what is a ```<div>``` tag?')
+    // Click on the submit button
+    await page.click('.monaco-text-button')
+
+    // Make sure the < and > characters were not escaped
+    await expect(page.locator('[id="workbench\\.parts\\.editor"]').getByText('what is a <div> tag?``')).toBeVisible()
+    await expect.poll(() => loggedEvents).toEqual(expectedOrderedEvents)
+})


### PR DESCRIPTION
Close: https://github.com/sourcegraph/cody/issues/1350 https://github.com/sourcegraph/sourcegraph/issues/56644

Issue caused by the change in  https://github.com/sourcegraph/cody/pull/404 where `<` and `>` are manually replaced by the `naiveHtmlEscape method`, which is being removed in this PR.

The naiveHtmlEscape method was replacing < and > characters with escaped version of the characters from the markdown text before rendering. This prevented markdown syntax like <tags> from rendering correctly by the `vscode.MarkdownString` method which has the `supportHtml` turns enabled.

Removed the naiveHtmlEscape method call so markdown text renders as intended.


### Before

`<` and `>` are replaced with ` &lt` and `&gt`

![image](https://github.com/sourcegraph/cody/assets/68532117/76035204-ac45-4630-9576-021e414043ba)


![image](https://github.com/sourcegraph/cody/assets/68532117/c51f1bc1-2bff-48c4-83b9-fbfb1ae22c06)

### After

`<` and `>` are displayed correctly:

![image](https://github.com/sourcegraph/cody/assets/68532117/c6709d09-3c83-4bfa-8f20-2ae49eeeb128)


![image](https://github.com/sourcegraph/cody/assets/68532117/fd59b3a9-4d6d-4ca0-82ca-00651552d275)


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Start an inline chat for line 310 to 325 https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/webviews/Chat.tsx?L310-325
2. Ask Cody: improve variable names and show me the improved code
3. You should see the `<` and `>` being displayed correctly


