### PR TITLE
refactor: update preamble rules and mixin

### DIFF
--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -6,32 +6,25 @@ export interface Preamble {
     answer: string
 }
 
-const actions = `You are Cody, an AI-powered coding assistant created by Sourcegraph. You work inside a text editor. You have access to my currently open files. You perform the following actions:
-- Answer general programming questions.
-- Answer questions about the code that I have provided to you.
-- Generate code that matches a written description.
-- Explain what a section of code does.`
+const actions =
+    'You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.'
 
-const rules = `In your responses, obey the following rules:
-- If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
-- Be as brief and concise as possible without losing clarity.
-- All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
-- Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
-- Only reference file names, repository names or URLs if you are sure they exist.`
+const rules = `Important rules to follow in all your responses:
+- All code snippets must be markdown-formatted, and enclosed in triple backticks.
+- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.
+- Do not make any assumptions about the code and file names or any misleading information.`
 
-const multiRepoRules = `In your responses, obey the following rules:
-- If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
-- Be as brief and concise as possible without losing clarity.
-- All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
-- Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
-- If you do not have access to a repository, tell me to add additional repositories to the chat context using repositories selector below the input box to help you answer the question.
-- Only reference file names, repository names or URLs if you are sure they exist.`
+const multiRepoRules = `Important rules to follow in all your responses:
+- All code snippets must be markdown-formatted, and enclosed in triple backticks.
+- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.
+- Do not make any assumptions about the code and file names or any misleading information.
+- If you do not have access to a repository, tell me to add additional repositories to the chat context using repositories selector below the input box to help you answer the question.`
 
-const answer = `Understood. I am Cody, an AI assistant made by Sourcegraph to help with programming tasks.
-I work inside a text editor. I have access to your currently open files in the editor.
+const answer = `Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.
+I am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.
 I will answer questions, explain code, and generate code as concisely and clearly as possible.
-My responses will be formatted using Markdown syntax for code blocks.
-I will acknowledge when I don't know an answer or need more context.`
+I will enclose any code snippets I provide in markdown backticks.
+I will let you know if I need more information to answer a question.`
 
 /**
  * Creates and returns an array of two messages: one from a human, and the supposed response from the AI assistant.
@@ -45,14 +38,11 @@ export function getPreamble(codebase: string | undefined, customPreamble?: Pream
     const preambleResponse = [answerText]
 
     if (codebase) {
-        const codebasePreamble =
-            `You have access to the \`${codebase}\` repository. You are able to answer questions about the \`${codebase}\` repository. ` +
-            `I will provide the relevant code snippets from the \`${codebase}\` repository when necessary to answer my questions. ` +
-            `If I ask you a question about a repository other than \`${codebase}\`, tell me to add additional repositories to the chat context using the repositories selector below the input box to help you answer the question.`
+        const codebasePreamble = `We are currently working in a repository called \`${codebase}\`. I will share any code snippets I can find from this codebase with you to answer my questions.`
 
         preamble.push(codebasePreamble)
         preambleResponse.push(
-            `I have access to the \`${codebase}\` repository and can answer questions about its files.`
+            `Understood. I will answer your questions using context you will share from the \`${codebase}\` repository.`
         )
     }
 

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -51,6 +51,15 @@ export function languagePromptMixin(languageCode: string): PromptMixin {
     return new PromptMixin(`(Reply as Cody, a coding assistant developed by Sourcegraph${languagePrompt}) `)
 }
 
