### PR TITLE
fix: smart selection not working on the first line of code

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Smart selection not working on the first line of code. [pull/1508](https://github.com/sourcegraph/cody/pull/1508)
+
 ### Changed
 
 - Start prompt mixin by default. [pull/1479](https://github.com/sourcegraph/cody/pull/1479)

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -138,7 +138,7 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
             return null
         }
         const selection = activeEditor.selection
-        if (selection?.start.line === undefined) {
+        if (!selection.start) {
             return null
         }
 

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -138,7 +138,7 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
             return null
         }
         const selection = activeEditor.selection
-        if (!selection?.start.line && selection?.start.line !== 0) {
+        if (selection?.start.line === undefined) {
             return null
         }
 

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -130,7 +130,6 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
      * Otherwise tries to get the folding range containing the cursor position.
      *
      * Returns null if no selection can be determined.
-     *
      * @returns The smart selection for the active editor, or null if none can be determined.
      */
     public async getActiveTextEditorSmartSelection(): Promise<ActiveTextEditorSelection | null> {
@@ -139,7 +138,7 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
             return null
         }
         const selection = activeEditor.selection
-        if (!selection?.start.line) {
+        if (!selection?.start.line && selection?.start.line !== 0) {
             return null
         }
 


### PR DESCRIPTION
fix: smart selection not working on the first line of code

This issue was caused by `!selection?.start.line` in the smart selection function excluding the possibility of `selection?.start.line === 0` (the vs code API returns the line number on display - 1, so line 1 in the editor would returns 0). 

This commit fixes that by explicitly checking selection.start.line is not null and is not equal to 0 before failing.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try running the `Generate Unit Tests` command on the first line of the file:

![image](https://github.com/sourcegraph/cody/assets/68532117/8d3a6622-8b87-4ece-87c1-6a46f520e706)


#### After

You should be able to run the command and the expanded range will be selected for you automatically when available:

![image](https://github.com/sourcegraph/cody/assets/68532117/465947db-dd04-45fc-a274-6cf447583925)


#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/b94fc7b1-6f70-450d-963c-2cfed99d2e47)
 
