### PR TITLE
feat: allow configuring file exclusions

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -298,7 +298,7 @@ export class Agent extends MessageHandler {
         const client = await createClient({
             initialTranscript: this.oldClient?.transcript,
             editor: new AgentEditor(this),
-            config: { ...config, useContext: 'embeddings', experimentalLocalSymbols: false },
+            config: { ...config, useContext: 'embeddings', experimentalLocalSymbols: false, excludeFiles: [] },
             setMessageInProgress: messageInProgress => {
                 this.notify('chat/updateMessageInProgress', messageInProgress)
             },

--- a/cli/src/client/context.ts
+++ b/cli/src/client/context.ts
@@ -23,7 +23,7 @@ export async function createCodebaseContext(
     const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
 
     const codebaseContext = new CodebaseContext(
-        { useContext: contextType, serverEndpoint, experimentalLocalSymbols: false },
+        { useContext: contextType, serverEndpoint, experimentalLocalSymbols: false, excludeFiles: [] },
         codebase,
         embeddingsSearch,
         new LocalKeywordContextFetcherMock(),

--- a/e2e/src/run.ts
+++ b/e2e/src/run.ts
@@ -24,6 +24,7 @@ async function runTestCase(testCase: TestCase, provider: CLIOptions['provider'])
             useContext: testCase.context,
             customHeaders: {},
             experimentalLocalSymbols: false,
+            excludeFiles: [],
         },
         setMessageInProgress: message => {
             latestMessage = message

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -23,7 +23,13 @@ export { Transcript }
 
 export type ClientInitConfig = Pick<
     ConfigurationWithAccessToken,
-    'serverEndpoint' | 'codebase' | 'useContext' | 'accessToken' | 'customHeaders' | 'experimentalLocalSymbols'
+    | 'serverEndpoint'
+    | 'codebase'
+    | 'useContext'
+    | 'accessToken'
+    | 'customHeaders'
+    | 'experimentalLocalSymbols'
+    | 'excludeFiles'
 >
 
 export interface ClientInit {

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -22,18 +22,22 @@ export class ChatQuestion implements Recipe {
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            this.getContextMessages(
+                truncatedText,
+                context.editor,
+                context.firstInteraction,
+                context.intentDetector,
+                context.codebaseContext,
+                context.editor.getActiveTextEditorSelection() || null
+            )
+        )
+
         return Promise.resolve(
             new Interaction(
                 { speaker: 'human', text: truncatedText, displayText: humanChatInput },
                 { speaker: 'assistant' },
-                this.getContextMessages(
-                    truncatedText,
-                    context.editor,
-                    context.firstInteraction,
-                    context.intentDetector,
-                    context.codebaseContext,
-                    context.editor.getActiveTextEditorSelection() || null
-                ),
+                contextMessages,
                 []
             )
         )
@@ -74,7 +78,7 @@ export class ChatQuestion implements Recipe {
             contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
         }
 
-        return contextMessages
+        return codebaseContext.removeExcludedFilesFromContext(Promise.resolve(contextMessages))
     }
 
     public static getEditorContext(editor: Editor): ContextMessage[] {

--- a/lib/shared/src/chat/recipes/code-question.ts
+++ b/lib/shared/src/chat/recipes/code-question.ts
@@ -22,6 +22,17 @@ export class CodeQuestion implements Recipe {
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            this.getContextMessages(
+                truncatedText,
+                context.editor,
+                context.firstInteraction,
+                context.intentDetector,
+                context.codebaseContext,
+                context.editor.getActiveTextEditorSelection() || null
+            )
+        )
+
         return Promise.resolve(
             new Interaction(
                 { speaker: 'human', text: truncatedText, displayText: humanChatInput },
@@ -29,14 +40,7 @@ export class CodeQuestion implements Recipe {
                     speaker: 'assistant',
                     text: `\`\`\`${getFileExtension(context.editor.getActiveTextEditorSelection()?.fileName ?? '')}\n`,
                 },
-                this.getContextMessages(
-                    truncatedText,
-                    context.editor,
-                    context.firstInteraction,
-                    context.intentDetector,
-                    context.codebaseContext,
-                    context.editor.getActiveTextEditorSelection() || null
-                ),
+                contextMessages,
                 []
             )
         )

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -84,13 +84,16 @@ export class CustomPrompt implements Recipe {
         const commandOutput = command.context?.output
 
         const truncatedText = truncateText(text, MAX_HUMAN_INPUT_TOKENS)
-        const contextMessages = this.getContextMessages(
-            truncatedText,
-            context.editor,
-            context.codebaseContext,
-            contextConfig,
-            selection,
-            commandOutput
+
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            this.getContextMessages(
+                truncatedText,
+                context.editor,
+                context.codebaseContext,
+                contextConfig,
+                selection,
+                commandOutput
+            )
         )
 
         return newInteraction({ text: truncatedText, displayText, contextMessages })
@@ -153,10 +156,11 @@ export class CustomPrompt implements Recipe {
         }
         if (promptContext.command && commandOutput) {
             const outputMessages = getTerminalOutputContext(commandOutput)
-            contextMessages.push(...outputMessages)
+            contextMessages.push(...outputMe ssages)
         }
         // Return sliced results
         const maxResults = Math.floor((NUM_CODE_RESULTS + NUM_TEXT_RESULTS) / 2) * 2
+
         return contextMessages.slice(-maxResults * 2)
     }
 
@@ -168,12 +172,12 @@ export class CustomPrompt implements Recipe {
 
         if (workspaceRootUri) {
             const rootFileNames = await getDirectoryFileListContext(workspaceRootUri, true)
-            contextMessages.push(...rootFileNames)
+            contextMessages.push(...rootFil eNames)
         }
         // Add package.json content only if files matches the ts/js extension regex
         if (selection?.fileName && getFileExtension(selection?.fileName).match(/ts|js/)) {
             const packageJson = await getPackageJsonContext(selection?.fileName)
-            contextMessages.push(...packageJson)
+            contextMessages.push(...packa geJson)
         }
         // Try adding import statements from current file as context
         if (selection?.fileName) {

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -156,7 +156,7 @@ export class CustomPrompt implements Recipe {
         }
         if (promptContext.command && commandOutput) {
             const outputMessages = getTerminalOutputContext(commandOutput)
-            contextMessages.push(...outputMe ssages)
+            contextMessages.push(...outputMessages)
         }
         // Return sliced results
         const maxResults = Math.floor((NUM_CODE_RESULTS + NUM_TEXT_RESULTS) / 2) * 2
@@ -172,12 +172,12 @@ export class CustomPrompt implements Recipe {
 
         if (workspaceRootUri) {
             const rootFileNames = await getDirectoryFileListContext(workspaceRootUri, true)
-            contextMessages.push(...rootFil eNames)
+            contextMessages.push(...rootFileNames)
         }
         // Add package.json content only if files matches the ts/js extension regex
         if (selection?.fileName && getFileExtension(selection?.fileName).match(/ts|js/)) {
             const packageJson = await getPackageJsonContext(selection?.fileName)
-            contextMessages.push(...packa geJson)
+            contextMessages.push(...packageJson)
         }
         // Try adding import statements from current file as context
         if (selection?.fileName) {

--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -68,6 +68,10 @@ export class Fixup implements Recipe {
         const intent = await this.getIntent(fixupTask, context)
         const promptText = this.getPrompt(fixupTask, intent)
 
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            Promise.resolve(this.getContextFromIntent(intent, fixupTask, quarterFileContext, context))
+        )
+
         return Promise.resolve(
             new Interaction(
                 {
@@ -77,7 +81,7 @@ export class Fixup implements Recipe {
                 {
                     speaker: 'assistant',
                 },
-                this.getContextFromIntent(intent, fixupTask, quarterFileContext, context),
+                contextMessages,
                 []
             )
         )

--- a/lib/shared/src/chat/recipes/generate-release-notes.ts
+++ b/lib/shared/src/chat/recipes/generate-release-notes.ts
@@ -78,7 +78,7 @@ export class ReleaseNotes implements Recipe {
         }
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
-        console.log(truncatedGitLogOutput)
+
         let truncatedLogMessage = ''
         if (truncatedGitLogOutput.length < gitLogOutput.length) {
             truncatedLogMessage = 'Truncated extra long git log output, so release notes may miss some changes.'

--- a/lib/shared/src/chat/recipes/inline-chat.ts
+++ b/lib/shared/src/chat/recipes/inline-chat.ts
@@ -48,6 +48,10 @@ export class InlineChat implements Recipe {
         // Text display in UI fpr human that includes the selected code
         const displayText = humanChatInput + InlineChat.displayPrompt.replace('{selectedText}', selection.selectedText)
 
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            Promise.resolve(this.getContextMessages(truncatedText, context.codebaseContext, selection, context.editor))
+        )
+
         return Promise.resolve(
             new Interaction(
                 {
@@ -56,7 +60,7 @@ export class InlineChat implements Recipe {
                     displayText,
                 },
                 { speaker: 'assistant' },
-                this.getContextMessages(truncatedText, context.codebaseContext, selection, context.editor),
+                contextMessages,
                 []
             )
         )

--- a/lib/shared/src/chat/recipes/inline-touch.ts
+++ b/lib/shared/src/chat/recipes/inline-touch.ts
@@ -88,6 +88,10 @@ export class InlineTouch implements Recipe {
             })
         )
 
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            Promise.resolve(this.getContextMessages(selection, currentDir))
+        )
+
         return Promise.resolve(
             new Interaction(
                 {
@@ -99,7 +103,7 @@ export class InlineTouch implements Recipe {
                     speaker: 'assistant',
                     prefix: 'Working on it! I will show you the new file when it is ready.\n\n',
                 },
-                this.getContextMessages(selection, currentDir),
+                contextMessages,
                 []
             )
         )

--- a/lib/shared/src/chat/recipes/next-questions.ts
+++ b/lib/shared/src/chat/recipes/next-questions.ts
@@ -25,6 +25,9 @@ export class NextQuestions implements Recipe {
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedText}\n\`\`\`\n\n${promptSuffix}`
 
         const assistantResponsePrefix = 'Sure, here are great follow-up discussion topics and learning ideas:\n\n - '
+        const contextMessages = context.codebaseContext.removeExcludedFilesFromContext(
+            this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext)
+        )
         return Promise.resolve(
             new Interaction(
                 { speaker: 'human', text: promptMessage },
@@ -33,7 +36,7 @@ export class NextQuestions implements Recipe {
                     prefix: assistantResponsePrefix,
                     text: assistantResponsePrefix,
                 },
-                this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext),
+                contextMessages,
                 []
             )
         )

--- a/lib/shared/src/chat/transcript/transcript.test.ts
+++ b/lib/shared/src/chat/transcript/transcript.test.ts
@@ -81,6 +81,7 @@ describe('Transcript', () => {
                         useContext: 'embeddings',
                         serverEndpoint: 'https://example.com',
                         experimentalLocalSymbols: false,
+                        excludeFiles: [],
                     },
                     'dummy-codebase',
                     embeddings,
@@ -123,6 +124,7 @@ describe('Transcript', () => {
                         useContext: 'embeddings',
                         serverEndpoint: 'https://example.com',
                         experimentalLocalSymbols: false,
+                        excludeFiles: [],
                     },
                     'dummy-codebase',
                     embeddings,
@@ -159,7 +161,12 @@ describe('Transcript', () => {
         })
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
-            { useContext: 'embeddings', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+            {
+                useContext: 'embeddings',
+                serverEndpoint: 'https://example.com',
+                experimentalLocalSymbols: false,
+                excludeFiles: [],
+            },
             'dummy-codebase',
             embeddings,
             defaultKeywordContextFetcher,
@@ -246,7 +253,12 @@ describe('Transcript', () => {
         })
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
-            { useContext: 'embeddings', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+            {
+                useContext: 'embeddings',
+                serverEndpoint: 'https://example.com',
+                experimentalLocalSymbols: false,
+                excludeFiles: [],
+            },
             'dummy-codebase',
             embeddings,
             defaultKeywordContextFetcher,
@@ -324,7 +336,12 @@ describe('Transcript', () => {
         })
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
-            { useContext: 'embeddings', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+            {
+                useContext: 'embeddings',
+                serverEndpoint: 'https://example.com',
+                experimentalLocalSymbols: false,
+                excludeFiles: [],
+            },
             'dummy-codebase',
             embeddings,
             defaultKeywordContextFetcher,

--- a/lib/shared/src/chat/useClient.ts
+++ b/lib/shared/src/chat/useClient.ts
@@ -23,7 +23,7 @@ import { reformatBotMessage } from './viewHelpers'
 
 export type CodyClientConfig = Pick<
     ConfigurationWithAccessToken,
-    'serverEndpoint' | 'useContext' | 'accessToken' | 'customHeaders' | 'experimentalLocalSymbols'
+    'serverEndpoint' | 'useContext' | 'accessToken' | 'customHeaders' | 'experimentalLocalSymbols' | 'excludeFiles'
 > & { debugEnable: boolean; needsEmailVerification: boolean }
 
 export interface CodyClientScope {

--- a/lib/shared/src/codebase-context/exclude-files.test.ts
+++ b/lib/shared/src/codebase-context/exclude-files.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+
+import { filterFilesToExclude } from './exclude-files'
+import { ContextMessage } from './messages'
+
+describe('filterFilesToExclude', () => {
+    test('returns empty array if no excludedFiles', async () => {
+        const result = await filterFilesToExclude(Promise.resolve([]), [])
+        expect(result).toEqual([])
+    })
+
+    test('filters out messages with matching filenames', async () => {
+        const messages: Promise<ContextMessage[]> = Promise.resolve([
+            { speaker: 'human', file: { fileName: 'file1.js' } },
+            { speaker: 'assistant', text: 'ok' },
+            { speaker: 'human', file: { fileName: 'file2.js' } },
+            { speaker: 'assistant', text: 'ok' },
+        ])
+        const result = await filterFilesToExclude(messages, ['file1.js'])
+        expect(result).toEqual([
+            { speaker: 'human', file: { fileName: 'file2.js' } },
+            { speaker: 'assistant', text: 'ok' },
+        ])
+    })
+
+    test('returns unfiltered messages if no match was found', async () => {
+        const messages: Promise<ContextMessage[]> = Promise.resolve([
+            { speaker: 'human', file: { fileName: 'file1.js' } },
+            { speaker: 'assistant', text: 'ok' },
+            { speaker: 'human', file: { fileName: 'file3.js' } },
+            { speaker: 'assistant', text: 'ok' },
+        ])
+        const result = await filterFilesToExclude(messages, ['file2.js'])
+        expect(result).toEqual([
+            { speaker: 'human', file: { fileName: 'file1.js' } },
+            { speaker: 'assistant', text: 'ok' },
+            { speaker: 'human', file: { fileName: 'file3.js' } },
+            { speaker: 'assistant', text: 'ok' },
+        ])
+    })
+
+    test('returns empty array if no messages', async () => {
+        const messages: Promise<ContextMessage[]> = Promise.resolve([])
+        const result = await filterFilesToExclude(messages, ['file.js'])
+        expect(result).toEqual([])
+    })
+
+    test('return empty array if the only interaction includes excluded file', async () => {
+        const messages: Promise<ContextMessage[]> = Promise.resolve([
+            { speaker: 'human', file: { fileName: 'file2.js' } },
+            { speaker: 'assistant', text: 'ok' },
+        ])
+        const result = await filterFilesToExclude(messages, ['file2.js'])
+        expect(result).toEqual([])
+    })
+
+    test('includes messages without filename after filtering out matches', async () => {
+        const messages: Promise<ContextMessage[]> = Promise.resolve([
+            { speaker: 'human', file: { fileName: 'file1.js' } },
+            { speaker: 'assistant', text: 'ok' },
+            { speaker: 'human', text: 'hello' },
+            { speaker: 'assistant' },
+        ])
+        const result = await filterFilesToExclude(messages, ['file1.js'])
+        expect(result).toEqual([{ speaker: 'human', text: 'hello' }, { speaker: 'assistant' }])
+    })
+})

--- a/lib/shared/src/codebase-context/exclude-files.ts
+++ b/lib/shared/src/codebase-context/exclude-files.ts
@@ -1,0 +1,27 @@
+import { ContextMessage } from './messages'
+
+export async function filterFilesToExclude(
+    messages: Promise<ContextMessage[]>,
+    excludedFiles?: string[]
+): Promise<ContextMessage[]> {
+    if (!excludedFiles) {
+        return messages
+    }
+    // remove any messages that has a filename that matches one of the files to exclude
+    // also remove the message after the one that matches the file to exclude
+    const contextMessages = await messages
+    const newMessages = []
+    for (let i = 0; i < contextMessages.length; i++) {
+        const message = contextMessages[i]
+        if (message.speaker === 'human' && message.file?.fileName) {
+            // find filesToExclude to see if the filename matches
+            const isFileToExclude = excludedFiles.some(file => message.file?.fileName.includes(file))
+            if (isFileToExclude) {
+                i++
+                continue
+            }
+        }
+        newMessages.push(message)
+    }
+    return newMessages
+}

--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -18,6 +18,7 @@ import { EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
 import { UnifiedContextFetcher } from '../unified-context'
 import { isError } from '../utils'
 
+import { filterFilesToExclude } from './exclude-files'
 import { ContextFile, ContextFileSource, ContextMessage, getContextMessageWithResponse } from './messages'
 
 export interface ContextSearchOptions {
@@ -28,7 +29,10 @@ export interface ContextSearchOptions {
 export class CodebaseContext {
     private embeddingResultsError = ''
     constructor(
-        private config: Pick<Configuration, 'useContext' | 'serverEndpoint' | 'experimentalLocalSymbols'>,
+        private config: Pick<
+            Configuration,
+            'useContext' | 'serverEndpoint' | 'experimentalLocalSymbols' | 'excludeFiles'
+        >,
         private readonly codebase: string | undefined,
         private embeddings: EmbeddingsSearch | null,
         private keywords: KeywordContextFetcher | null,
@@ -89,6 +93,10 @@ export class CodebaseContext {
                     ? this.getEmbeddingsContextMessages(query, options)
                     : this.getLocalContextMessages(query, options)
         }
+    }
+
+    public async removeExcludedFilesFromContext(messages: Promise<ContextMessage[]>): Promise<ContextMessage[]> {
+        return filterFilesToExclude(messages, this.config.excludeFiles)
     }
 
     public checkEmbeddingsConnection(): boolean {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -30,6 +30,7 @@ export interface Configuration {
     autocompleteExperimentalSyntacticPostProcessing?: boolean
     autocompleteExperimentalGraphContext?: boolean
     isRunningInsideAgent?: boolean
+    excludeFiles: string[]
 }
 
 export interface ConfigurationWithAccessToken extends Configuration {

--- a/lib/shared/src/test/mocks.ts
+++ b/lib/shared/src/test/mocks.ts
@@ -151,7 +151,12 @@ export function newRecipeContext(args?: Partial<RecipeContext>): RecipeContext {
         codebaseContext:
             args.codebaseContext ||
             new CodebaseContext(
-                { useContext: 'none', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+                {
+                    useContext: 'none',
+                    serverEndpoint: 'https://example.com',
+                    experimentalLocalSymbols: false,
+                    excludeFiles: [],
+                },
                 'dummy-codebase',
                 defaultEmbeddingsClient,
                 defaultKeywordContextFetcher,

--- a/slack/src/services/codebase-context.ts
+++ b/slack/src/services/codebase-context.ts
@@ -33,7 +33,7 @@ export async function createCodebaseContext(
         repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(sourcegraphClient, repoId) : null
 
     const codebaseContext = new CodebaseContext(
-        { useContext: contextType, serverEndpoint, experimentalLocalSymbols: false },
+        { useContext: contextType, serverEndpoint, experimentalLocalSymbols: false, excludeFiles: [] },
         codebase,
         embeddingsSearch,
         new LocalKeywordContextFetcherMock(),

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,9 +8,11 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- New configuration option `cody.excludeFiles` to exclude a list of files from sending to Cody. This is useful for files that contain secrets or other sensitive information. [pull/](https://github.com/sourcegraph/cody/pull/)
+
 ### Fixed
 
-- Fixes an issue where autocomplete suggestions where sometimes not shown when the overlap with the next line was too large. [pull/1320](https://github.com/sourcegraph/cody/pull/1320
+- Fixes an issue where autocomplete suggestions where sometimes not shown when the overlap with the next line was too large. [pull/1320](https://github.com/sourcegraph/cody/pull/1320)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -854,6 +854,19 @@
           "markdownDescription": "Enable Cody fix and explain options in the Quick Fix menu",
           "default": true
         },
+        "cody.excludeFiles": {
+          "order": 12,
+          "type": "array",
+          "markdownDescription": "Files to exclude from sending to Cody. This is useful for files that contain secrets or other sensitive information.",
+          "examples": [
+            [
+              ".json",
+              ".env",
+              "path/to/my/file.js",
+              "/dirName/"
+            ]
+          ]
+        },
         "cody.experimental.symf.path": {
           "order": 99,
           "type": "string",

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -44,6 +44,7 @@ export type Config = Pick<
     | 'experimentalEditorTitleCommandIcon'
     | 'experimentalLocalSymbols'
     | 'inlineChat'
+    | 'excludeFiles'
 >
 
 export enum ContextEvent {

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -41,6 +41,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocompleteCompleteSuggestWidgetSelection: false,
     autocompleteExperimentalSyntacticPostProcessing: false,
     autocompleteExperimentalGraphContext: false,
+    excludeFiles: [],
 }
 
 const getVSCodeSettings = (config: Partial<Configuration> = {}): Configuration => ({

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -42,6 +42,7 @@ describe('getConfiguration', () => {
             autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: false,
+            excludeFiles: [],
         })
     })
 
@@ -110,6 +111,8 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.advanced.agent.running':
                         return false
+                    case 'cody.excludeFiles':
+                        return []
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -150,6 +153,7 @@ describe('getConfiguration', () => {
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: true,
+            excludeFiles: [],
         })
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -81,6 +81,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
             CONFIG_KEY.autocompleteExperimentalGraphContext,
             false
         ),
+        excludeFiles: config.get<string[]>(CONFIG_KEY.excludeFiles, []),
 
         /**
          * UNDOCUMENTED FLAGS

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -36,6 +36,7 @@ type ExternalServicesConfiguration = Pick<
     | 'accessToken'
     | 'debugEnable'
     | 'experimentalLocalSymbols'
+    | 'excludeFiles'
 >
 
 export async function configureExternalServices(

--- a/web/src/settings/useConfig.ts
+++ b/web/src/settings/useConfig.ts
@@ -8,6 +8,7 @@ const DEFAULT_WEB_CONFIGURATION: WebConfiguration = {
     useContext: 'embeddings',
     customHeaders: {},
     experimentalLocalSymbols: false,
+    excludeFiles: [],
 }
 
 export type WebConfiguration = ClientInit['config']


### PR DESCRIPTION
Close: https://github.com/sourcegraph/cody/issues/1049

This change allows configuring file exclusions via the new  `'cody.excludeFiles'` configuration option.

Files can now be excluded from fetched context before they are sent to LLM to prevent sharing sensitive information from a known location, e.g. directory, file name, etc.

### Examples

configuration: cody.excludeFiles = [".json", ".env", "path/to/my/file.js", "/dirName/"]

files that will be excluded:
- anything with `.json` in the file name, e.g. `package.json`, `cody.json` etc
- anything with `.env` in the file name, e.g. `.env`, `vscode/.env`, etc
- the exact file `path/to/my/file.js`, e.g. `path/to/my/file.js`, or `new/path/to/my/file.js` etc
- all files under the `/dirName/` directory, e.g. `path/to/dirName/file.js`, `path/dirName/file.js` etc

I wanted to do the filtering in codebase-context/index.ts, but then we will need to do the filtering again when we combine them with context from the editor, so for now I think it makes more sense to do it at the recipe level. Open to other ideas and suggestions though!

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

WIP