### PR TITLE
fix: update post process logic for claude instant

### DIFF
--- a/completions-review-tool/data/anthropic-infill-1698086370191.json
+++ b/completions-review-tool/data/anthropic-infill-1698086370191.json
@@ -1,10 +1,11 @@
 [
   {
     "completions": [
-      "    const logger = signale.scope('logger')\n    logger.info(message)"
+      "    const logger = signale.scope('logger')\n    logger.info(message)",
+      "    signale.info(message)"
     ],
-    "elapsed": 1411,
-    "timestamp": "1694493644289",
+    "elapsed": 1290,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "logger.ts",
@@ -14,12 +15,12 @@
   },
   {
     "completions": [
-      "    const date = new Date();\n    const filename = path.join(__dirname, 'date.txt');\n\n    fs.writeFile(filename, date.toDateString(), err => {\n        if (err) {\n            console.error(err);\n            return;\n        }\n        console.log('Date written to', filename);\n    });",
-      "    const date = new Date();\n    const fileName = path.join(__dirname, 'date.txt');\n\n    fs.writeFileSync(fileName, date.toISOString(), 'utf8');",
-      "    const date = new Date();\n    const filename = path.join(__dirname, 'date.txt');\n    require('fs').writeFileSync(filename, date.toUTCString());"
+      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFile(filename, date.toISOString(), err => {\n        if (err) {\n            console.error('Failed to write date', err)\n        } else {\n            console.log('Written date to', filename)\n        }\n    })",
+      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFileSync(\n        filename,\n        date.toLocaleString(),\n        { flag: 'wx' }\n    )",
+      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFileSync(filename, date.toISOString(), 'utf8')"
     ],
-    "elapsed": 3471,
-    "timestamp": "1694493644289",
+    "elapsed": 1917,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "writer.ts",
@@ -29,12 +30,12 @@
   },
   {
     "completions": [
-      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return new vscode.TextLine(this.lines[lineNumber], lineNumber)",
-      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return new vscode.TextLine(this, lineNumber, this.lines[lineNumber - 1])",
-      "        const lineNumber = typeof position === 'number' ? position : position.line;\n        return new vscode.TextLine(this, lineNumber, this.lines[lineNumber - 1]);"
+      "        const lineNumber = this.lineNumber(position);\n        return {\n            text: this.lines[lineNumber - 1],\n            range: new vscode.Range(\n                this.positionAt(lineNumber, 0),\n                this.positionAt(lineNumber, this.lines[lineNumber].length)\n            )\n        };",
+      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return {\n            text: this.lines[lineNumber],\n            range: new vscode.Range(lineNumber, 0, lineNumber, this.lines[lineNumber].length)\n        }",
+      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return new vscode.TextLine(this.lines[lineNumber], lineNumber)"
     ],
-    "elapsed": 4604,
-    "timestamp": "1694493644289",
+    "elapsed": 1847,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "text-document.ts",
@@ -44,12 +45,11 @@
   },
   {
     "completions": [
-      "        try {\n                return require('os').platform();\n            } catch (err) {\n                return null;\n            }\n        } else {\n            return window.navigator.platform;\n        }",
       "        try {\n                return execFileSync('uname', ['-s']).toString().trim()\n            } catch (err) {\n                return null\n            }\n        } else {\n            return window.navigator.platform\n        }",
-      "        try {\n                return execFileSync('uname', ['-s']).toString().trim();\n            } catch (err) {\n                return null;\n            }\n        } else {\n            return window.navigator.platform;\n        }"
+      "        try {\n                return require('os').platform()\n            } catch (err) {\n                return null\n            }\n        } else {\n            return null\n        }"
     ],
-    "elapsed": 1539,
-    "timestamp": "1694493644289",
+    "elapsed": 1301,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "getOs.ts",
@@ -61,8 +61,8 @@
     "completions": [
       "    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;"
     ],
-    "elapsed": 920,
-    "timestamp": "1694493644289",
+    "elapsed": 746,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "isDarkColorScheme.ts",
@@ -72,23 +72,23 @@
   },
   {
     "completions": [
-      "    const min = Math.min(a, b);"
+      "    const min = Math.min(a, b)"
     ],
-    "elapsed": 860,
-    "timestamp": "1694493644289",
+    "elapsed": 1087,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "twoNums.ts",
       "languageId": "typescript",
-      "content": "function twoSum(a: number, b: number): number {\n    const sum = a + b\n    console.log(sum)\n    return sum\n}\n\nfunction minNum(a: number, b: number): number {\n    ️🔥\n    console.log(min)\n    return min\n}\n\nfunction maxNum(a: number, b: number): number {\n    const max = Math.max(a, b)\n    console.log(min)\n    return max\n}"
+      "content": "function twoSum(a: number, b: number): number {\n    const sum = a + b\n    console.log(sum)\n    return sum\n}\n\nfunction minNum(a: number, b: number): number {\n    ️🔥\n    console.log(min)\n    return min\n}\n\nfunction maxNum(a: number, b: number): number {\n    const max = Math.max(a, b)\n    console.log(max)\n    return max\n}"
     }
   },
   {
     "completions": [
       "// A function returns the sum of two numbers"
     ],
-    "elapsed": 2404,
-    "timestamp": "1694493644289",
+    "elapsed": 893,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "comment.ts",
@@ -98,10 +98,10 @@
   },
   {
     "completions": [
-      "const numbers = [5, 3, 6, 2, 10];"
+      "const array = [5, 3, 6, 2, 10];"
     ],
-    "elapsed": 724,
-    "timestamp": "1694493644289",
+    "elapsed": 851,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "LineAfterCompletedComment.ts",
@@ -111,10 +111,10 @@
   },
   {
     "completions": [
-      " calculate the difference of two numbers"
+      "function logSum(a: number, b: number): void {"
     ],
-    "elapsed": 1236,
-    "timestamp": "1694493644289",
+    "elapsed": 934,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "LineAfterIncompleteComment.ts",
@@ -124,10 +124,10 @@
   },
   {
     "completions": [
-      "function myFunction() {"
+      "function logGreeting() {"
     ],
-    "elapsed": 716,
-    "timestamp": "1694493644289",
+    "elapsed": 1319,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "LineAfterIncompleteCommentInEmptyDocs.ts",
@@ -139,8 +139,8 @@
     "completions": [
       "    return window.location.host === 'localhost' || window.location.host === '127.0.0.1';"
     ],
-    "elapsed": 819,
-    "timestamp": "1694493644289",
+    "elapsed": 956,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "isLocalhost.ts",
@@ -150,10 +150,10 @@
   },
   {
     "completions": [
-      "     * Wether to trim whitespace from the completion results"
+      "     * Wether to trim leading and trailing whitespace from suggestions"
     ],
-    "elapsed": 3071,
-    "timestamp": "1694493644289",
+    "elapsed": 1084,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [],
       "fileName": "interface.ts",
@@ -163,12 +163,11 @@
   },
   {
     "completions": [
-      "    return text.toLowerCase().replace(/[^\\w-]+/g, '')",
-      "    return text.toLowerCase().replace(/[^\\w-]/g, '');",
-      "    return text.toLowerCase().replace(/[^\\w-]+/g, '');"
+      "    return text.toLowerCase().replace(/[^\\w-]+/g, '');",
+      "    return text.toLowerCase().replace(/[^\\w-]+/g, '')"
     ],
-    "elapsed": 1540,
-    "timestamp": "1694493644289",
+    "elapsed": 1849,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [
         {
@@ -195,12 +194,12 @@
   },
   {
     "completions": [
-      "    var mockAnthropicResponseLines = []string{\"event: completion\", \"data: suggestion1\"}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n\n    var receivedEvents []types.CompletionResponse\n\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        receivedEvents = append(receivedEvents, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    require.Equal(t, 2, len(receivedEvents))\n    assert.Equal(t, \"completion\", receivedEvents[0].StopReason)\n    assert.Equal(t, \"suggestion1\", receivedEvents[0].Completion)\n}",
-      "    var mockAnthropicResponseLines = []string{`{\"Completion\": \"hello\"}`, `{\"StopReason\": \"Done\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n\n    var receivedResponses []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        receivedResponses = append(receivedResponses, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 2, len(receivedResponses))\n    assert.Equal(t, \"hello\", receivedResponses[0].Completion)\n    assert.Equal(t, types.StopReasonDone, receivedResponses[1].StopReason)\n}",
-      "    var mockAnthropicResponseLines = []string{`{\"Completion\": \"func\", \"StopReason\": \"\"}`, `{\"Completion\": \"(\", \"StopReason\": \"\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n\n    var completions []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completions = append(completions, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 2, len(completions))\n    assert.Equal(t, \"func\", completions[0].Completion)\n    assert.Equal(t, \"(\", completions[1].Completion)\n}"
+      "    mockResponseLines := []string{`{\"completion\":\"func main() \",\"stopReason\":\"Complete\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockResponseLines))\n    var events []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        events = append(events, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 1, len(events))\n    assert.Equal(t, \"func main() \", events[0].Completion)\n    assert.Equal(t, \"Complete\", events[0].StopReason)\n}",
+      "    var mockAnthropicResponseLines = []string{`{\"Completion\": \"func\", \"StopReason\": \"\"}`, `{\"Completion\": \"\", \"StopReason\": \"stream ended\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    var completions []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completions = append(completions, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, len(completions), 2)\n    assert.Equal(t, completions[0].Completion, \"func\")\n    assert.Equal(t, completions[1].StopReason, \"stream ended\")\n}",
+      "    mockAnthropicResponseLines := []string{`{\"Completion\":\"func main() {}\",\"StopReason\":\"Done\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    var completions []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completions = append(completions, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 1, len(completions))\n    assert.Equal(t, \"func main() {}\", completions[0].Completion)\n    assert.Equal(t, \"Done\", completions[0].StopReason)\n}"
     ],
-    "elapsed": 4303,
-    "timestamp": "1694493644289",
+    "elapsed": 4430,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [
         {
@@ -227,11 +226,10 @@
   },
   {
     "completions": [
-      "    issues = api_client.get_issues(state=\"open\")\n    assert isinstance(issues, list)\n    assert len(issues) > 0",
-      "    issues = api_client.get_issues(state=\"open\")\n    assert issues"
+      "    issues = api_client.github.get_issues(state=\"open\")"
     ],
-    "elapsed": 1540,
-    "timestamp": "1694493644289",
+    "elapsed": 4074,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [
         {
@@ -262,10 +260,10 @@
   },
   {
     "completions": [
-      "            tool_cls.create("
+      "            tool_cls.from_toolkit(self)"
     ],
-    "elapsed": 1265,
-    "timestamp": "1694493644289",
+    "elapsed": 2036,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [
         {
@@ -288,11 +286,12 @@
   },
   {
     "completions": [
-      "                providerConfig,\n                                statusBar: noopStatusBar,\n                                history: new History(),\n                        })\n\n                        const completions = await completionProvider.provideCompletionItems(\n                                codeWithoutCursor,\n                                context,\n                                token\n                        )\n\n                        return {\n                                requests,\n                                completions: completions as vscode.InlineCompletionItem[]\n                        }\n                }",
-      "                providerConfig,\n                history: new History(),\n                statusBar: noopStatusBar,"
+      "                providerConfig,\n                history: new History(),\n                noopStatusBar,",
+      "                ...providerConfig,\n                statusBar: noopStatusBar",
+      "                config: providerConfig,\n                statusBar: noopStatusBar"
     ],
-    "elapsed": 4273,
-    "timestamp": "1694493644289",
+    "elapsed": 1712,
+    "timestamp": "1698086370191",
     "sample": {
       "context": [
         {
@@ -314,7 +313,7 @@
       ],
       "fileName": "src/completions/completion.test.ts",
       "languageId": "typescript",
-      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nvi.mock('./context-embeddings.ts', () => ({\n    getContextFromEmbeddings: () => [],\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                contextWindowTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
+      "content": "import { beforeEach, describe, expect, it, vi } from 'vitest'\nimport type * as vscode from 'vscode'\nimport { URI } from 'vscode-uri'\n\nimport {\n    CompletionParameters,\n    CompletionResponse,\n} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'\n\nimport { vsCodeMocks } from '../testutils/mocks'\n\nimport { CodyCompletionItemProvider } from '.'\nimport { History } from './history'\nimport { createProviderConfig } from './providers/anthropic'\n\nvi.mock('vscode', () => ({\n    ...vsCodeMocks,\n    InlineCompletionTriggerKind: {\n        Invoke: 0,\n        Automatic: 1,\n    },\n    workspace: {\n        ...vsCodeMocks.workspace,\n        asRelativePath(path: string) {\n            return path\n        },\n        onDidChangeTextDocument() {\n            return null\n        },\n    },\n    window: {\n        ...vsCodeMocks.window,\n        visibleTextEditors: [],\n        tabGroups: { all: [] },\n    },\n}))\n\nfunction createCompletionResponse(completion: string): CompletionResponse {\n    return {\n        completion: truncateMultilineString(completion),\n        stopReason: 'unknown',\n    }\n}\n\nconst noopStatusBar = {\n    startLoading: () => () => {},\n} as any\n\nconst CURSOR_MARKER = '<cursor>'\n\n/**\n * A helper function used so that the below code example can be intended in code but will have their\n * prefix stripped. This is similar to what Vitest snapshots use but without the prettier hack so that\n * the starting ` is always in the same line as the function name :shrug:\n */\nfunction truncateMultilineString(string: string): string {\n    const lines = string.split('\n')\n\n    if (lines.length <= 1) {\n        return string\n    }\n\n    if (lines[0] !== '') {\n        return string\n    }\n\n    const regex = lines[1].match(/^ */)\n\n    const indentation = regex ? regex[0] : ''\n    return lines\n        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))\n        .slice(1)\n        .join('\n')\n}\n\ndescribe('Cody completions', () => {\n    /**\n     * A test helper to trigger a completion request. The code example must include\n     * a pipe character to denote the current cursor position.\n     *\n     * @example\n     *   complete(`\n     * async function foo() {\n     *   ${CURSOR_MARKER}\n     * }`)\n     */\n    let complete: (\n        code: string,\n        responses?: CompletionResponse[] | 'stall',\n        languageId?: string,\n        context?: vscode.InlineCompletionContext,\n    ) => Promise<{\n        requests: CompletionParameters[]\n        completions: vscode.InlineCompletionItem[]\n    }>\n    beforeEach(() => {\n        complete = async (\n            code: string,\n            responses?: CompletionResponse[] | 'stall',\n            languageId: string = 'typescript',\n            context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined },\n        ): Promise<{\n            requests: CompletionParameters[]\n            completions: vscode.InlineCompletionItem[]\n        }> => {\n            code = truncateMultilineString(code)\n\n            const requests: CompletionParameters[] = []\n            let requestCounter = 0\n            const completionsClient: any = {\n                complete(params: CompletionParameters): Promise<CompletionResponse> {\n                    requests.push(params)\n                    if (responses === 'stall') {\n                        // Creates a stalling request that never responds\n                        return new Promise(() => {})\n                    }\n                    return Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })\n                },\n            }\n            const providerConfig = createProviderConfig({\n                completionsClient,\n                maxContextTokens: 2048,\n            })\n            const completionProvider = new CodyCompletionItemProvider({\n                ️🔥\n            })\n\n            if (!code.includes(CURSOR_MARKER)) {\n                throw new Error('The test code must include a | to denote the cursor position')\n            }\n\n            const cursorIndex = code.indexOf(CURSOR_MARKER)\n            const prefix = code.slice(0, cursorIndex)\n            const suffix = code.slice(cursorIndex + CURSOR_MARKER.length)\n\n            const codeWithoutCursor = prefix + suffix\n\n            const token: any = {\n                onCancellationRequested() {\n                    return null\n                },\n            }\n            const document: any = {\n                filename: 'test.ts',\n                uri: URI.parse('file:///test.ts'),\n                languageId,"
     }
   }
 ]

--- a/completions-review-tool/data/anthropic-infill-1698092878117.json
+++ b/completions-review-tool/data/anthropic-infill-1698092878117.json
@@ -1,11 +1,12 @@
 [
   {
     "completions": [
+      "    const logger = signale.scope('my-logger')\n    logger.info(message)",
       "    const logger = signale.scope('logger')\n    logger.info(message)",
       "    signale.info(message)"
     ],
-    "elapsed": 1290,
-    "timestamp": "1698086370191",
+    "elapsed": 1617,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "logger.ts",
@@ -15,12 +16,12 @@
   },
   {
     "completions": [
-      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFile(filename, date.toISOString(), err => {\n        if (err) {\n            console.error('Failed to write date', err)\n        } else {\n            console.log('Written date to', filename)\n        }\n    })",
-      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFileSync(\n        filename,\n        date.toLocaleString(),\n        { flag: 'wx' }\n    )",
-      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFileSync(filename, date.toISOString(), 'utf8')"
+      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFileSync(filename, date.toISOString(), 'utf8')",
+      "    const date = new Date()\n    const filename = path.join(__dirname, 'date.txt')\n\n    fs.writeFileSync(filename, date.toISOString())",
+      "    const date = new Date();\n    const filename = path.join(__dirname, 'date.txt');\n\n    fs.writeFileSync(filename, date.toISOString(), 'utf8');"
     ],
-    "elapsed": 1917,
-    "timestamp": "1698086370191",
+    "elapsed": 1309,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "writer.ts",
@@ -30,12 +31,10 @@
   },
   {
     "completions": [
-      "        const lineNumber = this.lineNumber(position);\n        return {\n            text: this.lines[lineNumber - 1],\n            range: new vscode.Range(\n                this.positionAt(lineNumber, 0),\n                this.positionAt(lineNumber, this.lines[lineNumber].length)\n            )\n        };",
-      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return {\n            text: this.lines[lineNumber],\n            range: new vscode.Range(lineNumber, 0, lineNumber, this.lines[lineNumber].length)\n        }",
-      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return new vscode.TextLine(this.lines[lineNumber], lineNumber)"
+      "        const lineNumber = typeof position === 'number' ? position : position.line\n        return {\n            text: this.lines[lineNumber],\n            range: new vscode.Range(lineNumber, 0, lineNumber, this.lines[lineNumber].length)\n        }"
     ],
-    "elapsed": 1847,
-    "timestamp": "1698086370191",
+    "elapsed": 1763,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "text-document.ts",
@@ -45,11 +44,12 @@
   },
   {
     "completions": [
-      "        try {\n                return execFileSync('uname', ['-s']).toString().trim()\n            } catch (err) {\n                return null\n            }\n        } else {\n            return window.navigator.platform\n        }",
-      "        try {\n                return require('os').platform()\n            } catch (err) {\n                return null\n            }\n        } else {\n            return null\n        }"
+      "        try {\n                return require('os').platform();\n            } catch (error) {\n                return null;\n            }\n        } else {\n            return window.navigator.platform;\n        }",
+      "        try {\n            return require('os').platform()\n        } catch (err) {\n            return null\n        }\n    } else {\n        return null\n    }",
+      "        try {\n            return require('os').platform();\n        } catch (error) {\n            return null;\n        }\n    } else {\n        return null;\n    }"
     ],
-    "elapsed": 1301,
-    "timestamp": "1698086370191",
+    "elapsed": 1145,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "getOs.ts",
@@ -61,8 +61,8 @@
     "completions": [
       "    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;"
     ],
-    "elapsed": 746,
-    "timestamp": "1698086370191",
+    "elapsed": 865,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "isDarkColorScheme.ts",
@@ -74,8 +74,8 @@
     "completions": [
       "    const min = Math.min(a, b)"
     ],
-    "elapsed": 1087,
-    "timestamp": "1698086370191",
+    "elapsed": 2216,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "twoNums.ts",
@@ -87,8 +87,8 @@
     "completions": [
       "// A function returns the sum of two numbers"
     ],
-    "elapsed": 893,
-    "timestamp": "1698086370191",
+    "elapsed": 1127,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "comment.ts",
@@ -98,10 +98,10 @@
   },
   {
     "completions": [
-      "const array = [5, 3, 6, 2, 10];"
+      "function bubbleSort(array) {"
     ],
-    "elapsed": 851,
-    "timestamp": "1698086370191",
+    "elapsed": 1006,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "LineAfterCompletedComment.ts",
@@ -111,10 +111,10 @@
   },
   {
     "completions": [
-      "function logSum(a: number, b: number): void {"
+      "function printSum(a: number, b: number): void {"
     ],
-    "elapsed": 934,
-    "timestamp": "1698086370191",
+    "elapsed": 1047,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "LineAfterIncompleteComment.ts",
@@ -124,10 +124,10 @@
   },
   {
     "completions": [
-      "function logGreeting() {"
+      "function myFunction() {"
     ],
-    "elapsed": 1319,
-    "timestamp": "1698086370191",
+    "elapsed": 812,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "LineAfterIncompleteCommentInEmptyDocs.ts",
@@ -137,10 +137,10 @@
   },
   {
     "completions": [
-      "    return window.location.host === 'localhost' || window.location.host === '127.0.0.1';"
+      "    return window.location.host === 'localhost';"
     ],
-    "elapsed": 956,
-    "timestamp": "1698086370191",
+    "elapsed": 766,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "isLocalhost.ts",
@@ -150,10 +150,10 @@
   },
   {
     "completions": [
-      "     * Wether to trim leading and trailing whitespace from suggestions"
+      "     * Wether to trim whitespace from the completion results"
     ],
-    "elapsed": 1084,
-    "timestamp": "1698086370191",
+    "elapsed": 974,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [],
       "fileName": "interface.ts",
@@ -163,11 +163,12 @@
   },
   {
     "completions": [
+      "    return text.toLowerCase().replace(/[^a-z0-9-_]/g, '');",
       "    return text.toLowerCase().replace(/[^\\w-]+/g, '');",
       "    return text.toLowerCase().replace(/[^\\w-]+/g, '')"
     ],
-    "elapsed": 1849,
-    "timestamp": "1698086370191",
+    "elapsed": 1569,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [
         {
@@ -194,12 +195,12 @@
   },
   {
     "completions": [
-      "    mockResponseLines := []string{`{\"completion\":\"func main() \",\"stopReason\":\"Complete\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockResponseLines))\n    var events []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        events = append(events, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 1, len(events))\n    assert.Equal(t, \"func main() \", events[0].Completion)\n    assert.Equal(t, \"Complete\", events[0].StopReason)\n}",
-      "    var mockAnthropicResponseLines = []string{`{\"Completion\": \"func\", \"StopReason\": \"\"}`, `{\"Completion\": \"\", \"StopReason\": \"stream ended\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    var completions []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completions = append(completions, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, len(completions), 2)\n    assert.Equal(t, completions[0].Completion, \"func\")\n    assert.Equal(t, completions[1].StopReason, \"stream ended\")\n}",
-      "    mockAnthropicResponseLines := []string{`{\"Completion\":\"func main() {}\",\"StopReason\":\"Done\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    var completions []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completions = append(completions, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 1, len(completions))\n    assert.Equal(t, \"func main() {}\", completions[0].Completion)\n    assert.Equal(t, \"Done\", completions[0].StopReason)\n}"
+      "    var mockAnthropicResponseLines = []string{`{\"completion\":\"func main() {\"}`, `{\"completion\":\"fmt.Println(\\\"Hello World!\\\")\"}`, `{\"stopReason\":\"Complete\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    completions := []types.CompletionResponse{}\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completions = append(completions, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 3, len(completions))\n    assert.Equal(t, \"func main() {\", completions[0].Completion)\n    assert.Equal(t, \"fmt.Println(\\\"Hello World!\\\")\", completions[1].Completion)\n    assert.Equal(t, types.StopReasonComplete, completions[2].StopReason)\n}",
+      "    var mockAnthropicResponseLines = []string{`{\"completion\":\"func\", \"stopReason\":\"Complete\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    var completionsReceived []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completionsReceived = append(completionsReceived, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 1, len(completionsReceived))\n    assert.Equal(t, \"func\", completionsReceived[0].Completion)\n    assert.Equal(t, \"Complete\", completionsReceived[0].StopReason)\n}",
+      "    var mockAnthropicResponseLines = []string{`{\"Completion\":\"func main() {}\",\"StopReason\":\"Done\"}`}\n\n    mockClient := getMockClient(linesToResponse(mockAnthropicResponseLines))\n    var completionsReceived []types.CompletionResponse\n    err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error {\n        completionsReceived = append(completionsReceived, event)\n        return nil\n    })\n\n    require.NoError(t, err)\n    assert.Equal(t, 1, len(completionsReceived))\n    assert.Equal(t, \"func main() {}\", completionsReceived[0].Completion)\n    assert.Equal(t, \"Done\", completionsReceived[0].StopReason)\n}"
     ],
-    "elapsed": 4430,
-    "timestamp": "1698086370191",
+    "elapsed": 3757,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [
         {
@@ -226,10 +227,11 @@
   },
   {
     "completions": [
+      "    issues = api_client.github.get_issues(state=\"open\")\n    assert issues",
       "    issues = api_client.github.get_issues(state=\"open\")"
     ],
-    "elapsed": 4074,
-    "timestamp": "1698086370191",
+    "elapsed": 1706,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [
         {
@@ -262,8 +264,8 @@
     "completions": [
       "            tool_cls.from_toolkit(self)"
     ],
-    "elapsed": 2036,
-    "timestamp": "1698086370191",
+    "elapsed": 1159,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [
         {
@@ -286,12 +288,12 @@
   },
   {
     "completions": [
-      "                providerConfig,\n                history: new History(),\n                noopStatusBar,",
-      "                ...providerConfig,\n                statusBar: noopStatusBar",
+      "                config: providerConfig,\n                statusBar: noopStatusBar,\n                history: new History(),",
+      "                providerConfig,\n                statusBar: noopStatusBar,\n                history: new History(),",
       "                config: providerConfig,\n                statusBar: noopStatusBar"
     ],
-    "elapsed": 1712,
-    "timestamp": "1698086370191",
+    "elapsed": 1658,
+    "timestamp": "1698092878117",
     "sample": {
       "context": [
         {

--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -83,7 +83,7 @@ describe('[getInlineCompletions] common', () => {
         )
         expect(requests).toHaveLength(3)
         const messages = requests[0].messages
-        expect(messages.at(-1)!.text).toBe('<_cursor_> replaced:<CODE5711>class Range {\n\n\n    <_cursor_>')
+        expect(messages.at(-1)!.text).toBe('<CODE5711>class Range {')
     })
 
     test('uses a more complex prompt for larger files', async () => {
@@ -122,8 +122,8 @@ describe('[getInlineCompletions] common', () => {
         expect(messages.at(-1)).toMatchInlineSnapshot(`
             {
               "speaker": "assistant",
-              "text": "<_cursor_> replaced:<CODE5711>    constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
-                    this.startLine = <_cursor_>",
+              "text": "<CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+                    this.startLine =",
             }
         `)
         expect(requests[0].stopSequences).toEqual(['\n\nHuman:', '</CODE5711>', MULTILINE_STOP_SEQUENCE])

--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -83,7 +83,7 @@ describe('[getInlineCompletions] common', () => {
         )
         expect(requests).toHaveLength(3)
         const messages = requests[0].messages
-        expect(messages.at(-1)!.text).toBe('<CODE5711>class Range {\n')
+        expect(messages.at(-1)!.text).toBe('<_cursor_> replaced:<CODE5711>class Range {\n\n\n    <_cursor_>')
     })
 
     test('uses a more complex prompt for larger files', async () => {
@@ -122,8 +122,8 @@ describe('[getInlineCompletions] common', () => {
         expect(messages.at(-1)).toMatchInlineSnapshot(`
             {
               "speaker": "assistant",
-              "text": "<CODE5711>constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
-                    this.startLine =",
+              "text": "<_cursor_> replaced:<CODE5711>    constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+                    this.startLine = <_cursor_>",
             }
         `)
         expect(requests[0].stopSequences).toEqual(['\n\nHuman:', '</CODE5711>', MULTILINE_STOP_SEQUENCE])

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -96,7 +96,7 @@ export class AnthropicProvider extends Provider {
         const introMessages: Message[] = [
             {
                 speaker: 'human',
-                text: `You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.`,
+                text: 'You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.',
             },
             {
                 speaker: 'assistant',

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -216,6 +216,10 @@ export class AnthropicProvider extends Provider {
             // leading `\n` followed by whitespace that Claude might add.
             completion = completion.replace(/^\s*\n\s*/, '')
         } else {
+            // prevent normalizeStartLine from removing the starting new line
+            if (completion.startsWith('\n')) {
+                completion = '\n' + completion.trimStart()
+            }
             completion = trimLeadingWhitespaceUntilNewline(completion)
         }
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -74,16 +74,14 @@ export class AnthropicProvider extends Provider {
         const infillSuffix = this.options.docContext.suffix
         const relativeFilePath = vscode.workspace.asRelativePath(this.options.document.fileName)
 
-        const hasTrailingWhiteSpace = tail.raw !== tail.raw?.trimEnd()
-
         const prefixMessagesWithInfill: Message[] = [
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${relativeFilePath}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:\n\`\`\`\n${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}\n\`\`\``,
+                text: `Below is the code from file path ${relativeFilePath}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code enclosed in <completion_request> tags:\n<completion_request>${infillPrefix}${infillBlock}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}</completion_request>`,
             },
             {
                 speaker: 'assistant',
-                text: `${OPENING_CODE_TAG}${infillBlock}${hasTrailingWhiteSpace ? CLOSING_CODE_TAG : ''}`,
+                text: `${OPENING_CODE_TAG}`,
             },
         ]
 
@@ -114,8 +112,8 @@ export class AnthropicProvider extends Provider {
                     speaker: 'human',
                     text:
                         'symbol' in snippet && snippet.symbol !== ''
-                            ? `Documentation context for \`${snippet.symbol}\`:\n${snippet.content}`
-                            : `File context from '${snippet.fileName}':\n${snippet.content}`,
+                            ? `Documentation context for \`${snippet.symbol}\`: <shared_context>${snippet.content}</shared_context>`
+                            : `File context from '${snippet.fileName}': <shared_context>${snippet.content}</shared_context>`,
                 },
                 {
                     speaker: 'assistant',

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -216,10 +216,6 @@ export class AnthropicProvider extends Provider {
             // leading `\n` followed by whitespace that Claude might add.
             completion = completion.replace(/^\s*\n\s*/, '')
         } else {
-            // prevent normalizeStartLine from removing the starting new line
-            if (completion.startsWith('\n')) {
-                completion = '\n' + completion.trimStart()
-            }
             completion = trimLeadingWhitespaceUntilNewline(completion)
         }
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -10,10 +10,12 @@ import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import {
     CLOSING_CODE_TAG,
     extractFromCodeBlock,
+    fixBadCompletionStart,
     getHeadAndTail,
     MULTILINE_STOP_SEQUENCE,
     OPENING_CODE_TAG,
     PrefixComponents,
+    trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
 import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'
 import { InlineCompletionItemWithAnalytics } from '../text-processing/process-inline-completions'
@@ -213,7 +215,12 @@ export class AnthropicProvider extends Provider {
             // The prefix already contains a `\n` that Claude was not aware of, so we remove any
             // leading `\n` followed by whitespace that Claude might add.
             completion = completion.replace(/^\s*\n\s*/, '')
+        } else {
+            completion = trimLeadingWhitespaceUntilNewline(completion)
         }
+
+        // Remove bad symbols from the start of the completion string.
+        completion = fixBadCompletionStart(completion)
 
         return completion
     }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -74,6 +74,8 @@ export class AnthropicProvider extends Provider {
         const infillSuffix = this.options.docContext.suffix
         const relativeFilePath = vscode.workspace.asRelativePath(this.options.document.fileName)
 
+        const hasTrailingWhiteSpace = tail.raw !== tail.raw?.trimEnd()
+
         const prefixMessagesWithInfill: Message[] = [
             {
                 speaker: 'human',
@@ -81,7 +83,7 @@ export class AnthropicProvider extends Provider {
             },
             {
                 speaker: 'assistant',
-                text: `${OPENING_CODE_TAG}${infillBlock}${CLOSING_CODE_TAG}`,
+                text: `${OPENING_CODE_TAG}${infillBlock}${hasTrailingWhiteSpace ? CLOSING_CODE_TAG : ''}`,
             },
         ]
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -67,9 +67,10 @@ export class AnthropicProvider extends Provider {
         const { head, tail, overlap } = getHeadAndTail(this.options.docContext.prefix)
 
         // Infill block represents the code we want the model to complete
-        const infillBlock = `${tail.raw}`
+        const infillBlock = tail.raw
         // code before the cursor, without the code extracted for the infillBlock
-        const infillPrefix = head.raw?.startsWith(tail.trimmed) ? '' : `${head.raw}`
+        // TODO remove this after the bug where head and tail are duplicated
+        const infillPrefix = head.trimmed === tail.trimmed ? '' : head.raw
         // code after the cursor
         const infillSuffix = this.options.docContext.suffix
         const relativeFilePath = vscode.workspace.asRelativePath(this.options.document.fileName)
@@ -77,11 +78,11 @@ export class AnthropicProvider extends Provider {
         const prefixMessagesWithInfill: Message[] = [
             {
                 speaker: 'human',
-                text: `Below is the code from file path ${relativeFilePath}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code enclosed in <completion_request> tags:\n<completion_request>${infillPrefix}${infillBlock}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}</completion_request>`,
+                text: `Below is the code from file path ${relativeFilePath}. Review the code around the ${OPENING_CODE_TAG} tag to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose code only inside ${OPENING_CODE_TAG} precisely without duplicating existing implementations. Here is the code enclosed in <completion_request> tags:\n<completion_request>\n${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}\n</completion_request>`,
             },
             {
                 speaker: 'assistant',
-                text: `${OPENING_CODE_TAG}`,
+                text: `<_cursor_> replaced:${OPENING_CODE_TAG}${infillBlock}<_cursor_>`,
             },
         ]
 
@@ -95,7 +96,7 @@ export class AnthropicProvider extends Provider {
         const introMessages: Message[] = [
             {
                 speaker: 'human',
-                text: `You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in ${OPENING_CODE_TAG} tags. You only response with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.`,
+                text: `You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.`,
             },
             {
                 speaker: 'assistant',
@@ -112,12 +113,12 @@ export class AnthropicProvider extends Provider {
                     speaker: 'human',
                     text:
                         'symbol' in snippet && snippet.symbol !== ''
-                            ? `Documentation context for \`${snippet.symbol}\`: <shared_context>${snippet.content}</shared_context>`
-                            : `File context from '${snippet.fileName}': <shared_context>${snippet.content}</shared_context>`,
+                            ? `Documentation for \`${snippet.symbol}\`:\n<shared_context>${snippet.content}</shared_context>`
+                            : `File context from '${snippet.fileName}':\n<shared_context>${snippet.content}</shared_context>`,
                 },
                 {
                     speaker: 'assistant',
-                    text: 'I will refer to this code to complete your next request.',
+                    text: 'Context reviewed.',
                 },
             ]
             const numSnippetChars = messagesToText(snippetMessages).length + 1

--- a/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
+++ b/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
@@ -29,7 +29,7 @@ export function parseAndTruncateCompletion(
         useTreeSitter = true,
     } = params
 
-    const insertTextBeforeTruncation = normalizeStartLine(completion, prefix)
+    const insertTextBeforeTruncation = multiline ? normalizeStartLine(completion, prefix) : completion
 
     const parsed = parseCompletion({
         completion: { insertText: insertTextBeforeTruncation },

--- a/vscode/test/completions/mock-vscode.ts
+++ b/vscode/test/completions/mock-vscode.ts
@@ -26,13 +26,16 @@ const vscodeMock = {
                             return true
                         case 'cody.serverEndpoint':
                             return 'https://sourcegraph.com/'
-                        // case 'cody.autocomplete.advanced.provider':
-                        //     return 'fireworks'
+                        case 'cody.autocomplete.advanced.provider':
+                            return 'anthropic'
                         // case 'cody.autocomplete.advanced.model':
                         //     return 'llama-code-13b'
                         default:
                             return undefined
                     }
+                },
+                update() {
+                    return undefined
                 },
             }
         },


### PR DESCRIPTION
fix: use full infill block and adjust prefix

- fix prompt structure order, context should be shared after the role assigning
- empty prefix if it contains the infill block for issue where first line is duplicated 
- Simplify prompt messages to focus on providing clear context
- Add CLOSING tag for Assistant's infill block to preserve ending whitespace 
- This also fixed issues where multi-line autocomplete gets cut off.
- remove tags for context code as that might cause confusion for claude

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Fix: show multi-line completion after `{`:

![image](https://github.com/sourcegraph/cody/assets/68532117/20e6a072-0dde-4dbc-9856-1a043ce77dd5)

Fix: show multi-line completions the line after `{`

![image](https://github.com/sourcegraph/cody/assets/68532117/cfc41c9b-43bb-43cb-ab75-523760a0289f)

