### PR TITLE
Cody search panel

### DIFF
--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -39,7 +39,7 @@ export interface Result {
 }
 
 export interface IndexedKeywordContextFetcher {
-    getResults(query: string, scopeDir: string): Promise<Result[]>
+    getResults(query: string, scopeDirs: string[]): Promise<Promise<Result[]>[]>
 }
 
 /**

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -39,6 +39,34 @@ export interface Result {
 }
 
 export interface IndexedKeywordContextFetcher {
-    getIndexReady(scopeDir: string, whenReadyFn: () => void): Promise<boolean>
     getResults(query: string, scopeDir: string): Promise<Result[]>
+}
+
+/**
+ * File result that renders in the search panel webview
+ */
+export interface SearchPanelFile {
+    uriString: string
+    uriJSON: unknown
+    basename: string
+    dirname: string
+    wsname?: string
+    snippets: SearchPanelSnippet[]
+}
+
+/**
+ * Snippet result that renders in the search panel webview
+ */
+export interface SearchPanelSnippet {
+    contents: string
+    range: {
+        start: {
+            line: number
+            character: number
+        }
+        end: {
+            line: number
+            character: number
+        }
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       '@vscode/webview-ui-toolkit':
         specifier: ^1.2.2
         version: 1.2.2(react@18.2.0)
+      async-mutex:
+        specifier: ^0.4.0
+        version: 0.4.0
       axios:
         specifier: ^1.3.6
         version: 1.3.6
@@ -7407,6 +7410,12 @@ packages:
   /async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
     dev: true
+
+  /async-mutex@0.4.0:
+    resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
+    dependencies:
+      tslib: 2.1.0
+    dev: false
 
   /async@3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -225,6 +225,12 @@
           "when": "(!cody.activated && config.cody.experimental.chatPanel) || !config.cody.experimental.chatPanel"
         },
         {
+          "type": "webview",
+          "id": "cody.search",
+          "name": "Search",
+          "visibility": "visible"
+        },
+        {
           "id": "cody.fixup.tree.view",
           "name": "Fixups",
           "when": "cody.nonstop.fixups.enabled && cody.activated && !config.cody.experimental.chatPanel",
@@ -516,6 +522,22 @@
         "group": "Cody",
         "icon": "$(arrow-circle-down)",
         "when": "cody.activated && cody.hasChatHistory"
+      },
+      {
+        "command": "cody.search.index-update",
+        "category": "Cody",
+        "group": "Cody",
+        "title": "Update search index for current workspace folder",
+        "icon": "$(refresh)",
+        "when": "cody.activated && config.cody.experimental.new-search"
+      },
+      {
+        "command": "cody.search.index-update-all",
+        "category": "Cody",
+        "group": "Cody",
+        "title": "Update search indices for all workspace folders",
+        "icon": "$(sync)",
+        "when": "cody.activated && config.cody.experimental.new-search"
       }
     ],
     "keybindings": [
@@ -784,6 +806,16 @@
           "command": "cody.auth.signin",
           "when": "view == cody.support.tree.view && cody.activated",
           "group": "9_cody@0"
+        },
+        {
+          "command": "cody.search.index-update",
+          "when": "view == cody.search && cody.activated",
+          "group": "navigation@1"
+        },
+        {
+          "command": "cody.search.index-update-all",
+          "when": "view == cody.search && cody.activated",
+          "group": "navigation@2"
         }
       ],
       "editor/title": [
@@ -981,6 +1013,12 @@
           "type": "boolean",
           "markdownDescription": "Enable Cody fix and explain options in the Quick Fix menu",
           "default": true
+        },
+        "cody.experimental.new-search": {
+          "order": 99,
+          "type": "boolean",
+          "markdownDescription": "New search UI",
+          "default": false
         },
         "cody.experimental.symf.path": {
           "order": 99,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1147,6 +1147,7 @@
     "@types/stream-json": "^1.7.3",
     "@vscode/codicons": "^0.0.29",
     "@vscode/webview-ui-toolkit": "^1.2.2",
+    "async-mutex": "^0.4.0",
     "axios": "^1.3.6",
     "classnames": "^2.3.2",
     "date-fns": "^2.30.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -227,8 +227,9 @@
         {
           "type": "webview",
           "id": "cody.search",
-          "name": "Search",
-          "visibility": "visible"
+          "name": "Search (experimental)",
+          "visibility": "visible",
+          "when": "cody.activated && config.cody.experimental.new-search"
         },
         {
           "id": "cody.fixup.tree.view",

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -388,7 +388,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
 
         await addWebviewViewHTML(this.extensionUri, webviewView)
 
-        // Register webview
+        // Register to receive messages from webview
         this.disposables.push(webviewView.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message)))
     }
 

--- a/vscode/src/chat/local-code-search.ts
+++ b/vscode/src/chat/local-code-search.ts
@@ -82,8 +82,11 @@ export class LocalIndexedKeywordSearch implements Recipe {
             return 'Open a workspace folder to determine the search scope'
         }
 
-        const results = await symf.getResults(text, scopeDir)
-        const groupedResults = groupByFile(results)
+        const resultSets = await symf.getResults(text, [scopeDir])
+        if (resultSets.length === 0) {
+            return 'Open a workspace folder to determine the search scope'
+        }
+        const groupedResults = groupByFile(await resultSets[0])
         const resultsHTML = await htmlForResultGroups(groupedResults)
         return resultsHTML
     }

--- a/vscode/src/chat/local-code-search.ts
+++ b/vscode/src/chat/local-code-search.ts
@@ -82,13 +82,6 @@ export class LocalIndexedKeywordSearch implements Recipe {
             return 'Open a workspace folder to determine the search scope'
         }
 
