### PR TITLE
Autocomplete: do adjust a completion range if it does not match the current line suffix

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -354,7 +354,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
 
             // A completion that won't be visible in VS Code will not be returned and not be logged.
             if (visibleItems.length === 0) {
-                console.log('Invisible completions!')
                 // Returning null will clear any existing suggestions, thus we need to reset the
                 // last candidate.
                 this.lastCandidate = undefined
@@ -507,9 +506,9 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             // come in.
             const start = currentLine.range.start
 
-            // The completion will always exclude the same line suffix, so it has to overwrite the
-            // current same line suffix and reach to the end of the line.
-            const end = currentLine.range.end
+            // If the completion does not have a range set it will always exclude the same line suffix,
+            // so it has to overwrite the current same line suffix and reach to the end of the line.
+            const end = (completion.range?.end || currentLine.range.end) as vscode.Position
 
             const vscodeInsertRange = new vscode.Range(start, end)
             const trackedRange = new vscode.Range(

--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -18,6 +18,17 @@ describe('adjustRangeToOverwriteOverlappingCharacters', () => {
         ).toBeUndefined()
     })
 
+    it('no adjustment if completion does not match current line suffix', () => {
+        const item: InlineCompletionItem = { insertText: '"argument1", true' }
+        const { position } = documentAndPosition('myFunction(█)')
+        expect(
+            getRangeAdjustedForOverlappingCharacters(item, {
+                position,
+                currentLineSuffix: ')',
+            })
+        ).toBeUndefined()
+    })
+
     it('handles non-empty currentLineSuffix', () => {
         const item: InlineCompletionItem = { insertText: 'array) {' }
         const { position } = documentAndPosition('function sort(█)')

--- a/vscode/src/completions/text-processing/process-inline-completions.test.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { Range } from '../../testutils/mocks'
 import { range } from '../../testutils/textDocument'
 import { documentAndPosition } from '../test-helpers'
 import { InlineCompletionItem } from '../types'
@@ -38,6 +39,17 @@ describe('adjustRangeToOverwriteOverlappingCharacters', () => {
                 currentLineSuffix: ')',
             })
         ).toEqual<InlineCompletionItem['range']>(range(0, 14, 0, 15))
+    })
+
+    it('handles partial currentLineSuffix match', () => {
+        const item: InlineCompletionItem = { insertText: 'array) {' }
+        const { document, position } = documentAndPosition('function sort(█) {}')
+        const replaceRange = getRangeAdjustedForOverlappingCharacters(item, {
+            position,
+            currentLineSuffix: ') {}',
+        })
+
+        expect(document.getText(replaceRange as Range)).toEqual(') {')
     })
 
     it('handles whitespace in currentLineSuffix', () => {

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -4,6 +4,7 @@ import { Tree } from 'web-tree-sitter'
 import { dedupeWith } from '@sourcegraph/cody-shared/src/common'
 
 import { DocumentContext } from '../get-current-doc-context'
+import { completionMatchesSuffix } from '../inline-completion-item-provider'
 import { ItemPostProcessingInfo } from '../logger'
 import { getNodeAtCursorAndParents } from '../tree-sitter/ast-getters'
 import { asPoint, getCachedParseTreeForDocument } from '../tree-sitter/parse-tree-cache'
@@ -141,7 +142,7 @@ export function getRangeAdjustedForOverlappingCharacters(
     // TODO(sqs): This is a very naive implementation that will not work for many cases. It always
     // just clobbers the rest of the line.
 
-    if (!item.range && currentLineSuffix !== '') {
+    if (!item.range && currentLineSuffix !== '' && completionMatchesSuffix(item, currentLineSuffix)) {
         return { start: position, end: position.translate(undefined, currentLineSuffix.length) }
     }
 


### PR DESCRIPTION
## Context

- Fixes the issue where completions were needlessly hidden: `myFunction(█)` with the insert text being `"one", false` because the current line suffix `)` was not present in the generated completion. However, we still adjusted the completion insertion range to include it. 
- Fixes the issue where all the generated completions were hidden, even if only one needed to be ignored. Now, we filter out invisible completions individually and keep visible completions if we have any.

## Test plan

Added unit tests.
