### PR TITLE
Autocomplete: collect node types without pasted completion

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -51,6 +51,12 @@ describe('[getInlineCompletions] completion event', () => {
                   "greatGrandparent": "program",
                   "parent": "statement_block",
                 },
+                "nodeTypesWithCompletion": {
+                  "atCursor": "{",
+                  "grandparent": "function_declaration",
+                  "greatGrandparent": "program",
+                  "parent": "statement_block",
+                },
                 "parseErrorCount": 0,
                 "stopReason": "unit-test",
                 "truncatedWith": "tree-sitter",

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -14,7 +14,7 @@ describe('[getInlineCompletions] completion event', () => {
         const spy = vi.spyOn(CompletionLogger, 'loaded')
 
         await getInlineCompletions(
-            params('function foo() {█', [
+            params('function foo() {█}', [
                 {
                     completion: 'console.log(bar)\nreturn false}',
                     stopReason: 'unit-test',

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -76,8 +76,15 @@ export interface ItemPostProcessingInfo {
     lineTruncatedCount?: number
     // The truncation approach used.
     truncatedWith?: 'tree-sitter' | 'indentation'
-    // Syntax node types extracted from the tree-sitter parse-tree.
+    // Syntax node types extracted from the tree-sitter parse-tree without the completion pasted.
     nodeTypes?: {
+        atCursor?: string
+        parent?: string
+        grandparent?: string
+        greatGrandparent?: string
+    }
+    // Syntax node types extracted from the tree-sitter parse-tree with the completion pasted.
+    nodeTypesWithCompletion?: {
         atCursor?: string
         parent?: string
         grandparent?: string
@@ -448,6 +455,7 @@ function completionItemToItemInfo(item: InlineCompletionItemWithAnalytics): Comp
         lineTruncatedCount: item.lineTruncatedCount,
         truncatedWith: item.truncatedWith,
         nodeTypes: item.nodeTypes,
+        nodeTypesWithCompletion: item.nodeTypesWithCompletion,
     }
 }
 

--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -114,6 +114,12 @@ describe('process completion item', () => {
                 "greatGrandparent": "program",
                 "parent": "formal_parameters",
               },
+              "nodeTypesWithCompletion": {
+                "atCursor": "(",
+                "grandparent": "function_declaration",
+                "greatGrandparent": "program",
+                "parent": "formal_parameters",
+              },
               "parseErrorCount": 0,
               "range": {
                 "end": Position {
@@ -132,6 +138,12 @@ describe('process completion item', () => {
               "nodeTypes": {
                 "atCursor": "(",
                 "grandparent": "function_signature",
+                "greatGrandparent": "program",
+                "parent": "formal_parameters",
+              },
+              "nodeTypesWithCompletion": {
+                "atCursor": "(",
+                "grandparent": "ERROR",
                 "greatGrandparent": "program",
                 "parent": "formal_parameters",
               },
@@ -187,9 +199,46 @@ describe('process completion item', () => {
                 "greatGrandparent": undefined,
                 "parent": "if_statement",
               },
+              "nodeTypesWithCompletion": {
+                "atCursor": "statement_block",
+                "grandparent": "program",
+                "greatGrandparent": undefined,
+                "parent": "if_statement",
+              },
               "parseErrorCount": 0,
               "stopReason": "unknown",
               "truncatedWith": "tree-sitter",
+            },
+          ]
+        `)
+    })
+
+    it('adds parse info to single-line completions', () => {
+        const completions = processCompletions(
+            `
+            const one = █
+        `,
+            ['"one"']
+        )
+
+        expect(completions).toMatchInlineSnapshot(`
+          [
+            {
+              "insertText": "\\"one\\"",
+              "nodeTypes": {
+                "atCursor": "program",
+                "grandparent": undefined,
+                "greatGrandparent": undefined,
+                "parent": undefined,
+              },
+              "nodeTypesWithCompletion": {
+                "atCursor": "variable_declarator",
+                "grandparent": "program",
+                "greatGrandparent": undefined,
+                "parent": "lexical_declaration",
+              },
+              "parseErrorCount": 0,
+              "stopReason": "unknown",
             },
           ]
         `)

--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -109,10 +109,10 @@ describe('process completion item', () => {
             {
               "insertText": "array) {",
               "nodeTypes": {
-                "atCursor": "identifier",
-                "grandparent": "formal_parameters",
-                "greatGrandparent": "function_declaration",
-                "parent": "required_parameter",
+                "atCursor": "(",
+                "grandparent": "function_signature",
+                "greatGrandparent": "program",
+                "parent": "formal_parameters",
               },
               "parseErrorCount": 0,
               "range": {
@@ -130,10 +130,10 @@ describe('process completion item', () => {
             {
               "insertText": "array) new",
               "nodeTypes": {
-                "atCursor": "identifier",
-                "grandparent": "formal_parameters",
-                "greatGrandparent": "ERROR",
-                "parent": "required_parameter",
+                "atCursor": "(",
+                "grandparent": "function_signature",
+                "greatGrandparent": "program",
+                "parent": "formal_parameters",
               },
               "parseErrorCount": 1,
               "range": {
@@ -182,10 +182,10 @@ describe('process completion item', () => {
           }",
               "lineTruncatedCount": 2,
               "nodeTypes": {
-                "atCursor": "{",
-                "grandparent": "if_statement",
-                "greatGrandparent": "program",
-                "parent": "statement_block",
+                "atCursor": "statement_block",
+                "grandparent": "program",
+                "greatGrandparent": undefined,
+                "parent": "if_statement",
               },
               "parseErrorCount": 0,
               "stopReason": "unknown",

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -89,18 +89,36 @@ function processCompletion(params: ProcessItemParams): InlineCompletionItemWithA
     let { insertText } = parsed
     const initialLineCount = insertText.split('\n').length
 
-    // Use the parse tree without the pasted completion to get surrounding node types.
+    const positionBeforeCursor = asPoint(position.translate(undefined, -1))
+
+    // Use the parse tree WITHOUT the pasted completion to get surrounding node types.
+    // Helpful to optimize the completion AST triggers for higher CAR.
     const parseTreeCache = getCachedParseTreeForDocument(document)
     if (parseTreeCache) {
-        const captures = getNodeAtCursorAndParents(
-            parseTreeCache.tree.rootNode,
-            asPoint(position.translate(undefined, -1))
-        )
+        const captures = getNodeAtCursorAndParents(parseTreeCache.tree.rootNode, positionBeforeCursor)
 
         if (captures.length > 0) {
             const [atCursor, ...parents] = captures
 
             parsed.nodeTypes = {
+                atCursor: atCursor.node.type,
+                parent: parents[0]?.node.type,
+                grandparent: parents[1]?.node.type,
+                greatGrandparent: parents[2]?.node.type,
+            }
+        }
+    }
+
+    // Use the parse tree WITH the pasted completion to get surrounding node types.
+    // Helpful to understand CAR for incomplete code snippets.
+    // E.g., `const value = ` does not produce a valid AST, but `const value = 'someValue'` does
+    if (parsed.tree && parsed.points) {
+        const captures = getNodeAtCursorAndParents(parsed.tree.rootNode, positionBeforeCursor)
+
+        if (captures.length > 0) {
+            const [atCursor, ...parents] = captures
+
+            parsed.nodeTypesWithCompletion = {
                 atCursor: atCursor.node.type,
                 parent: parents[0]?.node.type,
                 grandparent: parents[1]?.node.type,

--- a/vscode/src/completions/tree-sitter/ast-getters.ts
+++ b/vscode/src/completions/tree-sitter/ast-getters.ts
@@ -1,39 +1,27 @@
-import Parser, { Point, SyntaxNode } from 'web-tree-sitter'
+import { Point, SyntaxNode } from 'web-tree-sitter'
 
 import { isDefined } from '@sourcegraph/cody-shared'
 
-import { Captures } from './query-tests/annotate-and-match-snapshot'
+/**
+ * Returns a descendant node at the start position and three parent nodes.
+ */
+export function getNodeAtCursorAndParents(
+    node: SyntaxNode,
+    startPosition: Point
+): readonly [{ readonly name: 'at_cursor'; readonly node: SyntaxNode }, ...{ name: string; node: SyntaxNode }[]] {
+    const atCursorNode = node.descendantForPosition(startPosition)
 
-interface AstGetters {
-    getNodeAtCursorAndParents: (
-        node: SyntaxNode,
-        startPosition: Point,
-        endPosition?: Point
-    ) => readonly [
-        { readonly name: 'at_cursor'; readonly node: Parser.SyntaxNode },
-        ...{ name: string; node: Parser.SyntaxNode }[],
-    ]
+    const parent = atCursorNode.parent
+    const parents = [parent, parent?.parent, parent?.parent?.parent].filter(isDefined).map(node => ({
+        name: 'parents',
+        node,
+    }))
+
+    return [
+        {
+            name: 'at_cursor',
+            node: atCursorNode,
+        },
+        ...parents,
+    ] as const
 }
-
-export const astGetters: AstGetters = {
-    /**
-     * Returns a descendant node at the start position and two parent nodes if they exist.
-     */
-    getNodeAtCursorAndParents: (node, startPosition) => {
-        const descendant = node.descendantForPosition(startPosition)
-        const parent = descendant.parent
-
-        const parents = [parent, parent?.parent, parent?.parent?.parent].filter(isDefined).map(node => ({
-            name: 'parents',
-            node,
-        }))
-
-        return [
-            {
-                name: 'at_cursor',
-                node: descendant,
-            },
-            ...parents,
-        ] as const
-    },
-} satisfies Record<string, Captures>

--- a/vscode/src/completions/tree-sitter/query-tests/node-at-cursor-and-parents.test.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/node-at-cursor-and-parents.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, it } from 'vitest'
 
 import { initTreeSitterParser } from '../../test-helpers'
-import { astGetters } from '../ast-getters'
+import { getNodeAtCursorAndParents } from '../ast-getters'
 import { SupportedLanguage } from '../grammars'
 import { getDocumentQuerySDK } from '../query-sdk'
 
@@ -18,7 +18,7 @@ describe('getNodeAtCursorAndParents', () => {
         await annotateAndMatchSnapshot({
             parser,
             language,
-            captures: astGetters.getNodeAtCursorAndParents,
+            captures: getNodeAtCursorAndParents,
             sourcesPath: 'test-data/parents.ts',
         })
     })

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/parents.snap.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/parents.snap.ts
@@ -170,8 +170,8 @@
 // ------------------------------------
 // Captures the whole try_statement block
 
-  export function tryHard() {
-//                          ^ start parents[3]
+  export function tryHard(message: string) {
+//                                         ^ start parents[3]
       try {
 //    ^ start parents[2]
 //        ^ at_cursor[1], start parents[1]
@@ -181,7 +181,7 @@
 //    ^ end parents[1]
           console.error('Opps!')
       } finally {
-          console.log('Done trying...')
+          console.log(message)
       }
 //    ^ end parents[2]
   }
@@ -192,4 +192,18 @@
 // parents[1]: statement_block
 // parents[2]: try_statement
 // parents[3]: statement_block
+
+// ------------------------------------
+
+  tryHard('Hello')
+//^^^^^^^^^^^^^^^^ parents[2], parents[3]
+//       ^^^^^^^^^ parents[1]
+//               ^ at_cursor[1]
+//               █
+
+// Nodes types:
+// at_cursor[1]: )
+// parents[1]: arguments
+// parents[2]: call_expression
+// parents[3]: expression_statement
 

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/parents.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/parents.ts
@@ -75,13 +75,18 @@ export function whatIf() {
 // ------------------------------------
 // Captures the whole try_statement block
 
-export function tryHard() {
+export function tryHard(message: string) {
     try {
     //  |
         new Doggo()
     } catch (error) {
         console.error('Opps!')
     } finally {
-        console.log('Done trying...')
+        console.log(message)
     }
 }
+
+// ------------------------------------
+
+tryHard('Hello')
+//             |


### PR DESCRIPTION
## Context

Via exploring data in BigQuery, I found that the definition of the `at_cursor` node types is inconsistent. I used the multiline trigger position for multiline suggestions and the completion start for singleline suggestions. Meaning that for singleline completions, we were getting data about the first suggested node. 

### Example 1

```ts
const value = █
```

And with the inserted completion:

```ts
const value = "hello"
```

We were getting `atCursor: 'string'` instead of `program` as per the initial AST. The second one has "more" data because tree-sitter does not understand that it's a variable declaration until the completion is inserted.

### Example 2

```ts
function getData(value█
```

And with the inserted completion:

```ts
function getData(value) {
```

We were getting `atCursor: ')'` (from the start of the inserted completion) instead of `identifier`, which is unhelpful for analysis. We care more about the prefix nodes than those generated by LLM.

## Changes

- Use the same `at_custor` position for single/multi-line completions (the column before the cursor). 
- Collect `nodeTypes` for both tree states: without the pasted completion and with it. 
    - The tree without the completion gives us AST patterns to optimize against before the completion request is made. 
    - The tree with the pasted completion gives us more information about the completion intent. E..g., from the example above, we will know that completion was inserted into the variable declaration.

## Test plan

Updated unit tests
