### PR TITLE
fix: swap custom prompts and default prompts order

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -22,6 +22,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - The `CodyAutocompleteMinimumLatency` feature flag is now split into three independent feature flags: `CodyAutocompleteLanguageLatency`, `CodyAutocompleteProviderLatency`, and `CodyAutocompleteUserLatency`. [pull/1351](https://github.com/sourcegraph/cody/pull/1351)
 - Prevents unhelpful autocomplete suggestions at the end of file when cursor position is at 0 and the line above is also empty. [pull/1330](https://github.com/sourcegraph/cody/pull/1330)
 - Adds popups to show the state of indexing for dotcom/Cody App in more situations. Fixes an issue where the database icon below the chat input status box was low contrast in some dark themes. [pull/1374](https://github.com/sourcegraph/cody/pull/1374)
+- Custom commands can no longer override default commands. [pull/1414](https://github.com/sourcegraph/cody/pull/1414)
 
 ## [0.14.0]
 

--- a/vscode/src/custom-prompts/PromptsProvider.ts
+++ b/vscode/src/custom-prompts/PromptsProvider.ts
@@ -53,7 +53,7 @@ export class PromptsProvider {
     public groupCommands(customCommands = new Map<string, CodyPrompt>()): void {
         const combinedMap = new Map([...this.defaultPromptsMap])
         combinedMap.set('separator', { prompt: 'separator', slashCommand: '' })
-        this.allCommands = new Map([...combinedMap, ...customCommands])
+        this.allCommands = new Map([...customCommands, ...combinedMap])
     }
 
     // dispose and reset the controller and builder


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C052G9Y5Y8H/p1697536651010599?thread_ts=1697536557.499619&cid=C052G9Y5Y8H

fix: swap custom prompts and default prompts order 

The order of adding custom prompts and default prompts to allCommands map is swapped to prioritize default prompts over custom.

This fixes an issue where custom prompts were overriding default prompts with the same name.

Loom provided by Vincent: https://www.loom.com/share/d8aea1426d4b409a86fde3eaefc76ed0?sid=2058611d-5f2d-4457-b3cf-6490ceefe08b

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- Create a custom command and name it `explain`
- Before: you will be running the custom command when trying to run `/explain`
- After: the new custom command will not override the built-in `/explain` command

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/a1aeb1fe-0cbe-4db2-afda-b93f332cca51)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/e92e9ade-fa94-4dd7-a23f-d887061b1dc3)
