### PR TITLE
Autocomplete: Log which retrieval strategy is used

### DIFF
--- a/vscode/src/completions/context/context-graph.ts
+++ b/vscode/src/completions/context/context-graph.ts
@@ -6,17 +6,13 @@ import { ContextSnippet } from '../types'
 import { GetContextResult } from './context'
 
 export interface GraphContextFetcher extends vscode.Disposable {
+    identifier: string
     getContextAtPosition(
         document: vscode.TextDocument,
         position: vscode.Position,
         maxChars: number,
         contextRange?: vscode.Range
     ): Promise<ContextSnippet[]>
-}
-
-export const emptyGraphContextFetcher: GraphContextFetcher = {
-    getContextAtPosition: () => Promise.resolve([]),
-    dispose: () => {},
 }
 
 interface Options {
@@ -67,6 +63,7 @@ export async function getContextFromGraph(options: Options): Promise<GetContextR
     return {
         context,
         logSummary: {
+            strategy: options.graphContextFetcher!.identifier,
             graph: includedGraphMatches,
             duration: performance.now() - start,
         },

--- a/vscode/src/completions/context/context.ts
+++ b/vscode/src/completions/context/context.ts
@@ -22,6 +22,7 @@ export interface GetContextOptions {
 }
 
 export type ContextSummary = Readonly<{
+    strategy: string
     embeddings?: number
     local?: number
     graph?: number
@@ -79,6 +80,7 @@ export async function getContext(options: GetContextOptions): Promise<GetContext
     return {
         context,
         logSummary: {
+            strategy: 'local',
             ...(includedLocalMatches ? { local: includedLocalMatches } : {}),
             duration: performance.now() - start,
         },

--- a/vscode/src/completions/context/lsp-light-graph-cache.ts
+++ b/vscode/src/completions/context/lsp-light-graph-cache.ts
@@ -16,6 +16,7 @@ import { SectionObserver } from './section-observer'
 import { CustomAbortController, CustomAbortSignal } from './utils'
 
 export class LspLightGraphCache implements GraphContextFetcher {
+    public identifier = 'lsp-light'
     private disposables: vscode.Disposable[] = []
     private cache: GraphCache = new GraphCache()
 

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -45,7 +45,7 @@ describe('logger', () => {
         expect(typeof id).toBe('string')
 
         CompletionLogger.start(id)
-        CompletionLogger.networkRequestStarted(id, { duration: 0.1337 })
+        CompletionLogger.networkRequestStarted(id, { strategy: 'fake', duration: 0.1337 })
         CompletionLogger.loaded(id, defaultRequestParams, [item])
         CompletionLogger.suggested(id, InlineCompletionsResultSource.Network, item)
         CompletionLogger.accept(id, document, item)
@@ -65,6 +65,7 @@ describe('logger', () => {
             providerModel: 'blazing-fast-llm',
             charCount: 3,
             contextSummary: {
+                strategy: 'fake',
                 duration: 0.1337,
             },
             items: [
@@ -106,7 +107,7 @@ describe('logger', () => {
 
         const id1 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id1)
-        CompletionLogger.networkRequestStarted(id1, { duration: 0 })
+        CompletionLogger.networkRequestStarted(id1, { strategy: 'fake', duration: 0 })
         CompletionLogger.loaded(id1, defaultRequestParams, [item])
         CompletionLogger.suggested(id1, InlineCompletionsResultSource.Network, item)
 
@@ -116,7 +117,7 @@ describe('logger', () => {
 
         const id2 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id2)
-        CompletionLogger.networkRequestStarted(id2, { duration: 0 })
+        CompletionLogger.networkRequestStarted(id2, { strategy: 'fake', duration: 0 })
         CompletionLogger.loaded(id2, defaultRequestParams, [item])
         CompletionLogger.suggested(id2, InlineCompletionsResultSource.Cache, item)
         CompletionLogger.accept(id2, document, item)
@@ -149,7 +150,7 @@ describe('logger', () => {
         // After accepting the completion, the ID won't be reused a third time
         const id3 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id3)
-        CompletionLogger.networkRequestStarted(id3, { duration: 0 })
+        CompletionLogger.networkRequestStarted(id3, { strategy: 'fake', duration: 0 })
         CompletionLogger.loaded(id3, defaultRequestParams, [item])
         CompletionLogger.suggested(id3, InlineCompletionsResultSource.Cache, item)
 

--- a/vscode/src/graph/bfg/BfgContextFetcher.ts
+++ b/vscode/src/graph/bfg/BfgContextFetcher.ts
@@ -55,6 +55,7 @@ function loadBFG(context: vscode.ExtensionContext): Promise<MessageHandler> {
 }
 
 export class BfgContextFetcher implements GraphContextFetcher {
+    public identifier = 'bfg'
     private loadedBFG: Promise<MessageHandler>
     private didFailLoading = false
     private latestRepoIndexing: Promise<void[]> = Promise.resolve([])

--- a/vscode/test/completions/run-code-completions-on-dataset.ts
+++ b/vscode/test/completions/run-code-completions-on-dataset.ts
@@ -138,6 +138,7 @@ async function generateCompletionsForDataset(codeSamples: Sample[]): Promise<voi
             const context = {
                 context: sample.context,
                 logSummary: {
+                    strategy: 'fake',
                     duration: 0,
                 },
             }


### PR DESCRIPTION
Adds a new `strategy` string to the context summary field so we can differentiate between lsp-light and bfg

## Test plan

<img width="1044" alt="Screenshot 2023-10-19 at 15 00 39" src="https://github.com/sourcegraph/cody/assets/458591/37ca478a-4006-4c62-8ad6-c308ea46bb94">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
