### PR TITLE
Autocomplete: Fix Fireworks multi-line completion timeouts

### DIFF
--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -160,7 +160,7 @@ export class FireworksProvider extends Provider {
             topK: 0,
             model,
             stopSequences: multiline ? ['\n\n', '\n\r\n'] : ['\n'],
-            timeoutMs: multiline ? 1500 : 5000,
+            timeoutMs: multiline ? 15000 : 5000,
         }
 
         tracer?.params(args)


### PR DESCRIPTION
My bad. I set the timeout to 1.5sec instead of 15sec. This breaks the current insiders build pretty badly so let's fix this quickly.

## Test plan

👀 
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
