### PR TITLE
fix: unresponsive selections in custom command menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Fixed an issue where autocomplete suggestions where sometimes not shown when the overlap with the next line was too large. [pull/1320](https://github.com/sourcegraph/cody/pull/1320)
 - Fixed unresponsive UI for the `Configure Custom Commands` option inside the `Cody: Custom Command (Experimental)` menu. [pull/1416](https://github.com/sourcegraph/cody/pull/1416)
+- Fixed last 5 used commands not showing up in the custom command history menu. [pull/1416](https://github.com/sourcegraph/cody/pull/1416)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,7 +13,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Fixes an issue where autocomplete suggestions where sometimes not shown when the overlap with the next line was too large. [pull/1320](https://github.com/sourcegraph/cody/pull/1320)
+- Fixed an issue where autocomplete suggestions where sometimes not shown when the overlap with the next line was too large. [pull/1320](https://github.com/sourcegraph/cody/pull/1320)
+- Fixed unresponsive UI for the `Configure Custom Commands` option inside the `Cody: Custom Command (Experimental)` menu. [pull/1416](https://github.com/sourcegraph/cody/pull/1416)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Added client-side request timeouts to Autocomplete requests. [pull/1355](https://github.com/sourcegraph/cody/pull/1355)
 - Added telemetry on how long accepted autocomplete requests are kept in the document. [pull/1380](https://github.com/sourcegraph/cody/pull/1380)
+- Added support for using (workspace) relative paths in `filePath`and `directoryPath` fields as context for Custom Commands. [pull/1385](https://github.com/sourcegraph/cody/pull/1385)
 
 ### Fixed
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -476,7 +476,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 if (!type) {
                     break
                 }
-                await this.editor.controllers.command?.config('add', type)
+                await this.editor.controllers.command?.configFileAction('add', type)
                 telemetryService.log('CodyVSCodeExtension:addCommandButton:clicked')
                 break
         }

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -283,16 +283,16 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
             // Show the list of prompts to the user using a quick pick
             const selected = await showCustomCommandMenu([...promptItems])
-            const commandKey = selected?.description || selected?.label
+            const commandKey = selected?.description
 
             if (!commandKey) {
                 return
             }
 
             switch (commandKey.length > 0) {
-                case commandKey === addOption.label:
+                case commandKey === addOption.description:
                     return await this.addNewUserCommandQuick()
-                case commandKey === configOption.label:
+                case commandKey === configOption.description:
                     return await this.configMenu('custom')
                 default:
                     // Run the prompt

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -283,9 +283,9 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
             // Show the list of prompts to the user using a quick pick
             const selected = await showCustomCommandMenu([...promptItems])
-            const commandKey = selected?.description
+            const commandKey = selected?.description || selected?.label
 
-            if (!selected || !commandKey) {
+            if (!commandKey) {
                 return
             }
 

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -116,6 +116,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         // Start the command runner
         const codyCommand = new CommandRunner(command, input, isFixupRequest)
         this.commandRunners.set(codyCommand.id, codyCommand)
+
+        // Save command to command history
         this.lastUsedCommands.add(command.slashCommand)
 
         // Fixup request will be taken care by the fixup recipe in the CommandRunner
@@ -262,19 +264,16 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         }
 
         try {
-            const recentlyUsed = this.getLastUsedCommands()
+            let recentlyUsed = getCustomMenuQuickPickItems(this.getLastUsedCommands()).reverse()
+            if (recentlyUsed.length > 0) {
+                recentlyUsed = [menu_separators.lastUsed, ...recentlyUsed]
+            }
 
             // Get the list of prompts from the cody.json file
             const commandsFromStore = this.custom.getCommands()
-            const promptList = recentlyUsed.length ? [...recentlyUsed, ...commandsFromStore] : commandsFromStore
+            const customCommands = getCustomMenuQuickPickItems(commandsFromStore)
 
-            const promptItems = promptList
-                ?.filter(command => command !== null && command?.[1]?.type !== 'default')
-                .map(commandItem => {
-                    const command = commandItem[1]
-                    const description = commandItem[0]
-                    return createQuickPickItem(command.description, description)
-                })
+            const promptItems = [...recentlyUsed, menu_separators.customCommands, ...customCommands]
 
             const configOption = menu_options.config
             const addOption = menu_options.add
@@ -283,16 +282,16 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
             // Show the list of prompts to the user using a quick pick
             const selected = await showCustomCommandMenu([...promptItems])
-            const commandKey = selected?.description
+            const commandKey = selected?.label
 
             if (!commandKey) {
                 return
             }
 
             switch (commandKey.length > 0) {
-                case commandKey === addOption.description:
+                case commandKey === addOption.label:
                     return await this.addNewUserCommandQuick()
-                case commandKey === configOption.description:
+                case commandKey === configOption.label:
                     return await this.configMenu('custom')
                 default:
                     // Run the prompt
@@ -325,12 +324,14 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             case 'delete':
             case 'file':
             case 'open': {
-                const type = selected.type || (await showcommandTypeQuickPick(action, this.custom.promptSize))
-                await this.config(action, type)
+                await this.configFileAction(
+                    action,
+                    selected.type || (await showcommandTypeQuickPick(action, this.custom.promptSize))
+                )
                 break
             }
             case 'add': {
-                await this.config(action)
+                await this.configFileAction(action)
                 break
             }
             case 'list':
@@ -348,7 +349,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      * Config file controller
      * handles operations on config files for user and workspace commands
      */
-    public async config(action: string, fileType?: CustomCommandType): Promise<void> {
+    public async configFileAction(action: string, fileType?: CustomCommandType): Promise<void> {
         switch (action) {
             case 'delete':
                 if ((await showRemoveConfirmationInput()) !== 'Yes') {
@@ -409,7 +410,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             const uri = this.custom.jsonFileUris[filePath]
             const doesExist = await this.tools.doesUriExist(uri)
             // create file if it doesn't exist
-            return doesExist ? this.tools.openFile(uri) : this.config('file', filePath)
+            return doesExist ? this.tools.openFile(uri) : this.configFileAction('file', filePath)
         }
         const fileUri = constructFileUri(filePath, this.tools.getUserInfo()?.workspaceRoot)
 
@@ -420,20 +421,18 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      * Get the list of recently used commands from the local storage
      */
     private getLastUsedCommands(): [string, CodyPrompt][] {
-        const commands = [...this.lastUsedCommands]?.map(id => [id, this.myPromptsMap.get(id) as CodyPrompt])?.reverse()
-        const filtered = commands?.filter(command => command[1] !== undefined) as [string, CodyPrompt][]
-
-        return filtered.length > 0 ? filtered : []
+        return [...this.lastUsedCommands]?.map(id => [id, this.default.get(id) as CodyPrompt]) || []
     }
 
     /**
      * Save the last used commands to local storage
      */
     private async saveLastUsedCommands(): Promise<void> {
-        // store the last 3 used commands
-        const commands = [...this.lastUsedCommands].filter(command => command !== 'separator').slice(0, 3)
+        const commands = [...this.lastUsedCommands].filter(key => this.default.get(key)?.slashCommand.length)
+
         if (commands.length > 0) {
-            await localStorage.setLastUsedCommands(commands)
+            // store the last 5 used commands
+            await localStorage.setLastUsedCommands(commands.slice(0, 5))
         }
 
         this.lastUsedCommands = new Set(commands)
@@ -508,4 +507,14 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         this.commandRunners = new Map()
         logDebug('CommandsController:dispose', 'disposed')
     }
+}
+
+function getCustomMenuQuickPickItems(commands: [string, CodyPrompt][]): vscode.QuickPickItem[] {
+    return commands
+        ?.filter(command => command !== null && command?.[1]?.type !== 'default')
+        .map(commandItem => {
+            const label = commandItem[0]
+            const command = commandItem[1]
+            return createQuickPickItem(label, command.description)
+        })
 }

--- a/vscode/src/custom-prompts/utils/menu.ts
+++ b/vscode/src/custom-prompts/utils/menu.ts
@@ -35,6 +35,7 @@ const fixOption: QuickPickItemWithSlashCommand = {
 const commandsSeparator: QuickPickItem = { kind: -1, label: 'commands' }
 const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'custom commands (experimental)' }
 const settingsSeparator: QuickPickItem = { kind: -1, label: 'settings' }
+const lastUsedSeparator: QuickPickItem = { kind: -1, label: 'last used' }
 // Common options
 const configOption: QuickPickItem = {
     label: 'Configure Custom Commands...',
@@ -55,6 +56,7 @@ export const menu_separators = {
     commands: commandsSeparator,
     customCommands: customCommandsSeparator,
     settings: settingsSeparator,
+    lastUsed: lastUsedSeparator,
 }
 
 export const menu_options = {

--- a/vscode/src/custom-prompts/utils/menu.ts
+++ b/vscode/src/custom-prompts/utils/menu.ts
@@ -31,11 +31,20 @@ const fixOption: QuickPickItemWithSlashCommand = {
     description: EDIT_COMMAND.description,
     slashCommand: EDIT_COMMAND.slashCommand,
 }
+// Seperators
 const commandsSeparator: QuickPickItem = { kind: -1, label: 'commands' }
 const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'custom commands (experimental)' }
-const configOption: QuickPickItem = { label: 'Configure Custom Commands...' }
 const settingsSeparator: QuickPickItem = { kind: -1, label: 'settings' }
-const addOption: QuickPickItem = { label: 'New Custom Command...', alwaysShow: true }
+// Common options
+const configOption: QuickPickItem = {
+    label: 'Configure Custom Commands...',
+    description: 'Manage your custom reusable commands',
+}
+const addOption: QuickPickItem = {
+    label: 'New Custom Command...',
+    alwaysShow: true,
+    description: 'Create a new reusable command',
+}
 
 export const recentlyUsedSeparatorAsPrompt: [string, CodyPrompt][] = [
     ['separator', { prompt: 'separator', slashCommand: '' }],


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1697105184992049

This PR fixes the issuses reported by Philipp where `` does not work in Custom Commands Menu. This issue was caused by the previous update when `description` has become a required field. 

- Updated options to include `description` field
- Now check for the description option instead of labels when checking the selected option in custom command menu.
- Also fixed `last five used custom commands` not showing up in the same menu

This fixes an issue where commands with null descriptions would not be run when selected.

![image](https://github.com/sourcegraph/cody/assets/68532117/84b6f50a-2e90-4e99-8f1c-7ae95edbec8b)

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Open the Custom Commands Menu from right clicking in your editor and then select `Custom Commands`

![image](https://github.com/sourcegraph/cody/assets/68532117/be25ced4-cefd-4b76-b3f1-787621dd8938)

2. At the bottom you will find `Configure Custom Commands...` and `New Custom Command...`

![image](https://github.com/sourcegraph/cody/assets/68532117/2ad0a034-a80c-44bb-801e-c75fc8aee97b)

These options should now work when building from this branch.

Other commands should still work as expected.