### PR TITLE
refactor: split min latency flags

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -15,7 +15,8 @@ export enum FeatureFlag {
     CodyAutocompleteLlamaCode7B = 'cody-autocomplete-default-llama-code-7b',
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-default-llama-code-13b',
     CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',
-    CodyAutocompleteMinimumLatency = 'cody-autocomplete-minimum-latency',
+    CodyAutocompleteLangBasedLatency = 'cody-autocomplete-lang-latency',
+    CodyAutocompleteUserBasedLatency = 'cody-autocomplete-user-latency',
     CodyAutocompleteSyntacticTriggers = 'cody-autocomplete-syntactic-triggers',
 }
 

--- a/vscode/src/completions/latency.test.ts
+++ b/vscode/src/completions/latency.test.ts
@@ -17,26 +17,26 @@ describe('getLatency', () => {
         const languageId = undefined
 
         // start with default high latency for unsupported lang with default user latency added
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // gradually increasing latency after 5 rejected suggestions
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // gradually increasing latency after 5 rejected suggestions
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
-        expect(getLatency(provider, fileName, languageId)).toBe(1400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1400)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         resetLatency()
         // next rejection doesn't change user latency until 5 rejected
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
     })
 
     it('returns gradually increasing latency up to max for CSS on anthropic provider when suggestions are rejected', () => {
@@ -45,44 +45,44 @@ describe('getLatency', () => {
         const languageId = 'css'
 
         // start with default high latency for low performance lang with default user latency added
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // start at default, but gradually increasing latency after 5 rejected suggestions
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
-        expect(getLatency(provider, fileName, languageId)).toBe(1400)
-        expect(getLatency(provider, fileName, languageId)).toBe(1600)
-        expect(getLatency(provider, fileName, languageId)).toBe(1800)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1800)
         // max latency at 2000
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // gradually increasing latency after 5 rejected suggestions
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
-        expect(getLatency(provider, fileName, languageId)).toBe(1400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1400)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1600)
-        expect(getLatency(provider, fileName, languageId)).toBe(1800)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1800)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
         // Latency will be reset after 5 minutes
         vi.advanceTimersByTime(5 * 60 * 1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // reset latency on accepted suggestion
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
     })
 
     it('returns increasing latency after rejecting suggestions on anthropic provider', () => {
@@ -91,19 +91,19 @@ describe('getLatency', () => {
         const languageId = 'typescript'
 
         // start at default, but gradually increasing latency after 5 rejected suggestions
-        expect(getLatency(provider, fileName, languageId, 'programe')).toBe(0)
-        expect(getLatency(provider, fileName, languageId, '')).toBe(0)
+        expect(getLatency(false, provider, fileName, languageId, 'programe')).toBe(0)
+        expect(getLatency(false, provider, fileName, languageId, '')).toBe(0)
         // baseline latency increased to 1000 due to comment node type
-        expect(getLatency(provider, fileName, languageId, 'comment')).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(0)
-        expect(getLatency(provider, fileName, languageId)).toBe(0)
+        expect(getLatency(false, provider, fileName, languageId, 'comment')).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(0)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(0)
         // gradually increasing latency after 5 rejected suggestions
-        expect(getLatency(provider, fileName, languageId)).toBe(200)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(600)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(0)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(0)
     })
 
     it('returns default latency for CSS after accepting suggestion and resets after 5 minutes', () => {
@@ -112,22 +112,22 @@ describe('getLatency', () => {
         const languageId = 'css'
 
         // start with default baseline latency with low performance and user latency added
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // reset to starting point on every accepted suggestion
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
         // Latency will be reset after 5 minutes
         vi.advanceTimersByTime(5 * 60 * 1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
     })
 
     it('returns increasing latency up to max after multiple rejections for supported language on non-anthropic provider', () => {
@@ -136,29 +136,29 @@ describe('getLatency', () => {
         const languageId = 'typescript'
 
         // start with default baseline latency with low performance and user latency added
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
         // latency should start increasing after 5 rejections, but max at 2000
-        expect(getLatency(provider, fileName, languageId)).toBe(600)
-        expect(getLatency(provider, fileName, languageId)).toBe(800)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
-        expect(getLatency(provider, fileName, languageId)).toBe(1400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(800)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1400)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1600)
-        expect(getLatency(provider, fileName, languageId)).toBe(1800)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1800)
         // max at 2000 after multiple rejections
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
         // Writing a comment will not increase latency over max
-        expect(getLatency(provider, fileName, languageId, 'comment')).toBe(2000)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId, 'comment')).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
         // reset latency on accepted suggestion
         resetLatency()
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
     })
 
     it('returns increasing latency up to max after rejecting multiple suggestions, resets after file change and accept', () => {
@@ -167,41 +167,77 @@ describe('getLatency', () => {
         const languageId = 'typescript'
 
         // start with default baseline latency with low performance and user latency added
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
         // latency should start increasing after 5 rejections, but max at 2000
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
-        expect(getLatency(provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(400)
 
-        expect(getLatency(provider, fileName, languageId)).toBe(600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(600)
         // line is a comment, so latency should be increased where:
         // base is 1000 due to line is a comment, and user latency is 400 as this is the 7th rejection
-        expect(getLatency(provider, fileName, languageId, 'comment')).toBe(1400)
-        expect(getLatency(provider, fileName, languageId)).toBe(1000)
-        expect(getLatency(provider, fileName, languageId)).toBe(1200)
-        expect(getLatency(provider, fileName, languageId)).toBe(1400)
-        expect(getLatency(provider, fileName, languageId)).toBe(1600)
-        expect(getLatency(provider, fileName, languageId)).toBe(1800)
+        expect(getLatency(false, provider, fileName, languageId, 'comment')).toBe(1400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1400)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1600)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(1800)
         // max at 2000 after multiple rejections
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
-        expect(getLatency(provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(false, provider, fileName, languageId)).toBe(2000)
 
         // reset latency on file change to default
         const newFileName = 'foo/test.ts'
         // latency should start increasing again after 5 rejections
-        expect(getLatency(provider, newFileName, languageId)).toBe(400)
-        expect(getLatency(provider, newFileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, newFileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, newFileName, languageId)).toBe(400)
         // line is a comment, so latency should be increased
-        expect(getLatency(provider, newFileName, languageId, 'comment')).toBe(1000)
-        expect(getLatency(provider, newFileName, languageId)).toBe(400)
-        expect(getLatency(provider, newFileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, newFileName, languageId, 'comment')).toBe(1000)
+        expect(getLatency(false, provider, newFileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, newFileName, languageId)).toBe(400)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getLatency(provider, newFileName, languageId)).toBe(600)
+        expect(getLatency(false, provider, newFileName, languageId)).toBe(600)
         // reset latency on accepted suggestion
         resetLatency()
-        expect(getLatency(provider, newFileName, languageId)).toBe(400)
+        expect(getLatency(false, provider, newFileName, languageId)).toBe(400)
+    })
+
+    it('returns 0 if unsupport flag feature flag is enabled and the current language is not low performance', () => {
+        const provider = 'anthropic'
+        const fileName = 'foo/bar/test.go'
+        const languageId = 'go'
+
+        // start with default high latency for unsupported lang with default user latency added
+        expect(getLatency(true, provider, fileName, languageId)).toBe(0)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(0)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(0)
+    })
+
+    it('returns increased latency if unsupport flag feature flag is enabled and the current language is not low performance', () => {
+        const provider = 'anthropic'
+        const fileName = 'foo/bar/test'
+        const languageId = 'css'
+
+        // start with default high latency for low performance lang with default user latency added
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1000)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1000)
+        // start at default, but gradually increasing latency after 5 rejected suggestions
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1200)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1400)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1600)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1800)
+        // max latency at 2000
+        expect(getLatency(true, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(2000)
+        expect(getLatency(true, provider, fileName, languageId)).toBe(2000)
+        // after the suggestion was accepted, user latency resets to 0, using baseline only
+        resetLatency()
+        expect(getLatency(true, provider, fileName, languageId)).toBe(1000)
     })
 })


### PR DESCRIPTION
refactor: replace cody autocomplete minimum latency flag with user and language based latency flags

Replaced the CodyAutocompleteMinimumLatency feature flag with two new flags:

- CodyAutocompleteUserBasedLatency: Enables minimum latency for Cody autocomplete. Works the same as the old `CodyAutocompleteMinimumLatency` flag but rename it to make sure the old flag will not be used in older versions. 
- CodyAutocompleteLangBasedLatency: Enables language-specific minimum latency for Cody autocomplete for low-performance languages ONLY

The getLatency function now checks both new flags and calculates latency accordingly.

This allows more granular control over autocomplete latency based on user and language.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Unit tests are updated.