### PR TITLE
Agent: exist process when stdout/stdin close

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -6,6 +6,12 @@ const agent = new Agent()
 
 console.log = console.error
 
+// Force the agent process to exit when stdin/stdout close as an attempt to
+// prevent zombie agent processes. We experienced this problem when we
+// forcefully exit the IntelliJ process during local `./gradlew :runIde`
+// workflows. We manually confirmed that this logic makes the agent exit even
+// when we forcefully quit IntelliJ
+// https://github.com/sourcegraph/cody/pull/1439#discussion_r1365610354
 process.stdout.on('close', () => process.exit(1))
 process.stdin.on('close', () => process.exit(1))
 

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -6,5 +6,8 @@ const agent = new Agent()
 
 console.log = console.error
 
+process.stdout.on('close', () => process.exit(1))
+process.stdin.on('close', () => process.exit(1))
+
 process.stdin.pipe(agent.messageDecoder)
 agent.messageEncoder.pipe(process.stdout)


### PR DESCRIPTION
We are seeing some cases for JetBrains team where the Cody agent process is still running after IntelliJ exits. I'm not sure if the diff in this PR fixes the problem but I figured it was worth a shot.

I'm open for suggestions to alternative fixes. We have already made changes on the JetBrains side that fix most of the instances of this problem. Since those changes, we have only been able to reproduce this issue with a local sandbox of IntelliJ (not normal installation)

## Test plan

n/a

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
