### PR TITLE
Add secondary telemetry to ContextProvider

### DIFF
--- a/lib/shared/src/telemetry-v2/index.ts
+++ b/lib/shared/src/telemetry-v2/index.ts
@@ -134,6 +134,9 @@ export type EventFeature =
     | 'cody.sidebar.commandConfigMenuButton.explain'
     | 'cody.sidebar.commandConfigMenuButton.smell'
     | 'cody.sidebar.commandConfigMenuButton.reset'
+    // context-provider-related events
+    | 'cody.auth'
+    | 'cody.auth.app'
 
 /**
  * Actions should denote a generic action within the scope of a feature. Where
@@ -150,6 +153,8 @@ export type EventAction =
     | 'opened'
     | 'closed'
     | 'hasCode'
+    | 'disconnected'
+    | 'connected'
 
 /**
  * MetadataKey is an allowlist of keys for the safe-for-export metadata parameter.

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -21,6 +21,7 @@ import { repositoryRemoteUrl } from '../repository/repositoryHelpers'
 import { AuthProvider } from '../services/AuthProvider'
 import { secretStorage } from '../services/SecretStorageProvider'
 import { telemetryService } from '../services/telemetry'
+import { telemetryRecorder } from '../services/telemetry-v2'
 
 import { ChatViewProviderWebview } from './ChatViewProvider'
 import { GraphContextProvider } from './GraphContextProvider'
@@ -168,10 +169,16 @@ export class ContextProvider implements vscode.Disposable {
         this.onConfigurationChange(newConfig)
         // When logged out, user's endpoint will be set to null
         const isLoggedOut = !authStatus.isLoggedIn && !authStatus.endpoint
-        const isAppEvent = isLocalApp(authStatus.endpoint || '') ? 'app:' : ''
+        const isAppEvent = isLocalApp(authStatus.endpoint || '') ? '.app' : ''
         const eventValue = isLoggedOut ? 'disconnected' : authStatus.isLoggedIn ? 'connected' : 'failed'
         // e.g. auth:app:connected, auth:app:disconnected, auth:failed
-        this.sendEvent(ContextEvent.Auth, isAppEvent + eventValue)
+        // this.sendEvent(ContextEvent.Auth, isAppEvent, eventValue)
+        switch (ContextEvent.Auth) {
+            case 'auth':
+                telemetryService.log(`CodyVSCodeExtension:Auth${isAppEvent.replace(/^\./, ':')}:${eventValue}`)
+                telemetryRecorder.recordEvent(`cody.auth${isAppEvent}`, eventValue)
+                break
+        }
     }
 
     /**
@@ -225,17 +232,6 @@ export class ContextProvider implements vscode.Disposable {
         }
 
         await send()
-    }
-
-    /**
-     * Log Events - naming convention: source:feature:action
-     */
-    private sendEvent(event: ContextEvent, value: string): void {
-        switch (event) {
-            case 'auth':
-                telemetryService.log(`CodyVSCodeExtension:Auth:${value}`)
-                break
-        }
     }
 
     public dispose(): void {
@@ -292,7 +288,6 @@ export class ContextProvider implements vscode.Disposable {
 
 /**
  * Gets codebase context for the current workspace.
- *
  * @param config Cody configuration
  * @param rgPath Path to rg (ripgrep) executable
  * @param editor Editor instance

--- a/vscode/test/e2e/inline-assist.test.ts
+++ b/vscode/test/e2e/inline-assist.test.ts
@@ -56,5 +56,11 @@ test('start a fixup job from inline chat with valid auth', async ({ page, sideba
     await expect.poll(() => loggedEvents).toEqual(expectedOrderedEvents)
     await expect
         .poll(() => loggedV2Events)
-        .toEqual(['cody.command.edit/executed', 'cody.recipe.fixup/executed', 'cody.fixup.apply/succeeded'])
+        .toEqual([
+            'cody.auth/failed',
+            'cody.auth/connected',
+            'cody.command.edit/executed',
+            'cody.recipe.fixup/executed',
+            'cody.fixup.apply/succeeded',
+        ])
 })

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -89,5 +89,11 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     await expect.poll(() => loggedEvents).toEqual(expectedOrderedEvents)
     await expect
         .poll(() => loggedV2Events)
-        .toEqual(['cody.command.edit/executed', 'cody.recipe.fixup/executed', 'cody.fixup.apply/succeeded'])
+        .toEqual([
+            'cody.auth/failed',
+            'cody.auth/connected',
+            'cody.command.edit/executed',
+            'cody.recipe.fixup/executed',
+            'cody.fixup.apply/succeeded',
+        ])
 })


### PR DESCRIPTION
## Test plan

run extension in debug mode
check test eventlogs on dotcom for event emission
check bigquery for event reception