### PR TITLE
fix: save transcript to chat history on abort

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Smart selection not working on the first line of code. [pull/1508](https://github.com/sourcegraph/cody/pull/1508)
+- Aborted messages are now saved to local chat history properly. [pull/1550](https://github.com/sourcegraph/cody/pull/1550)
 
 ### Changed
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -307,6 +307,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     }
 
     protected async abortCompletion(): Promise<void> {
+        await this.saveTranscriptToChatHistory()
         this.cancelCompletion()
         await this.multiplexer.notifyTurnComplete()
         await this.onCompletionEnd()


### PR DESCRIPTION
The commit adds a new call to saveTranscriptToChatHistory() before cancelling completion and notifying turn is complete. This saves the chat transcript to history when aborting a chat message.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. abort a message in progress
2. reload chat
3. open chat history for the message you aborted

#### Before

cody's response before you pressed abort is removed

<img width="754" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/74bf08c9-ee26-4218-ac2c-21d070cceaf2">

#### After

cody's response before you pressed abort is showing up in chat history