-        const whenReady = (): void => {
-            void vscode.window.showInformationMessage('Cody local index ready. Type "/symf" in the sidebar.')
-        }
-        if (!(await symf.getIndexReady(scopeDir, whenReady))) {
-            return 'Index is still building, try again in a few minutes. An alert will notify when the index is ready.'
-        }
-
         const results = await symf.getResults(text, scopeDir)
         const groupedResults = groupByFile(results)
         const resultsHTML = await htmlForResultGroups(groupedResults)

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -3,6 +3,7 @@ import { CodyPrompt, CustomCommandType } from '@sourcegraph/cody-shared/src/chat
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { SearchPanelFile } from '@sourcegraph/cody-shared/src/local-context'
 import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import type { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
 import { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
@@ -59,6 +60,12 @@ export type WebviewMessage =
           command: 'simplified-onboarding'
           type: 'install-app' | 'open-app' | 'reload-state' | 'web-sign-in-token'
       }
+    | { command: 'search'; query: string }
+    | {
+          command: 'show-search-result'
+          uriJSON: unknown
+          range: { start: { line: number; character: number }; end: { line: number; character: number } }
+      }
 
 /**
  * A message sent from the extension host to the webview.
@@ -76,6 +83,7 @@ export type ExtensionMessage =
     | { type: 'notice'; notice: { key: string } }
     | { type: 'custom-prompts'; prompts: [string, CodyPrompt][] }
     | { type: 'transcript-errors'; isTranscriptError: boolean }
+    | { type: 'update-search-results'; results: SearchPanelFile[]; query: string }
 
 /**
  * The subset of configuration that is visible to the webview.

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -84,6 +84,7 @@ export type ExtensionMessage =
     | { type: 'custom-prompts'; prompts: [string, CodyPrompt][] }
     | { type: 'transcript-errors'; isTranscriptError: boolean }
     | { type: 'update-search-results'; results: SearchPanelFile[]; query: string }
+    | { type: 'index-updated'; scopeDir: string }
 
 /**
  * The subset of configuration that is visible to the webview.

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode'
 import { logDebug } from '../log'
 import { getOSArch } from '../os'
 
-const symfVersion = 'v0.0.1'
+const symfVersion = 'v0.0.2'
 
 /**
  * Get the path to `symf`. If the symf binary is not found, download it.

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 
+import { Mutex } from 'async-mutex'
 import { mkdirp } from 'mkdirp'
 import * as vscode from 'vscode'
 
@@ -17,15 +18,15 @@ import { getSymfPath } from './download-symf'
 const execFile = promisify(_execFile)
 
 export class SymfRunner implements IndexedKeywordContextFetcher {
-    // Indexes in the progress of being built
-    private indicesInProgress: Map<string, Promise<void>> = new Map()
+    // The root of all symf index directories
+    private indexRoot: string
 
     // Which indexes have already been built. Omission does not mean that the index hasn't been built;
     // it just means we haven't yet checked whether the index directory exists on disk.
+    // Keyed by scope directory (the directory that the index covers).
     private indicesReady: Map<string, boolean> = new Map()
 
-    // The root of all symf index directories
-    private indexRoot: string
+    private indexLocks: Map<string, RWLock> = new Map()
 
     constructor(
         private context: vscode.ExtensionContext,
@@ -41,28 +42,56 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
     }
 
     /**
-     * Returns a Promise that resolves to whether the symf index is ready. An index is ready when the index
-     * directory exists on disk.
-     */
-    public async getIndexReady(scopeDir: string, whenReadyFn?: () => void): Promise<boolean> {
-        const { indexDir } = this.getIndexDir(scopeDir)
-        if (this.indicesReady.get(indexDir)) {
-            return true
-        }
-        const indexFileExists = await fileExists(path.join(indexDir, 'index.json'))
-
-        if (!indexFileExists && whenReadyFn) {
-            this.ensureIndexFor(scopeDir)
-                .then(whenReadyFn)
-                .catch(() => undefined)
-        }
-        return indexFileExists
-    }
-
-    /**
      * Returns the list of results from symf
      */
     public async getResults(query: string, scopeDir: string): Promise<Result[]> {
+        while (true) {
+            await this.getIndexLock(scopeDir).withWrite(async () => {
+                await this.unsafeEnsureIndex(scopeDir)
+            })
+
+            let indexNotFound = false
+            const stdout = await this.getIndexLock(scopeDir).withRead(async () => {
+                // Check again if index exists after we have the read lock
+                if (!this.indicesReady.get(scopeDir)) {
+                    indexNotFound = true
+                    return ''
+                }
+                return this.unsafeRunQuery(query, scopeDir)
+            })
+            if (indexNotFound) {
+                continue
+            }
+            const results = parseSymfStdout(stdout)
+            return results
+        }
+    }
+
+    public async deleteIndex(scopeDir: string): Promise<void> {
+        await this.getIndexLock(scopeDir).withWrite(async () => {
+            await this.unsafeDeleteIndex(scopeDir)
+        })
+    }
+
+    public async ensureIndex(scopeDir: string): Promise<void> {
+        await this.getIndexLock(scopeDir).withWrite(async () => {
+            await this.unsafeEnsureIndex(scopeDir)
+        })
+    }
+
+    private getIndexLock(scopeDir: string): RWLock {
+        const { indexDir } = this.getIndexDir(scopeDir)
+        let lock = this.indexLocks.get(indexDir)
+        if (lock) {
+            return lock
+        }
+        lock = new RWLock()
+        this.indexLocks.set(indexDir, lock)
+        return lock
+    }
+
+    private async unsafeRunQuery(query: string, scopeDir: string): Promise<string> {
+        const { indexDir } = this.getIndexDir(scopeDir)
         const accessToken = this.authToken
         if (!accessToken) {
             throw new Error('SymfRunner.getResults: No access token')
@@ -71,8 +100,6 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
         if (!serverEndpoint) {
             throw new Error('SymfRunner.getResults: No Sourcegraph server endpoint')
         }
-
-        const indexDir = await this.ensureIndexFor(scopeDir)
         const symfPath = await getSymfPath(this.context)
         if (!symfPath) {
             throw new Error('No symf executable')
@@ -91,42 +118,55 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
                     timeout: 1000 * 30, // timeout in 30secs
                 }
             )
-            const results = parseSymfStdout(stdout)
-            return results
+            return stdout
         } catch (error) {
-            handleSymfError(error)
+            showSymfError(error)
             throw error
         }
     }
 
