### PR TITLE
Autocomplete: use cursor position for the `blocks` query

### DIFF
--- a/vscode/src/completions/tree-sitter/queries.ts
+++ b/vscode/src/completions/tree-sitter/queries.ts
@@ -5,7 +5,7 @@ import { SupportedLanguage } from './grammars'
 export type QueryName = 'blocks' | 'singlelineTriggers'
 
 const JS_BLOCKS_QUERY = dedent`
-    (_ ("{")) @blocks
+    (_ ("{") @block_start) @trigger
 
     [(try_statement)
     (if_statement)] @parents
@@ -34,7 +34,7 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     },
     [SupportedLanguage.Go]: {
         blocks: dedent`
-            (_ ("{")) @blocks
+            (_ ("{") @block_start) @trigger
 
             [(if_statement)] @parents
         `,

--- a/vscode/src/completions/tree-sitter/query-sdk.ts
+++ b/vscode/src/completions/tree-sitter/query-sdk.ts
@@ -96,7 +96,7 @@ interface QueryWrappers {
             node: SyntaxNode,
             start: Point,
             end?: Point
-        ) => never[] | readonly [{ readonly node: SyntaxNode; readonly name: 'blocks' }]
+        ) => never[] | readonly [{ readonly node: SyntaxNode; readonly name: 'trigger' }]
     }
     singlelineTriggers: {
         getEnclosingTrigger: (
@@ -126,7 +126,7 @@ function getLanguageSpecificQueryWrappers(queries: ResolvedQueries, _parser: Par
                 const potentialParent = potentialParentNodes.find(capture => trigger.parent?.id === capture.node.id)
                     ?.node
 
-                return [{ node: potentialParent || trigger, name: 'blocks' }] as const
+                return [{ node: potentialParent || trigger, name: 'trigger' }] as const
             },
         },
         singlelineTriggers: {

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.go
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.go
@@ -19,7 +19,7 @@ func greet(name string) {
 
 func printNumbers() {
 	for i := 0; i < 10; i++ {
-		//                      |
+		//                  |
 		fmt.Println(i)
 	}
 }
@@ -28,7 +28,7 @@ func printNumbers() {
 
 func compare(x int) {
 	if x > 5 {
-		//       |
+		//   |
 		fmt.Println("Greater than 5")
 	} else {
 		fmt.Println("Less than or equal to 5")

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.snap.go
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.snap.go
@@ -37,7 +37,7 @@
   func printNumbers() {
       for i := 0; i < 10; i++ {
 //                            ^ start blocks[1]
-//                                █
+//                            █
           fmt.Println(i)
       }
 //    ^ end blocks[1]
@@ -51,7 +51,7 @@
   func compare(x int) {
       if x > 5 {
 //    ^ start blocks[1]
-//                 █
+//             █
           fmt.Println("Greater than 5")
       } else {
           fmt.Println("Less than or equal to 5")

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.snap.go
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.snap.go
@@ -10,92 +10,92 @@
   import "fmt"
 
   type Person struct {
-//                   ^ start blocks[1]
+//                   ^ start trigger[1]
 //                   █
       Name string
       Age  int
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: field_declaration_list
+// trigger[1]: field_declaration_list
 
 // ------------------------------------
 
   func greet(name string) {
-//                        ^ start blocks[1]
+//                        ^ start trigger[1]
 //                        █
       fmt.Println("Hello,", name)
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: block
+// trigger[1]: block
 
 // ------------------------------------
 
   func printNumbers() {
       for i := 0; i < 10; i++ {
-//                            ^ start blocks[1]
+//                            ^ start trigger[1]
 //                            █
           fmt.Println(i)
       }
-//    ^ end blocks[1]
+//    ^ end trigger[1]
   }
 
 // Nodes types:
-// blocks[1]: block
+// trigger[1]: block
 
 // ------------------------------------
 
   func compare(x int) {
       if x > 5 {
-//    ^ start blocks[1]
+//    ^ start trigger[1]
 //             █
           fmt.Println("Greater than 5")
       } else {
           fmt.Println("Less than or equal to 5")
       }
-//    ^ end blocks[1]
+//    ^ end trigger[1]
   }
 
 // Nodes types:
-// blocks[1]: if_statement
+// trigger[1]: if_statement
 
 // ------------------------------------
 
   var arr = [5]int{
-//                ^ start blocks[1]
+//                ^ start trigger[1]
 //                █
       1, 2, 3, 4, 5,
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: literal_value
+// trigger[1]: literal_value
 
 // ------------------------------------
 
   var dictionary = map[string]string{
-//                                  ^ start blocks[1]
+//                                  ^ start trigger[1]
 //                                  █
       "apple": "A fruit",
       "book":  "Something you read",
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: literal_value
+// trigger[1]: literal_value
 
 // ------------------------------------
 
   type Shape interface {
-//           ^ start blocks[1]
+//           ^ start trigger[1]
 //                     █
       Area() float64
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: interface_type
+// trigger[1]: interface_type
 

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.snap.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/blocks.snap.ts
@@ -6,99 +6,99 @@
 // ------------------------------------
 
   interface kek {
-//              ^ start blocks[1]
+//              ^ start trigger[1]
 //              █
       value: string
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: object_type
+// trigger[1]: object_type
 
 // ------------------------------------
 
   export function pek() {
-//                      ^ start blocks[1]
+//                      ^ start trigger[1]
 //                      █
       const data: kek = {
           value: 'wow',
       }
       return data
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
   export const hmmm = 1
 
 // Nodes types:
-// blocks[1]: statement_block
+// trigger[1]: statement_block
 
 // ------------------------------------
 
   class Animal {
-//             ^ start blocks[1]
+//             ^ start trigger[1]
 //             █
       constructor() {}
   }
-//^ end blocks[1]
+//^ end trigger[1]
 
 // Nodes types:
-// blocks[1]: class_body
+// trigger[1]: class_body
 
 // ------------------------------------
 
   export class Doggo extends Animal {
       public bark() {
-//                  ^ start blocks[1]
+//                  ^ start trigger[1]
 //                  █
           return {}
       }
-//    ^ end blocks[1]
+//    ^ end trigger[1]
   }
 
 // Nodes types:
-// blocks[1]: statement_block
+// trigger[1]: statement_block
 
 // ------------------------------------
 
   export function inconsistentIndentation() {
       if (Doggo) {
           const value = null; const arrow = () => {
-//                                                ^ start blocks[1]
+//                                                ^ start trigger[1]
 //                                                █
               console.log('Hello World!');
           }
-//        ^ end blocks[1]
+//        ^ end trigger[1]
       } else {
           const a = 1
       }
   }
 
 // Nodes types:
-// blocks[1]: statement_block
+// trigger[1]: statement_block
 
 // ------------------------------------
 // Captures the whole if_statement block
 
   export function whatIf() {
       if (Doggo) {
-//    ^ start blocks[1]
+//    ^ start trigger[1]
 //               █
           console.log('You are right!')
       } else {
           console.log('Nope -_-')
       }
-//    ^ end blocks[1]
+//    ^ end trigger[1]
   }
 
 // Nodes types:
-// blocks[1]: if_statement
+// trigger[1]: if_statement
 
 // ------------------------------------
 // Captures the whole try_statement block
 
   export function tryHard() {
       try {
-//    ^ start blocks[1]
+//    ^ start trigger[1]
 //        █
           new Doggo()
       } catch (error) {
@@ -106,9 +106,9 @@
       } finally {
           console.log('Done trying...')
       }
-//    ^ end blocks[1]
+//    ^ end trigger[1]
   }
 
 // Nodes types:
-// blocks[1]: try_statement
+// trigger[1]: try_statement
 


### PR DESCRIPTION
## Context

- Compare the found block node start position to the cursor position to improve query reliability.
- The same approach is already used to capture singleline completion triggers.

## Test plan

CI
