### PR TITLE
feat: auto format code after applying edits

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Code applied from the `/edit` command will be formatted automatically through the VS Code `formatDocument` API. [pull/1441](https://github.com/sourcegraph/cody/pull/1441)
+
 ### Fixed
 
 - User selection in active editor will not be replaced by smart selections for the `/edit` command. [pull/1429](https://github.com/sourcegraph/cody/pull/1429)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -305,6 +305,16 @@ export class FixupController
             const codeCount = countCode(replacementText)
             const source = task.source
             telemetryService.log('CodyVSCodeExtension:fixup:applied', { ...codeCount, source })
+
+            // format the selected area after applying edits
+            const range = new vscode.Range(
+                new vscode.Position(task.selectionRange.start.line, 0),
+                new vscode.Position(
+                    task.selectionRange.start.line + codeCount.lineCount,
+                    task.selectionRange.end.character
+                )
+            )
+            await vscode.commands.executeCommand('editor.action.formatDocument', range)
         }
 
         // TODO: is this the right transition for being all done?


### PR DESCRIPTION
Reported / requested in https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1697672986475259?thread_ts=1697672318.465339&cid=C05MW2TMYAV and https://sourcegraph.slack.com/archives/C03CSAER9LK/p1697148745798389?thread_ts=1696469865.956429&cid=C03CSAER9LK

fix: format code after applying edits

Automatically format the edited code after applying edits. 

A new range is calculated to format the selected area where fixes were applied.

The document is then formatted using the new range.

This commit fixes an issue where code was not formatted after applying quick fixes.

### Demo

https://github.com/sourcegraph/cody/assets/68532117/f5179669-5521-474e-bdde-38f328bb078b


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Perform an edit and confirm the edited area was formatted correctly.