### PR TITLE
Chat: Fix heading styles and inline code colors

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -37,8 +37,18 @@ const DOMPURIFY_CONFIG = {
         'tfoot',
         's',
         'u',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
     ],
     ALLOWED_URI_REGEXP,
+    FORBID_ATTR: [
+        // Disallow heading ids, or any ids
+        'id',
+    ],
 }
 
 /**

--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -53,6 +53,30 @@
     overflow-x: auto;
 }
 
+.content h1, .content h2, .content h3, .content h4, .content h5, .content h6 {
+    margin: 1.2em 0;
+}
+
+.content h1 {
+    font-size: 1.15em;
+    font-weight: 700;
+}
+
+.content h2 {
+    font-size: 1.1em;
+    font-weight: 700;
+}
+
+.content h3 {
+    font-size: inherit;
+    font-weight: 700;
+}
+
+.content h4, .content h5, .content h6 {
+    font-size: inherit;
+    font-weight: 600;
+}
+
 .content > div:first-child > *:first-child {
     margin-top: 0;
 }

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -27,16 +27,16 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     background-color: var(--vscode-sideBar-foreground, currentColor);
 }
 
+.transcript-item code, .transcript-item pre {
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
+}
+
 .transcript-item pre,
-.transcript-item span > code,
-.transcript-item p > code,
 .transcript-item pre > code {
     /* Our syntax highlighter emits colors intended for dark backgrounds only. */
     background-color: var(--vscode-editor-background);
     color: var(--vscode-editor-foreground);
-    font-family: var(--vscode-editor-font-family);
-    font-size: var(--vscode-editor-font-size);
-
     margin-bottom: 0;
 }
 
@@ -44,29 +44,14 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .human-transcript-item {
     border-style: solid;
     border-width: 1px;
     border-color: var(--vscode-sideBarSectionHeader-border);
-
     border-bottom: none;
 }
 
 body[data-vscode-theme-kind='vscode-light'] .transcript-item pre,
-body[data-vscode-theme-kind='vscode-light'] .transcript-item span > code,
-body[data-vscode-theme-kind='vscode-light'] .transcript-item p > code,
 body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
     /* Our syntax highlighter emits colors intended for dark backgrounds only. */
     background-color: var(--code-background);
     color: var(--code-foreground);
-    font-family: var(--vscode-editor-font-family);
-    font-size: var(--vscode-editor-font-size);
-
-    margin-bottom: 0;
-}
-
-body[data-vscode-theme-kind='vscode-light'] .transcript-item pre {
-    border-style: solid;
-    border-width: 1px;
-    border-color: var(--vscode-sideBarSectionHeader-border);
-
-    border-bottom: none;
 }
 
 .transcript-item ul:not(.transcript-action *),


### PR DESCRIPTION
Improves the rendering of headings and inline code elements in chat.

| Before | After |
| - | - |
| <img width="929" alt="Screenshot 2023-10-27 at 1 52 41 pm" src="https://github.com/sourcegraph/cody/assets/153/28bd1cc0-3d83-47c0-bbda-a4b018b3dede"> | <img width="929" alt="Screenshot 2023-10-27 at 1 52 08 pm" src="https://github.com/sourcegraph/cody/assets/153/1b4d8657-09fa-4cd0-b00a-54871f0896ab"> |
| <img width="929" alt="Screenshot 2023-10-27 at 1 52 45 pm" src="https://github.com/sourcegraph/cody/assets/153/3ea057a5-ea51-421c-9ff9-c6eef361a7d8"> | <img width="929" alt="Screenshot 2023-10-27 at 1 52 04 pm" src="https://github.com/sourcegraph/cody/assets/153/7bf0f7bf-4851-4c0d-92a4-f9353f03db7f"> |
| <img width="929" alt="Screenshot 2023-10-27 at 1 59 05 pm" src="https://github.com/sourcegraph/cody/assets/153/26bce527-b2ff-4f75-ad4d-ac2961d75dec"> | <img width="929" alt="Screenshot 2023-10-27 at 1 58 53 pm" src="https://github.com/sourcegraph/cody/assets/153/4f6013fc-47d3-4d33-96e5-9951bcb95511"> |

## Test plan

- Verified in chat output (using https://gist.github.com/toolmantim/2e426f846f7a668172c7cb15b0051fc9)