### PR TITLE
Autocomplete: Add StarCoder context window experiment

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -17,6 +17,7 @@ export enum FeatureFlag {
     CodyAutocompleteGraphContext = 'cody-autocomplete-graph-context',
     CodyAutocompleteMinimumLatency = 'cody-autocomplete-minimum-latency',
     CodyAutocompleteSyntacticTriggers = 'cody-autocomplete-syntactic-triggers',
+    CodyAutocompleteStarCoderExtendedTokenWindow = 'cody-autocomplete-starcoder-extended-token-window',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -26,7 +26,7 @@ export async function createProviderConfig(
         config.autocompleteAdvancedProvider
     )
     if (providerAndModelFromVSCodeConfig) {
-        const { provider, model } = providerAndModelFromVSCodeConfig
+        const { provider, model, starcoderExtendedTokenWindow } = providerAndModelFromVSCodeConfig
 
         switch (provider) {
             case 'unstable-codegen': {
@@ -49,6 +49,7 @@ export async function createProviderConfig(
                 return createUnstableFireworksProviderConfig({
                     client,
                     model: config.autocompleteAdvancedModel ?? model ?? null,
+                    starcoderExtendedTokenWindow,
                 })
             }
             case 'anthropic': {
@@ -120,20 +121,24 @@ export async function createProviderConfig(
     })
 }
 
-async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
-    configuredProvider: string | null
-): Promise<{ provider: string; model?: UnstableFireworksOptions['model'] } | null> {
+async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(configuredProvider: string | null): Promise<{
+    provider: string
+    model?: UnstableFireworksOptions['model']
+    starcoderExtendedTokenWindow?: boolean
+} | null> {
     if (configuredProvider) {
         return { provider: configuredProvider }
     }
 
-    const [starCoder7b, starCoder16b, starCoderHybrid, llamaCode7b, llamaCode13b] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
-    ])
+    const [starCoder7b, starCoder16b, starCoderHybrid, llamaCode7b, llamaCode13b, starcoderExtendedTokenWindow] =
+        await Promise.all([
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderExtendedTokenWindow),
+        ])
 
     if (starCoder7b || starCoder16b || starCoderHybrid || llamaCode7b || llamaCode13b) {
         const model = starCoder7b
@@ -145,7 +150,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
             : llamaCode7b
             ? 'llama-code-7b'
             : 'llama-code-13b'
-        return { provider: 'unstable-fireworks', model }
+        return { provider: 'unstable-fireworks', model, starcoderExtendedTokenWindow }
     }
 
     return null


### PR DESCRIPTION
StarCoder supports up to 8k token windows but we're currently limiting it to 2k to match out anthropic usage.

This PR adds an A/B test to increase the prompt up to an estimated 7k tokens which should still leave plenty of room for the answer.

## Test plan

- Be in the starcoder test group and connected to dotcom
- Mock out the call to `featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderExtendedTokenWindow)` (i.e return true instead)
- Observe the right limit is being picked up
    <img width="459" alt="Screenshot 2023-10-11 at 13 36 38" src="https://github.com/sourcegraph/cody/assets/458591/1a30c98e-7e17-4583-8242-d4625103dc6f">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
