### PR TITLE
Benchmarks: update benchmark config to match folder name

### DIFF
--- a/vscode/test/benchmark/datasets/typescript/object-property-access-closed-file/config.json
+++ b/vscode/test/benchmark/datasets/typescript/object-property-access-closed-file/config.json
@@ -1,7 +1,7 @@
 {
   "entryFile": "generate.ts",
-  "openFiles": ["types.ts"],
-  "closedFiles": [],
+  "openFiles": [],
+  "closedFiles": ["types.ts"],
   "solutionFile": "solution.ts",
   "testFile": "test.ts",
   "testCommand": "ts-node test.ts"

--- a/vscode/test/benchmark/datasets/typescript/object-property-access-open-file/config.json
+++ b/vscode/test/benchmark/datasets/typescript/object-property-access-open-file/config.json
@@ -1,7 +1,7 @@
 {
   "entryFile": "generate.ts",
-  "openFiles": [],
-  "closedFiles": ["types.ts"],
+  "openFiles": ["types.ts"],
+  "closedFiles": [],
   "solutionFile": "solution.ts",
   "testFile": "test.ts",
   "testCommand": "ts-node test.ts"


### PR DESCRIPTION
When running noticed the config was backward on these two
## Test plan
n/a bnechmark config change only
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
