### PR TITLE
draft: Chat Improvements in Agent

### DIFF
--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
-import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatMessage, MessageID } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { TranscriptID } from '@sourcegraph/cody-shared/src/chat/transcript/transcript2'
 import { event } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 import { CompletionEvent } from '../../vscode/src/completions/logger'
@@ -101,6 +102,9 @@ export type Notifications = {
     // request. The server should never send this notification outside of a
     // 'chat/executeRecipe' request.
     'chat/updateMessageInProgress': [ChatMessage | null]
+
+    'chat/update': [{ transcriptID: TranscriptID; messageID: MessageID; text: string }]
+    'chat/completed': [{ transcriptID: TranscriptID; messageID: MessageID; text: string }]
 
     'debug/message': [DebugMessage]
 }

--- a/agent/src/protocol.ts
+++ b/agent/src/protocol.ts
@@ -44,6 +44,8 @@ export type Requests = {
     'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string }, string | null]
     'graphql/getRepoId': [{ repoName: string }, string | null]
 
+    'chat/complete': [{ transcriptID: string; humanChatInput: string; data: object }, null]
+
     // ================
     // Server -> Client
     // ================

--- a/lib/shared/src/chat/client2.ts
+++ b/lib/shared/src/chat/client2.ts
@@ -1,9 +1,236 @@
-import { Transcript } from './transcript'
+import { CodebaseContext } from '../codebase-context'
+import { Editor } from '../editor'
+import { SourcegraphEmbeddingsSearchClient } from '../embeddings/client'
+import { SourcegraphIntentDetectorClient } from '../intent-detector/client'
+import { SourcegraphBrowserCompletionsClient } from '../sourcegraph-api/completions/browserClient'
+import { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
+import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
+import { isError } from '../utils'
 
-type Brand<T, B> = T & { readonly __brand: B }
+import { BotResponseMultiplexer } from './bot-response-multiplexer'
+import { ChatClient } from './chat'
+import { ClientInit, ClientInitConfig } from './client'
+import { getPreamble } from './preamble'
+import { getRecipe } from './recipes/browser-recipes'
+import { RecipeID } from './recipes/recipe'
+import { MessageID } from './transcript/messages'
+import { Transcript, TranscriptID } from './transcript/transcript2'
+import { reformatBotMessage } from './viewHelpers'
 
-type TranscriptID = Brand<string, 'TranscriptID'>
+export interface ChatStatus {
+    sourcegraphStatus: { authenticated: boolean; version: string }
+    codyStatus: { enabled: boolean; version: string }
+}
+
+export type MessageHandler = {
+    // TODO(tjdevries): Should this actually be a ChatMessage? instead of just the text...
+    //                  I think so, but I'm out of time for today
+    onMessageChange: (transcriptID: TranscriptID, messageID: MessageID, message: string) => void
+    onMessageComplete: (transcriptID: TranscriptID, messageID: MessageID, text: string) => void
+    onMessageError: (transcriptID: TranscriptID, messageID: MessageID, error: string) => void
+}
 
 export class ChatHandler {
-    constructor(transcripts: Map<TranscriptID, Transcript>) {}
+    constructor(
+        private config: ClientInitConfig,
+        private completionClient: SourcegraphCompletionsClient,
+        public status: ChatStatus,
+        private editor: Editor,
+        private intentDetector: SourcegraphIntentDetectorClient,
+        private codebaseContext: CodebaseContext,
+        private transcripts: Map<TranscriptID, Transcript>,
+        private messageHandler: MessageHandler
+    ) {}
+
+    // TODO: It kind of hurts that we have so much copied here.
+    //          I think the only thing that gets copied between old and new are the transcripts?
+    //          So it's possible we could pass some subset of the items or break this into smaller functions too.
+    public static async init(init: ClientInit, messageHandler: MessageHandler): Promise<ChatHandler> {
+        const config = { ...init.config, useContext: 'embeddings', experimentalLocalSymbols: false }
+        const fullConfig = { debugEnable: false, ...config }
+        const graphqlClient = new SourcegraphGraphQLAPIClient(fullConfig)
+        const sourcegraphVersion = await graphqlClient.getSiteVersion()
+
+        const sourcegraphStatus = { authenticated: false, version: '' }
+        if (!isError(sourcegraphVersion)) {
+            sourcegraphStatus.authenticated = true
+            sourcegraphStatus.version = sourcegraphVersion
+        }
+
+        const codyStatus = await graphqlClient.isCodyEnabled()
+        const status = { sourcegraphStatus, codyStatus }
+
+        const createCompletionsClient =
+            init.createCompletionsClient || (config => new SourcegraphBrowserCompletionsClient(config))
+        const completionClient = createCompletionsClient(fullConfig)
+
+        const repoId = config.codebase ? await graphqlClient.getRepoIdIfEmbeddingExists(config.codebase) : null
+        if (isError(repoId)) {
+            throw new Error(
+                `Cody could not access the '${config.codebase}' repository on your Sourcegraph instance. Details: ${repoId.message}`
+            )
+        }
+
+        const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId, true) : null
+        const codebaseContext = new CodebaseContext(init.config, config.codebase, embeddingsSearch, null, null, null)
+        const intentDetector = new SourcegraphIntentDetectorClient(graphqlClient, completionClient)
+
+        return new ChatHandler(
+            init.config,
+            completionClient,
+            status,
+            init.editor,
+            intentDetector,
+            codebaseContext,
+            new Map(),
+            messageHandler
+        )
+    }
+
+    public async resetClient(init: ClientInit): Promise<void> {
+        const config = init.config
+        this.config = { ...config, useContext: 'embeddings', experimentalLocalSymbols: false }
+        this.editor = init.editor
+
+        const fullConfig = { debugEnable: false, ...config }
+        const graphqlClient = new SourcegraphGraphQLAPIClient(fullConfig)
+        const sourcegraphVersion = await graphqlClient.getSiteVersion()
+
+        const sourcegraphStatus = { authenticated: false, version: '' }
+        if (!isError(sourcegraphVersion)) {
+            sourcegraphStatus.authenticated = true
+            sourcegraphStatus.version = sourcegraphVersion
+        }
+
+        const codyStatus = await graphqlClient.isCodyEnabled()
+        this.status = { sourcegraphStatus, codyStatus }
+        if (!sourcegraphStatus.authenticated || !codyStatus.enabled) {
+            // TODO: Should clear all the available items...?
+            return
+        }
+
+        const createCompletionsClient =
+            init.createCompletionsClient || (config => new SourcegraphBrowserCompletionsClient(config))
+        this.completionClient = createCompletionsClient(fullConfig)
+
+        const repoId = config.codebase ? await graphqlClient.getRepoIdIfEmbeddingExists(config.codebase) : null
+        if (isError(repoId)) {
+            throw new Error(
+                `Cody could not access the '${config.codebase}' repository on your Sourcegraph instance. Details: ${repoId.message}`
+            )
+        }
+
+        const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId, true) : null
+        this.codebaseContext = new CodebaseContext(config, config.codebase, embeddingsSearch, null, null, null)
+        this.intentDetector = new SourcegraphIntentDetectorClient(graphqlClient, this.completionClient)
+
+        return
+    }
+
+    private isValidAuth(): boolean {
+        return this.status.sourcegraphStatus.authenticated && this.status.codyStatus.enabled
+    }
+
+    public newTranscript(): TranscriptID {
+        const transcript = new Transcript()
+        this.transcripts.set(transcript.id, transcript)
+        return transcript.id
+    }
+
+    // TODO(tjdevries): Should execute recipe allow for nil transcript to simply run a "fresh" recipe?
+    //          I think this actually makes quite a bit of sense, because for one-shot commands
+    //          and for basically any "CodyAsk" you would always want a fresh conversation.
+    //
+    //          Otherwise it gets way too confused. So perhaps default is actually not providing
+    //          a transcript, and instead creates a new one and returns the corresponding transcriptID?
+    public async executeRecipe(
+        transcriptID: TranscriptID,
+        recipeID: RecipeID,
+        humanChatInput: string,
+        options: { signal?: AbortSignal }
+    ) {
+        // TODO: Probably should error? Or send an auth message.
+        // It's bad that we just silently stop doing stuff or just log to console in so many places
+        if (!this.isValidAuth()) {
+            return
+        }
+
+        const transcript = this.transcripts.get(transcriptID)!
+        const chatClient = new ChatClient(this.completionClient)
+
+        const recipe = getRecipe(recipeID)!
+        const interaction = await recipe.getInteraction(humanChatInput, {
+            // editor: options?.prefilledOptions ? withPreselectedOptions(editor, options.prefilledOptions) : editor,
+            editor: this.editor,
+            intentDetector: this.intentDetector,
+            codebaseContext: this.codebaseContext,
+            // TODO: I don't get why we have this?
+            responseMultiplexer: new BotResponseMultiplexer(),
+            firstInteraction: transcript.isEmpty,
+        })
+
+        if (!interaction) {
+            return // TODO: Error
+        }
+
+        const messageID = interaction.getHumanMessage().id!
+
+        const { prompt, contextFiles, preciseContexts } = await transcript.getPromptForLastInteraction(
+            getPreamble(this.config.codebase)
+        )
+
+        // TODO: This seems terrible, why doesn't this update the interaction directly?
+        //  or get generated when creating the interaction?
+        //  ISNT THIS JUST PUTTING THE STUFF BACK THAT WAS ALREADY THERE?
+        transcript.setUsedContextFilesForLastInteraction(contextFiles, preciseContexts)
+
+        const responsePrefix = interaction.getAssistantMessage().prefix ?? ''
+
+        // TODO: I don't know why we did this in each of the message possibilities:
+        //          Instead, we should just use IDs and then agents can be responsible for
+        //          for updating the corresponding transcript.
+        // sendTranscript(options?.data)
+
+        let responseText = ''
+        const chatCompletionPromise = new Promise<void>((resolve, reject) => {
+            const onAbort = chatClient.chat(prompt, {
+                onChange: (rawText: string) => {
+                    const text = reformatBotMessage(rawText, responsePrefix)
+                    transcript.addAssistantResponse(text)
+
+                    this.messageHandler.onMessageChange(transcriptID, messageID, text)
+                    responseText = text
+                },
+                onComplete: () => {
+                    this.messageHandler.onMessageComplete(transcriptID, messageID, responseText)
+
+                    resolve()
+                },
+                onError: error => {
+                    // Display error message as assistant response
+                    transcript.addErrorAsAssistantResponse(messageID, error)
+                    this.messageHandler.onMessageError(transcriptID, messageID, error)
+
+                    console.error(`Completion request failed: ${error}`)
+                    reject(new Error(error))
+                },
+            })
+
+            options?.signal?.addEventListener('abort', onAbort)
+        })
+
+        // Not 100% sure why we do this, I guess it's to pass the error up?
+        //  It seems we could just skip making the promise and just do all the
+        //  work we need in the callbacks.
+        await chatCompletionPromise
+    }
+
+    public async createNewChatMessage(
+        transcriptID: TranscriptID,
+        humanChatInput: string,
+        options: { signal?: AbortSignal }
+    ) {
+        // I would like to... not just execute a recipe, but that's going to have to wait for a separate PR
+        await this.executeRecipe(transcriptID, 'chat-question', humanChatInput, options)
+    }
 }

