### PR TITLE
Autocomplete: Add logging for partial acceptence delta

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -62,6 +62,7 @@ describe('[getInlineCompletions] completion event', () => {
                 "truncatedWith": "tree-sitter",
               },
             ],
+            "loggedPartialAcceptedLength": 0,
             "params": {
               "contextSummary": undefined,
               "id": "stable-uuid",

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -66,6 +66,8 @@ export interface CompletionEvent {
     acceptedAt: number | null
     // Information about each completion item received per one completion event
     items: CompletionItemInfo[]
+    // Already logged partially accepted length
+    loggedPartialAcceptedLength: number
 }
 
 export interface ItemPostProcessingInfo {
@@ -150,6 +152,7 @@ export function create(inputParams: Omit<CompletionEvent['params'], 'multilineMo
         suggestionAnalyticsLoggedAt: null,
         acceptedAt: null,
         items: [],
+        loggedPartialAcceptedLength: 0,
     })
 
     return id
@@ -307,10 +310,14 @@ export function partiallyAccept(id: SuggestionID, completion: InlineCompletionIt
         return
     }
 
+    const loggedPartialAcceptedLength = completionEvent.loggedPartialAcceptedLength
+    completionEvent.loggedPartialAcceptedLength = acceptedLength
+
     logCompletionEvent('partiallyAccepted', {
         ...getSharedParams(completionEvent),
         acceptedItem: { ...completionItemToItemInfo(completion) },
         acceptedLength,
+        acceptedLengthDelta: acceptedLength - loggedPartialAcceptedLength,
     })
 }
 


### PR DESCRIPTION
Log the delta of accepted lines with every completion accepted event. c.f.: https://sourcegraph.slack.com/archives/C05AGQYD528/p1696413170173559

## Test plan


Uploading Screen Recording 2023-10-11 at 16.11.26.mov…



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
