### PR TITLE
wip - refactor: new sidebar with chat webview panel

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -238,12 +238,7 @@
         },
         {
           "id": "cody.chat.tree.view",
-          "name": "Chat",
-          "when": "cody.activated"
-        },
-        {
-          "id": "cody.fixup.tree.view",
-          "name": "Edits",
+          "name": "Chats",
           "when": "cody.activated"
         },
         {
@@ -254,11 +249,6 @@
       ]
     },
     "viewsWelcome": [
-      {
-        "view": "cody.fixup.tree.view",
-        "contents": "No pending edits",
-        "when": "cody.nonstop.fixups.enabled && cody.activated"
-      },
       {
         "view": "cody.chat.tree.view",
         "contents": "Chat alongside your code, attach files, add additional context, and try out different LLM providers.\n[New Chat](command:cody.chat.panel.new)\nTo learn more about chat, [read the docs](https://docs.sourcegraph.com/).",
@@ -697,11 +687,6 @@
           "command": "cody.auth.signin",
           "when": "view == cody.support.tree.view && cody.activated",
           "group": "9_cody@0"
-        },
-        {
-          "command": "cody.fixup.apply-all",
-          "when": "cody.nonstop.fixups.enabled && view == cody.fixup.tree.view && cody.activated",
-          "group": "navigation"
         }
       ],
       "editor/title": [
@@ -750,20 +735,9 @@
       ],
       "view/item/context": [
         {
-          "command": "cody.fixup.apply-by-file",
-          "when": "cody.nonstop.fixups.enabled && view == cody.fixup.tree.view && cody.activated && viewItem == fsPath",
-          "enable": "cody.fixup.filesWithApplicableFixups",
+          "command": "cody.chat.history.clear",
+          "when": "view == cody.chat.tree.view && cody.activated",
           "group": "inline"
-        },
-        {
-          "command": "cody.fixup.apply",
-          "when": "cody.nonstop.fixups.enabled && view == cody.fixup.tree.view && cody.activated && viewItem == task",
-          "group": "inline@2"
-        },
-        {
-          "command": "cody.fixup.diff",
-          "when": "cody.nonstop.fixups.enabled && view == cody.fixup.tree.view && cody.activated && viewItem == task",
-          "group": "inline@1"
         }
       ]
     },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -224,22 +224,50 @@
           "type": "webview",
           "id": "cody.chat",
           "name": "Chat",
