### PR TITLE
fix: log failures during fixup apply and respin

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -167,6 +167,7 @@ export class FixupController
     private scheduleRespin(task: FixupTask): void {
         const MAX_SPIN_COUNT_PER_TASK = 5
         if (task.spinCount >= MAX_SPIN_COUNT_PER_TASK) {
+            telemetryService.log('CodyVSCodeExtension:fixup:respin', { count: task.spinCount })
             // TODO: Report an error message
             // task.error = `Cody tried ${task.spinCount} times but failed to edit the file`
             this.setTaskState(task, CodyTaskState.error)
@@ -198,6 +199,7 @@ export class FixupController
         const editOk = task.insertMode ? await this.insertEdit(editor, task) : await this.replaceEdit(editor, diff)
 
         if (!editOk) {
+            telemetryService.log('CodyVSCodeExtension:fixup:apply:failed')
             // TODO: Try to recover, for example by respinning
             void vscode.window.showWarningMessage('edit did not apply')
             return


### PR DESCRIPTION
fix: log failures during fixup apply and respin

This adds additional logging around fixup failures:

- Log when applying a fixup fails
- Log when respinning a fixup task, including the respin count


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

You can see the log events in the output channel for all events when running a fixup task.