--- a/lib/shared/src/chat/client2.ts
+++ b/lib/shared/src/chat/client2.ts
@@ -1,0 +1,9 @@
+import { Transcript } from './transcript'
+
+type Brand<T, B> = T & { readonly __brand: B }
+
+type TranscriptID = Brand<string, 'TranscriptID'>
+
+export class ChatHandler {
+    constructor(transcripts: Map<TranscriptID, Transcript>) {}
+}

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -9,6 +9,7 @@ import {
 } from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
+import { newAssistantMessage, newHumanMessage } from '../transcript/messages'
 
 import { isSingleWord, numResults } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -24,8 +25,8 @@ export class ChatQuestion implements Recipe {
 
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: truncatedText, displayText: humanChatInput },
-                { speaker: 'assistant' },
+                newHumanMessage(truncatedText, { displayText: humanChatInput }),
+                newAssistantMessage(),
                 this.getContextMessages(
                     truncatedText,
                     context.editor,

--- a/lib/shared/src/chat/recipes/generate-pr-description.ts
+++ b/lib/shared/src/chat/recipes/generate-pr-description.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
+import { newAssistantMessage, newHumanMessage } from '../transcript/messages'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
@@ -52,12 +53,8 @@ export class PrDescription implements Recipe {
         if (!gitCommitOutput) {
             const emptyGitCommitMessage = 'No commits history found in the current branch.'
             return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText },
-                {
-                    speaker: 'assistant',
-                    prefix: emptyGitCommitMessage,
-                    text: emptyGitCommitMessage,
-                },
+                newHumanMessage(undefined, { displayText: emptyGitCommitMessage }),
+                newAssistantMessage(emptyGitCommitMessage, { prefix: emptyGitCommitMessage }),
                 Promise.resolve([]),
                 []
             )

--- a/lib/shared/src/chat/recipes/generate-release-notes.ts
+++ b/lib/shared/src/chat/recipes/generate-release-notes.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'child_process'
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
+import { newAssistantMessage, newHumanMessage } from '../transcript/messages'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
@@ -66,12 +67,8 @@ export class ReleaseNotes implements Recipe {
         if (!gitLogOutput) {
             const emptyGitLogMessage = 'No recent changes found to generate release notes.'
             return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText },
-                {
-                    speaker: 'assistant',
-                    prefix: emptyGitLogMessage,
-                    text: emptyGitLogMessage,
-                },
+                newHumanMessage(undefined, { displayText: rawDisplayText }),
+                newAssistantMessage(emptyGitLogMessage, { prefix: emptyGitLogMessage }),
                 Promise.resolve([]),
                 []
             )

--- a/lib/shared/src/chat/recipes/git-log.ts
+++ b/lib/shared/src/chat/recipes/git-log.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
+import { newAssistantMessage, newHumanMessage } from '../transcript/messages'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
@@ -60,12 +61,8 @@ export class GitHistory implements Recipe {
         if (!gitLogOutput) {
             const emptyGitLogMessage = 'No recent changes found'
             return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText },
-                {
-                    speaker: 'assistant',
-                    prefix: emptyGitLogMessage,
-                    text: emptyGitLogMessage,
-                },
+                newHumanMessage(undefined, { displayText: rawDisplayText }),
+                newAssistantMessage(emptyGitLogMessage, { prefix: emptyGitLogMessage }),
                 Promise.resolve([]),
                 []
             )
@@ -80,12 +77,8 @@ export class GitHistory implements Recipe {
         const promptMessage = `Summarize these commits:\n${truncatedGitLogOutput}\n\nProvide your response in the form of a bulleted list. Do not mention the commit hashes.`
         const assistantResponsePrefix = `Here is a summary of recent changes:\n${truncatedLogMessage}`
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-            },
+            newHumanMessage(promptMessage, { displayText: rawDisplayText }),
+            newAssistantMessage(assistantResponsePrefix, { prefix: assistantResponsePrefix }),
             Promise.resolve([]),
             []
         )

