### PR TITLE
Enable feature flag checking for non dotcom instances

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -7,7 +7,6 @@ import { FeatureFlag, FeatureFlagProvider } from './FeatureFlagProvider'
 describe('FeatureFlagProvider', () => {
     it('evaluates the feature flag on dotcom', async () => {
         const apiClient = {
-            isDotCom: () => true,
             getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({}),
             evaluateFeatureFlag: vitest.fn().mockResolvedValue(true),
         } as unknown as SourcegraphGraphQLAPIClient
@@ -17,23 +16,8 @@ describe('FeatureFlagProvider', () => {
         expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
     })
 
-    it('does not make a network request when not on dotcom', async () => {
-        const apiClient = {
-            isDotCom: () => false,
-            getEvaluatedFeatureFlags: vitest.fn(),
-            evaluateFeatureFlag: vitest.fn(),
-        }
-
-        const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-
-        expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(false)
-        expect(apiClient.getEvaluatedFeatureFlags).not.toHaveBeenCalled()
-        expect(apiClient.evaluateFeatureFlag).not.toHaveBeenCalled()
-    })
-
     it('loads all evaluated feature flag on `syncAuthStatus`', async () => {
         const apiClient = {
-            isDotCom: () => true,
             getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: true,
             }),
@@ -53,7 +37,6 @@ describe('FeatureFlagProvider', () => {
 
     it('should handle API errors', async () => {
         const apiClient = {
-            isDotCom: () => true,
             getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue(new Error('API error')),
             evaluateFeatureFlag: vitest.fn().mockResolvedValue(new Error('API error')),
         }
@@ -65,7 +48,6 @@ describe('FeatureFlagProvider', () => {
 
     it('should refresh flags', async () => {
         const apiClient = {
-            isDotCom: () => true,
             getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: true,
             }),
@@ -94,7 +76,6 @@ describe('FeatureFlagProvider', () => {
         try {
             Date.now = () => 0
             const apiClient = {
-                isDotCom: () => true,
                 getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
                     [FeatureFlag.TestFlagDoNotUse]: true,
                 }),

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -46,7 +46,7 @@ export class FeatureFlagProvider {
     }
 
     public async evaluateFeatureFlag(flagName: FeatureFlag): Promise<boolean> {
-        if (!this.apiClient.isDotCom() || process.env.BENCHMARK_DISABLE_FEATURE_FLAGS) {
+        if (process.env.BENCHMARK_DISABLE_FEATURE_FLAGS) {
             return false
         }
 
@@ -65,12 +65,8 @@ export class FeatureFlagProvider {
     }
 
     private async refreshFeatureFlags(): Promise<void> {
-        if (this.apiClient.isDotCom()) {
-            const data = await this.apiClient.getEvaluatedFeatureFlags()
-            this.featureFlags = isError(data) ? {} : data
-        } else {
-            this.featureFlags = {}
-        }
+        const data = await this.apiClient.getEvaluatedFeatureFlags()
+        this.featureFlags = isError(data) ? {} : data
         this.lastUpdated = Date.now()
     }
 }


### PR DESCRIPTION
This way we can turn on some features on our dogfooding instance. They will default to return `null` for enterprise instances anyways.

## Test plan

- Tests still pass

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