-    // Returns the path to the index directory
-    private async ensureIndexFor(scopeDir: string): Promise<string> {
-        const { indexDir, tmpDir } = this.getIndexDir(scopeDir)
-        const readyAlready = await this.getIndexReady(scopeDir)
-        if (readyAlready) {
-            return indexDir
+    private async unsafeDeleteIndex(scopeDir: string): Promise<void> {
+        const trashRootDir = path.join(this.indexRoot, '.trash')
+        await mkdirp(trashRootDir)
+        const { indexDir } = this.getIndexDir(scopeDir)
+
+        if (!(await fileExists(indexDir))) {
+            // index directory no longer exists, nothing to do
+            return
         }
 
-        if (this.indicesInProgress.has(indexDir)) {
-            try {
-                await this.indicesInProgress.get(indexDir)
-                return indexDir
-            } catch {
-                // Retry if previous attempt failed
-                this.indicesInProgress.delete(indexDir)
-            }
+        // Unique name for trash directory
+        const trashDir = path.join(trashRootDir, `${path.basename(indexDir)}-${Date.now()}`)
+        if (await fileExists(trashDir)) {
+            // if trashDir already exists, error
+            throw new Error(`could not delete index ${indexDir}: target trash directory ${trashDir} already exists`)
         }
-        const newIndexPromise = this.upsertIndex(indexDir, tmpDir, scopeDir)
-        this.indicesInProgress.set(indexDir, newIndexPromise)
-        return newIndexPromise
-            .then(() => {
-                this.indicesReady.set(indexDir, true)
-                return indexDir
-            })
-            .catch(error => {
-                logDebug('symf', 'symf index creation failed', error)
-                throw error
-            })
+
+        this.indicesReady.set(scopeDir, false)
+        await rename(indexDir, trashDir)
+        void rm(trashDir, { recursive: true, force: true }) // delete in background
+    }
+
+    private async unsafeEnsureIndex(scopeDir: string): Promise<void> {
+        const readyAlready = this.indicesReady.get(scopeDir)
+        if (readyAlready) {
+            return
+        }
+        const { indexDir, tmpDir } = this.getIndexDir(scopeDir)
+
+        const indexFileExists = await fileExists(path.join(indexDir, 'index.json'))
+        if (indexFileExists) {
+            this.indicesReady.set(scopeDir, true)
+            return
+        }
+
+        try {
+            await this.unsafeUpsertIndex(indexDir, tmpDir, scopeDir)
+            this.indicesReady.set(scopeDir, true)
+        } catch (error) {
+            logDebug('symf', 'symf index creation failed', error)
+            throw error
+        }
     }
 
     private getIndexDir(scopeDir: string): { indexDir: string; tmpDir: string } {
@@ -137,7 +177,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
         }
     }
 
-    private async upsertIndex(indexDir: string, tmpIndexDir: string, scopeDir: string): Promise<void> {
+    private async unsafeUpsertIndex(indexDir: string, tmpIndexDir: string, scopeDir: string): Promise<void> {
         const symfPath = await getSymfPath(this.context)
         if (!symfPath) {
             return
@@ -167,7 +207,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
             await mkdirp(path.dirname(indexDir))
             await rename(tmpIndexDir, indexDir)
         } catch (error) {
-            handleSymfError(error)
+            showSymfError(error)
         }
     }
 }
@@ -217,7 +257,55 @@ function parseSymfStdout(stdout: string): Result[] {
     })
 }
 
