### PR TITLE
Autocomplete: keep completion metadata on cache hit

### DIFF
--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -167,8 +167,12 @@ describe('RequestManager', () => {
         provider1.resolveRequest(["log('hello')"])
 
         expect((await promise1).completions[0].insertText).toBe("log('hello')")
-        const { completions } = await promise2
-        expect(completions[0].insertText).toBe("'hello')")
+        const [completion] = (await promise2).completions
+        expect(completion.insertText).toBe("'hello')")
+
+        // Keeps completion meta-data on cache-hit
+        expect(completion).toHaveProperty('stopReason')
+        expect(completion).toHaveProperty('range')
 
         expect(provider2.didAbort).toBe(true)
     })

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -91,12 +91,15 @@ export function reuseLastCandidate({
                     handleDidPartiallyAcceptCompletionItem?.(lastCandidate.result.logId, item, acceptedLength)
                 }
 
-                return { insertText: remaining }
+                return { ...item, insertText: remaining }
             }
 
             // Allow reuse if only the indentation (leading whitespace) has changed.
             if (isIndentationChange) {
-                return { insertText: lastTriggerCurrentLinePrefix.slice(currentLinePrefix.length) + item.insertText }
+                return {
+                    ...item,
+                    insertText: lastTriggerCurrentLinePrefix.slice(currentLinePrefix.length) + item.insertText,
+                }
             }
 
             return undefined


### PR DESCRIPTION
## Context

> Digging into analytics events shows that pretty often, completion events come without the node types info from tree-sitter.

Fixes the above issue where we discard completion metadata when a cached completion is used.

## Test plan

Updated unit tests.
