### PR TITLE
Autocomplete: Fix suggest item race condition

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - User selection in active editor will not be replaced by smart selections for the `/edit` command. [pull/1429](https://github.com/sourcegraph/cody/pull/1429)
+- Fixes an issue that caused part of the autocomplete response to be completed when selecting an item from the suggest widget. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,7 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - User selection in active editor will not be replaced by smart selections for the `/edit` command. [pull/1429](https://github.com/sourcegraph/cody/pull/1429)
-- Fixes an issue that caused part of the autocomplete response to be completed when selecting an item from the suggest widget. [pull/](https://github.com/sourcegraph/cody/pull/)
+- Fixes an issue that caused part of the autocomplete response to be completed when selecting an item from the suggest widget. [pull/1477](https://github.com/sourcegraph/cody/pull/1477)
 
 ### Changed
 

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -85,7 +85,7 @@ describe('getCurrentDocContext', () => {
         })
     })
 
-    it('injects the selected item from the suggestions widget into the prompt', () => {
+    it('injects the selected item from the suggestions widget into the prompt when it overlaps', () => {
         const result = testGetCurrentDocContext(
             dedent`
                 console.a█
@@ -93,8 +93,8 @@ describe('getCurrentDocContext', () => {
             {
                 triggerKind: 0,
                 selectedCompletionInfo: {
-                    range: range(0, 8, 0, 10),
-                    text: 'assert',
+                    range: range(0, 7, 0, 9),
+                    text: '.assert',
                 },
             }
         )
@@ -109,6 +109,34 @@ describe('getCurrentDocContext', () => {
             nextNonEmptyLine: '',
             multilineTrigger: null,
             injectedPrefix: 'ssert',
+        })
+    })
+
+    it('injects the selected item from the suggestions widget into the prompt when it does not overlap', () => {
+        const result = testGetCurrentDocContext(
+            dedent`
+                // some line before
+                console.█
+            `,
+            {
+                triggerKind: 0,
+                selectedCompletionInfo: {
+                    range: range(1, 8, 1, 8),
+                    text: 'log',
+                },
+            }
+        )
+
+        expect(result).toEqual({
+            prefix: '// some line before\nconsole.log',
+            suffix: '',
+            contextRange: expect.any(Object),
+            currentLinePrefix: 'console.log',
+            currentLineSuffix: '',
+            prevNonEmptyLine: '// some line before',
+            nextNonEmptyLine: '',
+            multilineTrigger: null,
+            injectedPrefix: 'log',
         })
     })
 

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -68,10 +68,20 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
     let injectedPrefix = null
     if (context?.selectedCompletionInfo) {
         const { range, text } = context.selectedCompletionInfo
-        completePrefixWithContextCompletion = completePrefix.slice(0, range.start.character - position.character) + text
-        injectedPrefix = completePrefixWithContextCompletion.slice(completePrefix.length)
-        if (injectedPrefix === '') {
-            injectedPrefix = null
+        // A selected completion info attempts to replace the specified range with the inserted text
+        //
+        // We assume that the end of the range equals the current position, otherwise this would not
+        // inject a prefix
+        if (range.end.character === position.character && range.end.line === position.line) {
+            const lastLine = lines(completePrefix).at(-1)!
+            const beforeLastLine = completePrefix.slice(0, -lastLine.length)
+            completePrefixWithContextCompletion = beforeLastLine + lastLine.slice(0, range.start.character) + text
+            injectedPrefix = completePrefixWithContextCompletion.slice(completePrefix.length)
+            if (injectedPrefix === '') {
+                injectedPrefix = null
+            }
+        } else {
+            console.warn('The selected completion info does not match the current position')
         }
     }
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -79,7 +79,7 @@ export interface LastInlineCompletionCandidate {
     lastTriggerPosition: vscode.Position
 
     /** The selected info item. */
-    lastTriggerSelectedInfoItem: string | undefined
+    lastTriggerSelectedCompletionInfo: vscode.SelectedCompletionInfo | undefined
 
     /** The previously suggested result. */
     result: InlineCompletionsResult
@@ -177,7 +177,6 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         setIsLoading,
         abortSignal,
         tracer,
-        completeSuggestWidgetSelection = true,
         disableStreamingTruncation = false,
         handleDidAcceptCompletionItem,
         handleDidPartiallyAcceptCompletionItem,
@@ -218,7 +217,6 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
                   lastCandidate,
                   docContext,
                   selectedCompletionInfo,
-                  completeSuggestWidgetSelection,
                   handleDidAcceptCompletionItem,
                   handleDidPartiallyAcceptCompletionItem,
               })

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -157,7 +157,7 @@ describe('InlineCompletionItemProvider', () => {
               "character": 12,
               "line": 0,
             },
-            "lastTriggerSelectedInfoItem": undefined,
+            "lastTriggerSelectedCompletionInfo": undefined,
             "result": {
               "items": [
                 {
@@ -450,28 +450,29 @@ describe('InlineCompletionItemProvider', () => {
             const { document, position } = documentAndPosition(
                 dedent`
                     function foo() {
-                        console.l█
+                        console.█
                         console.foo()
                     }
                 `,
                 'typescript'
             )
+
             const fn = vi.fn(getInlineCompletions).mockResolvedValue({
                 logId: '1' as SuggestionID,
-                items: [{ insertText: "og('hello world!')", range: new vsCodeMocks.Range(1, 12, 1, 13) }],
+                items: [{ insertText: "log('hello world!')", range: new vsCodeMocks.Range(1, 12, 1, 12) }],
                 source: InlineCompletionsResultSource.Network,
             })
-
             const provider = new MockableInlineCompletionItemProvider(fn)
 
             // Ignore the first call, it will not use the selected completion info
             await provider.provideInlineCompletionItems(document, position, {
                 triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
-                selectedCompletionInfo: { text: 'dir', range: new vsCodeMocks.Range(1, 12, 1, 13) },
+                selectedCompletionInfo: { text: 'dir', range: new vsCodeMocks.Range(1, 12, 1, 12) },
             })
+
             const items = await provider.provideInlineCompletionItems(document, position, {
                 triggerKind: vsCodeMocks.InlineCompletionTriggerKind.Automatic,
-                selectedCompletionInfo: { text: 'log', range: new vsCodeMocks.Range(1, 12, 1, 13) },
+                selectedCompletionInfo: { text: 'log', range: new vsCodeMocks.Range(1, 12, 1, 12) },
             })
 
             expect(fn).toBeCalledWith(
@@ -486,25 +487,22 @@ describe('InlineCompletionItemProvider', () => {
                     }),
                 })
             )
-            expect(items).toMatchInlineSnapshot(`
-              {
-                "completionEvent": undefined,
-                "items": [
-                  InlineCompletionItem {
-                    "insertText": "    console.log('hello world!')",
-                    "range": Range {
-                      "end": Position {
-                        "character": 13,
-                        "line": 1,
-                      },
-                      "start": Position {
-                        "character": 0,
-                        "line": 1,
-                      },
+            expect(items?.items).toMatchInlineSnapshot(`
+              [
+                InlineCompletionItem {
+                  "insertText": "    console.log('hello world!')",
+                  "range": Range {
+                    "end": Position {
+                      "character": 12,
+                      "line": 1,
+                    },
+                    "start": Position {
+                      "character": 0,
+                      "line": 1,
                     },
                   },
-                ],
-              }
+                },
+              ]
             `)
         })
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -110,7 +110,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         }
 
         this.requestManager = new RequestManager({
-            completeSuggestWidgetSelection: this.config.completeSuggestWidgetSelection,
             disableNetworkCache: this.config.disableNetworkCache,
             disableRecyclingOfPreviousRequests: this.config.disableRecyclingOfPreviousRequests,
         })
@@ -367,7 +366,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     uri: document.uri,
                     lastTriggerPosition: position,
                     lastTriggerDocContext: docContext,
-                    lastTriggerSelectedInfoItem: context?.selectedCompletionInfo?.text,
+                    lastTriggerSelectedCompletionInfo: context?.selectedCompletionInfo,
                     result,
                 }
                 this.lastCandidate = items.length > 0 ? candidate : undefined

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -48,26 +48,21 @@ export interface RequestManagerResult {
 export class RequestManager {
     private cache = new RequestCache()
     private readonly inflightRequests: Set<InflightRequest> = new Set()
-    private completeSuggestWidgetSelection = true
     private disableNetworkCache = false
     private disableRecyclingOfPreviousRequests = false
 
     constructor(
         {
-            completeSuggestWidgetSelection = true,
             disableNetworkCache = false,
             disableRecyclingOfPreviousRequests = false,
         }: {
-            completeSuggestWidgetSelection?: boolean
             disableNetworkCache?: boolean
             disableRecyclingOfPreviousRequests?: boolean
         } = {
-            completeSuggestWidgetSelection: true,
             disableNetworkCache: false,
             disableRecyclingOfPreviousRequests: false,
         }
     ) {
-        this.completeSuggestWidgetSelection = completeSuggestWidgetSelection
         this.disableNetworkCache = disableNetworkCache
         this.disableRecyclingOfPreviousRequests = disableRecyclingOfPreviousRequests
     }
@@ -147,7 +142,7 @@ export class RequestManager {
             uri: document.uri,
             lastTriggerPosition: position,
             lastTriggerDocContext: docContext,
-            lastTriggerSelectedInfoItem: selectedCompletionInfo?.text,
+            lastTriggerSelectedCompletionInfo: selectedCompletionInfo,
             result: {
                 logId: '' as SuggestionID,
                 source: InlineCompletionsResultSource.Network,
@@ -170,7 +165,6 @@ export class RequestManager {
                 lastCandidate,
                 docContext: request.params.docContext,
                 selectedCompletionInfo: request.params.selectedCompletionInfo,
-                completeSuggestWidgetSelection: this.completeSuggestWidgetSelection,
             })
 
             if (synthesizedCandidate) {

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -14,12 +14,7 @@ import { InlineCompletionItemWithAnalytics } from './text-processing/process-inl
 
 type ReuseLastCandidateArgument =
     // required fields from InlineCompletionsParams
-    Required<
-        Pick<
-            InlineCompletionsParams,
-            'document' | 'position' | 'selectedCompletionInfo' | 'lastCandidate' | 'completeSuggestWidgetSelection'
-        >
-    > &
+    Required<Pick<InlineCompletionsParams, 'document' | 'position' | 'selectedCompletionInfo' | 'lastCandidate'>> &
         // optional fields from InlineCompletionsParams
         Pick<InlineCompletionsParams, 'handleDidAcceptCompletionItem' | 'handleDidPartiallyAcceptCompletionItem'> & {
             // additional fields
@@ -33,10 +28,9 @@ export function reuseLastCandidate({
     document,
     position,
     selectedCompletionInfo,
-    lastCandidate: { lastTriggerPosition, lastTriggerDocContext, lastTriggerSelectedInfoItem },
+    lastCandidate: { lastTriggerPosition, lastTriggerDocContext, lastTriggerSelectedCompletionInfo },
     lastCandidate,
     docContext: { currentLinePrefix, currentLineSuffix, nextNonEmptyLine },
-    completeSuggestWidgetSelection,
     handleDidAcceptCompletionItem,
     handleDidPartiallyAcceptCompletionItem,
 }: ReuseLastCandidateArgument): InlineCompletionsResult | null {
@@ -44,21 +38,38 @@ export function reuseLastCandidate({
     const isSameLine = lastTriggerPosition.line === position.line
     const isSameNextNonEmptyLine = lastTriggerDocContext.nextNonEmptyLine === nextNonEmptyLine
 
-    // If completeSuggestWidgetSelection is enabled, we have to compare that a last candidate is
-    // only reused if it is has same completion info selected.
-    const isSameTriggerSelectedInfoItem = completeSuggestWidgetSelection
-        ? lastTriggerSelectedInfoItem === selectedCompletionInfo?.text
+    // When the current request has an selectedCompletionInfo set, we have to compare that a last
+    // candidate is only reused if it is has same completion info selected.
+    //
+    // This will handle cases where the user fully accepts a completion info. In that case, the
+    // lastTriggerSelectedCompletionInfo.text will be set but the selectedCompletionInfo will be
+    // empty, allowing the last candidate to be reused.
+    const isSameSelectedInfoItemOrFullyAccepted = selectedCompletionInfo
+        ? lastTriggerSelectedCompletionInfo?.text === selectedCompletionInfo?.text
         : true
 
-    if (!isSameDocument || !isSameLine || !isSameNextNonEmptyLine || !isSameTriggerSelectedInfoItem) {
+    if (!isSameDocument || !isSameLine || !isSameNextNonEmptyLine || !isSameSelectedInfoItemOrFullyAccepted) {
         return null
     }
 
+    // The currentLinePrefix might have an injected prefix. This is usually expected, since we want
+    // to use eventual suggest widget state to guide the completion, but ofr the last candidate
+    // logic we need to get the line prefix as it appears in the document and there, the prefix is
+    // not present yet.
+    const lastTriggerCurrentLinePrefixInDocument = lastTriggerDocContext.injectedPrefix
+        ? lastTriggerDocContext.currentLinePrefix.slice(
+              0,
+              lastTriggerDocContext.currentLinePrefix.length - lastTriggerDocContext.injectedPrefix.length
+          )
+        : lastTriggerDocContext.currentLinePrefix
+
     // There are 2 reasons we can reuse a candidate: typing-as-suggested or change-of-indentation.
-    const lastTriggerCurrentLinePrefix = lastTriggerDocContext.currentLinePrefix
-    const isIndentation = isWhitespace(currentLinePrefix) && currentLinePrefix.startsWith(lastTriggerCurrentLinePrefix)
+
+    const isIndentation =
+        isWhitespace(currentLinePrefix) && currentLinePrefix.startsWith(lastTriggerCurrentLinePrefixInDocument)
     const isDeindentation =
-        isWhitespace(lastTriggerCurrentLinePrefix) && lastTriggerCurrentLinePrefix.startsWith(currentLinePrefix)
+        isWhitespace(lastTriggerCurrentLinePrefixInDocument) &&
+        lastTriggerCurrentLinePrefixInDocument.startsWith(currentLinePrefix)
     const isIndentationChange = currentLineSuffix === '' && (isIndentation || isDeindentation)
     let didAcceptCompletion = false
 
@@ -67,7 +78,7 @@ export function reuseLastCandidate({
             // Allow reuse if the user is (possibly) typing forward as suggested by the last
             // candidate completion. We still need to filter the candidate items to see which ones
             // the user's typing actually follows.
-            const lastCompletion = lastTriggerCurrentLinePrefix + item.insertText
+            const lastCompletion = lastTriggerCurrentLinePrefixInDocument + item.insertText
             const isTypingAsSuggested =
                 lastCompletion.startsWith(currentLinePrefix) && position.isAfterOrEqual(lastTriggerPosition)
             if (isTypingAsSuggested) {
@@ -86,7 +97,7 @@ export function reuseLastCandidate({
                 }
 
                 // Detect partial acceptance of the last candidate
-                const acceptedLength = currentLinePrefix.length - lastTriggerCurrentLinePrefix.length
+                const acceptedLength = currentLinePrefix.length - lastTriggerCurrentLinePrefixInDocument.length
                 if (isPartialAcceptance(item.insertText, acceptedLength)) {
                     handleDidPartiallyAcceptCompletionItem?.(lastCandidate.result.logId, item, acceptedLength)
                 }
@@ -98,7 +109,8 @@ export function reuseLastCandidate({
             if (isIndentationChange) {
                 return {
                     ...item,
-                    insertText: lastTriggerCurrentLinePrefix.slice(currentLinePrefix.length) + item.insertText,
+                    insertText:
+                        lastTriggerCurrentLinePrefixInDocument.slice(currentLinePrefix.length) + item.insertText,
                 }
             }
 
@@ -145,11 +157,6 @@ export function getRequestParamsFromLastCandidate(
         document,
         position: lastCandidate.lastTriggerPosition,
         docContext: lastCandidate.lastTriggerDocContext,
-        selectedCompletionInfo: lastCandidate.lastTriggerSelectedInfoItem
-            ? {
-                  range: new vscode.Range(0, 0, 0, 0),
-                  text: lastCandidate.lastTriggerSelectedInfoItem,
-              }
-            : undefined,
+        selectedCompletionInfo: lastCandidate.lastTriggerSelectedCompletionInfo,
     }
 }


### PR DESCRIPTION
This PR fixes a race condition that was observed when picking items from the suggest widget. The main reason for this was that the `reuseLastCandidate` logic was not aware of the _actual_ document state but only comparing the doc context `prefix`. This, in some cases, can have the suggest widget candidate injected. 

Now, for that logic, these two completions are exactly the same:

- A completion request for `console.█` with `log` selected in the suggest widget
- A completion request for `console.log█`

This made this logic conclude that it is safe to return the same suggest (`log`) in both cases, causing the repitition.

While working on this, I also noticed another issue with how we calculate the `current-doc`: Right now, this would only work if the selection to be replaced is non-emtpy. This seems to always be the case in production (thankfully) since suggest widget will only trigger once you insert a `.` and it will always replace this dot (so in the above case, it will be `console.█` with `.log` selected, with a range that replaced the `.`). This is not how we wrote our unit tests though and conceptually it shouldn't require this. Hence this PR also adds support for empty ranges in the current doc logic together with a bunch of tests.

This was likely introduced by us starting to propagate the `completeSuggestWidgetSelection` flag properly (which before was always false) but even before that, this race condition could sometimes happen. This implementation should be a bit more robust.

## Test plan

### Before

https://github.com/sourcegraph/cody/assets/458591/df0cf31e-113a-41b2-a58d-9da9709b29a5

### After

https://github.com/sourcegraph/cody/assets/458591/9071bb54-1df9-4cca-9cbd-b8e307768fa4





<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
