### PR TITLE
feat: add source tracking for recipe execution

### DIFF
--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -1,8 +1,12 @@
+import { ChatEventSource } from '../transcript/messages'
+
 import * as defaultPrompts from './cody.json'
 import { toSlashCommand } from './utils'
 
 // A list of default cody commands
-export const defaultCodyCommands = ['ask', 'doc', 'edit', 'smell', 'test', 'reset']
+export type CodyDefaultCommands = 'ask' | 'doc' | 'edit' | 'explain' | 'smell' | 'test' | 'reset'
+
+export const defaultChatCommands = new Set(['explain', 'doc', 'edit', 'smell', 'test'])
 
 export function getDefaultCommandsMap(editorCommands: CodyPrompt[] = []): Map<string, CodyPrompt> {
     const map = new Map<string, CodyPrompt>()
@@ -26,6 +30,16 @@ export function getDefaultCommandsMap(editorCommands: CodyPrompt[] = []): Map<st
     }
 
     return map
+}
+
+export function getCommandEventSource(command: CodyPrompt): ChatEventSource {
+    if (command?.type === 'default') {
+        const commandName = command.slashCommand.replace(/^\//, '')
+        if (defaultChatCommands.has(commandName)) {
+            return commandName as CodyDefaultCommands
+        }
+    }
+    return 'custom-commands'
 }
 
 export interface MyPrompts {

--- a/lib/shared/src/chat/prompts/utils.ts
+++ b/lib/shared/src/chat/prompts/utils.ts
@@ -6,6 +6,7 @@ import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH, MAX_RECIPE_INPUT_TOKENS }
 import { truncateText } from '../../prompt/truncation'
 import { getFileExtension, getNormalizedLanguageName } from '../recipes/helpers'
 import { Interaction } from '../transcript/interaction'
+import { ChatEventSource } from '../transcript/messages'
 
 import { CodyPromptContext } from '.'
 import { prompts } from './templates'
@@ -19,7 +20,7 @@ export async function newInteraction(args: {
     contextMessages?: Promise<ContextMessage[]>
     assistantText?: string
     assistantDisplayText?: string
-    source?: string
+    source?: ChatEventSource
 }): Promise<Interaction> {
     const { text, displayText, contextMessages, assistantText, assistantDisplayText, source } = args
     return Promise.resolve(
@@ -34,7 +35,6 @@ export async function newInteraction(args: {
 
 /**
  * Returns a Promise resolving to an Interaction object representing an error response from the assistant.
- *
  * @param errorMsg - The error message text to include in the assistant response.
  * @param displayText - Optional human-readable display text for the request.
  * @returns A Promise resolving to the Interaction object.
@@ -52,7 +52,6 @@ export async function newInteractionWithError(errorMsg: string, displayText = ''
 
 /**
  * Generates a prompt text string with the provided prompt and code
- *
  * @param prompt - The prompt text to include after the code snippet.
  * @param selection - The ActiveTextEditorSelection containing the code snippet.
  * @returns The constructed prompt text string, or null if no selection provided.
@@ -80,9 +79,7 @@ export function promptTextWithCodeSelection(
 
 /**
  * Checks if only the code selection context is required for the prompt.
- *
  * @param contextConfig - The context configuration object.
- *
  * @returns True if only the code selection is required based on the contextConfig, false otherwise.
  *
  * This checks if the contextConfig only contains the "selection" property, or if it contains no properties.
@@ -95,9 +92,7 @@ export function isOnlySelectionRequired(contextConfig: CodyPromptContext): boole
 
 /**
  * Extracts the test type from the given text.
- *
  * @param text - The text to extract the test type from.
- *
  * @returns The extracted test type, which will be "unit", "e2e", or "integration" if found.
  * Returns an empty string if no match is found.
  */
@@ -109,10 +104,8 @@ export function extractTestType(text: string): string {
 
 /**
  * Generates the prompt text to send to the human LLM model.
- *
  * @param commandInstructions - The human's instructions for the command. This will be inserted into the prompt template.
  * @param currentFileName - Optional current file name. If provided, will insert the normalized language name.
- *
  * @returns The constructed prompt text string.
  */
 export function getHumanLLMText(commandInstructions: string, currentFileName?: string): string {
@@ -142,7 +135,6 @@ export function toSlashCommand(command: string): string {
 
 /**
  * Creates a VS Code search pattern to find files matching the given file path.
- *
  * @param fsPath - The file system path of the file to generate a search pattern for.
  * @param fromRoot - Whether to search from the root directory. Default false.
  * @returns A search pattern string to find matching files.
@@ -183,7 +175,6 @@ export function createVSCodeTestSearchPattern(fsPath: string, allTestFiles?: boo
 /**
  * Creates an object containing the start line and line range
  * of the given editor selection.
- *
  * @param selection - The active text editor selection
  * @returns An object with the following properties:
  * - range: The line range of the selection as a string, e.g. "5-10"
@@ -203,9 +194,7 @@ export function createSelectionDisplayText(selection: ActiveTextEditorSelection)
 
 /**
  * Checks if the given file path is a valid test file name.
- *
  * @param fsPath - The file system path to check
- *
  * @returns boolean - True if the path is a valid test file name, false otherwise.
  *
  * Removes file extension and checks if file name starts with 'test' or

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -20,8 +20,8 @@ export class ChatQuestion implements Recipe {
     constructor(private debug: (filterLabel: string, text: string, ...args: unknown[]) => void) {}
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
         const source = this.id
+        const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
         return Promise.resolve(
             new Interaction(

--- a/lib/shared/src/chat/recipes/code-question.ts
+++ b/lib/shared/src/chat/recipes/code-question.ts
@@ -20,14 +20,16 @@ export class CodeQuestion implements Recipe {
     constructor(private debug: (filterLabel: string, text: string, ...args: unknown[]) => void) {}
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: truncatedText, displayText: humanChatInput },
+                { speaker: 'human', text: truncatedText, displayText: humanChatInput, source },
                 {
                     speaker: 'assistant',
                     text: `\`\`\`${getFileExtension(context.editor.getActiveTextEditorSelection()?.fileName ?? '')}\n`,
+                    source,
                 },
                 this.getContextMessages(
                     truncatedText,

--- a/lib/shared/src/chat/recipes/context-search.ts
+++ b/lib/shared/src/chat/recipes/context-search.ts
@@ -30,6 +30,7 @@ export class ContextSearch implements Recipe {
     public title = 'Codebase Context Search'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const query =
             humanChatInput?.replace(/^\/s(earch)?(\s)?/i, '') ||
             (await context.editor.showInputBox('Enter your search query here...')) ||
@@ -39,7 +40,6 @@ export class ContextSearch implements Recipe {
         }
         const truncatedText = truncateText(query.replace('/search ', '').replace('/s ', ''), MAX_HUMAN_INPUT_TOKENS)
         const workspaceRootUri = context.editor.getWorkspaceRootUri()
-        const source = this.id
         return new Interaction(
             {
                 speaker: 'human',

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -5,7 +5,7 @@ import { ContextMessage } from '../../codebase-context/messages'
 import { ActiveTextEditorSelection, Editor } from '../../editor'
 import { MAX_HUMAN_INPUT_TOKENS, NUM_CODE_RESULTS, NUM_TEXT_RESULTS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
-import { CodyPromptContext, defaultCodyPromptContext } from '../prompts'
+import { CodyPromptContext, defaultCodyPromptContext, getCommandEventSource } from '../prompts'
 import {
     extractTestType,
     getHumanLLMText,
@@ -30,10 +30,12 @@ import { Interaction } from '../transcript/interaction'
 import { getFileExtension, numResults } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
-/** ======================================================
+/**
+ * ======================================================
  * Recipe for running custom prompts from the cody.json files
  * Works with VS Code only
-====================================================== **/
+====================================================== *
+ */
 export class CustomPrompt implements Recipe {
     public id: RecipeID = 'custom-prompt'
     public title = 'Custom Prompt'
@@ -62,7 +64,7 @@ export class CustomPrompt implements Recipe {
         const commandName = command?.slashCommand || command?.description || promptText
 
         // Log all custom commands under 'custom'
-        const source = command?.type === 'default' ? command?.slashCommand.replace('/', '') : 'custom'
+        const source = getCommandEventSource(command)
 
         if (!promptText || !commandName) {
             const errorMessage = 'Please enter a valid prompt for the custom command.'

--- a/lib/shared/src/chat/recipes/explain-code-detailed.ts
+++ b/lib/shared/src/chat/recipes/explain-code-detailed.ts
@@ -10,6 +10,7 @@ export class ExplainCodeDetailed implements Recipe {
     public title = 'Explain Selected Code (Detailed)'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -25,8 +26,8 @@ export class ExplainCodeDetailed implements Recipe {
         const displayText = `Explain the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
-            { speaker: 'assistant' },
+            { speaker: 'human', text: promptMessage, displayText, source },
+            { speaker: 'assistant', source },
             getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,

--- a/lib/shared/src/chat/recipes/explain-code-high-level.ts
+++ b/lib/shared/src/chat/recipes/explain-code-high-level.ts
@@ -10,6 +10,7 @@ export class ExplainCodeHighLevel implements Recipe {
     public title = 'Explain Selected Code (High Level)'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -25,8 +26,8 @@ export class ExplainCodeHighLevel implements Recipe {
         const displayText = `Explain the following code at a high level:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
-            { speaker: 'assistant' },
+            { speaker: 'human', text: promptMessage, displayText, source },
+            { speaker: 'assistant', source },
             getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,

--- a/lib/shared/src/chat/recipes/find-code-smells.ts
+++ b/lib/shared/src/chat/recipes/find-code-smells.ts
@@ -10,6 +10,7 @@ export class FindCodeSmells implements Recipe {
     public title = 'Smell Code'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -34,11 +35,12 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
 
         const assistantResponsePrefix = ''
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'human', text: promptMessage, displayText, source },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
+                source,
             },
             new Promise(resolve => resolve([])),
             []

--- a/lib/shared/src/chat/recipes/generate-docstring.ts
+++ b/lib/shared/src/chat/recipes/generate-docstring.ts
@@ -15,6 +15,7 @@ export class GenerateDocstring implements Recipe {
     public title = 'Generate Docstring'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -49,11 +50,12 @@ export class GenerateDocstring implements Recipe {
 
         const assistantResponsePrefix = `Here is the generated documentation:\n\`\`\`${extension}\n${docStart}`
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'human', text: promptMessage, displayText, source },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
+                source,
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/lib/shared/src/chat/recipes/generate-pr-description.ts
+++ b/lib/shared/src/chat/recipes/generate-pr-description.ts
@@ -13,6 +13,7 @@ export class PrDescription implements Recipe {
     public title = 'Generate PR Description'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const dirPath = context.editor.getWorkspaceRootPath()
         if (!dirPath) {
             return Promise.resolve(null)
@@ -52,11 +53,12 @@ export class PrDescription implements Recipe {
         if (!gitCommitOutput) {
             const emptyGitCommitMessage = 'No commits history found in the current branch.'
             return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText },
+                { speaker: 'human', displayText: rawDisplayText, source },
                 {
                     speaker: 'assistant',
                     prefix: emptyGitCommitMessage,
                     text: emptyGitCommitMessage,
+                    source,
                 },
                 Promise.resolve([]),
                 []

--- a/lib/shared/src/chat/recipes/generate-release-notes.ts
+++ b/lib/shared/src/chat/recipes/generate-release-notes.ts
@@ -11,6 +11,7 @@ export class ReleaseNotes implements Recipe {
     public title = 'Generate Release Notes'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const dirPath = context.editor.getWorkspaceRootPath()
         if (!dirPath) {
             return null
@@ -66,11 +67,12 @@ export class ReleaseNotes implements Recipe {
         if (!gitLogOutput) {
             const emptyGitLogMessage = 'No recent changes found to generate release notes.'
             return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText },
+                { speaker: 'human', displayText: rawDisplayText, source },
                 {
                     speaker: 'assistant',
                     prefix: emptyGitLogMessage,
                     text: emptyGitLogMessage,
+                    source,
                 },
                 Promise.resolve([]),
                 []

--- a/lib/shared/src/chat/recipes/generate-test.ts
+++ b/lib/shared/src/chat/recipes/generate-test.ts
@@ -15,6 +15,7 @@ export class GenerateTest implements Recipe {
     public title = 'Generate Unit Test'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -33,11 +34,12 @@ export class GenerateTest implements Recipe {
         const displayText = `Generate a unit test for the following code:\n\`\`\`${extension}\n${selection.selectedText}\n\`\`\``
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'human', text: promptMessage, displayText, source },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
+                source,
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/lib/shared/src/chat/recipes/git-log.ts
+++ b/lib/shared/src/chat/recipes/git-log.ts
@@ -12,6 +12,7 @@ export class GitHistory implements Recipe {
     public title = 'Summarize Recent Code Changes'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const dirPath = context.editor.getWorkspaceRootPath()
         if (!dirPath) {
             return null
@@ -80,11 +81,12 @@ export class GitHistory implements Recipe {
         const promptMessage = `Summarize these commits:\n${truncatedGitLogOutput}\n\nProvide your response in the form of a bulleted list. Do not mention the commit hashes.`
         const assistantResponsePrefix = `Here is a summary of recent changes:\n${truncatedLogMessage}`
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
+            { speaker: 'human', text: promptMessage, displayText: rawDisplayText, source },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
+                source,
             },
             Promise.resolve([]),
             []

--- a/lib/shared/src/chat/recipes/improve-variable-names.ts
+++ b/lib/shared/src/chat/recipes/improve-variable-names.ts
@@ -15,6 +15,7 @@ export class ImproveVariableNames implements Recipe {
     public title = 'Improve Variable Names'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -33,11 +34,12 @@ export class ImproveVariableNames implements Recipe {
         const assistantResponsePrefix = `Here is the improved code:\n\`\`\`${extension}\n`
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'human', text: promptMessage, displayText, source },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
+                source,
             },
             getContextMessagesFromSelection(
                 truncatedSelectedText,

--- a/lib/shared/src/chat/recipes/inline-chat.ts
+++ b/lib/shared/src/chat/recipes/inline-chat.ts
@@ -18,6 +18,7 @@ export class InlineChat implements Recipe {
     constructor(private debug: (filterLabel: string, text: string, ...args: unknown[]) => void) {}
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         // Check if this is a touch request
         if (commandRegex.touch.test(humanChatInput)) {
             return new InlineTouch(this.debug).getInteraction(humanChatInput.replace(commandRegex.touch, ''), context)
@@ -47,7 +48,7 @@ export class InlineChat implements Recipe {
 
         // Text display in UI fpr human that includes the selected code
         const displayText = humanChatInput + InlineChat.displayPrompt.replace('{selectedText}', selection.selectedText)
-        const source = this.id
+
         return Promise.resolve(
             new Interaction(
                 {

--- a/lib/shared/src/chat/recipes/inline-touch.ts
+++ b/lib/shared/src/chat/recipes/inline-touch.ts
@@ -12,9 +12,11 @@ import { ChatQuestion } from './chat-question'
 import { commandRegex, contentSanitizer } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
 
-/** ======================================================
+/**
+ * ======================================================
  * Recipe for Generating a New File
-====================================================== **/
+====================================================== *
+ */
 export class InlineTouch implements Recipe {
     public id: RecipeID = 'inline-touch'
     public title = 'Inline Touch'
@@ -117,9 +119,11 @@ export class InlineTouch implements Recipe {
         await vscode.window.showTextDocument(filePath)
     }
 
-    /** ======================================================
+    /**
+     * ======================================================
      * Prompt Template for New File
-     * ====================================================== */
+     * ======================================================
+     */
 
     public static readonly newFilePrompt = `
     I am currently looking at this selected code from {fileName}:

--- a/lib/shared/src/chat/recipes/next-questions.ts
+++ b/lib/shared/src/chat/recipes/next-questions.ts
@@ -15,6 +15,7 @@ export class NextQuestions implements Recipe {
     public title = 'Next Questions'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const promptPrefix = 'Assume I have an answer to the following request:'
         const promptSuffix =
             'Generate one to three follow-up discussion topics that the human can ask you to uphold the conversation. Keep the topics very concise (try not to exceed 5 words per topic) and phrase them as questions.'
@@ -27,11 +28,12 @@ export class NextQuestions implements Recipe {
         const assistantResponsePrefix = 'Sure, here are great follow-up discussion topics and learning ideas:\n\n - '
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: promptMessage },
+                { speaker: 'human', text: promptMessage, source },
                 {
                     speaker: 'assistant',
                     prefix: assistantResponsePrefix,
                     text: assistantResponsePrefix,
+                    source,
                 },
                 this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext),
                 []

--- a/lib/shared/src/chat/recipes/translate.ts
+++ b/lib/shared/src/chat/recipes/translate.ts
@@ -12,6 +12,7 @@ export class TranslateToLanguage implements Recipe {
     public static options = languageNames
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const source = this.id
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
             await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
@@ -34,11 +35,12 @@ export class TranslateToLanguage implements Recipe {
         const assistantResponsePrefix = `Here is the code translated to ${toLanguage}:\n\`\`\`${markdownID}\n`
 
         return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText },
+            { speaker: 'human', text: promptMessage, displayText, source },
             {
                 speaker: 'assistant',
                 prefix: assistantResponsePrefix,
                 text: assistantResponsePrefix,
+                source,
             },
             Promise.resolve([]),
             []

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -132,7 +132,6 @@ export class Transcript {
     /**
      * Adds a error div to the assistant response. If the assistant has collected
      * some response before, we will add the error message after it.
-     *
      * @param errorText The error TEXT to be displayed. Do not wrap it in HTML tags.
      */
     public addErrorAsAssistantResponse(errorText: string): void {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -1,5 +1,7 @@
 import { ContextFile, PreciseContext } from '../../codebase-context/messages'
 import { Message } from '../../sourcegraph-api'
+import { CodyDefaultCommands } from '../prompts'
+import { RecipeID } from '../recipes/recipe'
 
 import { TranscriptJSON } from '.'
 
@@ -15,14 +17,14 @@ export interface ChatMessage extends Message {
     preciseContext?: PreciseContext[]
     buttons?: ChatButton[]
     data?: any
-    source?: string
+    source?: ChatEventSource
 }
 
 export interface InteractionMessage extends Message {
     displayText?: string
     prefix?: string
     error?: string
-    source?: string
+    source?: ChatEventSource
 }
 
 export interface UserLocalHistory {
@@ -37,3 +39,15 @@ export interface ChatHistory {
 export interface OldChatHistory {
     [chatID: string]: ChatMessage[]
 }
+
+export type ChatEventSource =
+    | 'chat'
+    | 'inline-chat'
+    | 'editor'
+    | 'menu'
+    | 'code-action'
+    | 'custom-commands'
+    | 'test'
+    | 'code-lens'
+    | CodyDefaultCommands
+    | RecipeID

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -213,7 +213,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         if (this.contextProvider.config.experimentalChatPredictions) {
             void this.runRecipeForSuggestion('next-questions', text)
         }
-        await this.executeRecipe('chat-question', text)
+        await this.executeRecipe('chat-question', text, 'sidebar')
     }
 
     /**

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -213,7 +213,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
         if (this.contextProvider.config.experimentalChatPredictions) {
             void this.runRecipeForSuggestion('next-questions', text)
         }
-        await this.executeRecipe('chat-question', text, 'sidebar')
+        await this.executeRecipe('chat-question', text, 'chat')
     }
 
     /**
@@ -309,7 +309,6 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
 
     /**
      * Handles copying code and detecting a paste event.
-     *
      * @param text - The text from code block when copy event is triggered
      * @param eventType - Either 'Button' or 'Keydown'
      */

--- a/vscode/src/chat/FixupViewProvider.ts
+++ b/vscode/src/chat/FixupViewProvider.ts
@@ -80,7 +80,7 @@ export class FixupProvider extends MessageProvider {
     }
 
     public async startFix(): Promise<void> {
-        await this.executeRecipe('fixup', this.task.id)
+        await this.executeRecipe('fixup', this.task.id, this.task.source)
     }
 
     public async abortFix(): Promise<void> {

--- a/vscode/src/chat/InlineChatViewProvider.ts
+++ b/vscode/src/chat/InlineChatViewProvider.ts
@@ -91,7 +91,7 @@ export class InlineChatViewProvider extends MessageProvider {
          */
         await this.editor.controllers.inline?.chat(reply, this.thread, isEditMode)
         this.editor.controllers.inline?.setResponsePending(true)
-        await this.executeRecipe('inline-chat', reply.trimStart())
+        await this.executeRecipe('inline-chat', reply.trimStart(), 'inline-chat')
     }
 
     public removeChat(): void {

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -288,7 +288,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         return this.platform.recipes.find(recipe => recipe.id === id)
     }
 
-    public async executeRecipe(recipeId: RecipeID, humanChatInput = ''): Promise<void> {
+    public async executeRecipe(recipeId: RecipeID, humanChatInput = '', source?: string): Promise<void> {
         if (this.isMessageInProgress) {
             this.handleError('Cannot execute multiple recipes. Please wait for the current recipe to finish.')
             return
@@ -370,7 +370,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 })
             }
         }
-        telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, { contextSummary })
+        telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, { contextSummary, source })
     }
 
     protected async runRecipeForSuggestion(recipeId: RecipeID, humanChatInput: string = ''): Promise<void> {
@@ -528,7 +528,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 if (!question) {
                     question = await showAskQuestionQuickPick()
                 }
-                await vscode.commands.executeCommand('cody.action.chat', question)
+                await vscode.commands.executeCommand('cody.action.chat', question, 'sidebar')
                 return null
             }
             case /^\/edit(\s)?/.test(text):

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -489,7 +489,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 break
         }
         // Get prompt details from controller by title then execute prompt's command
-        return this.executeRecipe('custom-prompt', title)
+        return this.executeRecipe('custom-prompt', title, 'custom-command')
     }
 
     protected async chatCommandsFilter(

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -8,7 +8,12 @@ import { newInteraction } from '@sourcegraph/cody-shared/src/chat/prompts/utils'
 import { Recipe, RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { Interaction } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
-import { ChatHistory, ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import {
+    ChatEventSource,
+    ChatHistory,
+    ChatMessage,
+    UserLocalHistory,
+} from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Typewriter } from '@sourcegraph/cody-shared/src/chat/typewriter'
 import { reformatBotMessage } from '@sourcegraph/cody-shared/src/chat/viewHelpers'
 import { annotateAttribution, Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
@@ -288,7 +293,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         return this.platform.recipes.find(recipe => recipe.id === id)
     }
 
-    public async executeRecipe(recipeId: RecipeID, humanChatInput = '', source?: string): Promise<void> {
+    public async executeRecipe(recipeId: RecipeID, humanChatInput = '', source?: ChatEventSource): Promise<void> {
         if (this.isMessageInProgress) {
             this.handleError('Cannot execute multiple recipes. Please wait for the current recipe to finish.')
             return
@@ -296,7 +301,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
 
         // Filter the human input to check for chat commands and retrieve the correct recipe id
         // e.g. /edit from 'chat-question' should be redirected to use the 'fixup' recipe
-        const command = await this.chatCommandsFilter(humanChatInput, recipeId)
+        const command = await this.chatCommandsFilter(humanChatInput, recipeId, source)
         if (!command) {
             return
         }
@@ -489,13 +494,14 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 break
         }
         // Get prompt details from controller by title then execute prompt's command
-        return this.executeRecipe('custom-prompt', title, 'custom-command')
+        return this.executeRecipe('custom-prompt', title, 'custom-commands')
     }
 
     protected async chatCommandsFilter(
         text: string,
-        recipeId: RecipeID
-    ): Promise<{ text: string; recipeId: RecipeID } | null> {
+        recipeId: RecipeID,
+        source?: ChatEventSource
+    ): Promise<{ text: string; recipeId: RecipeID; source?: ChatEventSource } | null> {
         // Inline chat has its own filter for slash commands
         if (recipeId === 'inline-chat') {
             return { text, recipeId }
@@ -528,11 +534,11 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 if (!question) {
                     question = await showAskQuestionQuickPick()
                 }
-                await vscode.commands.executeCommand('cody.action.chat', question, 'sidebar')
+                await vscode.commands.executeCommand('cody.action.chat', question, 'menu')
                 return null
             }
             case /^\/edit(\s)?/.test(text):
-                await vscode.commands.executeCommand('cody.command.edit-code', { instruction: text }, 'sidebar')
+                await vscode.commands.executeCommand('cody.command.edit-code', { instruction: text }, source)
                 return null
             default: {
                 if (!this.editor.getActiveTextEditor()?.filePath) {
@@ -547,7 +553,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     // If no command found, send error message to view
                     await this.addCustomInteraction(`__${text}__ is not a valid command`, text)
                 }
-                return { text: commandRunnerID, recipeId: 'custom-prompt' }
+                return { text: commandRunnerID, recipeId: 'custom-prompt', source }
             }
         }
     }

--- a/vscode/src/code-actions/explain.ts
+++ b/vscode/src/code-actions/explain.ts
@@ -24,7 +24,7 @@ export class ExplainCodeAction implements vscode.CodeActionProvider {
         const instruction = this.getCodeActionInstruction(diagnostics)
         action.command = {
             command: 'cody.action.chat',
-            arguments: [instruction, range],
+            arguments: [instruction, 'code-action'],
             title: 'Ask Cody to Explain',
         }
         action.diagnostics = diagnostics

--- a/vscode/src/code-actions/explain.ts
+++ b/vscode/src/code-actions/explain.ts
@@ -16,10 +16,10 @@ export class ExplainCodeAction implements vscode.CodeActionProvider {
         if (diagnostics.length === 0) {
             return []
         }
-        return [this.createCommandCodeAction(diagnostics, range)]
+        return [this.createCommandCodeAction(diagnostics)]
     }
 
-    private createCommandCodeAction(diagnostics: vscode.Diagnostic[], range: vscode.Range): vscode.CodeAction {
+    private createCommandCodeAction(diagnostics: vscode.Diagnostic[]): vscode.CodeAction {
         const action = new vscode.CodeAction('Ask Cody to Explain', vscode.CodeActionKind.QuickFix)
         const instruction = this.getCodeActionInstruction(diagnostics)
         action.command = {

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -231,11 +231,11 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                 case selectedCommandID === menu_options.chat.slashCommand: {
                     let input = userPrompt.trim()
                     if (input) {
-                        return await vscode.commands.executeCommand('cody.action.chat', input)
+                        return await vscode.commands.executeCommand('cody.action.chat', input, 'command')
                     }
                     input = await showAskQuestionQuickPick()
                     await vscode.commands.executeCommand('cody.chat.focus')
-                    return await vscode.commands.executeCommand('cody.action.chat', input)
+                    return await vscode.commands.executeCommand('cody.action.chat', input, 'command')
                 }
                 case selectedCommandID === menu_options.fix.slashCommand: {
                     const source = 'menu'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -185,13 +185,14 @@ const register = async (
     const executeRecipeInSidebar = async (
         recipe: RecipeID,
         openChatView = true,
-        humanInput?: string
+        humanInput?: string,
+        source?: string
     ): Promise<void> => {
         if (openChatView) {
             await sidebarChatProvider.setWebviewView('chat')
         }
 
-        await sidebarChatProvider.executeRecipe(recipe, humanInput)
+        await sidebarChatProvider.executeRecipe(recipe, humanInput, source)
     }
 
     const executeFixup = async (
@@ -335,8 +336,8 @@ const register = async (
             await sidebarChatProvider.clearHistory()
         }),
         // Recipes
-        vscode.commands.registerCommand('cody.action.chat', async (input: string) => {
-            await executeRecipeInSidebar('chat-question', true, input)
+        vscode.commands.registerCommand('cody.action.chat', async (input: string, source?: string) => {
+            await executeRecipeInSidebar('chat-question', true, input, source)
         }),
         vscode.commands.registerCommand('cody.action.commands.menu', async () => {
             await editor.controllers.command?.menu('default')

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 import { commandRegex } from '@sourcegraph/cody-shared/src/chat/recipes/helpers'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
+import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
@@ -186,7 +187,7 @@ const register = async (
         recipe: RecipeID,
         openChatView = true,
         humanInput?: string,
-        source?: string
+        source: ChatEventSource = 'editor'
     ): Promise<void> => {
         if (openChatView) {
             await sidebarChatProvider.setWebviewView('chat')
@@ -203,7 +204,7 @@ const register = async (
             auto?: boolean
             insertMode?: boolean
         } = {},
-        source = 'editor' // where the command was triggered from
+        source: ChatEventSource = 'editor' // where the command was triggered from
     ): Promise<void> => {
         telemetryService.log('CodyVSCodeExtension:command:edit:executed', { source })
         const document = args.document || vscode.window.activeTextEditor?.document
@@ -216,7 +217,7 @@ const register = async (
             return
         }
 
-        const task = args.instruction?.replace('/edit', '').trim()
+        const task = args.instruction?.replace(/^\/edit/, '').trim()
             ? fixup.createTask(document.uri, args.instruction, range, args.auto, args.insertMode, source)
             : await fixup.promptUserForTask()
         if (!task) {
@@ -288,7 +289,7 @@ const register = async (
                     auto?: boolean
                     insertMode?: boolean
                 },
-                source?: string
+                source?: ChatEventSource
             ) => executeFixup(args, source)
         ),
         vscode.commands.registerCommand('cody.inline.new', async () => {
@@ -336,7 +337,7 @@ const register = async (
             await sidebarChatProvider.clearHistory()
         }),
         // Recipes
-        vscode.commands.registerCommand('cody.action.chat', async (input: string, source?: string) => {
+        vscode.commands.registerCommand('cody.action.chat', async (input: string, source?: ChatEventSource) => {
             await executeRecipeInSidebar('chat-question', true, input, source)
         }),
         vscode.commands.registerCommand('cody.action.commands.menu', async () => {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { FixupIntent, FixupIntentClassification } from '@sourcegraph/cody-shared/src/chat/recipes/fixup'
+import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { VsCodeFixupController, VsCodeFixupTaskRecipeData } from '@sourcegraph/cody-shared/src/editor'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
@@ -113,7 +114,7 @@ export class FixupController
         selectionRange: vscode.Range,
         autoApply = false,
         insertMode?: boolean,
-        source?: string
+        source?: ChatEventSource
     ): FixupTask {
         const fixupFile = this.files.forUri(documentUri)
         const task = new FixupTask(fixupFile, instruction, selectionRange, autoApply, insertMode, source)
@@ -187,16 +188,12 @@ export class FixupController
 
     /**
      * Retrieves the intent for a specific task based on the selected text and other contextual information.
-     *
      * @param taskId - The ID of the task for which the intent is to be determined.
      * @param intentDetector - The detector used to classify the intent from available options.
-     *
      * @returns A promise that resolves to a `FixupIntent` which can be one of the intents like 'add', 'edit', etc.
-     *
      * @throws
      * - Will throw an error if no code is selected for fixup.
      * - Will throw an error if the selected text exceeds the defined maximum limit.
-     *
      * @todo (umpox): Explore shorter and more efficient ways to detect intent.
      * Possible methods:
      * - Input -> Match first word against update|fix|add|delete verbs
@@ -237,7 +234,6 @@ export class FixupController
      * 1. Finds the document URI from it's fileName
      * 2. If the selection starts in a folding range, moves the selection start position back to the start of that folding range.
      * 3. If the selection ends in a folding range, moves the selection end positionforward to the end of that folding range.
-     *
      * @returns A Promise that resolves to an `vscode.Range` which represents the combined "smart" selection.
      */
     private async getFixupTaskSmartSelection(task: FixupTask, selectionRange: vscode.Range): Promise<vscode.Range> {
@@ -648,7 +644,7 @@ export class FixupController
             return
         }
         const diff = this.applicableDiffOrRespin(task, editor.document)
-        if (!diff || diff.mergedText === undefined) {
+        if (diff?.mergedText === undefined) {
             return
         }
         // show diff view between the current document and replacement
@@ -690,7 +686,7 @@ export class FixupController
         const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
         // Remove the previous task and code lenses
         this.cancel(id)
-        void vscode.commands.executeCommand('cody.command.edit-code', { range, instruction, document }, 'regenerate')
+        void vscode.commands.executeCommand('cody.command.edit-code', { range, instruction, document }, 'code-lens')
     }
 
     private setTaskState(task: FixupTask, state: CodyTaskState): void {

--- a/vscode/src/non-stop/FixupFileObserver.ts
+++ b/vscode/src/non-stop/FixupFileObserver.ts
@@ -21,7 +21,6 @@ export class FixupFileObserver {
      * document is renamed or deleted the FixupFile will be updated to provide
      * the current file URI. This creates a FixupFile if one does not exist and
      * starts tracking it; see maybeForUri.
-     *
      * @param uri the URI of the document to monitor.
      * @returns a new FixupFile representing the document.
      */
@@ -38,7 +37,6 @@ export class FixupFileObserver {
      * Gets the FixupFile for a given URI, if one exists. This operation is
      * fast; vscode event sinks which are provided a URI can use this to quickly
      * check whether the file may have fixups.
-     *
      * @param uri the URI of the document of interest.
      * @returns a FixupFile representing the document, if one exists.
      */

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+
 import { Diff } from './diff'
 import { FixupFile } from './FixupFile'
 import { CodyTaskState } from './utils'
@@ -31,10 +33,9 @@ export class FixupTask {
         // insert mode means insert replacement at selection, otherwise replace selection contents with replacement
         public insertMode?: boolean,
         // the source of the instruction, e.g. 'code-action', 'doc', etc
-        public source?: string
+        public source?: ChatEventSource
     ) {
         this.id = Date.now().toString(36).replaceAll(/\d+/g, '')
-        this.source = source?.replace('/', '')
     }
 
     /**

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -63,7 +63,7 @@ export class FixupTypingUI {
         const match = instruction.match(CHAT_RE)
         if (match?.[1]) {
             // If we got here, we have a selection; start chat with match[1].
-            await vscode.commands.executeCommand('cody.action.chat', match[1])
+            await vscode.commands.executeCommand('cody.action.chat', match[1], 'fixup')
             return null
         }
 

--- a/vscode/test/integration/chat.test.ts
+++ b/vscode/test/integration/chat.test.ts
@@ -19,7 +19,7 @@ suite('Chat', function () {
     test('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.focus')
         const chatView = await getChatViewProvider()
-        await chatView.executeRecipe('chat-question', 'hello from the human')
+        await chatView.executeRecipe('chat-question', 'hello from the human', 'test')
 
         assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)
         await waitUntil(async () => /^hello from the assistant$/.test((await getTranscript(1)).displayText || ''))


### PR DESCRIPTION
feat: add source tracking for recipe execution

- Pass source parameter to executeRecipe() to track where recipe was triggered from
- Update callsites to pass source: 'sidebar', 'code-action', 'command' for `chat-question` specifically
- Log source in recipe execution telemetry

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Click `Ask Cody to Explain` and check the output channel, you should see the following telemetry event:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:recipe:chat-question:executed {"contextSummary":{"embeddings":4,"local":2},"source":"code-action"}
```

Where `source` of the chat-question is `code-action`

When submitted a question from side bar:

```
logEvent (telemetry disabled): CodyVSCodeExtension:recipe:chat-question:executed {"contextSummary":{"embeddings":13,"local":1},"source":"sidebar"}
```