-          "visibility": "visible"
+          "when": "!cody.webviewPanel"
+        },
+        {
+          "id": "cody.commands.tree.view",
+          "name": "Commands",
+          "when": "cody.activated"
+        },
+        {
+          "id": "cody.search.tree.view",
+          "name": "Search",
+          "when": "cody.activated"
+        },
+        {
+          "id": "cody.chat.tree.view",
+          "name": "Chat",
+          "when": "cody.activated"
         },
         {
           "id": "cody.fixup.tree.view",
-          "name": "Fixups",
-          "when": "cody.nonstop.fixups.enabled && cody.activated",
-          "icon": "cody.svg",
-          "contextualTitle": "Fixups"
+          "name": "Edits",
+          "when": "cody.activated"
+        },
+        {
+          "id": "cody.support.tree.view",
+          "name": "Settings & Support",
+          "when": "cody.activated"
         }
       ]
     },
     "viewsWelcome": [
       {
         "view": "cody.fixup.tree.view",
-        "contents": "No pending Cody fixups",
+        "contents": "No pending edits",
         "when": "cody.nonstop.fixups.enabled && cody.activated"
+      },
+      {
+        "view": "cody.chat.tree.view",
+        "contents": "Chat alongside your code, attach files, add additional context, and try out different LLM providers.\n[New Chat](command:cody.chat.panel.new)\nTo learn more about chat, [read the docs](https://docs.sourcegraph.com/).",
+        "when": "cody.activated"
+      },
+      {
+        "view": "cody.search.tree.view",
+        "contents": "Search code using natural language queries, such as 'Password hashing' or 'Authentication redirects'.\n[Enable Search Indexing](command:cody.search.panel)\nTo learn more about AI search, [read the docs](https://docs.sourcegraph.com/).",
+        "when": "cody.activated"
       }
     ],
     "commands": [
@@ -312,18 +340,26 @@
         "title": "Sign In"
       },
       {
-        "command": "cody.interactive.clear",
+        "command": "cody.chat.panel.new",
         "category": "Cody",
         "title": "Start a New Chat Session",
+        "when": "cody.activated",
         "group": "Cody",
         "icon": "$(add)"
       },
       {
-        "command": "cody.history",
+        "command": "cody.chat.history.clear",
         "category": "Cody",
-        "title": "Chat History",
+        "title": "Clear Chat History",
         "group": "Cody",
-        "icon": "$(history)"
+        "icon": "$(trash)"
+      },
+      {
+        "command": "cody.chat.history.export",
+        "category": "Cody",
+        "title": "Export Chat History",
+        "group": "Cody",
+        "icon": "$(export)"
       },
       {
         "command": "cody.status-bar.interacted",
@@ -631,38 +667,35 @@
       ],
       "view/title": [
         {
-          "command": "cody.interactive.clear",
-          "when": "view == cody.chat && cody.activated",
+          "command": "cody.chat.panel.new",
+          "when": "view == cody.chat.tree.view && cody.activated",
           "group": "navigation@1"
         },
         {
-          "command": "cody.history",
-          "when": "view == cody.chat && cody.activated",
+          "command": "cody.chat.history.clear",
+          "when": "view == cody.chat.tree.view && cody.activated",
+          "enablement": "!cody.chat.history.isEmpty",
           "group": "navigation@2"
         },
         {
-          "command": "cody.status-bar.interacted",
-          "when": "view == cody.chat && cody.activated",
-          "group": "navigation@4"
+          "command": "cody.chat.history.export",
+          "when": "view == cody.chat.tree.view && cody.activated",
+          "enablement": "!cody.chat.history.isEmpty",
+          "group": "navigation@3"
         },
         {
           "command": "cody.feedback",
-          "when": "view == cody.chat",
+          "when": "view == cody.support.tree.view",
           "group": "7_cody@0"
         },
         {
           "command": "cody.welcome",
-          "when": "view == cody.chat",
+          "when": "view == cody.support.tree.view",
           "group": "7_cody@0"
         },
         {
-          "command": "cody.auth.signout",
-          "when": "view == cody.chat && cody.activated",
-          "group": "9_cody@2"
-        },
-        {
           "command": "cody.auth.signin",
-          "when": "view == cody.chat && cody.activated",
+          "when": "view == cody.support.tree.view && cody.activated",
           "group": "9_cody@0"
         },
         {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -224,7 +224,7 @@
           "type": "webview",
           "id": "cody.chat",
           "name": "Chat",
-          "when": "!cody.webviewPanel"
+          "when": "!cody.activated"
         },
         {
           "id": "cody.commands.tree.view",

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -407,8 +407,9 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
      */
     public async createWebviewPanel(): Promise<void> {
         if (this.webviewPanel) {
-            await this.clearAndRestartSession()
-            this.webviewPanel.reveal()
+            if (!this.webviewPanel.visible) {
+                this.webviewPanel.reveal(vscode.ViewColumn.Two)
+            }
             return
         }
 
@@ -449,10 +450,14 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         this.contextProvider.webview = panel.webview
 
         this.webviewPanel = panel
+
         panel.onDidDispose(() => {
             this.webviewPanel = undefined
             panel.dispose()
         })
+
+        await this.clearAndRestartSession()
+
         await vscode.commands.executeCommand('setContext', 'cody.webviewPanel', true)
     }
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -394,6 +394,12 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
      * Creates the webview panel for the Cody chat interface if it doesn't already exist.
      */
     public async createWebviewPanel(): Promise<void> {
+        // Create the webview panel only if the user is logged in.
+        // Allows users to login via the sidebar webview.
+        if (!this.authProvider.getAuthStatus()?.isLoggedIn) {
+            return
+        }
+
         // Checks if the webview panel already exists and is visible.
         // If so, returns early to avoid creating a duplicate.
         // Otherwise, reveals the existing panel or creates a new one.

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -542,6 +542,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     // If no command found, send error message to view
                     await this.addCustomInteraction(`__${text}__ is not a valid command`, text)
                 }
+                // Run command in a new webview to avoid conflicts with context from previous chat
+                await vscode.commands.executeCommand('cody.chat.panel.new')
                 return { text: commandRunnerID, recipeId: 'custom-prompt' }
             }
         }

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -121,9 +121,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         this.loadChatHistory()
         this.sendTranscript()
         this.sendHistory()
-        await this.loadRecentChat()
         await this.contextProvider.init()
         await this.sendCodyCommands()
