### PR TITLE
Autocomplete: add `// only` support to `tree-sitter` snapshot tests

### DIFF
--- a/vscode/src/completions/tree-sitter/query-tests/annotate-and-match-snapshot.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/annotate-and-match-snapshot.ts
@@ -231,6 +231,10 @@ interface AnnotateAndMatchParams {
     captures: Captures
 }
 
+/**
+ * Add "// only", or other comment delimiter for the current language, to
+ * focus on one code sample (similar to `it.only` from `jest`).
+ */
 export async function annotateAndMatchSnapshot(params: AnnotateAndMatchParams): Promise<void> {
     const { captures, sourcesPath, parser, language } = params
 
@@ -241,13 +245,15 @@ export async function annotateAndMatchSnapshot(params: AnnotateAndMatchParams): 
     // Queries are used on specific parts of the source code (e.g., range of the inserted multiline completion).
     // Snippets are required to mimick such behavior and test the order of returned captures.
     const snippets = code.split(separator)
+    // Support "// only" to focus on one code sample at a time
+    const onlySnippet = snippets.findLast(snippet => snippet.startsWith(`${delimiter} only`))
 
     const header = dedent`
         ${commentOutLines(DOCUMENTATION_HEADER, delimiter)}
         ${delimiter}
     `.trim()
 
-    const annotated = snippets
+    const annotated = (onlySnippet ? [onlySnippet] : snippets)
         .map(snippet => {
             return annotateSnippets({ code: snippet, language, parser, captures })
         })

--- a/vscode/src/completions/tree-sitter/query-tests/annotate-and-match-snapshot.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/annotate-and-match-snapshot.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 
 import dedent from 'dedent'
+import { findLast } from 'lodash'
 import { expect } from 'vitest'
 import Parser, { Point, SyntaxNode } from 'web-tree-sitter'
 
@@ -246,7 +247,7 @@ export async function annotateAndMatchSnapshot(params: AnnotateAndMatchParams): 
     // Snippets are required to mimick such behavior and test the order of returned captures.
     const snippets = code.split(separator)
     // Support "// only" to focus on one code sample at a time
-    const onlySnippet = snippets.findLast(snippet => snippet.startsWith(`${delimiter} only`))
+    const onlySnippet = findLast(snippets, snippet => snippet.startsWith(`${delimiter} only`))
 
     const header = dedent`
         ${commentOutLines(DOCUMENTATION_HEADER, delimiter)}


### PR DESCRIPTION
## Context

Adds `// only` support to tree-sitter snapshot tests. It's similar to `it.only()` from `jest` and helps to debug code samples in isolation.

## Test plan

CI
