### PR TITLE
BFG: bump to 5.2.4257

### DIFF
--- a/vscode/src/graph/bfg/BfgContextFetcher.ts
+++ b/vscode/src/graph/bfg/BfgContextFetcher.ts
@@ -113,7 +113,12 @@ export class BfgContextFetcher implements GraphContextFetcher {
             contextRange,
         })
 
-        return [...responses.symbols, ...responses.files]
+        // Just in case, handle non-object results
+        if (typeof responses !== 'object') {
+            return []
+        }
+
+        return [...(responses?.symbols || []), ...(responses?.files || [])]
     }
 
     public dispose(): void {

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -10,7 +10,8 @@ import { fileExists } from '../../local-context/download-symf'
 import { logDebug } from '../../log'
 import { getOSArch } from '../../os'
 
-const defaultBfgVersion = '0.1.0'
+// Available releases: https://github.com/sourcegraph/bfg/releases
+const defaultBfgVersion = '5.2.4257'
 
 export async function downloadBfg(context: vscode.ExtensionContext): Promise<string | null> {
     const config = vscode.workspace.getConfiguration()

--- a/vscode/src/jsonrpc/bfg-protocol.ts
+++ b/vscode/src/jsonrpc/bfg-protocol.ts
@@ -11,7 +11,7 @@ export type Requests = {
     'bfg/initialize': [{ clientName: string }, { serverVersion: string }]
     'bfg/contextAtPosition': [
         { uri: string; content: string; position: Position; maxChars: number; contextRange?: Range },
-        { symbols: SymbolContextSnippet[]; files: FileContextSnippet[] },
+        { symbols?: SymbolContextSnippet[]; files?: FileContextSnippet[] },
     ]
     'bfg/gitRevision/didChange': [{ gitDirectoryUri: string }, void]
     'bfg/shutdown': [null, void]


### PR DESCRIPTION
The release is running so the binary artifacts are not available yet. Let's wait with merging until Monday.

## Test plan
- Start local mode with BFG enabled
- Confirm that it downloads the binary, indexes the codebase and returns relevant symbol context
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
