### PR TITLE
fix: use selectionRange in edits when available

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- User selection in active editor will not be replaced by smart selections for the `/edit` command. [pull/1429](https://github.com/sourcegraph/cody/pull/1429)
+
 ### Changed
 
 - Changed the "Ask Cody to Explain" Code Action to respond in the Cody sidebar instead of Inline Chat. [pull/1427](https://github.com/sourcegraph/cody/pull/1427)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -228,7 +228,8 @@ export class FixupController
     }
 
     /**
-     * This function retrieves a "smart" selection a FixupTask.
+     * This function retrieves a "smart" selection for a FixupTask when selectionRange is not available.
+     *
      * The idea of a "smart" selection is to look at both the start and end positions of the current selection,
      * and attempt to expand those positions to encompass more meaningful chunks of code, such as folding regions.
      *
@@ -242,6 +243,11 @@ export class FixupController
     private async getFixupTaskSmartSelection(task: FixupTask, selectionRange: vscode.Range): Promise<vscode.Range> {
         const fileName = task.fixupFile.uri.fsPath
         const documentUri = vscode.Uri.file(fileName)
+
+        // Use selectionRange when it's available
+        if (selectionRange && !selectionRange?.start.isEqual(selectionRange.end)) {
+            return selectionRange
+        }
 
         // Retrieve the start position of the current selection
         const activeCursorStartPosition = selectionRange.start


### PR DESCRIPTION
Fix regression caused by changes in https://github.com/sourcegraph/cody/pull/1317

The commit fixes an issue where getSmartSelection was always recalculating a selection even when a valid selectionRange was already provided.

Currently, the /edit command does not respect user selection when it's available:

https://github.com/sourcegraph/cody/assets/68532117/1b07e72f-3802-4f2a-8f14-f2abbb33ae84

This becomes an issue as folding range is still in the experimental stage. It also cause the code lens to jump around, unless it's intended as I haven't read through the PR 😅 

This PR adds a check to use selectionRange when it is available and not an empty range. 

This provides a fallback in case where "smart" selection is not working for users.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Select code in your editor and run the /edit command, the range should not be expanded for you.
