### PR TITLE
feat: add icons and enablement conditions for commands

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -261,32 +261,49 @@
         "command": "cody.command.edit-code",
         "category": "Ask Cody",
         "title": "Edit Code",
-        "icon": "$(sparkle)"
+        "when": "cody.activated && editorTextFocusd",
+        "icon": "$(wand)"
       },
       {
         "command": "cody.command.explain-code",
         "category": "Ask Cody",
-        "title": "Explain Code"
+        "title": "Explain Code",
+        "icon": "$(output)",
+        "when": "cody.activated && editorFocus"
       },
       {
         "command": "cody.command.generate-tests",
         "category": "Ask Cody",
-        "title": "Generate Unit Tests"
+        "title": "Generate Unit Tests",
+        "icon": "$(package)",
+        "when": "cody.activated && editorTextFocusd"
       },
       {
         "command": "cody.command.document-code",
         "category": "Ask Cody",
-        "title": "Document Code"
+        "title": "Document Code",
+        "icon": "$(book)",
+        "when": "cody.activated && editorTextFocus"
       },
       {
         "command": "cody.command.smell-code",
         "category": "Ask Cody",
-        "title": "Find Code Smells"
+        "title": "Find Code Smells",
+        "icon": "$(symbol-keyword)",
+        "when": "cody.activated && editorFocus"
+      },
+      {
+        "command": "cody.action.commands.custom.menu",
+        "category": "Ask Cody",
+        "title": "Custom Commands",
+        "icon": "$(tools)",
+        "when": "cody.activated && workspaceFolderCount > 0"
       },
       {
         "command": "cody.command.context-search",
         "category": "Ask Cody",
-        "title": "Codebase Context Search"
+        "title": "Codebase Context Search",
+        "when": "cody.activated && workspaceFolderCount > 0"
       },
       {
         "command": "cody.auth.signout",
@@ -316,7 +333,8 @@
         "category": "Cody",
         "title": "Start a New Chat Session",
         "group": "Cody",
-        "icon": "$(add)"
+        "icon": "$(add)",
+        "when": "cody.activated"
       },
       {
         "command": "cody.history",
@@ -429,13 +447,6 @@
         "icon": "$(diff)"
       },
       {
-        "command": "cody.action.commands.custom.menu",
-        "category": "Ask Cody",
-        "title": "Custom Commands",
-        "when": "cody.activated",
-        "icon": "$(bookmark)"
-      },
-      {
         "command": "cody.action.commands.menu",
         "category": "Cody",
         "title": "Commands",
@@ -499,6 +510,10 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "cody.command.edit-code",
+          "when": "cody.activated && editorTextFocusd"
+        },
+        {
           "command": "cody.command.explain-code",
           "when": "false"
         },
@@ -521,6 +536,10 @@
         {
           "command": "cody.command.document-code",
           "when": "false"
+        },
+        {
+          "command": "cody.action.commands.custom.menu",
+          "when": "cody.activated"
         },
         {
           "command": "cody.focus",
@@ -570,10 +589,6 @@
         {
           "command": "cody.guardrails.debug",
           "when": "config.cody.experimental.guardrails && editorHasSelection"
-        },
-        {
-          "command": "cody.action.commands.custom.menu",
-          "when": "cody.activated"
         }
       ],
       "editor/context": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -261,7 +261,7 @@
         "command": "cody.command.edit-code",
         "category": "Ask Cody",
         "title": "Edit Code",
-        "when": "cody.activated && editorTextFocusd",
+        "when": "cody.activated && editorTextFocus",
         "icon": "$(wand)"
       },
       {
@@ -276,7 +276,7 @@
         "category": "Ask Cody",
         "title": "Generate Unit Tests",
         "icon": "$(package)",
-        "when": "cody.activated && editorTextFocusd"
+        "when": "cody.activated && editorTextFocus"
       },
       {
         "command": "cody.command.document-code",
@@ -511,7 +511,7 @@
       "commandPalette": [
         {
           "command": "cody.command.edit-code",
-          "when": "cody.activated && editorTextFocusd"
+          "when": "cody.activated && editorTextFocus"
         },
         {
           "command": "cody.command.explain-code",


### PR DESCRIPTION
feat: add icons and enablement conditions for commands

This commit adds icons and "when" enablement conditions for various Cody commands in the package.json file. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Commands should be toggled based on the new when clauses.