-function handleSymfError(error: unknown): void {
+/**
+ * A simple read-write lock.
+ *
+ * Note: it is possible for an overlapping succession of readers to starve out
+ * any writers that are waiting for the mutex to be released. In practice, this
+ * is not an issue, because we don't expect the user to issue neverending
+ * while trying to update the index.
+ */
+class RWLock {
+    /**
+     * Invariants:
+     * - if readers > 0, then mu is locked
+     * - if readers === 0 and mu is locked, then a writer is holding the lock
+     */
+    private readers = 0
+    private mu = new Mutex()
+
+    public async withRead<T>(fn: () => Promise<T>): Promise<T> {
+        while (this.readers === 0) {
+            if (this.mu.isLocked()) {
+                // If mu is locked at this point, it must be held by the writer.
+                // We spin in this case, rather than try to acquire the lock,
+                // because multiple readers blocked on acquiring the lock will
+                // execute serially when the writer releases the lock (whereas
+                // we want all reads to be concurrent).
+                await new Promise(resolve => setTimeout(resolve, 100))
+                continue
+            }
+            // No readers or writers: acquire lock for readers
+            await this.mu.acquire()
+            break
+        }
+        this.readers++
+        try {
+            return await fn()
+        } finally {
+            this.readers--
+            if (this.readers === 0) {
+                this.mu.release()
+            }
+        }
+    }
+
+    public async withWrite<T>(fn: () => Promise<T>): Promise<T> {
+        return this.mu.runExclusive(fn)
+    }
+}
+
+function showSymfError(error: unknown): void {
     const errorString = `${error}`
     let errorMessage: string
     if (errorString.includes('ENOENT')) {

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -264,18 +264,14 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
             maxCPUs = 2
         }
         try {
-            const proc = spawn(
-                symfPath,
-                ['--index-root', tmpIndexDir, 'add', '--langs', 'go,typescript,python', scopeDir],
-                {
-                    env: {
-                        ...process.env,
-                        GOMAXPROCS: `${maxCPUs}`, // use at most one cpu for indexing
-                    },
-                    stdio: ['ignore', 'ignore', 'ignore'],
-                    timeout: 1000 * 60 * 10, // timeout in 10 minutes
-                }
-            )
+            const proc = spawn(symfPath, ['--index-root', tmpIndexDir, 'add', scopeDir], {
+                env: {
+                    ...process.env,
+                    GOMAXPROCS: `${maxCPUs}`, // use at most one cpu for indexing
+                },
+                stdio: ['ignore', 'ignore', 'ignore'],
+                timeout: 1000 * 60 * 10, // timeout in 10 minutes
+            })
             // wait for proc to finish
             await new Promise<void>((resolve, reject) => {
                 proc.on('error', reject)

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -179,7 +179,7 @@ const register = async (
 
     if (symfRunner) {
         const searchViewProvider = new SearchViewProvider(context.extensionUri, symfRunner)
-        searchViewProvider.registerCommands()
+        searchViewProvider.initialize()
         disposables.push(searchViewProvider)
         disposables.push(
             vscode.window.registerWebviewViewProvider('cody.search', searchViewProvider, {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -196,7 +196,7 @@ const register = async (
                 .then(token => {
                     symfRunner.setSourcegraphAuth(authStatus.endpoint, token)
                 })
-                .catch(() => { })
+                .catch(() => {})
         } else {
             symfRunner?.setSourcegraphAuth(null, null)
         }
@@ -504,7 +504,7 @@ const register = async (
                     if (config.isRunningInsideAgent) {
                         throw new Error(
                             'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
-                            'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
+                                'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
                         )
                     }
                     return

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -23,6 +23,7 @@ import { PlatformContext } from './extension.common'
 import { configureExternalServices } from './external-services'
 import { FixupController } from './non-stop/FixupController'
 import { showSetupNotification } from './notifications/setup-notification'
+import { SearchViewProvider } from './search/SearchViewProvider'
 import { AuthProvider } from './services/AuthProvider'
 import { showFeedbackSupportQuickPick } from './services/FeedbackOptions'
 import { GuardrailsProvider } from './services/GuardrailsProvider'
@@ -176,6 +177,17 @@ const register = async (
         })
     )
 
+    if (symfRunner) {
+        const searchViewProvider = new SearchViewProvider(context.extensionUri, symfRunner)
+        searchViewProvider.registerCommands()
+        disposables.push(searchViewProvider)
+        disposables.push(
+            vscode.window.registerWebviewViewProvider('cody.search', searchViewProvider, {
+                webviewOptions: { retainContextWhenHidden: true },
+            })
+        )
+    }
+
     // Adds a change listener to the auth provider that syncs the auth status
     authProvider.addChangeListener((authStatus: AuthStatus) => {
         void chatManager.syncAuthStatus(authStatus)
@@ -184,7 +196,7 @@ const register = async (
                 .then(token => {
                     symfRunner.setSourcegraphAuth(authStatus.endpoint, token)
                 })
-                .catch(() => {})
+                .catch(() => { })
         } else {
             symfRunner?.setSourcegraphAuth(null, null)
         }
@@ -492,7 +504,7 @@ const register = async (
                     if (config.isRunningInsideAgent) {
                         throw new Error(
                             'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
-                                'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
+                            'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
                         )
                     }
                     return

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode'
 import { Result, SearchPanelFile, SearchPanelSnippet } from '@sourcegraph/cody-shared/src/local-context'
 
 import { WebviewMessage } from '../chat/protocol'
+import { getActiveEditor } from '../editor/active-editor'
 import { SymfRunner } from '../local-context/symf'
 
 const searchDecorationType = vscode.window.createTextEditorDecorationType({
@@ -303,7 +304,7 @@ function getScopeDirs(): string[] {
     if (!folders) {
         return []
     }
-    const uri = vscode.window.activeTextEditor?.document?.uri
+    const uri = getActiveEditor()?.document.uri
     if (!uri) {
         return folders.map(f => f.uri.fsPath)
     }

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -227,7 +227,6 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
     // TODO(beyang): support cancellation through symf
     private async onDidReceiveQuery(query: string): Promise<void> {
-        console.log('# onDidReceiveQuery', query)
         const cancellationToken = this.cancellationManager.cancelExistingAndStartNew()
 
         if (query.trim().length === 0) {

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -157,6 +157,11 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
                 })
             })
         )
+        this.disposables.push(
+            this.symfRunner.registerIndexListener(scopeDir => {
+                void this.webview?.postMessage({ type: 'index-updated', scopeDir })
+            })
+        )
     }
 
     public async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
@@ -221,8 +226,8 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
 
     // TODO(beyang): support cancellation through symf
-    // TODO(beyang): caching
     private async onDidReceiveQuery(query: string): Promise<void> {
+        console.log('# onDidReceiveQuery', query)
         const cancellationToken = this.cancellationManager.cancelExistingAndStartNew()
 
         if (query.trim().length === 0) {

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -47,7 +47,9 @@ class IndexManager {
             this.currentlyRefreshing.add(scopeDir)
 
             await this.symf.deleteIndex(scopeDir)
-            await this.symf.ensureIndex(scopeDir, showIndexProgress)
+            await this.symf.ensureIndex(scopeDir, showIndexProgress, { hard: true })
+        } catch (error) {
+            void vscode.window.showErrorMessage(`Error refreshing search index for ${scopeDir}: ${error}`)
         } finally {
             this.currentlyRefreshing.delete(scopeDir)
         }
@@ -203,7 +205,7 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
         await vscode.window.withProgress({ location: { viewId: 'cody.search' } }, async () => {
             const cumulativeResults: SearchPanelFile[] = []
-            const resultSets = await symf.getResultsMulti(query, scopeDirs, showIndexProgress)
+            const resultSets = await symf.getResults(query, scopeDirs, showIndexProgress)
             for (const resultSet of resultSets) {
                 try {
                     cumulativeResults.push(...(await resultsToDisplayResults(await resultSet)))

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -1,0 +1,303 @@
+import * as os from 'os'
+import * as path from 'path'
+
+import * as vscode from 'vscode'
+
+import { Result, SearchPanelFile, SearchPanelSnippet } from '@sourcegraph/cody-shared/src/local-context'
+
+import { WebviewMessage } from '../chat/protocol'
+import { SymfRunner } from '../local-context/symf'
+
+const searchDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: new vscode.ThemeColor('searchEditor.findMatchBackground'),
+    borderColor: new vscode.ThemeColor('searchEditor.findMatchBorder'),
+})
+
+class CancellationManager implements vscode.Disposable {
+    private tokenSource?: vscode.CancellationTokenSource
+
+    public cancelExistingAndStartNew(): vscode.CancellationToken {
+        if (this.tokenSource) {
+            this.tokenSource.cancel()
+            this.tokenSource.dispose()
+        }
+        this.tokenSource = new vscode.CancellationTokenSource()
+        return this.tokenSource.token
+    }
+
+    public dispose(): void {
+        if (this.tokenSource) {
+            const ts = this.tokenSource
+            this.tokenSource = undefined
+            ts.cancel()
+            ts.dispose()
+        }
+    }
+}
+
+class IndexManager {
+    private currentlyRefreshing = new Set<string>()
+    constructor(private symf: SymfRunner) {}
+
+    public async refreshIndex(scopeDir: string): Promise<void> {
+        if (this.currentlyRefreshing.has(scopeDir)) {
+            return
+        }
+        try {
+            this.currentlyRefreshing.add(scopeDir)
+
+            await this.symf.deleteIndex(scopeDir)
+            await this.ensureIndex(scopeDir)
+        } finally {
+            this.currentlyRefreshing.delete(scopeDir)
+        }
+    }
+
+    private async ensureIndex(scopeDir: string): Promise<void> {
+        const { base, dir, wsName } = getRenderableComponents(scopeDir)
+        const prettyScopeDir = wsName ? path.join(wsName, dir, base) : path.join(dir, base)
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Cody: building search index for ${prettyScopeDir}`,
+                cancellable: false,
+            },
+            async () => {
+                await this.symf.ensureIndex(scopeDir)
+            }
+        )
+    }
+}
+
+export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
+    private disposables: vscode.Disposable[] = []
+    private webview?: vscode.Webview
+    private cancellationManager = new CancellationManager()
+    private indexManager: IndexManager
+
+    constructor(
+        private extensionUri: vscode.Uri,
+        private symfRunner: SymfRunner
+    ) {
+        this.indexManager = new IndexManager(this.symfRunner)
+        this.disposables.push(this.cancellationManager)
+    }
+
+    public dispose(): void {
+        for (const d of this.disposables) {
+            d.dispose()
+        }
+        this.disposables = []
+    }
+
+    public registerCommands(): void {
+        this.disposables.push(
+            vscode.commands.registerCommand('cody.search.index-update', async () => {
+                const scopeDir = getCurrentWorkspaceRoot()
+                if (!scopeDir) {
+                    void vscode.window.showWarningMessage('Open a workspace folder to index')
+                    return
+                }
+                await this.indexManager.refreshIndex(scopeDir)
+            }),
+            vscode.commands.registerCommand('cody.search.index-update-all', async () => {
+                const folders = vscode.workspace.workspaceFolders
+                if (!folders) {
+                    void vscode.window.showWarningMessage('Open a workspace folder to index')
+                    return
+                }
+                for (const folder of folders) {
+                    await this.indexManager.refreshIndex(folder.uri.fsPath)
+                }
+            })
+        )
+    }
+
+    public async resolveWebviewView(webviewView: vscode.WebviewView): Promise<void> {
+        this.webview = webviewView.webview
+        const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
+
+        webviewView.webview.options = {
+            enableScripts: true,
+            enableCommandUris: true,
+            localResourceRoots: [webviewPath],
+        }
+
+        // Create Webview using vscode/index.html
+        const root = vscode.Uri.joinPath(webviewPath, 'search.html')
+        const bytes = await vscode.workspace.fs.readFile(root)
+        const decoded = new TextDecoder('utf-8').decode(bytes)
+        const resources = webviewView.webview.asWebviewUri(webviewPath)
+
+        // Set HTML for webview
+        // This replace variables from the vscode/dist/index.html with webview info
+        // 1. Update URIs to load styles and scripts into webview (eg. path that starts with ./)
+        // 2. Update URIs for content security policy to only allow specific scripts to be run
+        webviewView.webview.html = decoded
+            .replaceAll('./', `${resources.toString()}/`)
+            .replaceAll('{cspSource}', webviewView.webview.cspSource)
+
+        // Register to receive messages from webview
+        this.disposables.push(webviewView.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message)))
+    }
+
+    private async onDidReceiveMessage(message: WebviewMessage): Promise<void> {
+        switch (message.command) {
+            case 'search': {
+                await this.onDidReceiveQuery(message.query)
+                break
+            }
+            case 'show-search-result': {
+                const { range, uriJSON } = message
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const uri = vscode.Uri.from(uriJSON as any)
+                const vscodeRange = new vscode.Range(
+                    range.start.line,
+                    range.start.character,
+                    range.end.line,
+                    range.end.character
+                )
+
+                // show file and range in editor
+                const doc = await vscode.workspace.openTextDocument(uri)
+                const editor = await vscode.window.showTextDocument(doc, {
+                    selection: vscodeRange,
+                    preserveFocus: true,
+                })
+                const isWholeFile = vscodeRange.start.line === 0 && vscodeRange.end.line === doc.lineCount - 1
+                if (!isWholeFile) {
+                    editor.setDecorations(searchDecorationType, [vscodeRange])
+                    editor.revealRange(vscodeRange, vscode.TextEditorRevealType.InCenterIfOutsideViewport)
+                }
+                break
+            }
+        }
+    }
+
+    // TODO(beyang): support cancellation through symf
+    // TODO(beyang): caching
+    private async onDidReceiveQuery(query: string): Promise<void> {
+        const cancellationToken = this.cancellationManager.cancelExistingAndStartNew()
+
+        if (query.trim().length === 0) {
+            await this.webview?.postMessage({ type: 'update-search-results', results: [] })
+            return
+        }
+
+        const symf = this.symfRunner
+        if (!symf) {
+            throw new Error('this.symfRunner is undefined')
+        }
+
+        const scopeDir = getCurrentWorkspaceRoot()
+        if (!scopeDir) {
+            void vscode.window.showErrorMessage('Open a workspace folder to determine the search scope')
+            return
+        }
+
+        // Check cancellation after index is ready
+        if (cancellationToken.isCancellationRequested) {
+            return
+        }
+
+        const panelResults = await vscode.window.withProgress({ location: { viewId: 'cody.search' } }, async () => {
+            const results = await symf.getResults(query, scopeDir)
+            const groupedResults = groupByFile(results)
+
+            // fetch file contents to send to webview
+            const textDecoder = new TextDecoder('utf-8')
+            const rawPanelResults: (SearchPanelFile | null)[] = await Promise.all(
+                groupedResults.map(async group => {
+                    const uri = vscode.Uri.file(group.file)
+                    try {
+                        const contents = await vscode.workspace.fs.readFile(uri)
+                        const { base, dir, wsName } = getRenderableComponents(group.file)
+                        return {
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                            uriJSON: uri.toJSON(),
+                            uriString: uri.toString(),
+                            basename: base,
+                            dirname: dir,
+                            wsname: wsName,
+                            snippets: group.results.map((result: Result): SearchPanelSnippet => {
+                                return {
+                                    contents: textDecoder.decode(
+                                        contents.subarray(result.range.startByte, result.range.endByte)
+                                    ),
+                                    range: {
+                                        start: {
+                                            line: result.range.startPoint.row,
+                                            character: result.range.startPoint.col,
+                                        },
+                                        end: {
+                                            line: result.range.endPoint.row,
+                                            character: result.range.endPoint.col,
+                                        },
+                                    },
+                                }
+                            }),
+                        }
+                    } catch {
+                        return null
+                    }
+                })
+            )
+            return rawPanelResults.filter(result => result !== null) as SearchPanelFile[]
+        })
+
+        await this.webview?.postMessage({ type: 'update-search-results', results: panelResults, query })
+    }
+}
+
+function getRenderableComponents(filename: string): { base: string; dir: string; wsName?: string } {
+    // get workspace folders
+    const wsFolders = vscode.workspace.workspaceFolders
+    const home = os.homedir()
+
+    const base = path.basename(filename)
+    const absdir = path.dirname(filename)
+
+    if (wsFolders) {
+        for (const wsFolder of wsFolders) {
+            const reldir = path.relative(wsFolder.uri.fsPath, absdir)
+            if (!reldir.startsWith('..')) {
+                return { base, dir: reldir, wsName: wsFolders.length > 1 ? wsFolder.name : undefined }
+            }
+        }
+    }
+
+    // No matches in workspace folders, check home directory
+    const reldir = path.relative(home, absdir)
+    if (!reldir.startsWith('..')) {
+        return { base, dir: reldir }
+    }
+    return { base, dir: absdir }
+}
+
+function getCurrentWorkspaceRoot(): string | null {
+    const uri = vscode.window.activeTextEditor?.document?.uri
+    if (uri) {
+        const wsFolder = vscode.workspace.getWorkspaceFolder(uri)
+        if (wsFolder) {
+            return wsFolder.uri.fsPath
+        }
+    }
+    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? null
+}
+
+function groupByFile(results: Result[]): { file: string; results: Result[] }[] {
+    const groups: { file: string; results: Result[] }[] = []
+
+    for (const result of results) {
+        const group = groups.find(g => g.file === result.file)
+        if (group) {
+            group.results.push(result)
+        } else {
+            groups.push({
+                file: result.file,
+                results: [result],
+            })
+        }
+    }
+    return groups
+}

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -93,7 +93,7 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.disposables = []
     }
 
-    public registerCommands(): void {
+    public initialize(): void {
         this.disposables.push(
             vscode.commands.registerCommand('cody.search.index-update', async () => {
                 const scopeDirs = getScopeDirs()
@@ -112,6 +112,17 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
                 for (const folder of folders) {
                     await this.indexManager.refreshIndex(folder.uri.fsPath)
                 }
+            })
+        )
+        // Kick off search index creation for all workspace folders
+        vscode.workspace.workspaceFolders?.forEach(folder => {
+            void this.symfRunner.ensureIndex(folder.uri.fsPath, showIndexProgress, { hard: false })
+        })
+        this.disposables.push(
+            vscode.workspace.onDidChangeWorkspaceFolders(event => {
+                event.added.forEach(folder => {
+                    void this.symfRunner.ensureIndex(folder.uri.fsPath, showIndexProgress, { hard: false })
+                })
             })
         )
     }

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -62,9 +62,7 @@ export const test = base
             // Bring the cody sidebar to the foreground
             await page.click('[aria-label="Cody"]')
             // Ensure that we remove the hover from the activity icon
-            await page.getByRole('heading', { name: 'Cody' }).hover()
-            // Minimize the search panel for now
-            await page.getByRole('heading', { name: 'Search' }).click()
+            await page.getByRole('heading', { name: 'Cody: Chat' }).hover()
             // Wait for Cody to become activated
             // TODO(philipp-spiess): Figure out which playwright matcher we can use that works for
             // the signed-in and signed-out cases

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -62,7 +62,9 @@ export const test = base
             // Bring the cody sidebar to the foreground
             await page.click('[aria-label="Cody"]')
             // Ensure that we remove the hover from the activity icon
-            await page.getByRole('heading', { name: 'Cody: Chat' }).hover()
+            await page.getByRole('heading', { name: 'Cody' }).hover()
+            // Minimize the search panel for now
+            await page.getByRole('heading', { name: 'Search' }).click()
             // Wait for Cody to become activated
             // TODO(philipp-spiess): Figure out which playwright matcher we can use that works for
             // the signed-in and signed-out cases

--- a/vscode/webviews/SearchPanel.module.css
+++ b/vscode/webviews/SearchPanel.module.css
@@ -26,6 +26,16 @@
     font: inherit;
 }
 
+.search-input:placeholder-shown {
+    text-overflow: ellipsis;
+}
+
+.search-input::placeholder {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
 .search-input:focus,
 .search-input:focus-visible,
 .search-input:focus-within {

--- a/vscode/webviews/SearchPanel.module.css
+++ b/vscode/webviews/SearchPanel.module.css
@@ -1,0 +1,116 @@
+.outer-container {
+    background-color: var(--vscode-sideBar-background);
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+}
+
+.outer-container:focus {
+    outline-width: 0;
+}
+
+.search-input-container {
+    display: grid;
+}
+
+.search-input {
+    color: var(--vscode-input-foreground);
+    background-color: var(--vscode-input-background);
+    border-color: var(--vscode-input-border, transparent);
+    resize: none;
+    border-radius: 2px;
+    height: 1.3em;
+    padding: 8px 8px 8px 8px;
+    font: inherit;
+}
+
+.search-input:focus,
+.search-input:focus-visible,
+.search-input:focus-within {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+    color: var(--vscode-inputOption-activeForeground);
+    border-color: var(--vscode-inputOption-activeBorder, transparent);
+}
+
+.search-result-row-inner {
+    height: 22px;
+    display: flex;
+    position: relative;
+}
+
+.search-result-row:hover {
+    background-color: var(--vscode-list-hoverBackground);
+}
+
+.search-result-row-inner-selected {
+    color: var(--vscode-list-focusForeground);
+    background-color: var(--vscode-list-inactiveSelectionBackground);
+}
+
+.outer-container:focus .search-result-row-inner-selected {
+    color: var(--vscode-list-activeSelectionForeground);
+    background-color: var(--vscode-list-activeSelectionBackground);
+    outline: solid 1px var(--vscode-list-focusOutline);
+    z-index: 1;
+}
+
+.search-result-indent {
+    width: 8px;
+}
+
+.search-result-indent-guide {
+    position: absolute;
+    top: 0;
+    left: 16px;
+    border-left: 1px solid transparent;
+    border-color: var(--vscode-tree-indentGuidesStroke);
+    height: 100%;
+}
+
+.search-result-twistie {
+    display: flex !important;
+    flex-shrink: 0;
+    align-items: center;
+    height: 100%;
+    padding-left: 8px;
+    padding-right: 6px;
+    width: 16px;
+}
+
+.search-result-twistie-noindent {
+    padding-left: 0px;
+}
+
+.search-result-content {
+    height: 100%;
+    line-height: 22px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.filematch-label {
+    vertical-align: center;
+}
+
+.filematch-icon {
+    color: var(--vscode-banner-iconForeground);
+}
+
+.filematch-icon > i {
+    vertical-align: 'text-bottom';
+}
+
+.filematch-description {
+    font-size: 0.9em;
+    color: var(--vscode-search-resultsInfoForeground);
+}
+
+.input-row {
+    border-top: solid 1px var(--vscode-sideBarSectionHeader-border);
+    gap: 0.3rem;
+    padding: 0.75rem 0.75rem 1rem 0.75rem;
+}

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -98,7 +98,6 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                     break
                 }
                 case 'index-updated': {
-                    console.log('### clearing cache because index updated for:', message.scopeDir)
                     resultsCache.clear()
                     break
                 }

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -1,0 +1,283 @@
+/**
+ * Disabling the following rule is necessary to be consistent with the behavior of the VS Code search
+ * panel, which does not support tabbing through list items and requires using the arrow keys.
+ */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+import React, { useEffect, useRef } from 'react'
+
+import { debounce } from 'lodash'
+
+import { SearchPanelFile } from '@sourcegraph/cody-shared/src/local-context'
+
+import type { VSCodeWrapper } from './utils/VSCodeApi'
+
+import styles from './SearchPanel.module.css'
+
+const SEARCH_DEBOUNCE_MS = 500
+
+function doSearch(vscodeAPI: VSCodeWrapper, query: string): void {
+    if (query.length > 0) {
+        vscodeAPI.postMessage({ command: 'search', query })
+    }
+}
+
+const debouncedDoSearch = debounce(doSearch, SEARCH_DEBOUNCE_MS)
+
+export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
+    const [query, setQuery] = React.useState('')
+    const [results, setResults] = React.useState<SearchPanelFile[]>([])
+    const [selectedResult, setSelectedResult] = React.useState<[number, number]>([-1, -1])
+    const [collapsedFileResults, setCollapsedFileResults] = React.useState<{ [key: number]: boolean }>({})
+    const outerContainerRef = useRef<HTMLDivElement>(null)
+    const queryInputRef = useRef<HTMLTextAreaElement>(null)
+
+    // Update search results when query changes
+    useEffect(() => {
+        if (query.trim().length === 0) {
+            setResults([])
+            setSelectedResult([-1, -1])
+            return
+        }
+        debouncedDoSearch(vscodeAPI, query)
+    }, [vscodeAPI, query])
+
+    // update the search results when we get results from the extension backend
+    useEffect(() => {
+        return vscodeAPI.onMessage(message => {
+            switch (message.type) {
+                case 'update-search-results': {
+                    if (message.query === query) {
+                        setResults(message.results)
+                        setSelectedResult([-1, -1])
+                        break
+                    }
+                }
+            }
+        })
+    }, [vscodeAPI, query])
+
+    // When selection changes, send a message to the extension indicating the file and range
+    useEffect(() => {
+        if (selectedResult[0] === -1 || selectedResult[1] === -1) {
+            return
+        }
+        const selectedFile = results[selectedResult[0]]
+        const selectedSnippet = selectedFile.snippets[selectedResult[1]]
+        vscodeAPI.postMessage({
+            command: 'show-search-result',
+            uriJSON: selectedFile.uriJSON,
+            range: selectedSnippet.range,
+        })
+    }, [selectedResult, vscodeAPI, results])
+
+    const toggleFileExpansion = React.useCallback((fileIndex: number) => {
+        setCollapsedFileResults(prev => {
+            const newCollapsedFileResults = { ...prev }
+            newCollapsedFileResults[fileIndex] = !prev[fileIndex]
+            return newCollapsedFileResults
+        })
+    }, [])
+
+    const onInputChange = React.useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setQuery(e.target.value)
+    }, [])
+
+    const onInputKeyDown = React.useCallback(
+        (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+            if (e.key === 'Enter') {
+                e.preventDefault()
+                debouncedDoSearch.cancel()
+                doSearch(vscodeAPI, query)
+            } else if (e.key === 'ArrowDown') {
+                // detect if command key is selected
+                if (e.metaKey && results.length > 0) {
+                    // remove focus from textarea
+                    outerContainerRef.current?.focus()
+                    if (selectedResult[0] === -1) {
+                        setSelectedResult([0, -1])
+                    }
+                }
+                e.stopPropagation()
+            } else if (e.key === 'ArrowUp') {
+                e.stopPropagation()
+            }
+        },
+        [vscodeAPI, query, results.length, selectedResult]
+    )
+
+    const onKeyDownUpdateSelection = React.useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            let [fileIndex, snippetIndex] = selectedResult
+            if (fileIndex === -1) {
+                return
+            }
+            if (e.metaKey && e.key === 'ArrowUp') {
+                queryInputRef.current?.focus()
+                return
+            }
+            if (e.key === 'ArrowDown') {
+                snippetIndex++
+                const numSnippets = collapsedFileResults[fileIndex] ? 0 : results[fileIndex].snippets.length
+                if (snippetIndex >= numSnippets) {
+                    fileIndex++
+                    if (fileIndex >= results.length) {
+                        return
+                    }
+                    snippetIndex = -1
+                }
+                setSelectedResult([fileIndex, snippetIndex])
+            } else if (e.key === 'ArrowUp') {
+                snippetIndex--
+                if (snippetIndex < -1) {
+                    fileIndex--
+                    if (fileIndex < 0) {
+                        return
+                    }
+                    const numSnippets = collapsedFileResults[fileIndex] ? 0 : results[fileIndex].snippets.length
+                    snippetIndex = numSnippets - 1
+                }
+                if (fileIndex < 0) {
+                    setSelectedResult([-1, -1])
+                } else {
+                    setSelectedResult([fileIndex, snippetIndex])
+                }
+            } else if (e.key === 'ArrowLeft') {
+                if (selectedResult[1] === -1) {
+                    // Collapse file
+                    setCollapsedFileResults(prev => {
+                        const newCollapsedFileResults = { ...prev }
+                        newCollapsedFileResults[fileIndex] = true
+                        return newCollapsedFileResults
+                    })
+                } else {
+                    // Select file
+                    setSelectedResult([selectedResult[0], -1])
+                }
+            } else if (e.key === 'ArrowRight') {
+                if (selectedResult[1] === -1) {
+                    if (collapsedFileResults[fileIndex]) {
+                        // Expand file
+                        setCollapsedFileResults(prev => {
+                            const newCollapsedFileResults = { ...prev }
+                            delete newCollapsedFileResults[fileIndex]
+                            return newCollapsedFileResults
+                        })
+                    } else {
+                        // Select snippet
+                        setSelectedResult([selectedResult[0], 0])
+                    }
+                }
+            }
+        },
+        [selectedResult, results, collapsedFileResults]
+    )
+
+    return (
+        <div
+            role="listbox"
+            className={styles.outerContainer}
+            onKeyDown={onKeyDownUpdateSelection}
+            tabIndex={0}
+            ref={outerContainerRef}
+        >
+            <form className={styles.inputRow}>
+                <div className={styles.searchInputContainer}>
+                    <textarea
+                        placeholder="Type a keyword query or describe what you're looking for"
+                        className={styles.searchInput}
+                        onChange={onInputChange}
+                        onKeyDown={onInputKeyDown}
+                        ref={queryInputRef}
+                    />
+                </div>
+            </form>
+            <div className={styles.searchResultsContainer}>
+                {results.map((result, fileIndex) => (
+                    <>
+                        {/* File result */}
+                        <div
+                            key={`${result.uriString}`}
+                            className={styles.searchResultRow}
+                            onKeyDown={e => e.key === 'Enter' && setSelectedResult([fileIndex, 0])}
+                            onClick={() => setSelectedResult([fileIndex, -1])}
+                        >
+                            <div
+                                className={`${styles.searchResultRowInner} ${
+                                    selectedResult[0] === fileIndex &&
+                                    selectedResult[1] === -1 &&
+                                    styles.searchResultRowInnerSelected
+                                }`}
+                            >
+                                <div
+                                    className={styles.searchResultTwistie}
+                                    onClick={() => toggleFileExpansion(fileIndex)}
+                                    onKeyDown={e => e.key === 'Enter' && toggleFileExpansion(fileIndex)}
+                                >
+                                    <i
+                                        className={`codicon ${
+                                            collapsedFileResults[fileIndex]
+                                                ? 'codicon-chevron-right'
+                                                : 'codicon-chevron-down'
+                                        }`}
+                                    />
+                                </div>
+                                <div className={styles.searchResultContent}>
+                                    <div className={styles.filematchLabel}>
+                                        <span className={styles.filematchIcon}>
+                                            <i className="codicon codicon-file-code" />
+                                        </span>
+                                        &nbsp;
+                                        <span className={styles.filematchTitle}>{result.basename}</span>
+                                        <span className={styles.filematchDescription}>
+                                            &nbsp;
+                                            {result.wsname && <span>{result.wsname}&nbsp;&middot;&nbsp;</span>}
+                                            <span>{result.dirname}</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        {/* Snippet results */}
+                        {!collapsedFileResults[fileIndex] &&
+                            result.snippets.map((snippet, snippetIndex) => (
+                                <div
+                                    className={styles.searchResultRow}
+                                    key={`${result.uriString}#L${snippet.range.start.line}:${snippet.range.start.character}-${snippet.range.end.line}:${snippet.range.end.character}`}
+                                    onClick={() => setSelectedResult([fileIndex, snippetIndex])}
+                                    onKeyDown={e => e.key === 'Enter' && setSelectedResult([fileIndex, snippetIndex])}
+                                >
+                                    <div
+                                        className={`${styles.searchResultRowInner} ${
+                                            selectedResult[0] === fileIndex &&
+                                            selectedResult[1] === snippetIndex &&
+                                            styles.searchResultRowInnerSelected
+                                        }`}
+                                    >
+                                        <div className={styles.searchResultIndent}>
+                                            <div className={styles.searchResultIndentGuide} />
+                                        </div>
+                                        <div
+                                            className={`${styles.searchResultTwistie} ${styles.searchResultTwistieNoindent}`}
+                                        />
+                                        <div className={styles.searchResultContent}>
+                                            {firstInterestingLine(snippet.contents)}
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                    </>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function firstInterestingLine(contents: string): string {
+    const lines = contents.split('\n')
+    for (const line of lines) {
+        if (line.trim().length > 3) {
+            return line
+        }
+    }
+    return lines[0]
+}

--- a/vscode/webviews/search.html
+++ b/vscode/webviews/search.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Security-Policy"
         content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource}; font-src {cspSource};" />
     <!-- DO NOT REMOVE: THIS FILE IS THE ENTRY FILE FOR CODY WEBVIEW -->
-    <title>Cody</title>
+    <title>Cody Search</title>
 </head>
 
 <body>

--- a/vscode/webviews/search.html
+++ b/vscode/webviews/search.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- This content security policy also implicitly disables inline scripts and styles. -->
+    <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource}; font-src {cspSource};" />
+    <!-- DO NOT REMOVE: THIS FILE IS THE ENTRY FILE FOR CODY WEBVIEW -->
+    <title>Cody</title>
+</head>
+
+<body>
+    <div id="root"></div>
+    <script type="module" src="search.tsx"></script>
+</body>
+
+</html>

--- a/vscode/webviews/search.tsx
+++ b/vscode/webviews/search.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import ReactDOM from 'react-dom/client'
+
+import { SearchPanel } from './SearchPanel'
+
+import './index.css'
+
+import { getVSCodeAPI } from './utils/VSCodeApi'
+
+ReactDOM.createRoot(document.querySelector('#root') as HTMLElement).render(
+    <React.StrictMode>
+        <SearchPanel vscodeAPI={getVSCodeAPI()} />
+    </React.StrictMode>
+)

--- a/vscode/webviews/vite.config.ts
+++ b/vscode/webviews/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
             },
             input: {
                 index: resolve(__dirname, 'index.html'),
+                search: resolve(__dirname, 'search.html')
             },
             output: {
                 entryFileNames: '[name].js',

--- a/vscode/webviews/vite.config.ts
+++ b/vscode/webviews/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
             },
             input: {
                 index: resolve(__dirname, 'index.html'),
-                search: resolve(__dirname, 'search.html')
+                search: resolve(__dirname, 'search.html'),
             },
             output: {
                 entryFileNames: '[name].js',


### PR DESCRIPTION
Adds a symf-powered Cody search panel that meets @toolmantim's design.

Watch the loom: https://www.loom.com/share/7ea48cc631d5407e9b746463275625ae?sid=f68e7f01-be12-472d-a2ab-19975808940d

## Caveats
There is no easy way to import the language-specific file icons from the user's VS Code theme. We could just use one of the default themes' (there are two) icon sets, but I think that would look janky if the user is using another theme. So all files currently share the same icon, which is pulled from the non-file icon set, which is made available to exensions:

<img width="315" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/27b701fd-c9c3-41c0-9c9f-833d359071d6">


## Test plan

- [ ] Open a repository and search for something.
  - [ ] Verify `symf` dowloaded properly
  - [ ] Verify index is built
  - [ ] Verify results show up
- [ ] Add another workspace folder to the workspace
  - [ ] Do another search, verify results show up for both folders
- [ ] Add a function to a file and save. Click the "reindex all" button in the search panel header
  - [ ] Do a search for the function and verify it shows up in search results
- [ ] Verify the appearance works well for different VS Code themes

Try it on different repositories in different languages (including ones we don't typically use).