### PR TITLE
Move Chromium installation into install-deps so "pnpm test:e2e" works on Windows

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -33,7 +33,7 @@
     "download-wasm": "ts-node-transpile-only ./scripts/download-wasm-modules.ts",
     "release:dry-run": "pnpm run download-wasm && CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
     "storybook": "storybook dev -p 6007 --no-open --no-version-updates --no-release-notes",
-    "test:e2e": "tsc --build && { pnpm exec playwright install chromium & install_pw_pid=$!; node dist/tsc/test/e2e/install-deps.js & install_vscode_pid=$!; wait $install_pw_pid && wait $install_vscode_pid; } && pnpm run -s build:dev:desktop && playwright test",
+    "test:e2e": "tsc --build && node dist/tsc/test/e2e/install-deps.js && pnpm run -s build:dev:desktop && playwright test",
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:benchmark": "BENCHMARK_DISABLE_FEATURE_FLAGS=true tsc --build ./test/benchmark && pnpm run -s build:dev:desktop && ./benchmark.sh",
     "test:benchmark:copilot": "BENCHMARK_COMPARE_WITH=github.copilot pnpm run test:benchmark",

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -8,7 +8,7 @@ import * as uuid from 'uuid'
 
 import { run, sendTestInfo } from '../fixtures/mock-server'
 
-import { installDeps } from './install-deps'
+import { installVsCode } from './install-deps'
 
 export const test = base
     .extend<{}>({
@@ -17,7 +17,7 @@ export const test = base
 
             const vscodeRoot = path.resolve(__dirname, '..', '..')
 
-            const vscodeExecutablePath = await installDeps()
+            const vscodeExecutablePath = await installVsCode()
             const extensionDevelopmentPath = vscodeRoot
 
             const userDataDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))

--- a/vscode/test/e2e/install-deps.ts
+++ b/vscode/test/e2e/install-deps.ts
@@ -1,9 +1,31 @@
+import { spawn } from 'child_process'
+
 import { downloadAndUnzipVSCode } from '@vscode/test-electron'
 
 export const vscodeVersion = '1.81.1'
 
-export function installDeps(): Promise<string> {
+export function installVsCode(): Promise<string> {
     return downloadAndUnzipVSCode(vscodeVersion)
+}
+
+export function installChromium(): Promise<void> {
+    const proc = spawn('pnpm', ['exec', 'playwright', 'install', 'chromium'], { shell: true })
+    return new Promise<void>((resolve, reject) => {
+        proc.on('error', e => console.error(e))
+        proc.stderr.on('data', e => console.error(e.toString()))
+        proc.stdout.on('data', e => console.log(e.toString()))
+        proc.on('close', code => {
+            if (code) {
+                reject(new Error(`Process failed: ${code}}`))
+            } else {
+                resolve()
+            }
+        })
+    })
+}
+
+export function installAllDeps(): Promise<unknown> {
+    return Promise.all([installVsCode(), installChromium()])
 }
 
 if (require.main === module) {
@@ -15,7 +37,7 @@ if (require.main === module) {
         5 * 60 * 1000 // 5 minutes
     )
     void (async () => {
-        await installDeps()
+        await installAllDeps()
         clearTimeout(timeout)
     })()
 }


### PR DESCRIPTION
This changes the npm script for `test:e2e` to not use syntax that doesn't work on Windows. I believe the intention of the script was to install VS Code and Chromium in parallel which this change still does, but with both done from the TS file which is more easily run in the NPM script in a way that works across platforms.

While this fixes `pnpm test:unit` on Windows for me locally, this change does not enable the bots yet because some of the tests fail when run on GitHub on Windows and that requires some debugging (locally, everything passes). I'll debug this in another PR (I'd like to get screenshots or videos working for failures, but when I try this locally I just get blank white screenshots/videos so it also requires some additional debugging).

## Test plan

These changes are to the test setup themselves, if the bots are still running `pnpm test:e2e` and the tests passing, everything is working.
