### PR TITLE
pass the sourcegraph url to symf

### DIFF
--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -29,12 +29,14 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
 
     constructor(
         private context: vscode.ExtensionContext,
+        private sourcegraphServerEndpoint: string | null,
         private authToken: string | null
     ) {
         this.indexRoot = path.join(os.homedir(), '.cody-symf')
     }
 
-    public setAuthToken(authToken: string | null): void {
+    public setSourcegraphAuth(endpoint: string | null, authToken: string | null): void {
+        this.sourcegraphServerEndpoint = endpoint
         this.authToken = authToken
     }
 
@@ -65,6 +67,10 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
         if (!accessToken) {
             throw new Error('SymfRunner.getResults: No access token')
         }
+        const serverEndpoint = this.sourcegraphServerEndpoint
+        if (!serverEndpoint) {
+            throw new Error('SymfRunner.getResults: No Sourcegraph server endpoint')
+        }
 
         const indexDir = await this.ensureIndexFor(scopeDir)
         const symfPath = await getSymfPath(this.context)
@@ -78,6 +84,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
                 {
                     env: {
                         SOURCEGRAPH_TOKEN: accessToken,
+                        SOURCEGRAPH_URL: serverEndpoint,
                         HOME: process.env.HOME,
                     },
                     maxBuffer: 1024 * 1024 * 1024,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -112,13 +112,13 @@ const register = async (
     const authProvider = new AuthProvider(initialConfig)
     await authProvider.init()
 
-    const symfRunner = platform.createSymfRunner?.(context, initialConfig.accessToken)
+    const symfRunner = platform.createSymfRunner?.(context, initialConfig.serverEndpoint, initialConfig.accessToken)
     if (symfRunner) {
         authProvider.addChangeListener(async (authStatus: AuthStatus) => {
             if (authStatus.isLoggedIn) {
-                symfRunner.setAuthToken(await getAccessToken())
+                symfRunner.setSourcegraphAuth(authStatus.endpoint, await getAccessToken())
             } else {
-                symfRunner.setAuthToken(null)
+                symfRunner.setSourcegraphAuth(null, null)
             }
         })
     }
@@ -514,7 +514,7 @@ const register = async (
             externalServicesOnDidConfigurationChange(newConfig)
             void createOrUpdateEventLogger(newConfig, isExtensionModeDevOrTest)
             platform.onConfigurationChange?.(newConfig)
-            symfRunner?.setAuthToken(newConfig.accessToken)
+            symfRunner?.setSourcegraphAuth(newConfig.serverEndpoint, newConfig.accessToken)
         },
     }
 }


### PR DESCRIPTION
Pass the Sourcegraph URL via environment variable to `symf`, in addition to the access token, which is already passed. This enables `/symf` to work with non-sourcegraph.com instances.

## Test plan

Locally on this branch:
- [ ] On `main` or in your current Cody (not this branch), try signing into s2 and running `/symf <query>`. It should not work, because `symf` does not have the appropriate URL for s2.
- [ ] Check out this branch and run Cody from it
- [ ] Test out a search query with `/symf <query>`. It should work now.
- [ ] Sign out of Sourcegraph
- [ ] Sign into sourcegraph.com
- [ ] Test out the search query
- [ ] Sign out
- [ ] Sign into s2
- [ ] Test out the search query