### PR TITLE
fix: apply latency only when last suggestion was read

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -22,7 +22,7 @@ import {
 } from './get-inline-completions'
 import { getLatency, LatencyFeatureFlags, resetLatency } from './latency'
 import * as CompletionLogger from './logger'
-import { CompletionEvent, SuggestionID } from './logger'
+import { CompletionEvent, READ_TIMEOUT_MS, SuggestionID } from './logger'
 import { ProviderConfig } from './providers/provider'
 import { RequestManager, RequestParams } from './request-manager'
 import { getRequestParamsFromLastCandidate } from './reuse-last-candidate'
@@ -270,7 +270,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     provider: await minLatencyFlagsPromises.provider,
                 }
                 // Do not apply the minimum latency if the last suggestion was not read, e.g when user was typing
-                const isLastSuggestionRead = start - this.lastCompletionRequestTimestamp > 750
+                const isLastSuggestionRead = start - this.lastCompletionRequestTimestamp > READ_TIMEOUT_MS
                 this.lastCompletionRequestTimestamp = start
                 const isMinLatencyEnabled =
                     latencyFeatureFlags.user || latencyFeatureFlags.language || latencyFeatureFlags.provider

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -100,7 +100,7 @@ interface CompletionItemInfo extends ItemPostProcessingInfo {
     stopReason?: string
 }
 
-const READ_TIMEOUT_MS = 750
+export const READ_TIMEOUT_MS = 750
 
 // Maintain a cache of active suggestion lifecycle
 const activeSuggestions = new LRUCache<SuggestionID, CompletionEvent>({


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/pull/1351

fix: apply min latency only when last suggestion was read

The minimum latency for code suggestions is now only applied when the last suggestion was read by the user. This avoids applying the latency when the user is actively typing and has not read the previous suggestions.

The lastCompletionRequestTimestamp property tracks when the last suggestion request was made. The latency is skipped if the time since last request is less than 750ms.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Check the output channel. You should not see latency getting increased after 5 keystrokes, which is the current behavior.
