### PR TITLE
Fixup: Only apply formatting changes to a range, and clean the undo stack

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -291,7 +291,11 @@ export class FixupController
 
         editor.revealRange(task.selectionRange)
 
-        const editOk = task.insertMode ? await this.insertEdit(editor, task) : await this.replaceEdit(editor, diff)
+        // We will format this code once applied, so we avoid placing an undo stop after this edit to avoid cluttering the undo stack.
+        const applyEditOptions = { undoStopBefore: true, undoStopAfter: false }
+        const editOk = task.insertMode
+            ? await this.insertEdit(editor, task, applyEditOptions)
+            : await this.replaceEdit(editor, diff, applyEditOptions)
 
         if (!editOk) {
             telemetryService.log('CodyVSCodeExtension:fixup:apply:failed')
@@ -307,14 +311,30 @@ export class FixupController
             telemetryService.log('CodyVSCodeExtension:fixup:applied', { ...codeCount, source })
 
             // format the selected area after applying edits
-            const range = new vscode.Range(
+            const editedRange = new vscode.Range(
                 new vscode.Position(task.selectionRange.start.line, 0),
                 new vscode.Position(
                     task.selectionRange.start.line + codeCount.lineCount,
                     task.selectionRange.end.character
                 )
             )
-            await vscode.commands.executeCommand('editor.action.formatDocument', range)
+            const formattingChanges = await vscode.commands.executeCommand<vscode.TextEdit[]>(
+                'vscode.executeFormatDocumentProvider',
+                editor.document.uri,
+                {}
+            )
+
+            const furtherChanges = formattingChanges.filter(change => editedRange.contains(change.range))
+            await editor.edit(
+                editBuilder => {
+                    for (const change of furtherChanges) {
+                        editBuilder.replace(change.range, change.newText)
+                    }
+                },
+                // Add the missing undo stop after this change.
+                // Now when the user hits 'undo', the entire format and edit will be undone at once.
+                { undoStopBefore: false, undoStopAfter: true }
+            )
         }
 
         // TODO: is this the right transition for being all done?
@@ -325,7 +345,11 @@ export class FixupController
     }
 
     // Replace edit returned by Cody at task selection range
-    private async replaceEdit(editor: vscode.TextEditor, diff: Diff): Promise<boolean> {
+    private async replaceEdit(
+        editor: vscode.TextEditor,
+        diff: Diff,
+        options?: { undoStopBefore: boolean; undoStopAfter: boolean }
+    ): Promise<boolean> {
         logDebug('FixupController:edit', 'replacing ')
         const editOk = await editor.edit(editBuilder => {
             for (const edit of diff.edits) {
@@ -337,12 +361,16 @@ export class FixupController
                     edit.text
                 )
             }
-        })
+        }, options)
         return editOk
     }
 
     // Insert edit returned by Cody at task selection range
-    private async insertEdit(editor: vscode.TextEditor, task: FixupTask): Promise<boolean> {
+    private async insertEdit(
+        editor: vscode.TextEditor,
+        task: FixupTask,
+        options?: { undoStopBefore: boolean; undoStopAfter: boolean }
+    ): Promise<boolean> {
         logDebug('FixupController:edit', 'inserting')
         const text = task.replacement
         const range = task.selectionRange
@@ -359,7 +387,7 @@ export class FixupController
         // Insert updated text at selection range
         const editOk = await editor.edit(editBuilder => {
             editBuilder.insert(range.start, replacementText)
-        })
+        }, options)
         return editOk
     }
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -318,16 +318,18 @@ export class FixupController
                     task.selectionRange.end.character
                 )
             )
-            const formattingChanges = await vscode.commands.executeCommand<vscode.TextEdit[]>(
-                'vscode.executeFormatDocumentProvider',
-                editor.document.uri,
-                {}
-            )
 
-            const furtherChanges = formattingChanges.filter(change => editedRange.contains(change.range))
+            const formattingChanges = (
+                await vscode.commands.executeCommand<vscode.TextEdit[]>(
+                    'vscode.executeFormatDocumentProvider',
+                    editor.document.uri,
+                    {}
+                )
+            ).filter(change => editedRange.contains(change.range))
+
             await editor.edit(
                 editBuilder => {
-                    for (const change of furtherChanges) {
+                    for (const change of formattingChanges) {
                         editBuilder.replace(change.range, change.newText)
                     }
                 },


### PR DESCRIPTION
## Description

This PR:
- Only applies the formatting changes to the fixup selection. By calling the format provider directly and filtering the edit down to the selection range. VS Code only provides `formatDocument` and `formatSelection` direct commands, so this is the approach that gives us the control we need.
- Preserves a single undo/redo action for both the fixup and the formatting change. A user would have to undo a fixup twice if it also applied formatting. This should be an implementation detail and not visible to the user. Now both changes are consolidated into a single undo/redo action.


https://github.com/sourcegraph/cody/assets/9516420/7f5d6b9f-7c2b-4594-b1ad-25ac2d0b575b



## Test plan

Tested locally, see demo

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