--- a/lib/shared/src/chat/recipes/inline-chat.ts
+++ b/lib/shared/src/chat/recipes/inline-chat.ts
@@ -4,6 +4,7 @@ import { ActiveTextEditorSelection, Editor } from '../../editor'
 import { MAX_HUMAN_INPUT_TOKENS, MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
+import { newAssistantMessage, newHumanMessage } from '../transcript/messages'
 
 import { ChatQuestion } from './chat-question'
 import { Fixup } from './fixup'
@@ -50,12 +51,8 @@ export class InlineChat implements Recipe {
 
         return Promise.resolve(
             new Interaction(
-                {
-                    speaker: 'human',
-                    text: promptText,
-                    displayText,
-                },
-                { speaker: 'assistant' },
+                newHumanMessage(promptText, { displayText }),
+                newAssistantMessage(),
                 this.getContextMessages(truncatedText, context.codebaseContext, selection, context.editor),
                 []
             )

--- a/lib/shared/src/chat/recipes/inline-touch.ts
+++ b/lib/shared/src/chat/recipes/inline-touch.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto'
+
 import * as vscode from 'vscode'
 
 import { ContextMessage } from '../../codebase-context/messages'
@@ -7,6 +9,7 @@ import { truncateText } from '../../prompt/truncation'
 import { BufferedBotResponseSubscriber } from '../bot-response-multiplexer'
 import { getEditorDirContext, getEditorOpenTabsContext } from '../prompts/vscode-context'
 import { Interaction } from '../transcript/interaction'
+import { MessageID } from '../transcript/messages'
 
 import { ChatQuestion } from './chat-question'
 import { commandRegex, contentSanitizer } from './helpers'
@@ -91,11 +94,13 @@ export class InlineTouch implements Recipe {
         return Promise.resolve(
             new Interaction(
                 {
+                    id: randomUUID() as MessageID,
                     speaker: 'human',
                     text: promptText,
                     displayText,
                 },
                 {
+                    id: randomUUID() as MessageID,
                     speaker: 'assistant',
                     prefix: 'Working on it! I will show you the new file when it is ready.\n\n',
                 },

--- a/lib/shared/src/chat/recipes/next-questions.ts
+++ b/lib/shared/src/chat/recipes/next-questions.ts
@@ -6,6 +6,7 @@ import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH, MAX_CURRENT_FILE_TOKENS }
 import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
+import { newAssistantMessage, newHumanMessage } from '../transcript/messages'
 
 import { numResults } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -27,12 +28,8 @@ export class NextQuestions implements Recipe {
         const assistantResponsePrefix = 'Sure, here are great follow-up discussion topics and learning ideas:\n\n - '
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: promptMessage },
-                {
-                    speaker: 'assistant',
-                    prefix: assistantResponsePrefix,
-                    text: assistantResponsePrefix,
-                },
+                newHumanMessage(promptMessage),
+                newAssistantMessage(assistantResponsePrefix, { prefix: assistantResponsePrefix }),
                 this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext),
                 []
             )

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -28,8 +28,12 @@ export class Interaction {
         return { ...this.assistantMessage }
     }
 
-    public setAssistantMessage(assistantMessage: InteractionMessage): void {
-        this.assistantMessage = assistantMessage
+    public setAssistantMessage(text: string, displayText?: string): void {
+        this.assistantMessage.text = text
+
+        if (displayText) {
+            this.assistantMessage.displayText = displayText
+        }
     }
 
     public getHumanMessage(): InteractionMessage {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -1,7 +1,11 @@
+import { randomUUID } from 'crypto'
+
 import { ContextFile, PreciseContext } from '../../codebase-context/messages'
 import { Message } from '../../sourcegraph-api'
 
 import { TranscriptJSON } from '.'
+
+export type MessageID = string & { readonly __brand: 'MessageID' }
 
 export interface ChatButton {
     label: string
@@ -10,6 +14,7 @@ export interface ChatButton {
 }
 
 export interface ChatMessage extends Message {
+    id?: MessageID
     displayText?: string
     contextFiles?: ContextFile[]
     preciseContext?: PreciseContext[]
@@ -18,9 +23,39 @@ export interface ChatMessage extends Message {
 }
 
 export interface InteractionMessage extends Message {
+    // ugh, forget it. i will fix all of these if we get buy in
+    id?: MessageID
     displayText?: string
     prefix?: string
     error?: string
+}
+
+function newMessage(
+    speaker: 'human' | 'assistant',
+    text?: string,
+    options?: { displayText?: string; prefix?: string }
+): InteractionMessage {
+    return {
+        id: randomUUID() as MessageID,
+        speaker,
+        text,
+        displayText: options?.displayText,
+        prefix: options?.prefix,
+    }
+}
+
+export function newHumanMessage(
+    text?: string,
+    options?: { displayText?: string; prefix?: string }
+): InteractionMessage {
+    return newMessage('human', text, options)
+}
+
+export function newAssistantMessage(
+    text?: string,
+    options?: { displayText?: string; prefix?: string }
+): InteractionMessage {
+    return newMessage('assistant', text, options)
 }
 
 export interface UserLocalHistory {

--- a/slack/src/mention-handler.ts
+++ b/slack/src/mention-handler.ts
@@ -120,7 +120,7 @@ function startCompletionStreaming(
     streamCompletions(promptMessages, {
         onChange: text => {
             // console.log('Stream update: ', text)
-            lastInteraction.setAssistantMessage({ ...lastInteraction.getAssistantMessage(), text })
+            lastInteraction.setAssistantMessage(text)
             onBotMessageChange(channel, inProgressMessageTs, reformatBotMessage(text, '') + suffix)?.catch(
                 console.error
             )


### PR DESCRIPTION
# Proposed Changes

Primary goal is to make chat a "first-class citizen" of the agent protocol.

- `Transcript` and `Message` both use an `id` to identify them
- The ChatHandler (name tbd) uses these `id`s to interact with `Transcript` and `Message`
  - This prevents accidental mutation and state changes from within the javascript side that won't get synchronized across the protocol boundary.
  - This makes sure that anything we need to do with `Transcript`s and `Message`s can be done via IDs (and thus, through the protocol without many changes)
- No longer rely on `last` transcript and/or `last` message, but instead always require IDs over the wire and within the agent.
  - This allows us to explicitly control whether recipes/chats inherit the current transcript, and have multiple conversations work simultaneously  
  - This also means that when we send "update" notifications for chat, the client does not have to track which was the latest message sent / etc but instead just updates the corresponding transcript/message using the `id`s provided.

(obviously will not have transcript2 and client2, but just using those for now to test out the differences) 

## Current Status

This is *not* complete. I don't plan on trying to merge with `client2` but this let me try exploring the new API without everything breaking immediately.

My goal is that we primarily:
- Use `id`s to communicate and mutate the transcripts. This prevents us from updating state of an object/class in javascript and not having those updates synced into the clients.
- Make each `chat/` message use `transcriptID` and `messageID` when appropriate.
  - This allows us to do one-shot recipes without sharing the same transcript history (for example, if you have a chat right now and then ask it to do a task, the transcripts are shared unless you first reset the transcript... then you've lost your chat history. This is fundamentally broken and bad behavior).
- Should hopefully simplify a lot of the logic and reasoning because we don't implicitly just use the `last` thing of everything (instead, use IDs. Don't keep global state of `last` thing cause it's too confusing and prevents plenty of meaningful and useful improvements)


I know that I have merge conflicts cause @olafurpg moved the agent protocol, I will fix those next week when I'm back in office. I just wanted to push a draft PR so that we can at least see if this direction is helpful at all before I got through the last bits of the work (that will take the most time of course). I will try and fix up all the VS Code side things required for this as well, or at least provide the same default behavior as before and the VS Code team can update as necessary after that. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
- [ ] DO NOT MERGE
