### PR TITLE
feat: add source tracing for code generated

### DIFF
--- a/lib/shared/src/chat/prompts/utils.ts
+++ b/lib/shared/src/chat/prompts/utils.ts
@@ -19,12 +19,13 @@ export async function newInteraction(args: {
     contextMessages?: Promise<ContextMessage[]>
     assistantText?: string
     assistantDisplayText?: string
+    source?: string
 }): Promise<Interaction> {
-    const { text, displayText, contextMessages, assistantText, assistantDisplayText } = args
+    const { text, displayText, contextMessages, assistantText, assistantDisplayText, source } = args
     return Promise.resolve(
         new Interaction(
-            { speaker: 'human', text, displayText },
-            { speaker: 'assistant', text: assistantText, displayText: assistantDisplayText },
+            { speaker: 'human', text, displayText, source },
+            { speaker: 'assistant', text: assistantText, displayText: assistantDisplayText, source },
             Promise.resolve(contextMessages || []),
             []
         )

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -21,11 +21,12 @@ export class ChatQuestion implements Recipe {
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
+        const source = this.id
 
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: truncatedText, displayText: humanChatInput },
-                { speaker: 'assistant' },
+                { speaker: 'human', text: truncatedText, displayText: humanChatInput, source },
+                { speaker: 'assistant', source },
                 this.getContextMessages(
                     truncatedText,
                     context.editor,

--- a/lib/shared/src/chat/recipes/context-search.ts
+++ b/lib/shared/src/chat/recipes/context-search.ts
@@ -39,16 +39,19 @@ export class ContextSearch implements Recipe {
         }
         const truncatedText = truncateText(query.replace('/search ', '').replace('/s ', ''), MAX_HUMAN_INPUT_TOKENS)
         const workspaceRootUri = context.editor.getWorkspaceRootUri()
+        const source = this.id
         return new Interaction(
             {
                 speaker: 'human',
                 text: '',
                 displayText: query,
+                source,
             },
             {
                 speaker: 'assistant',
                 text: '',
                 displayText: await this.displaySearchResults(truncatedText, context.codebaseContext, workspaceRootUri),
+                source,
             },
             new Promise(resolve => resolve([])),
             []

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -61,6 +61,9 @@ export class CustomPrompt implements Recipe {
         const promptText = command.prompt
         const commandName = command?.slashCommand || command?.description || promptText
 
+        // Log all custom commands under 'custom'
+        const source = command?.type === 'default' ? command?.slashCommand.replace('/', '') : 'custom'
+
         if (!promptText || !commandName) {
             const errorMessage = 'Please enter a valid prompt for the custom command.'
             return newInteractionWithError(errorMessage, promptText || '')
@@ -78,7 +81,7 @@ export class CustomPrompt implements Recipe {
         // Attach code selection to prompt text if only selection is needed as context
         if (selection && isOnlySelectionRequired(contextConfig)) {
             const contextMessages = Promise.resolve(getCurrentFileContextFromEditorSelection(selection))
-            return newInteraction({ text, displayText, contextMessages })
+            return newInteraction({ text, displayText, contextMessages, source })
         }
 
         const commandOutput = command.context?.output
@@ -93,7 +96,7 @@ export class CustomPrompt implements Recipe {
             commandOutput
         )
 
-        return newInteraction({ text: truncatedText, displayText, contextMessages })
+        return newInteraction({ text: truncatedText, displayText, contextMessages, source })
     }
 
     private async getContextMessages(

--- a/lib/shared/src/chat/recipes/inline-chat.ts
+++ b/lib/shared/src/chat/recipes/inline-chat.ts
@@ -47,15 +47,16 @@ export class InlineChat implements Recipe {
 
         // Text display in UI fpr human that includes the selected code
         const displayText = humanChatInput + InlineChat.displayPrompt.replace('{selectedText}', selection.selectedText)
-
+        const source = this.id
         return Promise.resolve(
             new Interaction(
                 {
                     speaker: 'human',
                     text: promptText,
                     displayText,
+                    source,
                 },
-                { speaker: 'assistant' },
+                { speaker: 'assistant', source },
                 this.getContextMessages(truncatedText, context.codebaseContext, selection, context.editor),
                 []
             )

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -29,7 +29,8 @@ export class Interaction {
     }
 
     public setAssistantMessage(assistantMessage: InteractionMessage): void {
-        this.assistantMessage = assistantMessage
+        const source = assistantMessage.source || this.assistantMessage.source
+        this.assistantMessage = { ...assistantMessage, source }
     }
 
     public getHumanMessage(): InteractionMessage {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -15,12 +15,14 @@ export interface ChatMessage extends Message {
     preciseContext?: PreciseContext[]
     buttons?: ChatButton[]
     data?: any
+    source?: string
 }
 
 export interface InteractionMessage extends Message {
     displayText?: string
     prefix?: string
     error?: string
+    source?: string
 }
 
 export interface UserLocalHistory {

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -106,8 +106,8 @@ export interface FeedbackButtonsProps {
 }
 
 export interface CodeBlockActionsProps {
-    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button') => void
-    insertButtonOnSubmit: (text: string, newFile?: boolean) => void
+    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', source?: string) => void
+    insertButtonOnSubmit: (text: string, newFile?: boolean, source?: string) => void
 }
 
 export interface ChatCommandsProps {

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -22,6 +22,8 @@ interface CodeBlocksProps {
 
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
+
+    source?: string // the name of the executed command that generated the code
 }
 
 function createButtons(
@@ -29,7 +31,8 @@ function createButtons(
     copyButtonClassName?: string,
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit'],
     insertButtonClassName?: string,
-    insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
+    insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
+    source?: string
 ): HTMLElement {
     const container = document.createElement('div')
     container.className = styles.container
@@ -53,7 +56,8 @@ function createButtons(
         'Copy Code',
         CopyCodeBlockIcon,
         codeBlockActions,
-        copyButtonClassName
+        copyButtonClassName,
+        source
     )
     buttons.append(copyButton)
 
@@ -66,7 +70,8 @@ function createButtons(
                 'Insert Code at Cursor',
                 InsertCodeBlockIcon,
                 codeBlockActions,
-                insertButtonClassName
+                insertButtonClassName,
+                source
             )
         )
 
@@ -77,7 +82,8 @@ function createButtons(
                 'Save Code to New File...',
                 SaveCodeBlockIcon,
                 codeBlockActions,
-                insertButtonClassName
+                insertButtonClassName,
+                source
             )
         )
     }
@@ -90,12 +96,6 @@ function createButtons(
 /**
  * Creates a button to perform an action on a code block.
  *
- * @param type - The type of action button: 'copy', 'insert', or 'new'.
- * @param text - The text content of the code block.
- * @param title - The title attribute for the button.
- * @param iconSvg - The SVG icon to display in the button.
- * @param codeBlockActions - The callback actions to perform on click.
- * @param className - Optional additional CSS class names for the button.
  * @returns The button element.
  */
 function createCodeBlockActionButton(
@@ -107,7 +107,8 @@ function createCodeBlockActionButton(
         copy: CodeBlockActionsProps['copyButtonOnSubmit']
         insert?: CodeBlockActionsProps['insertButtonOnSubmit']
     },
-    className?: string
+    className?: string,
+    source?: string
 ): HTMLElement {
     const button = document.createElement('button')
 
@@ -122,7 +123,7 @@ function createCodeBlockActionButton(
             button.innerHTML = CheckCodeBlockIcon
             navigator.clipboard.writeText(text).catch(error => console.error(error))
             button.className = classNames(styleClass, className)
-            codeBlockActions.copy(text, 'Button')
+            codeBlockActions.copy(text, 'Button', source)
             setTimeout(() => (button.innerHTML = iconSvg), 5000)
         })
     }
@@ -134,10 +135,10 @@ function createCodeBlockActionButton(
 
     switch (type) {
         case 'insert':
-            button.addEventListener('click', () => insertOnSubmit(text, false))
+            button.addEventListener('click', () => insertOnSubmit(text, false, source))
             break
         case 'new':
-            button.addEventListener('click', () => insertOnSubmit(text, true))
+            button.addEventListener('click', () => insertOnSubmit(text, true, source))
             break
     }
 
@@ -150,6 +151,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
     copyButtonOnSubmit,
     insertButtonClassName,
     insertButtonOnSubmit,
+    source,
 }) {
     const rootRef = useRef<HTMLDivElement>(null)
 
@@ -167,7 +169,8 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                     copyButtonClassName,
                     copyButtonOnSubmit,
                     insertButtonClassName,
-                    insertButtonOnSubmit
+                    insertButtonOnSubmit,
+                    source
                 )
 
                 // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
@@ -181,7 +184,15 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                 })
             }
         }
-    }, [displayText, copyButtonClassName, insertButtonClassName, rootRef, copyButtonOnSubmit, insertButtonOnSubmit])
+    }, [
+        displayText,
+        copyButtonClassName,
+        insertButtonClassName,
+        rootRef,
+        copyButtonOnSubmit,
+        insertButtonOnSubmit,
+        source,
+    ])
 
     return useMemo(
         () => <div ref={rootRef} dangerouslySetInnerHTML={{ __html: renderCodyMarkdown(displayText) }} />,

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -180,6 +180,7 @@ export const TranscriptItem: React.FunctionComponent<
                             copyButtonOnSubmit={copyButtonOnSubmit}
                             insertButtonClassName={codeBlocksInsertButtonClassName}
                             insertButtonOnSubmit={insertButtonOnSubmit}
+                            source={message.source}
                         />
                     )
                 ) : inProgress ? (

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -30,9 +30,9 @@ export type WebviewMessage =
           range?: { startLine: number; startCharacter: number; endLine: number; endCharacter: number }
       }
     | { command: 'edit'; text: string }
-    | { command: 'insert'; text: string }
-    | { command: 'newFile'; text: string }
-    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; commandName?: string }
+    | { command: 'insert'; text: string; source?: string }
+    | { command: 'newFile'; text: string; source?: string }
+    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; source?: string }
     | {
           command: 'auth'
           type:

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -215,7 +215,7 @@ const register = async (
         }
 
         const task = args.instruction?.replace('/edit', '').trim()
-            ? fixup.createTask(document.uri, args.instruction, range, args.auto, args.insertMode)
+            ? fixup.createTask(document.uri, args.instruction, range, args.auto, args.insertMode, source)
             : await fixup.promptUserForTask()
         if (!task) {
             return

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -462,7 +462,7 @@ export class FixupController
                 task.replacement = text
                 this.setTaskState(task, CodyTaskState.ready)
                 telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', {
-                    codeCount: countCode(text),
+                    ...countCode(text),
                     source: task.source,
                 })
                 break

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -111,10 +111,11 @@ export class FixupController
         instruction: string,
         selectionRange: vscode.Range,
         autoApply = false,
