### PR TITLE
refactor: simplify auth state management

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.test.ts
@@ -16,7 +16,7 @@ describe('FeatureFlagProvider', () => {
         expect(await provider.evaluateFeatureFlag(FeatureFlag.TestFlagDoNotUse)).toBe(true)
     })
 
-    it('loads all evaluated feature flag on `syncAuthStatus`', async () => {
+    it('loads all evaluated feature flag on `onAuthStatusChange`', async () => {
         const apiClient = {
             getEvaluatedFeatureFlags: vitest.fn().mockResolvedValue({
                 [FeatureFlag.TestFlagDoNotUse]: true,
@@ -25,7 +25,7 @@ describe('FeatureFlagProvider', () => {
         }
 
         const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-        provider.syncAuthStatus()
+        provider.onAuthStatusChange()
 
         // Wait for the async initialization
         await nextTick()
@@ -63,7 +63,7 @@ describe('FeatureFlagProvider', () => {
             [FeatureFlag.TestFlagDoNotUse]: false,
         })
 
-        provider.syncAuthStatus()
+        provider.onAuthStatusChange()
 
         // Wait for the async reload
         await nextTick()
@@ -83,7 +83,7 @@ describe('FeatureFlagProvider', () => {
             }
 
             const provider = new FeatureFlagProvider(apiClient as unknown as SourcegraphGraphQLAPIClient)
-            provider.syncAuthStatus()
+            provider.onAuthStatusChange()
 
             // Wait for the async initialization
             await nextTick()

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -60,7 +60,7 @@ export class FeatureFlagProvider {
         return this.featureFlags[flagName]
     }
 
-    public syncAuthStatus(): void {
+    public onAuthStatusChange(): void {
         void this.refreshFeatureFlags()
     }
 

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -195,7 +195,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
     }
 
     public async simplifiedOnboardingReloadEmbeddingsState(): Promise<void> {
-        await this.contextProvider.forceUpdateCodebaseContext()
+        await this.contextProvider.forceUpdateCodebaseContext(this.authProvider.getAuthStatus())
     }
 
     private appWatcherChanged(appWatcher: LocalAppWatcher): void {

--- a/vscode/src/chat/ChatViewProvider.ts
+++ b/vscode/src/chat/ChatViewProvider.ts
@@ -48,7 +48,7 @@ export class ChatViewProvider extends MessageProvider implements vscode.WebviewV
             case 'ready':
                 // The web view is ready to receive events. We need to make sure that it has an up
                 // to date config, even if it was already published
-                await this.authProvider.announceNewAuthStatus()
+                this.authProvider.announceNewAuthStatus()
                 break
             case 'initialized':
                 logDebug('ChatViewProvider:onDidReceiveMessage:initialized', '')

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -4,7 +4,6 @@ import { commandRegex } from '@sourcegraph/cody-shared/src/chat/recipes/helpers'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
@@ -118,7 +117,6 @@ const register = async (
     const symfRunner = platform.createSymfRunner?.(context, initialConfig.serverEndpoint, initialConfig.accessToken)
 
     graphqlClient.onConfigurationChange(initialConfig)
-    void featureFlagProvider.syncAuthStatus()
 
     const {
         intentDetector,
@@ -512,8 +510,7 @@ const register = async (
      *  NOTE: This is executed whenever auth status changes
      */
     authProvider.addChangeListener((authStatus: AuthStatus) => {
-        void contextProvider.syncAuthStatus(authStatus)
-        void featureFlagProvider.syncAuthStatus()
+        void contextProvider.onAuthStatusChange(authStatus)
         void setupAutocomplete()
         updateAuthStatusBarIndicator(authStatus)
 
@@ -529,7 +526,6 @@ const register = async (
     })
 
     await setupAutocomplete()
-    updateAuthStatusBarIndicator(authProvider.getAuthStatus())
 
     // Initiate inline chat when feature flag is on
     if (!initialConfig.inlineChat) {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -321,13 +321,6 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
-        vscode.commands.registerCommand('cody.auth.sync', () => {
-            // NOTE: This is executed whenever auth status changes
-            const result = contextProvider.syncAuthStatus()
-            // Important that we return a promise here to allow `AuthProvider`
-            // to `await` on the auth config changes to propagate.
-            return result
-        }),
         // Commands
         vscode.commands.registerCommand('cody.interactive.clear', async () => {
             await sidebarChatProvider.clearAndRestartSession()
@@ -516,8 +509,10 @@ const register = async (
 
     /**
      *  Update services that rely on auth status changes
+     *  NOTE: This is executed whenever auth status changes
      */
     authProvider.addChangeListener((authStatus: AuthStatus) => {
+        void contextProvider.syncAuthStatus()
         void featureFlagProvider.syncAuthStatus()
         void setupAutocomplete()
         updateAuthStatusBarIndicator(authStatus)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -512,7 +512,7 @@ const register = async (
      *  NOTE: This is executed whenever auth status changes
      */
     authProvider.addChangeListener((authStatus: AuthStatus) => {
-        void contextProvider.syncAuthStatus()
+        void contextProvider.syncAuthStatus(authStatus)
         void featureFlagProvider.syncAuthStatus()
         void setupAutocomplete()
         updateAuthStatusBarIndicator(authStatus)

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -251,7 +251,7 @@ export class AuthProvider {
         const isLoggedIn = isAuthed(authStatus)
         authStatus.isLoggedIn = isLoggedIn
         await this.storeAuthInfo(endpoint, token)
-        await this.syncAuthStatus(authStatus)
+        this.syncAuthStatus(authStatus)
         await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
         return { authStatus, isLoggedIn }
     }
@@ -263,22 +263,21 @@ export class AuthProvider {
     }
 
     // Set auth status and share it with chatview
-    private async syncAuthStatus(authStatus: AuthStatus): Promise<void> {
+    private syncAuthStatus(authStatus: AuthStatus): void {
         if (this.authStatus === authStatus) {
             return
         }
         this.authStatus = authStatus
-        await this.announceNewAuthStatus()
+        this.announceNewAuthStatus()
     }
 
-    public async announceNewAuthStatus(): Promise<void> {
+    public announceNewAuthStatus(): void {
         if (this.authStatus.endpoint === 'init' || !this.webview) {
             return
         }
         for (const listener of this.listeners) {
             listener(this.getAuthStatus())
         }
-        await vscode.commands.executeCommand('cody.auth.sync')
     }
     /**
      * Display app state in webview view that is used during Signin flow

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -4,7 +4,7 @@ import { loggedEvents, resetLoggedEvents, SERVER_URL, VALID_TOKEN } from '../fix
 
 import { signOut, test } from './helpers'
 
-const expectedOrderedEvents = ['CodyVSCodeExtension:logout:clicked']
+const expectedOrderedEvents = ['CodyVSCodeExtension:logout:clicked', 'CodyVSCodeExtension:Auth:disconnected']
 
 test.beforeEach(() => {
     void resetLoggedEvents()


### PR DESCRIPTION
refactor: simplify auth state management on start-up

Syncing auth status after a change is now handled directly in AuthProvider.

Came across this when I was working on the new chat UI -- it looks like we have both `cody.auth.sync` and `authProvider.addChangeListener` to handle auth change events. This PR proposes addressing auth state changes in one central auth listener to remove the need to have multiple places to auth update events. 

- Remove redundant auth sync command registration `cody.auth.sync`
- Move auth state update logic into dedicated auth change listener
- Consolidate status bar indicator, completions setup, and other auth-dependent services into auth change handler
- Remove redundant auth sync logic
- Pass auth status object on auth change to status bar indicator instead of re-checking
- Fetch access token before setting in symfRunner to avoid null errors
- fix: remove redundant auth sync command registration

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

All the current tests should pass, and everything should work as before.

Try logging-in and then logout, and then log back in, each time try auto-completion and chat. Everything should work as before.
