### PR TITLE
Autocomplete: add `jsx_attribute` completion intent

### DIFF
--- a/vscode/src/completions/test-helpers.ts
+++ b/vscode/src/completions/test-helpers.ts
@@ -12,6 +12,7 @@ import { wrapVSCodeTextDocument } from '../testutils/textDocument'
 
 import { SupportedLanguage } from './tree-sitter/grammars'
 import { createParser } from './tree-sitter/parser'
+import { DocumentQuerySDK, getDocumentQuerySDK } from './tree-sitter/query-sdk'
 
 /**
  * A tag function for creating a {@link CompletionResponse}, for use in tests only.
@@ -66,11 +67,28 @@ export function documentAndPosition(
 
 export const CUSTOM_WASM_LANGUAGE_DIR = path.resolve(ROOT_PATH, 'vscode/resources/wasm')
 
+/**
+ * Should be used in tests only.
+ */
 export function initTreeSitterParser(language = SupportedLanguage.TypeScript): Promise<Parser> {
     return createParser({
         language,
         grammarDirectory: CUSTOM_WASM_LANGUAGE_DIR,
     })
+}
+
+/**
+ * Should be used in tests only.
+ */
+export async function initTreeSitterSDK(language = SupportedLanguage.TypeScript): Promise<DocumentQuerySDK> {
+    await initTreeSitterParser(language)
+    const sdk = getDocumentQuerySDK(language)
+
+    if (!sdk) {
+        throw new Error('Document query SDK is not initialized')
+    }
+
+    return sdk
 }
 
 interface FormattedMatch {

--- a/vscode/src/completions/tree-sitter/queries.ts
+++ b/vscode/src/completions/tree-sitter/queries.ts
@@ -22,11 +22,13 @@ export const intentPriority = [
     'type_declaration.name',
     'type_declaration.body',
     'arguments',
-    'block_statement',
     'import.source',
     'comment',
     'argument',
+    'parameter',
     'parameters',
+    'jsx_attribute.value',
+    'return_statement.value',
     'return_statement',
     'string',
 ] as const
@@ -72,7 +74,6 @@ const JS_INTENTS_QUERY = dedent`
         name: (_) @class.name!
         body: (class_body ("{") @class.body.cursor) @class.body)
 
-    (_ ("{") @block_statement.cursor) @block_statement
     (arguments ("(") @arguments.cursor) @arguments
 
     ; Atomic intents
@@ -87,6 +88,12 @@ const JS_INTENTS_QUERY = dedent`
     (formal_parameters (_) @parameter!)
     (return_statement) @return_statement!
     (return_statement (_) @return_statement.value!)
+`
+
+const JSX_INTENTS_QUERY = dedent`
+    ${JS_INTENTS_QUERY}
+
+    (jsx_attribute (_) @jsx_attribute.value!)
 `
 
 const TS_INTENTS_QUERY = dedent`
@@ -108,6 +115,12 @@ const TS_INTENTS_QUERY = dedent`
         value: (object_type ("{") @type_declaration.body.cursor) @type_declaration.body)
 `
 
+const TSX_INTENTS_QUERY = dedent`
+    ${TS_INTENTS_QUERY}
+
+    (jsx_attribute (_) @jsx_attribute.value!)
+`
+
 const TS_SINGLELINE_TRIGGERS_QUERY = dedent`
     (interface_declaration (object_type ("{") @block_start)) @trigger
     (type_alias_declaration (object_type ("{") @block_start)) @trigger
@@ -122,7 +135,7 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     [SupportedLanguage.JSX]: {
         blocks: JS_BLOCKS_QUERY,
         singlelineTriggers: '',
-        intents: JS_INTENTS_QUERY,
+        intents: JSX_INTENTS_QUERY,
     },
     [SupportedLanguage.TypeScript]: {
         blocks: JS_BLOCKS_QUERY,
@@ -132,7 +145,7 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     [SupportedLanguage.TSX]: {
         blocks: JS_BLOCKS_QUERY,
         singlelineTriggers: TS_SINGLELINE_TRIGGERS_QUERY,
-        intents: TS_INTENTS_QUERY,
+        intents: TSX_INTENTS_QUERY,
     },
     [SupportedLanguage.Go]: {
         blocks: dedent`

--- a/vscode/src/completions/tree-sitter/query-tests/intents.test.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/intents.test.ts
@@ -1,15 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { initTreeSitterParser } from '../../test-helpers'
+import { initTreeSitterSDK } from '../../test-helpers'
 import { SupportedLanguage } from '../grammars'
-import { getDocumentQuerySDK } from '../query-sdk'
 
 import { annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
 
 describe('getIntent', () => {
     it('typescript', async () => {
-        await initTreeSitterParser(SupportedLanguage.TypeScript)
-        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TypeScript)
 
         await annotateAndMatchSnapshot({
             parser,
@@ -20,14 +18,35 @@ describe('getIntent', () => {
     })
 
     it('typescript incomplete code', async () => {
-        await initTreeSitterParser(SupportedLanguage.TypeScript)
-        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TypeScript)
 
         await annotateAndMatchSnapshot({
             parser,
             language,
             captures: queries.getCompletionIntent,
             sourcesPath: 'test-data/intents-partial.ts',
+        })
+    })
+
+    it('javascriptreact', async () => {
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.JSX)
+
+        await annotateAndMatchSnapshot({
+            parser,
+            language,
+            captures: queries.getCompletionIntent,
+            sourcesPath: 'test-data/intents.jsx',
+        })
+    })
+
+    it('typescriptreact', async () => {
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TSX)
+
+        await annotateAndMatchSnapshot({
+            parser,
+            language,
+            captures: queries.getCompletionIntent,
+            sourcesPath: 'test-data/intents.tsx',
         })
     })
 })

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/intents.jsx
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/intents.jsx
@@ -1,0 +1,11 @@
+function ComponentObject() {
+    return <button onClick={}></button>
+    //                     |
+}
+
+// ------------------------------------
+
+function ComponentString() {
+    return <div color=""></div>
+    //                |
+}

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/intents.snap.jsx
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/intents.snap.jsx
@@ -1,0 +1,27 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// ------------------------------------
+
+  function ComponentObject() {
+      return <button onClick={}></button>
+//                           ^^ jsx_attribute.value[1]
+//                           █
+  }
+
+// Nodes types:
+// jsx_attribute.value[1]: jsx_expression
+
+// ------------------------------------
+
+  function ComponentString() {
+      return <div color=""></div>
+//                      ^^ jsx_attribute.value[1]
+//                      █
+  }
+
+// Nodes types:
+// jsx_attribute.value[1]: string
+

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/intents.snap.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/intents.snap.ts
@@ -92,17 +92,6 @@
 
 // ------------------------------------
 
-  function withEmptyBlockStatement() {
-      functionName(); { }
-//                    ^^^ block_statement[1]
-//                    █
-  }
-
-// Nodes types:
-// block_statement[1]: statement_block
-
-// ------------------------------------
-
   function returnStatement() {
       return
 //    ^^^^^^ return_statement[1]

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/intents.snap.tsx
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/intents.snap.tsx
@@ -1,0 +1,27 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// ------------------------------------
+
+  function ComponentObject() {
+      return <button onClick={}></button>
+//                           ^^ jsx_attribute.value[1]
+//                           █
+  }
+
+// Nodes types:
+// jsx_attribute.value[1]: jsx_expression
+
+// ------------------------------------
+
+  function ComponentString() {
+      return <div color=""></div>
+//                      ^^ jsx_attribute.value[1]
+//                      █
+  }
+
+// Nodes types:
+// jsx_attribute.value[1]: string
+

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/intents.ts
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/intents.ts
@@ -50,13 +50,6 @@ function functionName() {}
 
 // ------------------------------------
 
-function withEmptyBlockStatement() {
-    functionName(); { }
-    //              |
-}
-
-// ------------------------------------
-
 function returnStatement() {
     return
     //   |

--- a/vscode/src/completions/tree-sitter/query-tests/test-data/intents.tsx
+++ b/vscode/src/completions/tree-sitter/query-tests/test-data/intents.tsx
@@ -1,0 +1,11 @@
+function ComponentObject() {
+    return <button onClick={}></button>
+    //                     |
+}
+
+// ------------------------------------
+
+function ComponentString() {
+    return <div color=""></div>
+    //                |
+}


### PR DESCRIPTION
## Context

- This PR adds the JSX-specific completion intent, `jsx_attribute`, which is one of the most popular suggestions (~10% of all JS/TS suggested completions) with low average CAR (~15%) based on [the analytics data](https://console.cloud.google.com/bigquery?sq=839055276916:addb416ff2c146e39f524b526cccd9d8).
- Follow-up for https://github.com/sourcegraph/cody/pull/1457
- Closes https://github.com/sourcegraph/cody/issues/1472
- Part of https://github.com/sourcegraph/cody/issues/1455

## Test plan

Added new unit tests.
