### PR TITLE
Autocomplete: Mark Fireworks provider as stable

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -22,7 +22,7 @@ export interface Configuration {
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
     experimentalLocalSymbols: boolean
-    autocompleteAdvancedProvider: 'anthropic' | 'unstable-codegen' | 'unstable-fireworks' | 'unstable-openai' | null
+    autocompleteAdvancedProvider: 'anthropic' | 'unstable-codegen' | 'fireworks' | 'unstable-openai' | null
     autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedModel: string | null
     autocompleteAdvancedAccessToken: string | null

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+- The Fireworks autocomplete provider is now considered stable. [pull/1363](https://github.com/sourcegraph/cody/pull/1363)
+
 ## [0.14.0]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -895,8 +895,8 @@
           "enum": [
             null,
             "anthropic",
+            "fireworks",
             "unstable-codegen",
-            "unstable-fireworks",
             "unstable-openai"
           ],
           "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -107,7 +107,7 @@ describe('createProviderConfig', () => {
         it('returns "fireworks" provider config and corresponding model if specified', async () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({
-                    autocompleteAdvancedProvider: 'unstable-fireworks',
+                    autocompleteAdvancedProvider: 'fireworks',
                     autocompleteAdvancedModel: 'starcoder-3b',
                 }),
                 dummyCodeCompletionsClient,
@@ -119,7 +119,7 @@ describe('createProviderConfig', () => {
 
         it('returns "fireworks" provider config if specified in settings and default model', async () => {
             const provider = await createProviderConfig(
-                getVSCodeSettings({ autocompleteAdvancedProvider: 'unstable-fireworks' }),
+                getVSCodeSettings({ autocompleteAdvancedProvider: 'fireworks' }),
                 dummyCodeCompletionsClient,
                 {}
             )

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -6,12 +6,9 @@ import { logError } from '../../log'
 import { CodeCompletionsClient } from '../client'
 
 import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
+import { createProviderConfig as createFireworksProviderConfig, FireworksOptions } from './fireworks'
 import { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableCodeGenProviderConfig } from './unstable-codegen'
-import {
-    createProviderConfig as createUnstableFireworksProviderConfig,
-    UnstableFireworksOptions,
-} from './unstable-fireworks'
 import { createProviderConfig as createUnstableOpenAIProviderConfig } from './unstable-openai'
 
 export async function createProviderConfig(
@@ -45,8 +42,8 @@ export async function createProviderConfig(
                     client,
                 })
             }
-            case 'unstable-fireworks': {
-                return createUnstableFireworksProviderConfig({
+            case 'fireworks': {
+                return createFireworksProviderConfig({
                     client,
                     model: config.autocompleteAdvancedModel ?? model ?? null,
                 })
@@ -94,7 +91,7 @@ export async function createProviderConfig(
                 })
 
             case 'fireworks':
-                return createUnstableFireworksProviderConfig({
+                return createFireworksProviderConfig({
                     client,
                     model: model ?? null,
                 })
@@ -122,7 +119,7 @@ export async function createProviderConfig(
 
 async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     configuredProvider: string | null
-): Promise<{ provider: string; model?: UnstableFireworksOptions['model'] } | null> {
+): Promise<{ provider: string; model?: FireworksOptions['model'] } | null> {
     if (configuredProvider) {
         return { provider: configuredProvider }
     }
@@ -145,7 +142,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
             : llamaCode7b
             ? 'llama-code-7b'
             : 'llama-code-13b'
-        return { provider: 'unstable-fireworks', model }
+        return { provider: 'fireworks', model }
     }
 
     return null

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -16,7 +16,7 @@ import {
     standardContextSizeHints,
 } from './provider'
 
-export interface UnstableFireworksOptions {
+export interface FireworksOptions {
     model: FireworksModel
     maxContextTokens?: number
     client: Pick<CodeCompletionsClient, 'complete'>
@@ -71,12 +71,12 @@ function getMaxContextTokens(model: FireworksModel): number {
 
 const MAX_RESPONSE_TOKENS = 256
 
-export class UnstableFireworksProvider extends Provider {
+export class FireworksProvider extends Provider {
     private model: FireworksModel
     private promptChars: number
     private client: Pick<CodeCompletionsClient, 'complete'>
 
-    constructor(options: ProviderOptions, { model, maxContextTokens, client }: Required<UnstableFireworksOptions>) {
+    constructor(options: ProviderOptions, { model, maxContextTokens, client }: Required<FireworksOptions>) {
         super(options)
         this.model = model
         this.promptChars = tokensToChars(maxContextTokens - MAX_RESPONSE_TOKENS)
@@ -250,7 +250,7 @@ export class UnstableFireworksProvider extends Provider {
 export function createProviderConfig({
     model,
     ...otherOptions
-}: Omit<UnstableFireworksOptions, 'model' | 'maxContextTokens'> & { model: string | null }): ProviderConfig {
+}: Omit<FireworksOptions, 'model' | 'maxContextTokens'> & { model: string | null }): ProviderConfig {
     const resolvedModel =
         model === null || model === ''
             ? 'starcoder-hybrid'
@@ -268,7 +268,7 @@ export function createProviderConfig({
 
     return {
         create(options: ProviderOptions) {
-            return new UnstableFireworksProvider(options, { model: resolvedModel, maxContextTokens, ...otherOptions })
+            return new FireworksProvider(options, { model: resolvedModel, maxContextTokens, ...otherOptions })
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
         enableExtendedMultilineTriggers: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -36,6 +36,15 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         debugRegex = new RegExp('.*')
     }
 
+    let autocompleteAdvancedProvider: Configuration['autocompleteAdvancedProvider'] = config.get(
+        CONFIG_KEY.autocompleteAdvancedProvider,
+        null
+    )
+    // Backwards compatibility for old config values
+    if (autocompleteAdvancedProvider === 'unstable-fireworks') {
+        autocompleteAdvancedProvider = 'fireworks'
+    }
+
     return {
         // NOTE: serverEndpoint is now stored in Local Storage instead but we will still keep supporting the one in confg
         // to use as fallback for users who do not have access to local storage
@@ -62,7 +71,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         experimentalLocalSymbols: config.get(CONFIG_KEY.experimentalLocalSymbols, false),
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
         experimentalEditorTitleCommandIcon: config.get(CONFIG_KEY.experimentalEditorTitleCommandIcon, false),
-        autocompleteAdvancedProvider: config.get(CONFIG_KEY.autocompleteAdvancedProvider, null),
+        autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,
             null


### PR DESCRIPTION
90% of our community usage now goes through this code path so it better be stable

## Test plan

Ensured that starting this with `unstable-fireworks` in the config option will properly load the right adapter.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
