### PR TITLE
fix: remove redundant conditional checks

### DIFF
--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -124,17 +124,13 @@ export class CustomPrompt implements Recipe {
             const currentDirMessages = await getCurrentDirContext(isUnitTestRequest)
             contextMessages.push(...currentDirMessages)
         }
-        if (!promptContext.directoryPath) {
-            if (promptContext.directoryPath) {
-                const dirMessages = await getEditorDirContext(promptContext.directoryPath, selection?.fileName)
-                contextMessages.push(...dirMessages)
-            }
+        if (promptContext.directoryPath) {
+            const dirMessages = await getEditorDirContext(promptContext.directoryPath, selection?.fileName)
+            contextMessages.push(...dirMessages)
         }
-        if (!promptContext.filePath) {
-            if (promptContext.filePath) {
-                const fileMessages = await getFilePathContext(promptContext.filePath)
-                contextMessages.push(...fileMessages)
-            }
+        if (promptContext.filePath) {
+            const fileMessages = await getFilePathContext(promptContext.filePath)
+            contextMessages.push(...fileMessages)
         }
 
         // Context for unit tests requests


### PR DESCRIPTION
fix: remove redundant conditional checks

Removed redundant conditional checks and nested if statements that were added by accident when switching from `switch` statement to `if` statement 😓 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Simple removal of redundant code. Current tests for custom commands are still passing.