### PR TITLE
Autocomplete: prevent negative `position.character` value

### DIFF
--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -214,12 +214,7 @@ describe('process completion item', () => {
     })
 
     it('adds parse info to single-line completions', () => {
-        const completions = processCompletions(
-            `
-            const one = █
-        `,
-            ['"one"']
-        )
+        const completions = processCompletions('const one = █', ['"one"'])
 
         expect(completions).toMatchInlineSnapshot(`
           [

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -89,7 +89,10 @@ function processCompletion(params: ProcessItemParams): InlineCompletionItemWithA
     let { insertText } = parsed
     const initialLineCount = insertText.split('\n').length
 
-    const positionBeforeCursor = asPoint(position.translate(undefined, -1))
+    const positionBeforeCursor = asPoint({
+        line: position.line,
+        character: Math.max(0, position.character - 1),
+    })
 
     // Use the parse tree WITHOUT the pasted completion to get surrounding node types.
     // Helpful to optimize the completion AST triggers for higher CAR.


### PR DESCRIPTION
## Context

Fixes the runtime error caused by the negative `position.character` value.

## Test plan

Unit tests