+        await this.clearAndRestartSession()
     }
 
     public async clearAndRestartSession(): Promise<void> {
@@ -640,23 +640,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             })
         } catch (error) {
             logError('MessageProvider:exportHistory', 'Failed to export chat history', error)
-        }
-    }
-
-    /**
-     * Loads the most recent chat
-     */
-    private async loadRecentChat(): Promise<void> {
-        const localHistory = localStorage.getChatHistory()
-        if (localHistory) {
-            const chats = localHistory.chat
-            const sortedChats = Object.entries(chats).sort(
-                (a, b) => +new Date(b[1].lastInteractionTimestamp) - +new Date(a[1].lastInteractionTimestamp)
-            )
-            const chatID = sortedChats[0][0]
-            if (chatID !== this.currentChatID) {
-                await this.restoreSession(chatID)
-            }
         }
     }
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -121,9 +121,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         this.loadChatHistory()
         this.sendTranscript()
         this.sendHistory()
+        await this.loadRecentChat()
         await this.contextProvider.init()
         await this.sendCodyCommands()
-        await this.clearAndRestartSession()
     }
 
     public async clearAndRestartSession(): Promise<void> {
@@ -152,6 +152,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Restores a session from a chatID
      */
     public async restoreSession(chatID: string): Promise<void> {
+        if (chatID === this.currentChatID) {
+            return
+        }
         await this.saveTranscriptToChatHistory()
         this.cancelCompletion()
         this.currentChatID = chatID
@@ -640,6 +643,23 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             })
         } catch (error) {
             logError('MessageProvider:exportHistory', 'Failed to export chat history', error)
+        }
+    }
+
+    /**
+     * Loads the most recent chat
+     */
+    private async loadRecentChat(): Promise<void> {
+        const localHistory = localStorage.getChatHistory()
+        if (localHistory) {
+            const chats = localHistory.chat
+            const sortedChats = Object.entries(chats).sort(
+                (a, b) => +new Date(b[1].lastInteractionTimestamp) - +new Date(a[1].lastInteractionTimestamp)
+            )
+            const chatID = sortedChats[0][0]
+            if (chatID !== this.currentChatID) {
+                await this.restoreSession(chatID)
+            }
         }
     }
 

