### PR TITLE
Agent: downgrade to Node.js v16 for standalone binaries

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -17,7 +17,7 @@
     "agent": "pnpm run build && node dist/index.js",
     "agent:debug": "pnpm run build && node --inspect ./dist/index.js",
     "build-ts": "tsc --build",
-    "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t latest-linux-arm64,latest-linux-x64,latest-macos-arm64,latest-macos-x64,latest-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
+    "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t node16-linux-arm64,node16-linux-x64,node16-macos-arm64,node16-macos-x64,node16-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "lint": "pnpm run lint:js",
     "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
     "test": "pnpm run build && vitest"


### PR DESCRIPTION
Previously, the standalone binaries for the agent embedded the latest version of Node.js, which at this time is most likely v20. Some users are unable to the the JetBrains plugin because they are hitting on the following network error in the agent

```
routines:final_renegotiate:unsafe legacy renegotiation disabled
```

This article here suggests that the error only happens in Node.js v17 and newer.
https://jfrog.com/help/r/artifactory-why-am-i-observing-unsafe-legacy-renegotiation-disabled-during-npm-install/artifactory-why-am-i-observing-unsafe-legacy-renegotiation-disabled-during-npm-install This PR is an attempt to fix this problem by using Node.js v16 in the agent.

Fixes https://github.com/sourcegraph/customer/issues/2427

## Test plan

We are already running Node.js v16 tests in CI.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
