### PR TITLE
Autocomplete: update the outdated setting description

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -924,7 +924,7 @@
             "llama-code-13b",
             "llama-code-13b-instruct"
           ],
-          "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `unstable-fireworks` provider"
+          "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
           "type": "boolean",

--- a/vscode/test/completions/mock-vscode.ts
+++ b/vscode/test/completions/mock-vscode.ts
@@ -27,7 +27,7 @@ const vscodeMock = {
                         case 'cody.serverEndpoint':
                             return 'https://sourcegraph.com/'
                         // case 'cody.autocomplete.advanced.provider':
-                        //     return 'unstable-fireworks'
+                        //     return 'fireworks'
                         // case 'cody.autocomplete.advanced.model':
                         //     return 'llama-code-13b'
                         default:


### PR DESCRIPTION
Updated the outdated setting description. The `fireworks` provider is stable.

## Test plan

n/a
