### PR TITLE
BFG: fix git URI inference on Windows

### DIFF
--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -1,5 +1,3 @@
-import * as path from 'path'
-
 import * as vscode from 'vscode'
 
 import { API, GitExtension } from './builtinGitExtension'
@@ -9,13 +7,7 @@ export function repositoryRemoteUrl(uri: vscode.Uri): string | undefined {
 }
 
 export function gitDirectoryUri(uri: vscode.Uri): vscode.Uri | undefined {
-    const git = gitAPI()
-    const rootPath = git?.getRepository(uri)?.rootUri?.fsPath
-    if (!rootPath) {
-        return undefined
-    }
-
-    return vscode.Uri.from({ scheme: 'file', path: path.join(rootPath, '.git') })
+    return gitAPI()?.getRepository(uri)?.rootUri
 }
 
 function gitRepositoryRemoteUrl(uri: vscode.Uri): string | undefined {


### PR DESCRIPTION
Previously, the URI was encoded incorrectly because we passed a Windows path with backslashes as URI paths, meaning they got escaped. This PR fixes the problem by removing the logic to send the .git/ subdirectory because gix infers it anyways on the server side.


## Test plan
Manually tested on Windows.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
