### PR TITLE
Autocomplete: fix `canUsePartialCompletion` for completions with leading new lines

### DIFF
--- a/vscode/src/completions/can-use-partial-completion.ts
+++ b/vscode/src/completions/can-use-partial-completion.ts
@@ -23,6 +23,7 @@ export function canUsePartialCompletion(
     partialResponse: string,
     { document, multiline, docContext: { prefix, suffix } }: CanUsePartialCompletionParams
 ): boolean {
+    // return false
     const lastNlIndex = partialResponse.lastIndexOf('\n')
 
     // If there is no `\n` in the completion, we have not received a single full line yet
@@ -34,10 +35,18 @@ export function canUsePartialCompletion(
     const completion = partialResponse.slice(0, lastNlIndex)
 
     if (multiline) {
-        let truncated = truncateMultilineCompletion(completion, prefix, suffix, document.languageId)
-        truncated = trimUntilSuffix(truncated, prefix, suffix, document.languageId)
+        // `truncateMultilineCompletion` removes the leading new line in some cases
+        // so we explicitly check if lines the end of the completions were deleted.
+        const { truncatedEnd, text: withTruncatedBlock } = truncateMultilineCompletion(
+            completion,
+            prefix,
+            suffix,
+            document.languageId
+        )
 
-        return truncated.split('\n').length < completion.split('\n').length
+        const withTruncatedSuffix = trimUntilSuffix(withTruncatedBlock, prefix, suffix, document.languageId)
+
+        return truncatedEnd || withTruncatedSuffix.split('\n').length < withTruncatedBlock.split('\n').length
     }
 
     const isNonEmptyLine = completion.trim() !== ''

--- a/vscode/src/completions/can-use-partial-completion.ts
+++ b/vscode/src/completions/can-use-partial-completion.ts
@@ -23,7 +23,6 @@ export function canUsePartialCompletion(
     partialResponse: string,
     { document, multiline, docContext: { prefix, suffix } }: CanUsePartialCompletionParams
 ): boolean {
-    // return false
     const lastNlIndex = partialResponse.lastIndexOf('\n')
 
     // If there is no `\n` in the completion, we have not received a single full line yet

--- a/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
@@ -1,5 +1,5 @@
 import dedent from 'dedent'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { InlineCompletionsResultSource } from '../get-inline-completions'
 import { completion, nextTick } from '../test-helpers'
@@ -7,7 +7,7 @@ import { completion, nextTick } from '../test-helpers'
 import { getInlineCompletions, params, V } from './helpers'
 
 describe('[getInlineCompletions] streaming', () => {
-    test('terminates early for a single-line request', async () => {
+    it('terminates early for a single-line request', async () => {
         const abortController = new AbortController()
         expect(
             await getInlineCompletions({
@@ -26,7 +26,7 @@ describe('[getInlineCompletions] streaming', () => {
         })
     })
 
-    test('does not include unfinished lines in results', async () => {
+    it('does not include unfinished lines in results', async () => {
         const abortController = new AbortController()
         expect(
             await getInlineCompletions({
@@ -48,7 +48,7 @@ describe('[getInlineCompletions] streaming', () => {
         })
     })
 
-    test('uses the multi-line truncation logic to terminate early for multi-line completions', async () => {
+    it('uses the multi-line truncation logic to terminate early for multi-line completions', async () => {
         const abortController = new AbortController()
         const result = await getInlineCompletions({
             ...params(
@@ -90,7 +90,7 @@ describe('[getInlineCompletions] streaming', () => {
         expect(result?.source).toBe(InlineCompletionsResultSource.Network)
     })
 
-    test('uses the next non-empty line comparison logic to terminate early for multi-line completions', async () => {
+    it('uses the next non-empty line comparison logic to terminate early for multi-line completions', async () => {
         const abortController = new AbortController()
         expect(
             await getInlineCompletions({
@@ -133,5 +133,72 @@ describe('[getInlineCompletions] streaming', () => {
             items: [{ insertText: 'const a = new Array()' }],
             source: InlineCompletionsResultSource.Network,
         })
+    })
+
+    it('uses the multi-line truncation logic to terminate early for multi-line completions with leading new line', async () => {
+        const abortController = new AbortController()
+
+        const result = await getInlineCompletions({
+            ...params(
+                dedent`
+                    function bubbleSort() {
+                        █
+                    }
+                `,
+                [
+                    completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()`,
+                ],
+                {
+                    async onNetworkRequest(_params, onPartialResponse) {
+                        onPartialResponse?.(
+                            completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (`
+                        )
+                        await nextTick()
+                        expect(abortController.signal.aborted).toBe(false)
+                        onPartialResponse?.(
+                            completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()`
+                        )
+                        await nextTick()
+                        expect(abortController.signal.aborted).toBe(true)
+                    },
+                }
+            ),
+            abortSignal: abortController.signal,
+        })
+
+        expect(result?.items[0].insertText).toMatchInlineSnapshot(`
+          "const merge = (left, right) => {
+              let arr = [];
+              while (left.length && right.length) {
+                  if (true) {}
+              }"
+        `)
+        expect(result?.source).toBe(InlineCompletionsResultSource.Network)
+    })
+
+    it.skip('cuts-off multlineline compeltions with inconsistent indentation correctly', async () => {
+        const abortController = new AbortController()
+
+        const result = await getInlineCompletions({
+            ...params(
+                dedent`
+                    function bubbleSort() {
+                        █
+                    }
+                `,
+                [completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`],
+                {
+                    async onNetworkRequest(_params, onPartialResponse) {
+                        onPartialResponse?.(completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`)
+                        await nextTick()
+                        expect(abortController.signal.aborted).toBe(false)
+                    },
+                }
+            ),
+            abortSignal: abortController.signal,
+        })
+
+        expect(result?.items[0].insertText).toMatchInlineSnapshot('"// Bubble sort algorithm"')
+        expect(result?.source).toBe(InlineCompletionsResultSource.Network)
     })
 })

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -4,8 +4,8 @@ import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
+import { canUsePartialCompletion } from '../can-use-partial-completion'
 import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
-import { canUsePartialCompletion } from '../streaming'
 import {
     CLOSING_CODE_TAG,
     extractFromCodeBlock,
@@ -190,13 +190,13 @@ export class AnthropicProvider extends Provider {
                     params,
                     (incompleteResponse: CompletionResponse) => {
                         const processedCompletion = this.postProcess(incompleteResponse.completion)
-                        if (
-                            canUsePartialCompletion(processedCompletion, {
-                                document: { languageId: this.options.languageId },
-                                multiline: this.options.multiline,
-                                docContext: this.options.docContext,
-                            })
-                        ) {
+                        const usePartialCompletion = canUsePartialCompletion(processedCompletion, {
+                            document: { languageId: this.options.languageId },
+                            multiline: this.options.multiline,
+                            docContext: this.options.docContext,
+                        })
+
+                        if (usePartialCompletion) {
                             resolve({ ...incompleteResponse, completion: processedCompletion })
                             abortController.abort()
                         }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,9 +1,9 @@
 import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
+import { canUsePartialCompletion } from '../can-use-partial-completion'
 import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import { getLanguageConfig } from '../language'
-import { canUsePartialCompletion } from '../streaming'
 import { Completion, ContextSnippet } from '../types'
 import { forkSignal } from '../utils'
 

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,8 +1,8 @@
 import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
+import { canUsePartialCompletion } from '../can-use-partial-completion'
 import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
-import { canUsePartialCompletion } from '../streaming'
 import { getHeadAndTail } from '../text-processing'
 import { Completion, ContextSnippet } from '../types'
 import { forkSignal } from '../utils'

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -136,7 +136,7 @@ function processCompletion(params: ProcessItemParams): InlineCompletionItemWithA
             insertText = truncateParsedCompletion({ completion: parsed, document })
             parsed.truncatedWith = 'tree-sitter'
         } else {
-            insertText = truncateMultilineCompletion(insertText, prefix, suffix, document.languageId)
+            insertText = truncateMultilineCompletion(insertText, prefix, suffix, document.languageId).text
             parsed.truncatedWith = 'indentation'
         }
         const truncatedLineCount = insertText.split('\n').length


### PR DESCRIPTION
## Context

In cases where multiline completions start with a leading new line, we do not account for the fact that the `truncateMultilineCompletion` call strips it. That's why `canUsePartialCompletion` returns false positives, leading to prematurely truncated multline completions.

```js
{
  "completion": {
    "text": "\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {",
    "newLines": 4
  },
  "truncated": {
    "text": "const merge = (left, right) => {\n    let arr = [];\n    while (left.length && right.length) {",
    "newLines": 3
  },
  "conditionForPartialReuse": "truncated.split('\n').length < completion.split('\n').length"
}
```

- [Slack thread.](https://sourcegraph.slack.com/archives/C05AGQYD528/p1697139038515929)
- A follow-up issue: https://github.com/sourcegraph/cody/issues/1387


## Test plan

Added unit tests.
