### PR TITLE
add new aliases for x86_64 architecture

### DIFF
--- a/vscode/src/os.ts
+++ b/vscode/src/os.ts
@@ -13,6 +13,7 @@ export function getOSArch(): {
         arm64: 'aarch64',
         aarch64: 'aarch64',
         x86_64: 'x86_64',
+        x64: 'x86_64',
         i386: 'x86',
         i686: 'x86',
     }


### PR DESCRIPTION
A new alias x64 was added for the x86_64 architecture in the getOSArch function.

For windows with x64 returned by`os.arch()` currently returns undefined as it's missing on the list.

![image](https://github.com/sourcegraph/cody/assets/68532117/8f86e9d0-5eef-4d5c-bd14-1a3656a7ff69)

On Windows, os.arch() can return 'x64', 'ia32', or 'x86' to indicate 64-bit or 32-bit architectures.

Without the 'x64': 'x86_64' mapping, if os.arch() returns 'x64' on Windows, the arch value would be undefined in the return value of getOSArch.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

This is also what we used to create the URLs for downloading Cody App