--- a/vscode/src/chat/local-code-search.ts
+++ b/vscode/src/chat/local-code-search.ts
@@ -9,6 +9,8 @@ import { IndexedKeywordContextFetcher, Result } from '@sourcegraph/cody-shared/s
 import { MAX_HUMAN_INPUT_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
 
+import { getActiveEditor } from '../editor/vscode-editor'
+
 /**
  * Uses symf to run an LLM-enhanced indexed keyword search for the user's query
  */
@@ -166,7 +168,7 @@ ${firstNLines(text, 10)}
 }
 
 function getCurrentWorkspaceRoot(): string | null {
-    const uri = vscode.window.activeTextEditor?.document?.uri
+    const uri = getActiveEditor()?.document?.uri
     if (uri) {
         const wsFolder = vscode.workspace.getWorkspaceFolder(uri)
         if (wsFolder) {

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { CodyPrompt } from '@sourcegraph/cody-shared'
 
 import { getSmartSelection } from '../editor/utils'
+import { getActiveEditor } from '../editor/vscode-editor'
 import { logDebug } from '../log'
 import { telemetryService } from '../services/telemetry'
 
@@ -44,7 +45,7 @@ export class CommandRunner implements vscode.Disposable {
         logDebug('CommandRunner:init', this.kind)
 
         // Commands only work in active editor / workspace unless context specifies otherwise
-        this.editor = vscode.window.activeTextEditor || undefined
+        this.editor = getActiveEditor()
         if (!this.editor || command.context?.none) {
             const errorMsg = 'Failed to create command: No active text editor found.'
             logDebug('CommandRunner:int:fail', errorMsg)

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -5,6 +5,7 @@ import { VsCodeCommandsController } from '@sourcegraph/cody-shared/src/editor'
 
 import { logDebug, logError } from '../log'
 import { localStorage } from '../services/LocalStorageProvider'
+import { TreeViewProvider } from '../services/TreeViewProvider'
 
 import { CommandRunner } from './CommandRunner'
 import { CustomPromptsStore } from './CustomPromptsStore'
@@ -42,6 +43,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
     public userFileWatcher: vscode.FileSystemWatcher | null = null
 
     public commandRunners = new Map<string, CommandRunner>()
+    private treeView = new TreeViewProvider('command')
 
     constructor(context: vscode.ExtensionContext) {
         this.tools = new ToolsProvider(context)
@@ -53,6 +55,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         this.lastUsedCommands = new Set(localStorage.getLastUsedCommands())
         this.custom.activate()
         this.fileWatcherInit()
+
+        vscode.window.registerTreeDataProvider('cody.commands.tree.view', this.treeView)
     }
 
     /**

--- a/vscode/src/custom-prompts/ToolsProvider.ts
+++ b/vscode/src/custom-prompts/ToolsProvider.ts
@@ -4,13 +4,14 @@ import { promisify } from 'util'
 
 import * as vscode from 'vscode'
 
+import { getActiveEditor } from '../editor/vscode-editor'
 import { logDebug, logError } from '../log'
 
 import { UserWorkspaceInfo } from './utils'
 import { outputWrapper } from './utils/helpers'
 
 const rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath
-const currentFilePath = vscode.window.activeTextEditor?.document.uri.fsPath
+const currentFilePath = getActiveEditor()?.document.uri.fsPath
 const homePath = os.homedir() || process.env.HOME || process.env.USERPROFILE || ''
 const _exec = promisify(exec)
 /**

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -188,6 +188,7 @@ const register = async (
         humanInput?: string
     ): Promise<void> => {
         if (openChatView) {
+            await sidebarChatProvider.createWebviewPanel()
             await sidebarChatProvider.setWebviewView('chat')
         }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -233,6 +233,10 @@ const register = async (
     vscode.window.registerTreeDataProvider('cody.search.tree.view', new TreeViewProvider('search'))
 
     disposables.push(
+        // Placeholder for search panel command
+        vscode.commands.registerCommand('cody.search.panel', () =>
+            vscode.window.showInformationMessage('Coming soon...')
+        ),
         // Inline Chat Provider
         vscode.commands.registerCommand('cody.comment.add', async (comment: vscode.CommentReply) => {
             const isEditMode = commandRegex.edit.test(comment.text.trimStart())

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -16,7 +16,7 @@ import { AuthStatus, CODY_FEEDBACK_URL } from './chat/protocol'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './completions/tree-sitter/parse-tree-cache'
 import { getConfiguration, getFullConfig } from './configuration'
-import { VSCodeEditor } from './editor/vscode-editor'
+import { getActiveEditor, VSCodeEditor } from './editor/vscode-editor'
 import { PlatformContext } from './extension.common'
 import { configureExternalServices } from './external-services'
 import { FixupController } from './non-stop/FixupController'
@@ -206,12 +206,13 @@ const register = async (
         source = 'editor' // where the command was triggered from
     ): Promise<void> => {
         telemetryService.log('CodyVSCodeExtension:command:edit:executed', { source })
-        const document = args.document || vscode.window.activeTextEditor?.document
+        const activeEditor = getActiveEditor()
+        const document = args.document || activeEditor?.document
         if (!document) {
             return
         }
 
-        const range = args.range || vscode.window.activeTextEditor?.selection
+        const range = args.range || activeEditor?.selection
         if (!range) {
             return
         }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -74,15 +74,15 @@ export class FixupController
         this._disposables.push(
             vscode.workspace.onDidChangeTextDocument(this.editObserver.textDocumentChanged.bind(this.editObserver))
         )
-        this.registerTreeView()
     }
 
     /**
      * Register the tree view that provides an additional UI for Fixups.
      * Call this if the feature is enabled.
      * TODO: We should move this to a QuickPick and enable it by default.
+     * NOTE: deprecated
      */
-    private registerTreeView(): void {
+    public registerTreeView(): void {
         this._disposables.push(vscode.window.registerTreeDataProvider('cody.fixup.tree.view', this.taskViewProvider))
         void vscode.commands.executeCommand('setContext', 'cody.nonstop.fixups.enabled', true)
     }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -74,6 +74,7 @@ export class FixupController
         this._disposables.push(
             vscode.workspace.onDidChangeTextDocument(this.editObserver.textDocumentChanged.bind(this.editObserver))
         )
+        this.registerTreeView()
     }
 
     /**
@@ -81,8 +82,9 @@ export class FixupController
      * Call this if the feature is enabled.
      * TODO: We should move this to a QuickPick and enable it by default.
      */
-    public registerTreeView(): void {
+    private registerTreeView(): void {
         this._disposables.push(vscode.window.registerTreeDataProvider('cody.fixup.tree.view', this.taskViewProvider))
+        void vscode.commands.executeCommand('setContext', 'cody.nonstop.fixups.enabled', true)
     }
 
     // FixupFileCollection

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { EDIT_COMMAND, menu_buttons } from '../custom-prompts/utils/menu'
+import { getActiveEditor } from '../editor/vscode-editor'
 
 import { FixupTask } from './FixupTask'
 import { FixupTaskFactory } from './roles'
@@ -50,7 +51,7 @@ export class FixupTypingUI {
     }
 
     public async show(): Promise<FixupTask | null> {
-        const editor = vscode.window.activeTextEditor
+        const editor = getActiveEditor()
         if (!editor) {
             return null
         }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -169,7 +169,9 @@ export class AuthProvider {
         await localStorage.deleteEndpoint()
         await this.auth(endpoint, null)
         this.authStatus.endpoint = ''
+        await vscode.commands.executeCommand('setContext', 'cody.webviewPanel', false)
         await vscode.commands.executeCommand('setContext', 'cody.activated', false)
+        await vscode.commands.executeCommand('cody.chat.focus')
     }
 
     // Create Auth Status

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 import { ActiveTextEditorSelection, VsCodeInlineController } from '@sourcegraph/cody-shared/src/editor'
 import { SURROUNDING_LINES } from '@sourcegraph/cody-shared/src/prompt/constants'
 
+import { getActiveEditor } from '../editor/vscode-editor'
 import { CodyTaskState } from '../non-stop/utils'
 
 import { CodeLensProvider } from './CodeLensProvider'
@@ -210,7 +211,7 @@ export class InlineController implements VsCodeInlineController {
         if (!this.commentController) {
             return null
         }
-        const editor = vscode.window.activeTextEditor
+        const editor = getActiveEditor()
         if (!editor || !humanInput || editor.document.uri.scheme !== 'file') {
             return null
         }

--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -37,6 +37,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
         const updatedTree: vscode.TreeItem[] = []
         treeItems.forEach(item => {
             const treeItem = new vscode.TreeItem({ label: item.title })
+            treeItem.id = item.id
             treeItem.iconPath = new vscode.ThemeIcon(item.icon)
             treeItem.description = item.description
             treeItem.command = { command: item.command.command, title: item.title, arguments: item.command.args }
@@ -95,6 +96,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
 interface CodySidebarTreeItem {
     title: string
     icon: string
+    id?: string
     description?: string
     command: {
         command: string
@@ -189,6 +191,7 @@ export function createCodyChatTreeItems(
         const lastHumanMessage = entry.interactions.findLast(interaction => interaction.humanMessage)
         if (lastHumanMessage?.humanMessage.displayText && lastHumanMessage?.humanMessage.text) {
             chatTreeItems.push({
+                id,
                 title: lastHumanMessage.humanMessage.displayText.split('\n')[0],
                 icon: 'comment',
                 command: { command: 'cody.chat.panel.restore', args: [id] },
@@ -198,6 +201,7 @@ export function createCodyChatTreeItems(
     })
     if (currentEmptyChatID) {
         chatTreeItems.push({
+            id: currentEmptyChatID,
             title: 'New Chat',
             icon: 'comment',
             command: { command: 'cody.chat.panel.restore', args: [currentEmptyChatID] },

--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -199,7 +199,7 @@ export function createCodyChatTreeItems(
             })
         }
     })
-    if (currentEmptyChatID) {
+    if (currentEmptyChatID && chatTreeItems.length) {
         chatTreeItems.push({
             id: currentEmptyChatID,
             title: 'New Chat',

--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -1,0 +1,208 @@
+import * as vscode from 'vscode'
+
+import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+
+import { CODY_DOC_URL } from '../chat/protocol'
+
+type CodyTreeItemType = 'command' | 'support' | 'search' | 'chat'
+export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+    private treeNodes: vscode.TreeItem[] = []
+    private _disposables: vscode.Disposable[] = []
+    private _onDidChangeTreeData = new vscode.EventEmitter<vscode.TreeItem | undefined | void>()
+    public readonly onDidChangeTreeData = this._onDidChangeTreeData.event
+
+    constructor(private type: CodyTreeItemType) {
+        this.updateTree(this.getCodyTreeItems(type))
+        this.refresh()
+    }
+
+    /**
+     * Gets the tree view items to display based on the provided type.
+     */
+    private getCodyTreeItems(type: CodyTreeItemType): CodySidebarTreeItem[] {
+        switch (type) {
+            case 'command':
+                return commandsItems
+            case 'support':
+                return supportItems
+            default:
+                return []
+        }
+    }
+
+    /**
+     * Updates the tree view with the provided tree items.
+     */
+    public updateTree(treeItems: CodySidebarTreeItem[]): void {
+        const updatedTree: vscode.TreeItem[] = []
+        treeItems.forEach(item => {
+            const treeItem = new vscode.TreeItem({ label: item.title })
+            treeItem.iconPath = new vscode.ThemeIcon(item.icon)
+            treeItem.description = item.description
+            treeItem.command = { command: item.command.command, title: item.title, arguments: item.command.args }
+
+            updatedTree.push(treeItem)
+        })
+        this.treeNodes = updatedTree
+        this.refresh()
+    }
+
+    /**
+     * Refresh the tree view to get the latest data
+     */
+    public refresh(): void {
+        if (this.type === 'chat') {
+            void vscode.commands.executeCommand('setContext', 'cody.chat.history.isEmpty', this.treeNodes.length === 0)
+        }
+        this._onDidChangeTreeData.fire()
+    }
+
+    /**
+     * Get parents items first
+     * Then returns children items for each parent item
+     */
+    public getChildren(): vscode.TreeItem[] {
+        return [...this.treeNodes.values()]
+    }
+
+    /**
+     * Get individual tree item
+     */
+    public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+        return element
+    }
+
+    /**
+     * Empty the tree view
+     */
+    public reset(): void {
+        this.treeNodes = []
+        this.refresh()
+    }
+
+    /**
+     * Dispose the disposables
+     */
+    public dispose(): void {
+        this.reset()
+        for (const disposable of this._disposables) {
+            disposable.dispose()
+        }
+        this._disposables = []
+    }
+}
+
+interface CodySidebarTreeItem {
+    title: string
+    icon: string
+    description?: string
+    command: {
+        command: string
+        args?: string[] | { [key: string]: string }[]
+    }
+}
+
+const supportItems: CodySidebarTreeItem[] = [
+    {
+        title: 'Extension Settings',
+        icon: 'gear',
+        command: { command: 'cody.settings.extension' },
+    },
+    {
+        title: 'Feature Settings',
+        icon: 'cody-logo',
+        command: { command: 'cody.status-bar.interacted' },
+    },
+    {
+        title: 'Documentation & Help',
+        icon: 'question',
+        command: { command: 'vscode.open', args: [CODY_DOC_URL.href] },
+    },
+    {
+        title: 'Keyboard Shortcuts',
+        icon: 'keyboard',
+        command: { command: 'workbench.action.openGlobalKeybindings' },
+    },
+    {
+        title: 'Sign Out',
+        icon: 'log-out',
+        command: { command: 'cody.auth.signout' },
+    },
+]
+
+const commandsItems: CodySidebarTreeItem[] = [
+    {
+        title: 'Document',
+        icon: 'output',
+        description: 'Add code documentation',
+        command: { command: 'cody.command.document-code' },
+    },
+    {
+        title: 'Edit',
+        icon: 'wand',
+        command: { command: 'cody.command.edit-code' },
+        description: 'Edit Code with Instructions',
+    },
+    {
+        title: 'Explain',
+        icon: 'mortar-board',
+        command: { command: 'cody.command.explain-code' },
+        description: 'Explain code',
+    },
+    {
+        title: 'Smell',
+        icon: 'debug',
+        command: { command: 'cody.command.smell-code' },
+        description: 'Identify code smells',
+    },
+    {
+        title: 'Test',
+        icon: 'beaker',
+        command: { command: 'cody.command.generate-tests' },
+        description: 'Generate unit tests',
+    },
+    {
+        title: 'Custom',
+        icon: 'bookmark',
+        command: { command: 'cody.action.commands.menu' },
+        description: 'Custom commands',
+    },
+]
+
+/**
+ * Creates tree items for the Cody chat history to show in the sidebar.
+ *
+ * Takes the user's chat history and current empty chat ID.
+ * Returns an array of CodySidebarTreeItems representing the chat history.
+ * Loops through the chat history entries and creates a tree item for each one,
+ * using the last human message text as the title.
+ * Also adds a "New Chat" item if there is a current empty chat ID.
+ * Reverses the array order so newest chats appear first.
+ */
+export function createCodyChatTreeItems(
+    userHistory: UserLocalHistory,
+    currentEmptyChatID?: string
+): CodySidebarTreeItem[] {
+    const chatTreeItems: CodySidebarTreeItem[] = []
+    const chatHistoryEntries = [...Object.entries(userHistory.chat)]
+    chatHistoryEntries.forEach(([id, entry]) => {
+        const lastHumanMessage = entry.interactions.findLast(interaction => interaction.humanMessage)
+        if (lastHumanMessage?.humanMessage.displayText && lastHumanMessage?.humanMessage.text) {
+            chatTreeItems.push({
+                title: lastHumanMessage.humanMessage.displayText.split('\n')[0],
+                icon: 'comment',
+                command: { command: 'cody.chat.panel.restore', args: [id] },
+                description: entry.lastInteractionTimestamp,
+            })
+        }
+    })
+    if (currentEmptyChatID) {
+        chatTreeItems.push({
+            title: 'New Chat',
+            icon: 'comment',
+            command: { command: 'cody.chat.panel.restore', args: [currentEmptyChatID] },
+            description: 'Current',
+        })
+    }
+    return chatTreeItems.reverse()
+}

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -28,10 +28,16 @@ test('requires a valid auth token and allows logouts', async ({ page, sidebar })
     await page.getByRole('combobox', { name: 'input' }).fill(VALID_TOKEN)
     await page.getByRole('combobox', { name: 'input' }).press('Enter')
 
-    // Collapse the task tree view
-    await page.getByRole('button', { name: 'Fixups Section' }).click()
+    await page.getByRole('heading', { name: 'Cody' }).hover()
+    await page.getByRole('heading', { name: 'Commands' }).hover()
+    await page.getByRole('heading', { name: 'Search' }).hover()
+    await page.getByRole('heading', { name: 'Chats' }).hover()
 
-    await expect(sidebar.getByText("Hello! I'm Cody.")).toBeVisible()
+    await expect(sidebar.getByText('Enable Search Indexing')).toBeVisible()
+    await expect(sidebar.getByText('Sign Out')).toBeVisible()
+
+    await sidebar.getByRole('button', { name: 'New Chat' }).click()
+    await expect(page.getByText("Hello! I'm Cody.")).toBeVisible()
 
     // Check if embeddings server connection error is visible
     await expect(sidebar.getByText('Error while establishing embeddings server connection.')).not.toBeVisible()

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -11,12 +11,12 @@ export const sidebarSignin = async (page: Page, sidebar: Frame): Promise<void> =
     await page.getByRole('combobox', { name: 'input' }).fill(VALID_TOKEN)
     await page.getByRole('combobox', { name: 'input' }).press('Enter')
 
-    // Collapse the task tree view
-    await page.getByRole('button', { name: 'Fixups Section' }).click()
+    await expect(page.getByRole('button', { name: 'New Chat' })).toBeVisible()
 
-    await expect(sidebar.getByText("Hello! I'm Cody.")).toBeVisible()
-
-    await page.getByRole('button', { name: 'Chat Section' }).hover()
+    // if the clear notification is visible, click on it
+    if (await page.getByRole('button', { name: /Clear Notification.*/ }).isVisible()) {
+        await page.getByRole('button', { name: /Clear Notification.*/ }).click()
+    }
 }
 
 // Selector for the Explorer button in the sidebar that would match on Mac and Linux

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -60,7 +60,8 @@ export const test = base
             const page = await app.firstWindow()
 
             // Bring the cody sidebar to the foreground
-            await page.click('[aria-label="Cody"]')
+            // await page.click('[aria-label="Cody"]')
+
             // Ensure that we remove the hover from the activity icon
             await page.getByRole('heading', { name: 'Cody: Chat' }).hover()
             // Wait for Cody to become activated
@@ -70,7 +71,7 @@ export const test = base
 
             await run(async () => {
                 // Ensure we're signed out.
-                if (await page.isVisible('[aria-label="User Settings"]')) {
+                if (!(await page.isVisible('[aria-label="New Chat"]'))) {
                     await signOut(page)
                 }
 

--- a/vscode/test/e2e/history.test.ts
+++ b/vscode/test/e2e/history.test.ts
@@ -13,34 +13,31 @@ test('checks if clear chat history button clears history and current session', a
 
     // Bring the cody sidebar to the foreground
     await page.click('[aria-label="Cody"]')
-    await page.click('[aria-label="Chat History"]')
-    await expect(sidebar.getByText('Chat History')).toBeVisible()
 
     // start a new chat session and check history
 
-    await page.click('[aria-label="Start a New Chat Session"]')
-    await expect(sidebar.getByText("Hello! I'm Cody. I can write code and answer questions for you.")).toBeVisible()
+    await page.getByRole('button', { name: 'New Chat', exact: true }).click()
 
-    await sidebar.getByRole('textbox', { name: 'Chat message' }).fill('Hola')
-    await sidebar.locator('vscode-button').getByRole('img').click()
+    await page.getByRole('heading', { name: 'Cody Chat' }).click()
 
-    await expect(sidebar.getByText('hello from the assistant')).toBeVisible()
+    await page.getByRole('textbox', { name: 'Chat message' }).fill('Hola')
+    await page.locator('vscode-button').getByRole('img').click()
 
-    await page.click('[aria-label="Start a New Chat Session"]')
-    await sidebar.getByRole('textbox', { name: 'Chat message' }).fill('Hey')
-    await sidebar.locator('vscode-button').getByRole('img').click()
+    await expect(page.getByText('hello from the assistant')).toBeVisible()
 
-    await expect(sidebar.getByText('hello from the assistant')).toBeVisible()
-    await expect(sidebar.getByText('Hola')).not.toBeVisible()
+    await page.getByRole('button', { name: 'Start a New Chat Session' }).click()
+    await page.getByRole('textbox', { name: 'Chat message' }).fill('Hey')
+    await page.locator('vscode-button').getByRole('img').click()
 
-    await page.getByRole('button', { name: 'Chat History' }).click()
+    await expect(page.getByText('hello from the assistant')).toBeVisible()
+    await expect(page.getByText('Hola')).not.toBeVisible()
 
     // Remove Hey history item from chat history view
-    await expect(sidebar.getByText('Hey')).toBeVisible()
-    await sidebar.locator('vscode-button').filter({ hasText: 'Clear' }).click()
-    await expect(sidebar.getByText('Hey')).not.toBeVisible()
+    await expect(page.getByText('Hey')).toBeVisible()
+    await page.locator('vscode-button').filter({ hasText: 'Clear' }).click()
+    await expect(page.getByText('Hey')).not.toBeVisible()
 
-    await page.click('[aria-label="Start a New Chat Session"]')
+    await page.getByRole('button', { name: 'Start a New Chat Session' }).click()
 
     // Open the Cody Commands palette and run a command
     await page.getByRole('button', codyEditorCommandButtonRole).click()
@@ -48,5 +45,5 @@ test('checks if clear chat history button clears history and current session', a
     await page.keyboard.press('Enter')
 
     // Check if the old message "Hey" is cleared
-    await expect(sidebar.getByText('Hey')).not.toBeVisible()
+    await expect(page.getByText('Hey')).not.toBeVisible()
 })

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -32,7 +32,7 @@ export async function beforeIntegrationTest(): Promise<void> {
  */
 export async function afterIntegrationTest(): Promise<void> {
     await ensureExecuteCommand('cody.interactive.clear')
-    await ensureExecuteCommand('cody.history.clear')
+    await ensureExecuteCommand('cody.chat.history.clear')
     await ensureExecuteCommand('cody.test.token', null)
 }
 


### PR DESCRIPTION
Part of https://github.com/sourcegraph/cody/issues/1410

This PR implements the design shown in https://github.com/sourcegraph/cody/issues/1377

![Screenshot 2023-10-17 at 5 48 14 AM](https://github.com/sourcegraph/cody/assets/68532117/5bbb4284-3bd0-4a77-a872-7c1b4440a0b2)

- Adds command, chat, search, support side view containers
- Include edits (fixup) side view by default
- Updates chat tree view with new ID and moves visibility logic
- Adds welcome messages for chat and search in side views  
- Updates commands for chat panel and history clearing
- Updates view containers for navigation commands
- Chat View has been moved out of sidebar into editor panel, default to open in split view

Loom Demo: https://www.loom.com/share/181f4a5c464f43c398b2e66de4d16ff4?sid=3452fddd-74ba-495a-8bb1-9d32e8800c84

### TODO

Update tests 😭 

### Follow-up works

I'm going to try to keep this PR small to make it easier to review, meaning there will be some follow-up works I will need to do after this PR Is merged, which includes:
- remove any functions/methods & views related to chat history
- allow export and removal of an individual chat 


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

TBC