### PR TITLE
Custom Commands: Fix custom command menu not showing for a single custom command

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Smart selection not working on the first line of code. [pull/1508](https://github.com/sourcegraph/cody/pull/1508)
 - Adjust a completion range if it does not match the current line suffix. [pull/1507](https://github.com/sourcegraph/cody/pull/1507)
+- Custom Commands: Fix custom command menu not showing for a single custom command. [pull/1532](https://github.com/sourcegraph/cody/pull/1532)
 
 ### Changed
 

--- a/vscode/src/custom-prompts/CustomPromptsStore.ts
+++ b/vscode/src/custom-prompts/CustomPromptsStore.ts
@@ -161,7 +161,7 @@ export class CustomPromptsStore implements vscode.Disposable {
             if (type === 'user') {
                 this.myPromptsJSON = json
             }
-            this.promptSize[type] = this.myPromptsMap.size - 1
+            this.promptSize[type] = this.myPromptsMap.size
         } catch (error) {
             logDebug('CustomPromptsStore:build', 'failed', { verbose: error })
         }


### PR DESCRIPTION
The Custom Commands action shows the incorrect menu (the generic custom commands config quickpick) if you only have a single custom command defined, due to an off-by-one. This fixes it so it shows the correct menu.

## Test plan

- Created a single custom command. Tested the action.