### PR TITLE
Autocomplete: Implement client-side timeouts

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Added client-side request timeouts to Autocomplete requests. [pull/1355](https://github.com/sourcegraph/cody/pull/1355)
+
 ### Fixed
 
 - Fixes an issue where autocomplete suggestions where sometimes not shown when the overlap with the next line was too large. [pull/1320](https://github.com/sourcegraph/cody/pull/1320

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -11,12 +11,15 @@ import {
     isAbortError,
     NetworkError,
     RateLimitError,
+    TimeoutError,
     TracedError,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { fetch } from '../fetch'
 
-export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'>
+import { forkSignal } from './utils'
+
+export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & { timeoutMs: number }
 
 export interface CodeCompletionsClient {
     complete(
@@ -35,122 +38,142 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
         return new URL('/.api/completions/code', config.serverEndpoint).href
     }
 
-    return {
-        async complete(params, onPartialResponse, signal): Promise<CompletionResponse> {
-            const log = logger?.startCompletion(params)
+    function completeWithTimeout(
+        params: CodeCompletionsParams,
+        onPartialResponse?: (incompleteResponse: CompletionResponse) => void,
+        signal?: AbortSignal
+    ): Promise<CompletionResponse> {
+        const abortController = signal ? forkSignal(signal) : new AbortController()
+        return Promise.race([
+            complete(params, onPartialResponse, abortController.signal),
+            createTimeout(params.timeoutMs).finally(() => {
+                // We abort the network request in the next run loop so that the race promise can be
+                // rejected with the timeout error before that.
+                setTimeout(() => abortController.abort(), 0)
+            }),
+        ])
+    }
 
-            const tracingFlagEnabled = await featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteTracing
+    async function complete(
+        params: CodeCompletionsParams,
+        onPartialResponse?: (incompleteResponse: CompletionResponse) => void,
+        signal?: AbortSignal
+    ): Promise<CompletionResponse> {
+        const log = logger?.startCompletion(params)
+
+        const tracingFlagEnabled = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteTracing)
+
+        const headers = new Headers(config.customHeaders)
+        // Force HTTP connection reuse to reduce latency.
+        // c.f. https://github.com/microsoft/vscode/issues/173861
+        headers.set('Connection', 'keep-alive')
+        if (config.accessToken) {
+            headers.set('Authorization', `token ${config.accessToken}`)
+        }
+        if (tracingFlagEnabled) {
+            headers.set('X-Sourcegraph-Should-Trace', 'true')
+        }
+
+        // We enable streaming only for Node environments right now because it's hard to make
+        // the polyfilled fetch API work the same as it does in the browser.
+        //
+        // TODO(philipp-spiess): Feature test if the response is a Node or a browser stream and
+        // implement SSE parsing for both.
+        const isNode = typeof process !== 'undefined'
+        const enableStreaming = !!isNode
+
+        const url = getCodeCompletionsEndpoint()
+        const response: Response = await fetch(url, {
+            method: 'POST',
+            body: JSON.stringify({
+                ...params,
+                stream: enableStreaming,
+            }),
+            headers,
+            signal,
+        })
+
+        const traceId = response.headers.get('x-trace') ?? undefined
+
+        // When rate-limiting occurs, the response is an error message
+        if (response.status === 429) {
+            const retryAfter = response.headers.get('retry-after')
+            const limit = response.headers.get('x-ratelimit-limit')
+            throw new RateLimitError(
+                await response.text(),
+                limit ? parseInt(limit, 10) : undefined,
+                retryAfter ? new Date(retryAfter) : undefined
             )
+        }
 
-            const headers = new Headers(config.customHeaders)
-            // Force HTTP connection reuse to reduce latency.
-            // c.f. https://github.com/microsoft/vscode/issues/173861
-            headers.set('Connection', 'keep-alive')
-            if (config.accessToken) {
-                headers.set('Authorization', `token ${config.accessToken}`)
-            }
-            if (tracingFlagEnabled) {
-                headers.set('X-Sourcegraph-Should-Trace', 'true')
-            }
+        if (!response.ok) {
+            throw new NetworkError(response, traceId)
+        }
 
-            // We enable streaming only for Node environments right now because it's hard to make
-            // the polyfilled fetch API work the same as it does in the browser.
-            //
-            // TODO(philipp-spiess): Feature test if the response is a Node or a browser stream and
-            // implement SSE parsing for both.
-            const isNode = typeof process !== 'undefined'
-            const enableStreaming = !!isNode
+        if (response.body === null) {
+            throw new TracedError('No response body', traceId)
+        }
 
-            const url = getCodeCompletionsEndpoint()
-            const response: Response = await fetch(url, {
-                method: 'POST',
-                body: JSON.stringify({
-                    ...params,
-                    stream: enableStreaming,
-                }),
-                headers,
-                signal,
-            })
+        // For backward compatibility, we have to check if the response is an SSE stream or a
+        // regular JSON payload. This ensures that the request also works against older backends
+        const isStreamingResponse = response.headers.get('content-type') === 'text/event-stream'
 
-            const traceId = response.headers.get('x-trace') ?? undefined
+        if (isStreamingResponse) {
+            let lastResponse: CompletionResponse | undefined
+            try {
+                // The any cast is necessary because `node-fetch` (The polyfill for fetch we use via
+                // `isomorphic-fetch`) does not implement a proper ReadableStream interface but
+                // instead exposes a Node Stream.
+                //
+                // Since we directly require from `isomporphic-fetch` and gate this branch out from
+                // non Node environments, the response.body will always be a Node Stream instead
+                const iterator = createSSEIterator(response.body as any as AsyncIterableIterator<BufferSource>)
 
-            // When rate-limiting occurs, the response is an error message
-            if (response.status === 429) {
-                const retryAfter = response.headers.get('retry-after')
-                const limit = response.headers.get('x-ratelimit-limit')
-                throw new RateLimitError(
-                    await response.text(),
-                    limit ? parseInt(limit, 10) : undefined,
-                    retryAfter ? new Date(retryAfter) : undefined
-                )
-            }
-
-            if (!response.ok) {
-                throw new NetworkError(response, traceId)
-            }
-
-            if (response.body === null) {
-                throw new TracedError('No response body', traceId)
-            }
-
-            // For backward compatibility, we have to check if the response is an SSE stream or a
-            // regular JSON payload. This ensures that the request also works against older backends
-            const isStreamingResponse = response.headers.get('content-type') === 'text/event-stream'
-
-            if (isStreamingResponse) {
-                let lastResponse: CompletionResponse | undefined
-                try {
-                    // The any cast is necessary because `node-fetch` (The polyfill for fetch we use via
-                    // `isomorphic-fetch`) does not implement a proper ReadableStream interface but
-                    // instead exposes a Node Stream.
-                    //
-                    // Since we directly require from `isomporphic-fetch` and gate this branch out from
-                    // non Node environments, the response.body will always be a Node Stream instead
-                    const iterator = createSSEIterator(response.body as any as AsyncIterableIterator<BufferSource>)
-
-                    for await (const chunk of iterator) {
-                        if (chunk.event === 'completion') {
-                            lastResponse = JSON.parse(chunk.data) as CompletionResponse
-                            onPartialResponse?.(lastResponse)
-                        }
+                for await (const chunk of iterator) {
+                    if (chunk.event === 'completion') {
+                        lastResponse = JSON.parse(chunk.data) as CompletionResponse
+                        onPartialResponse?.(lastResponse)
                     }
+                }
 
-                    if (lastResponse === undefined) {
-                        throw new TracedError('No completion response received', traceId)
-                    }
+                if (lastResponse === undefined) {
+                    throw new TracedError('No completion response received', traceId)
+                }
+                log?.onComplete(lastResponse)
+
+                return lastResponse
+            } catch (error) {
+                if (isAbortError(error as Error) && lastResponse) {
                     log?.onComplete(lastResponse)
-
-                    return lastResponse
-                } catch (error) {
-                    if (isAbortError(error as Error) && lastResponse) {
-                        log?.onComplete(lastResponse)
-                    }
-
-                    const message = `error parsing streaming CodeCompletionResponse: ${error}`
-                    log?.onError(message)
-                    throw new TracedError(message, traceId)
                 }
-            } else {
-                const result = await response.text()
-                try {
-                    const response = JSON.parse(result) as CompletionResponse
 
-                    if (typeof response.completion !== 'string' || typeof response.stopReason !== 'string') {
-                        const message = `response does not satisfy CodeCompletionResponse: ${result}`
-                        log?.onError(message)
-                        throw new TracedError(message, traceId)
-                    } else {
-                        log?.onComplete(response)
-                        return response
-                    }
-                } catch (error) {
-                    const message = `error parsing response CodeCompletionResponse: ${error}, response text: ${result}`
-                    log?.onError(message)
-                    throw new TracedError(message, traceId)
-                }
+                const message = `error parsing streaming CodeCompletionResponse: ${error}`
+                log?.onError(message)
+                throw new TracedError(message, traceId)
             }
-        },
+        } else {
+            const result = await response.text()
+            try {
+                const response = JSON.parse(result) as CompletionResponse
+
+                if (typeof response.completion !== 'string' || typeof response.stopReason !== 'string') {
+                    const message = `response does not satisfy CodeCompletionResponse: ${result}`
+                    log?.onError(message)
+                    throw new TracedError(message, traceId)
+                } else {
+                    log?.onComplete(response)
+                    return response
+                }
+            } catch (error) {
+                const message = `error parsing response CodeCompletionResponse: ${error}, response text: ${result}`
+                log?.onError(message)
+                throw new TracedError(message, traceId)
+            }
+        }
+    }
+
+    return {
+        complete: completeWithTimeout,
         onConfigurationChange(newConfig) {
             config = newConfig
         },
@@ -217,4 +240,8 @@ function parseSSEEvent(message: string): SSEMessage {
     }
 
     return { event, data }
+}
+
+function createTimeout(timeoutMs: number): Promise<never> {
+    return new Promise((_, reject) => setTimeout(() => reject(new TimeoutError('The request timed out')), timeoutMs))
 }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -2,12 +2,9 @@ import * as anthropic from '@anthropic-ai/sdk'
 
 import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
-import {
-    CompletionParameters,
-    CompletionResponse,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-import { CodeCompletionsClient } from '../client'
+import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import { canUsePartialCompletion } from '../streaming'
 import {
     CLOSING_CODE_TAG,
@@ -143,18 +140,20 @@ export class AnthropicProvider extends Provider {
             throw new Error(`prompt length (${prompt.length}) exceeded maximum character length (${this.promptChars})`)
         }
 
-        const args: CompletionParameters = this.options.multiline
+        const args: CodeCompletionsParams = this.options.multiline
             ? {
                   temperature: 0.5,
                   messages: prompt,
                   maxTokensToSample: MAX_RESPONSE_TOKENS,
                   stopSequences: MULTI_LINE_STOP_SEQUENCES,
+                  timeoutMs: 15000,
               }
             : {
                   temperature: 0.5,
                   messages: prompt,
                   maxTokensToSample: Math.min(50, MAX_RESPONSE_TOKENS),
                   stopSequences: SINGLE_LINE_STOP_SEQUENCES,
+                  timeoutMs: 5000,
               }
         tracer?.params(args)
 
@@ -181,7 +180,7 @@ export class AnthropicProvider extends Provider {
 
     private async fetchAndProcessCompletions(
         client: Pick<CodeCompletionsClient, 'complete'>,
-        params: CompletionParameters,
+        params: CodeCompletionsParams,
         abortSignal: AbortSignal
     ): Promise<CompletionResponse> {
         // The Async executor is required to return the completion early if a partial result from SSE can be used.


### PR DESCRIPTION
This PR adds client side timeouts as discussed in [this Slack thread](https://sourcegraph.slack.com/archives/C05497E9MDW/p1696521645079319).

The reason for this are the following:

Our current server-side backend does request retrying for a fixed number of times. For Autocomplete however, latency is of upmost importance so we don't really want to retry requests for a long time. In some cases, we see requests being retried for up to 30 minutes which is just putting additional pressure on the downstream processes without providing a great UX. Since timeouts are highly client specific, we decided that adding those to the client is the best approach for now. All of our middleware respect aborted requests so all we need to do is to start a race between a timeout and abort the request if that is hit. 

**Note:** This PR is best reviewed [with whitespace changes ignored](https://github.com/sourcegraph/cody/pull/1355/files?w=1).

## Test plan

- Modify the code to have a timeout below 100ms
- Trigger an autocomplete request
- Observe that a timeout error is thrown

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
