### PR TITLE
Enable e2e tests for Windows on bots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,10 +158,7 @@ jobs:
         if: ${{ failure() }}
         with:
           name: playwright-recordings ${{ matrix.runner }}
-          path: |
-            playwright
-            test-results
-            vscode/test-results
+          path: playwright/**/*.webm
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,11 @@ jobs:
         if: github.ref == 'refs/heads/main' && (matrix.runner == 'windows' || matrix.runner == 'macos')
 
   test-e2e:
-    runs-on: ubuntu-latest
-    name: 'test-e2e (ubuntu)' # required to match the GitHub PR status check requirement
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu, windows]
+    runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -105,6 +108,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e
+        if: matrix.runner == 'ubuntu'
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         if: matrix.runner == 'ubuntu'
+      - run: pnpm -C vscode run test:e2e
+        if: matrix.runner != 'ubuntu'
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,10 @@ jobs:
         if: ${{ failure() }}
         with:
           name: playwright-recordings ${{ matrix.runner }}
-          path: playwright/**/*.webm
+          path: |
+            playwright
+            test-results
+            vscode/test-results
 
   build:
     runs-on: ubuntu-latest

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -5,15 +5,4 @@ export default defineConfig({
     // Give failing tests a second chance
     retries: 2,
     testDir: 'test/e2e',
-    timeout: 120000,
-    expect: {
-        timeout: 10000,
-    },
-    use: {
-        // screenshot: 'only-on-failure',
-        video: 'retain-on-failure',
-        actionTimeout: 200000,
-        navigationTimeout: 600000,
-        trace: 'retain-on-failure',
-    },
 })

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -5,4 +5,15 @@ export default defineConfig({
     // Give failing tests a second chance
     retries: 2,
     testDir: 'test/e2e',
+    timeout: 120000,
+    expect: {
+        timeout: 10000,
+    },
+    use: {
+        // screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+        actionTimeout: 200000,
+        navigationTimeout: 600000,
+        trace: 'retain-on-failure',
+    },
 })

--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -47,8 +47,13 @@ test('shows chat history in sidebar and update chat panel correctly', async ({ p
     await expect(page.getByRole('tab', { name: 'Hey' })).toBeVisible()
 
     // Click the delete chat button twice to remove the chats we submitted
+    // Check for counts to ensure we wait for the delete to be completed before
+    // trying to click again, or we might quickly click the last one twice
+    await expect(page.getByLabel('Delete Chat')).toHaveCount(2)
+    await page.getByLabel('Delete Chat').last().click()
+    await expect(page.getByLabel('Delete Chat')).toHaveCount(1)
+    await page.getByLabel('Delete Chat').last().click()
+
     // Once the chat history is empty, the 'New Chat' button should show up
-    await page.getByLabel('Delete Chat').last().click()
-    await page.getByLabel('Delete Chat').last().click()
     await expect(page.getByRole('button', { name: 'New Chat', exact: true })).toBeVisible()
 })


### PR DESCRIPTION
Enables the e2e bots on Windows.

## Test plan

Tested by the bots - the status checks on this PR should have a Windows e2e bot that is green.

![image](https://github.com/sourcegraph/cody/assets/1078012/20f12fe5-359b-429c-a070-8acdcfe42814)

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
