### PR TITLE
Removing classifyIntent call to LLM to optimize Fixup recipes

### DIFF
--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -2,7 +2,6 @@ import { URI } from 'vscode-uri'
 
 import { CodyPrompt } from '../chat/prompts'
 import { FixupIntent } from '../chat/recipes/fixup'
-import { IntentDetector } from '../intent-detector'
 
 export interface ActiveTextEditor {
     content: string
@@ -72,7 +71,7 @@ export interface VsCodeFixupController {
         taskId: string,
         options: { enableSmartSelection?: boolean }
     ): Promise<VsCodeFixupTaskRecipeData | undefined>
-    getTaskIntent(taskId: string, intentDetector: IntentDetector): Promise<FixupIntent>
+    getTaskIntent(taskId: string): Promise<FixupIntent>
 }
 
 export interface VsCodeCommandsController {
@@ -100,7 +99,6 @@ export interface Editor<
 
     /**
      * The path of the workspace root if on the file system, otherwise `null`.
-     *
      * @deprecated Use {@link Editor.getWorkspaceRootUri} instead.
      */
     getWorkspaceRootPath(): string | null

--- a/vscode/src/chat/InlineChatViewProvider.ts
+++ b/vscode/src/chat/InlineChatViewProvider.ts
@@ -87,7 +87,7 @@ export class InlineChatViewProvider extends MessageProvider {
         /**
          * TODO(umpox):
          * We create a new comment and trigger the inline chat recipe, but may end up closing this comment and running a fix instead
-         * We should detect intent here (through regex and then `classifyIntentFromOptions`) and run the correct recipe/controller instead.
+         * We should detect intent here (through regex and other fast alternatives) and run the correct recipe/controller instead.
          */
         await this.editor.controllers.inline?.chat(reply, this.thread, isEditMode)
         this.editor.controllers.inline?.setResponsePending(true)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1,9 +1,8 @@
 import * as vscode from 'vscode'
 
-import { FixupIntent, FixupIntentClassification } from '@sourcegraph/cody-shared/src/chat/recipes/fixup'
+import { FixupIntent } from '@sourcegraph/cody-shared/src/chat/recipes/fixup'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { VsCodeFixupController, VsCodeFixupTaskRecipeData } from '@sourcegraph/cody-shared/src/editor'
-import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
 
@@ -214,17 +213,11 @@ export class FixupController
     /**
      * Retrieves the intent for a specific task based on the selected text and other contextual information.
      * @param taskId - The ID of the task for which the intent is to be determined.
-     * @param intentDetector - The detector used to classify the intent from available options.
-     * @returns A promise that resolves to a `FixupIntent` which can be one of the intents like 'add', 'edit', etc.
+     * @returns A promise that resolves to a `FixupIntent` which can be one of the intents 'add' or 'edit'.
      * @throws
-     * - Will throw an error if no code is selected for fixup.
      * - Will throw an error if the selected text exceeds the defined maximum limit.
-     * @todo (umpox): Explore shorter and more efficient ways to detect intent.
-     * Possible methods:
-     * - Input -> Match first word against update|fix|add|delete verbs
-     * - Context -> Infer intent from context, e.g. Current file is a test -> Test intent, Current selection is a comment symbol -> Documentation intent
      */
-    public async getTaskIntent(taskId: string, intentDetector: IntentDetector): Promise<FixupIntent> {
+    public async getTaskIntent(taskId: string): Promise<FixupIntent> {
         const task = this.tasks.get(taskId)
         if (!task) {
             throw new Error('Select some code to fixup.')
@@ -241,12 +234,7 @@ export class FixupController
             return 'add'
         }
 
-        const intent = await intentDetector.classifyIntentFromOptions(
-            task.instruction,
-            FixupIntentClassification,
-            'edit'
-        )
-        return intent
+        return 'edit'
     }
 
     /**


### PR DESCRIPTION
Solves Part 1 of #1544 
Quoting @umpox 
<img width="899" alt="image" src="https://github.com/sourcegraph/cody/assets/11155207/2a9d7139-61af-4b96-80b7-54eee365d4c4">



## Test plan

Tested locally in debug mode with fixup/chat/inline 