+/**
+ * Creates a default prompt mixin that instructs Cody to identify itself and avoid hallucinations.
+ */
+export function defaultPromptMixin(): PromptMixin {
+    const identity = 'Reply as Cody, a coding assistant developed by Sourcegraph.'
+    const hallucinate = 'Never make any assumptions nor provide any misleading or hypothetical examples.'
+    return new PromptMixin(`(${identity} ${hallucinate})`)
+}
+
 export function newPromptMixin(text: string): PromptMixin {
     return new PromptMixin(text)
 }

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { Recipe } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { languagePromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
+import { defaultPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import type { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/browserClient'
 import type { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
@@ -39,7 +39,7 @@ export interface PlatformContext {
 
 export function activate(context: vscode.ExtensionContext, platformContext: PlatformContext): ExtensionApi {
     const api = new ExtensionApi()
-    PromptMixin.add(languagePromptMixin(vscode.env.language))
+    PromptMixin.add(defaultPromptMixin())
 
     start(context, platformContext)
         .then(disposable => {


### PR DESCRIPTION
Updating current preamble, rules, and prompt mixin with new findings from https://github.com/sourcegraph/cody/pull/907.

Issue 1: Cody hallucinates about file path and code

One of the main issues we saw in Chat is Cody hallucinating about files and code that do not exist in the shared context.

I noticed this is mainly because of how we phrased our context, as Cody do not understand the relationship between each code snippet we share with them. For more information, see https://github.com/sourcegraph/cody/pull/907#discussion_r1320490212

One of the many prompts I've tried to prevent hallucination is to add `Do not make any assumptions about the code and file names or any misleading information` to the question, which has been working well for me. This is also the prompt we added to all our commands. [A customer has also confirmed](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1697747191354829?thread_ts=1697626152.033629&cid=C04MSD3DP5L) that adding this to their questions stopped Cody from hallucinating and received better responses from Chat, this is why I propose adding it to `PromptMixin`, which will be added to the start of every question (instead of Preabmle, which is added to the start of the session and will get left out as the conversation gets longer.)

I don't think this will be 100% hallucination-proof, but it works a lot better than what we currently have.

#### Before

- lib/share/ui/src/components/CodeBlock is not the correct path

![Screenshot 2023-10-18 at 2 45 49 PM](https://github.com/sourcegraph/cody/assets/68532117/9e8b6438-b37c-4745-a5f5-c6abcc2ceec8)


#### After

-  make well-informed answers

![Screenshot 2023-10-18 at 2 47 07 PM](https://github.com/sourcegraph/cody/assets/68532117/87d8b9ce-b8bc-4298-a7be-9a6957a58c36)

Issue 2: The current preambles need to be updated, and not working as intended most of the times.

Addressed by this PR with the following changes:
- Simplified the preamble actions and rules text to be more concise.
- Removed redundant rules that will always be false, e.g. Cody never has direct access to your file or repository even when we tell them they do. 
- Removed detailed instructions about code formatting and limitations, leaving just the essential rules
- Shortened the preamble answer to focus on the core assistant persona and capabilities

Issue 3: Cody will not answer in language that is not the default language of the editor

CLOSE https://github.com/sourcegraph/cody/discussions/1011 && https://github.com/sourcegraph/cody/issues/988

Many users have complained that they cannot get Cody to answer their questions because Cody refused to answer questions that is not the same as the default language of the editor.

Addressed by this PR with the following changes: Remove `languagePromptMixin` from the `activate` event for editors, which allows Cody to answer in the same language as the question

#### Before

<img width="609" alt="Screenshot 2023-10-19 at 5 08 17 PM" src="https://github.com/sourcegraph/cody/assets/68532117/6265a46e-d5e8-489b-a92d-824b56a391dc">

#### After

<img width="624" alt="Screenshot 2023-10-19 at 5 07 57 PM" src="https://github.com/sourcegraph/cody/assets/68532117/b1478a0f-8bfa-468b-abe2-69588f1deef6">

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask Cody a question in another language that is not the same as your editor. Cody should still be able to answer your question in the same language.
2. Ask Cody a question in editor, and then ask the same question in Web to compare the quality. Questions where Cody hallucinates on Web should not happen in the editor when using the updated prompts.

Example question to ask in the cody repo: `Do we format the completion item before we suggest them?`

<img width="883" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/86b1c8c5-4e2c-4674-9ad6-18382dbb2813">