### PR TITLE
Add secondary telemetry to Chat

### DIFF
--- a/lib/shared/src/telemetry-v2/index.ts
+++ b/lib/shared/src/telemetry-v2/index.ts
@@ -137,6 +137,8 @@ export type EventFeature =
     // context-provider-related events
     | 'cody.auth'
     | 'cody.auth.app'
+    // chat-related events
+    | 'cody.feedback'
 
 /**
  * Actions should denote a generic action within the scope of a feature. Where
@@ -155,6 +157,8 @@ export type EventAction =
     | 'hasCode'
     | 'disconnected'
     | 'connected'
+    | 'thumbsUp'
+    | 'thumbsDown'
 
 /**
  * MetadataKey is an allowlist of keys for the safe-for-export metadata parameter.

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -8,6 +8,7 @@ import { ChatHistory, ChatMessage } from '@sourcegraph/cody-shared/src/chat/tran
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 
 import { AuthMethod, AuthStatus, LocalEnv } from '../src/chat/protocol'
+import { telemetryRecorder } from '../src/services/telemetry-v2'
 
 import { Chat } from './Chat'
 import { LoadingPage } from './LoadingPage'
@@ -197,6 +198,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             suggestions={suggestions}
                             setSuggestions={setSuggestions}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             chatCommands={myPrompts || undefined}
                             isTranscriptError={isTranscriptError}
                             applessOnboarding={{

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -7,7 +7,6 @@ import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { CodyPrompt } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
-import { EventAction } from '@sourcegraph/cody-shared/src/telemetry-v2'
 import { TelemetryRecorder } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
 import {
     ChatButtonProps,
@@ -96,15 +95,17 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         [vscodeAPI]
     )
 
+    type Feedback = 'thumbsUp' | 'thumbsDown'
+
     const onFeedbackBtnClick = useCallback(
-        (text: EventAction) => {
+        (text: string) => {
             telemetryService.log(`CodyVSCodeExtension:codyFeedback:${text}`, {
                 value: text,
                 lastChatUsedEmbeddings: Boolean(
                     transcript.at(-1)?.contextFiles?.some(file => file.source === 'embeddings')
                 ),
             })
-            telemetryRecorder.recordEvent('cody.feedback', text, {
+            telemetryRecorder.recordEvent('cody.feedback', text as Feedback, {
                 privateMetadata: {
                     value: text,
                     lastChatUsedEmbeddings: Boolean(

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -7,6 +7,8 @@ import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { CodyPrompt } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+import { EventAction } from '@sourcegraph/cody-shared/src/telemetry-v2'
+import { TelemetryRecorder } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
 import {
     ChatButtonProps,
     Chat as ChatUI,
@@ -41,6 +43,7 @@ interface ChatboxProps {
     setInputHistory: (history: string[]) => void
     vscodeAPI: VSCodeWrapper
     telemetryService: TelemetryService
+    telemetryRecorder: TelemetryRecorder
     suggestions?: string[]
     setSuggestions?: (suggestions: undefined | string[]) => void
     chatCommands?: [string, CodyPrompt][]
@@ -64,6 +67,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     setInputHistory,
     vscodeAPI,
     telemetryService,
+    telemetryRecorder,
     suggestions,
     setSuggestions,
     chatCommands,
@@ -93,15 +97,23 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 
     const onFeedbackBtnClick = useCallback(
-        (text: string) => {
+        (text: EventAction) => {
             telemetryService.log(`CodyVSCodeExtension:codyFeedback:${text}`, {
                 value: text,
                 lastChatUsedEmbeddings: Boolean(
                     transcript.at(-1)?.contextFiles?.some(file => file.source === 'embeddings')
                 ),
             })
+            telemetryRecorder.recordEvent('cody.feedback', text, {
+                privateMetadata: {
+                    value: text,
+                    lastChatUsedEmbeddings: Boolean(
+                        transcript.at(-1)?.contextFiles?.some(file => file.source === 'embeddings')
+                    ),
+                },
+            })
         },
-        [telemetryService, transcript]
+        [telemetryService, telemetryRecorder, transcript]
     )
 
     const onCopyBtnClick = useCallback(


### PR DESCRIPTION
## Test plan

run extension in debug mode
check test eventlogs on dotcom for event emission
check bigquery for event reception


Background: https://docs.sourcegraph.com/dev/background-information/telemetry
Introduction of new SDK: https://github.com/sourcegraph/cody/pull/1192
Issue this work https://github.com/sourcegraph/sourcegraph/issues/56284, but this is quite out of date - https://github.com/sourcegraph/cody/pull/1192 has more context than the issue