-        insertMode?: boolean
+        insertMode?: boolean,
+        source?: string
     ): FixupTask {
         const fixupFile = this.files.forUri(documentUri)
-        const task = new FixupTask(fixupFile, instruction, selectionRange, autoApply, insertMode)
+        const task = new FixupTask(fixupFile, instruction, selectionRange, autoApply, insertMode, source)
         this.tasks.set(task.id, task)
         this.setTaskState(task, CodyTaskState.working)
         return task
@@ -294,8 +295,9 @@ export class FixupController
 
         const replacementText = task.replacement
         if (replacementText) {
-            const tokenCount = countCode(replacementText)
-            telemetryService.log('CodyVSCodeExtension:fixup:applied', tokenCount)
+            const codeCount = countCode(replacementText)
+            const source = task.source
+            telemetryService.log('CodyVSCodeExtension:fixup:applied', { ...codeCount, source })
         }
 
         // TODO: is this the right transition for being all done?
@@ -459,7 +461,10 @@ export class FixupController
                 task.inProgressReplacement = undefined
                 task.replacement = text
                 this.setTaskState(task, CodyTaskState.ready)
-                telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', countCode(text))
+                telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', {
+                    codeCount: countCode(text),
+                    source: task.source,
+                })
                 break
         }
         this.textDidChange(task)

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -29,9 +29,12 @@ export class FixupTask {
         // auto apply replacement to selection once received from LLM
         public autoApply = false,
         // insert mode means insert replacement at selection, otherwise replace selection contents with replacement
-        public insertMode?: boolean
+        public insertMode?: boolean,
+        // the source of the instruction, e.g. 'code-action', 'doc', etc
+        public source?: string
     ) {
         this.id = Date.now().toString(36).replaceAll(/\d+/g, '')
+        this.source = source?.replace('/', '')
     }
 
     /**

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -56,7 +56,7 @@ export class InlineController implements VsCodeInlineController {
     private codeLenses: Map<string, CodeLensProvider> = new Map()
 
     // Track acceptance of generated code by Cody in Inline Chat
-    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '' }
+    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '' }
     private insertInProgress = false
     private lastClipboardText = ''
 
@@ -137,7 +137,7 @@ export class InlineController implements VsCodeInlineController {
         // Track paste event - it checks if the copied text is part of the text string
         vscode.workspace.onDidChangeTextDocument(async e => {
             const changedText = e.contentChanges[0]?.text
-            const { code, lineCount, charCount, eventName } = this.lastCopiedCode
+            const { code, lineCount, charCount, eventName, source } = this.lastCopiedCode
             const clipboardText = await vscode.env.clipboard.readText()
             // Skip if the document is not a file or if the copied text is from insert
             if (!code || !changedText || e.document.uri.scheme !== 'file') {
@@ -157,6 +157,7 @@ export class InlineController implements VsCodeInlineController {
                     op,
                     lineCount,
                     charCount,
+                    source,
                 })
             }
         })
@@ -317,7 +318,7 @@ export class InlineController implements VsCodeInlineController {
                 if (groupedText.includes(clipboardText)) {
                     this.lastClipboardText = clipboardText
                     const eventName = 'inlineChat:Copy'
-                    this.setLastCopiedCode(clipboardText, eventName)
+                    this.setLastCopiedCode(clipboardText, eventName, 'inline-chat')
                 }
             }
         })
@@ -325,18 +326,19 @@ export class InlineController implements VsCodeInlineController {
 
     public setLastCopiedCode(
         code: string,
-        eventName: string
+        eventName: string,
+        source = ''
     ): { code: string; lineCount: number; charCount: number; eventName: string } {
         // All non-copy events are considered as insertions since we don't need to listen for paste events
         this.insertInProgress = !eventName.startsWith('copy')
         const { lineCount, charCount } = countCode(code)
-        const codeCount = { code, lineCount, charCount, eventName }
+        const codeCount = { code, lineCount, charCount, eventName, source }
         this.lastCopiedCode = codeCount
 
         // Currently supported events are: copy, insert, save
         const op = eventName.includes('copy') ? 'copy' : eventName.startsWith('insert') ? 'insert' : 'save'
 
-        const args = { op, charCount, lineCount }
+        const args = { op, charCount, lineCount, source }
         telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
         return codeCount
     }

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -328,7 +328,7 @@ export class InlineController implements VsCodeInlineController {
         code: string,
         eventName: string,
         source = ''
-    ): { code: string; lineCount: number; charCount: number; eventName: string } {
+    ): { code: string; lineCount: number; charCount: number; eventName: string; source?: string } {
         // All non-copy events are considered as insertions since we don't need to listen for paste events
         this.insertInProgress = !eventName.startsWith('copy')
         const { lineCount, charCount } = countCode(code)

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -12,7 +12,6 @@ const expectedOrderedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',
-    'CodyVSCodeExtension:chatResponse:noCode',
 ]
 
 test.beforeEach(() => {

--- a/vscode/test/e2e/inline-assist-inline-touch.test.ts
+++ b/vscode/test/e2e/inline-assist-inline-touch.test.ts
@@ -10,7 +10,6 @@ const expectedOrderedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',
-    'CodyVSCodeExtension:chatResponse:noCode',
     'CodyVSCodeExtension:fixup:codeLens:clicked',
     'CodyVSCodeExtension:fixup:applied',
 ]

--- a/vscode/test/e2e/inline-assist.test.ts
+++ b/vscode/test/e2e/inline-assist.test.ts
@@ -10,7 +10,6 @@ const expectedOrderedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',
-    'CodyVSCodeExtension:chatResponse:noCode',
     'CodyVSCodeExtension:fixup:codeLens:clicked',
     'CodyVSCodeExtension:fixup:applied',
 ]

--- a/vscode/test/e2e/inline-chat.test.ts
+++ b/vscode/test/e2e/inline-chat.test.ts
@@ -8,7 +8,6 @@ import { test } from './helpers'
 const expectedOrderedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:inline-chat:executed',
-    'CodyVSCodeExtension:chatResponse:noCode',
 ]
 
 test.beforeEach(() => {

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -10,7 +10,6 @@ const expectedOrderedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
     'CodyVSCodeExtension:recipe:fixup:executed',
     'CodyVSCodeExtension:fixupResponse:hasCode',
-    'CodyVSCodeExtension:chatResponse:noCode',
     'CodyVSCodeExtension:fixup:codeLens:clicked',
     'CodyVSCodeExtension:fixup:codeLens:clicked',
     'CodyVSCodeExtension:fixup:applied',

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -107,25 +107,24 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 
     const onCopyBtnClick = useCallback(
-        (text: string, eventType: 'Button' | 'Keydown' = 'Button', command?: string) => {
+        (text: string, eventType: 'Button' | 'Keydown' = 'Button', source?: string) => {
             const op = 'copy'
-            const commandName = command
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, commandName })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, source })
         },
         [vscodeAPI]
     )
 
     const onInsertBtnClick = useCallback(
-        (text: string, newFile = false) => {
+        (text: string, newFile = false, source?: string) => {
             const op = newFile ? 'newFile' : 'insert'
             const eventType = 'Button'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, source })
         },
         [vscodeAPI]
     )


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1697492286748349

This PR adds `source` to trace the origin for the code generated by Cody.

- Add source field to InteractionMessage to track origin of messages
- Populate source with recipe ID for each message
- Populate source with command name for custom prompts
- Log 'custom' for custom commands in source field  
- Pass source through newInteraction and log in messages
- Log source in messages
- Also removed `chatResponse:noCode` telemetry as it was not being logged correctly (all `hasCode` events will always ends with `noCode`)

## Examples

Example output for `/doc` command:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:fixupResponse:hasCode {"codeCount":{"lineCount":7,"charCount":246},"source":"doc"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:fixup:applied {"lineCount":7,"charCount":246,"source":"doc"}
```

Example output for `/test` command:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chatResponse:hasCode {"lineCount":27,"charCount":679,"source":"test"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"op":"insert","charCount":679,"lineCount":27,"source":"test"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"op":"insert","charCount":679,"lineCount":27,"source":"test"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:copyButton:clicked {"op":"copy","charCount":679,"lineCount":27,"source":"test"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:keyDown:Paste:clicked {"op":"paste","lineCount":27,"charCount":679,"source":"test"}
```

Example output from a `chat-question` (e.g. what does a unit test looks like in python?):

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chatResponse:hasCode {"lineCount":14,"charCount":275,"source":"chat-question"}
```

Example output when copying, pasting, and inserting code generated from a chat-question:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chatResponse:hasCode {"lineCount":15,"charCount":276,"source":"chat-question"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"op":"insert","charCount":276,"lineCount":15,"source":"chat-question"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:copyButton:clicked {"op":"copy","charCount":276,"lineCount":15,"source":"chat-question"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:keyDown:Paste:clicked {"op":"paste","lineCount":15,"charCount":276,"source":"chat-question"}
```

Example of code generated from a `custom command` (all logged under `source: custom`:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chatResponse:hasCode {"lineCount":6,"charCount":255,"source":"custom"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"op":"insert","charCount":255,"lineCount":6,"source":"custom"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:copyButton:clicked {"op":"copy","charCount":255,"lineCount":6,"source":"custom"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:keyDown:Paste:clicked {"op":"paste","lineCount":6,"charCount":255,"source":"custom"}
```

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Run /test, /doc, and ask Cody a question that would generate code (e.g. what does a unit test looks like in Java?)
2. Check the output channel to see the events with lineCount includes the `source` field