### PR TITLE
BFG: use RFC 795 naming conventions

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -937,7 +937,7 @@
           "markdownDescription": "Rank autocomplete results with tree-sitter."
         },
         "cody.autocomplete.experimental.graphContext": {
-          "type": "enum",
+          "type": "string",
           "default": null,
           "enum": [
             null,


### PR DESCRIPTION
Previously, we used an ad-hoc naming convention for BFG binaries. Going forward, we will publish binaries using the naming conventions from RFC
795. The new binaries are named

- bfg-macos-arm64
- bfg-macos-x86
- bfg-linux-x86
- bfg-windows-x86


## Test plan

Manually tested by running plugin with BFG enabled and confirmed the following tree structure in the global cache directory
```
❯ pwd
/Users/olafurpg/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai
❯ tree
.
└── bfg
   └── bfg-0.1.0-macos-arm64
```

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
