### PR TITLE
Autocomplete: Add feature flag to test Claude Cyan

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -9,6 +9,7 @@ export enum FeatureFlag {
 
     CodyAutocompleteTracing = 'cody-autocomplete-tracing',
     CodyAutocompleteIncreasedDebounceTimeEnabled = 'cody-autocomplete-increased-debounce-time-enabled',
+    CodyAutocompleteAnthropicCyan = 'cody-autocomplete-anthropic-cyan',
     CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -33,7 +33,7 @@ describe('[getInlineCompletions] completion event', () => {
 
         // Get `suggestionId` from `CompletionLogger.loaded` call.
         const suggestionId: CompletionLogger.SuggestionID = spy.mock.calls[0][0]
-        const completionEvent = CompletionLogger.getCompletionEvent(suggestionId!)
+        const completionEvent = CompletionLogger.getCompletionEvent(suggestionId)
 
         return omit(completionEvent, [
             'acceptedAt',
@@ -88,7 +88,7 @@ describe('[getInlineCompletions] completion event', () => {
               "multiline": true,
               "multilineMode": "block",
               "providerIdentifier": "anthropic",
-              "providerModel": "claude-instant-infill",
+              "providerModel": "claude-instant-1.2",
               "triggerKind": "Automatic",
               "type": "inline",
             },
@@ -133,7 +133,7 @@ describe('[getInlineCompletions] completion event', () => {
                   "multiline": false,
                   "multilineMode": null,
                   "providerIdentifier": "anthropic",
-                  "providerModel": "claude-instant-infill",
+                  "providerModel": "claude-instant-1.2",
                   "triggerKind": "Automatic",
                   "type": "inline",
                 },

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -65,6 +65,7 @@ export function params(
     }
     const providerConfig = createProviderConfig({
         client,
+        model: null,
     })
 
     const { document, position } = documentAndPosition(code, languageId, URI_FIXTURE.toString())

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -61,6 +61,7 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
             providerConfig: createProviderConfig({
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
                 client: null as any,
+                model: null,
             }),
             triggerNotice: null,
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -33,10 +33,10 @@ import {
 export const MULTI_LINE_STOP_SEQUENCES = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG]
 export const SINGLE_LINE_STOP_SEQUENCES = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE]
 
-interface AnthropicOptions {
+export interface AnthropicOptions {
     maxContextTokens?: number
     client: Pick<CodeCompletionsClient, 'complete'>
-    mode?: 'infill'
+    model?: 'claude-instant-1.2-cyan' | 'claude-instant-1.2'
 }
 
 const MAX_RESPONSE_TOKENS = 256
@@ -44,12 +44,13 @@ const MAX_RESPONSE_TOKENS = 256
 export class AnthropicProvider extends Provider {
     private promptChars: number
     private client: Pick<CodeCompletionsClient, 'complete'>
+    private model: AnthropicOptions['model']
 
-    constructor(options: ProviderOptions, { maxContextTokens, client }: Required<AnthropicOptions>) {
+    constructor(options: ProviderOptions, { maxContextTokens, client, model }: Required<AnthropicOptions>) {
         super(options)
         this.promptChars = tokensToChars(maxContextTokens - MAX_RESPONSE_TOKENS)
-
         this.client = client
+        this.model = model
     }
 
     public emptyPromptLength(): number {
@@ -141,21 +142,23 @@ export class AnthropicProvider extends Provider {
             throw new Error(`prompt length (${prompt.length}) exceeded maximum character length (${this.promptChars})`)
         }
 
-        const requestParams: CodeCompletionsParams = this.options.multiline
-            ? {
-                  temperature: 0.5,
-                  messages: prompt,
-                  maxTokensToSample: MAX_RESPONSE_TOKENS,
-                  stopSequences: MULTI_LINE_STOP_SEQUENCES,
-                  timeoutMs: 15000,
-              }
-            : {
-                  temperature: 0.5,
-                  messages: prompt,
-                  maxTokensToSample: Math.min(50, MAX_RESPONSE_TOKENS),
-                  stopSequences: SINGLE_LINE_STOP_SEQUENCES,
-                  timeoutMs: 5000,
-              }
+        const requestParams: CodeCompletionsParams = {
+            temperature: 0.5,
+            messages: prompt,
+            ...(this.model === 'claude-instant-1.2-cyan' ? { model: 'anthropic/claude-instant-1.2-cyan' } : undefined),
+            ...(this.options.multiline
+                ? {
+                      maxTokensToSample: MAX_RESPONSE_TOKENS,
+                      stopSequences: MULTI_LINE_STOP_SEQUENCES,
+                      timeoutMs: 15000,
+                  }
+                : {
+                      maxTokensToSample: Math.min(50, MAX_RESPONSE_TOKENS),
+                      stopSequences: SINGLE_LINE_STOP_SEQUENCES,
+                      timeoutMs: 5000,
+                  }),
+        }
+
         tracer?.params(requestParams)
 
         const completions = await Promise.all(
@@ -228,16 +231,29 @@ export class AnthropicProvider extends Provider {
 
 export function createProviderConfig({
     maxContextTokens = 2048,
-    mode = 'infill',
+    model,
     ...otherOptions
-}: AnthropicOptions): ProviderConfig {
+}: Omit<AnthropicOptions, 'model'> & { model: string | null }): ProviderConfig {
+    let definedModel: 'claude-instant-1.2-cyan' | 'claude-instant-1.2'
+    switch (model) {
+        case 'claude-instant-1.2-cyan':
+            definedModel = 'claude-instant-1.2-cyan'
+            break
+        case 'claude-instant-1.2':
+        case null:
+            definedModel = 'claude-instant-1.2'
+            break
+        default:
+            throw new Error(`Invalid model: ${model}`)
+    }
+
     return {
         create(options: ProviderOptions) {
-            return new AnthropicProvider(options, { maxContextTokens, mode, ...otherOptions })
+            return new AnthropicProvider(options, { maxContextTokens, model: definedModel, ...otherOptions })
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
         enableExtendedMultilineTriggers: true,
         identifier: 'anthropic',
-        model: 'claude-instant-infill',
+        model: definedModel,
     }
 }

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -80,7 +80,7 @@ describe('createProviderConfig', () => {
                 {}
             )
             expect(provider?.identifier).toBe('anthropic')
-            expect(provider?.model).toBe('claude-instant-infill')
+            expect(provider?.model).toBe('claude-instant-1.2')
         })
 
         it('returns "fireworks" provider config and corresponding model if specified', async () => {
@@ -119,17 +119,17 @@ describe('createProviderConfig', () => {
             expect(provider?.model).toBe('gpt-35-turbo')
         })
 
-        it('returns "anthropic" provider config if specified in VSCode settings; model is ignored', async () => {
+        it('returns "anthropic" provider config if specified in VSCode settings', async () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({
                     autocompleteAdvancedProvider: 'anthropic',
-                    autocompleteAdvancedModel: 'hello-world',
+                    autocompleteAdvancedModel: 'claude-instant-1.2-cyan',
                 }),
                 dummyCodeCompletionsClient,
                 {}
             )
             expect(provider?.identifier).toBe('anthropic')
-            expect(provider?.model).toBe('claude-instant-infill')
+            expect(provider?.model).toBe('claude-instant-1.2-cyan')
         })
 
         it('provider specified in VSCode settings takes precedence over the one defined in the site config', async () => {
@@ -155,30 +155,30 @@ describe('createProviderConfig', () => {
                 // sourcegraph
                 { codyLLMConfig: { provider: 'sourcegraph', completionModel: 'hello-world' }, expected: null },
                 {
-                    codyLLMConfig: { provider: 'sourcegraph', completionModel: 'anthropic/claude-instant-infill' },
-                    expected: { provider: 'anthropic', model: 'claude-instant-infill' },
+                    codyLLMConfig: { provider: 'sourcegraph', completionModel: 'anthropic/claude-instant-1.2' },
+                    expected: { provider: 'anthropic', model: 'claude-instant-1.2' },
                 },
                 {
                     codyLLMConfig: { provider: 'sourcegraph', completionModel: 'anthropic/' },
                     expected: null,
                 },
                 {
-                    codyLLMConfig: { provider: 'sourcegraph', completionModel: '/claude-instant-infill' },
+                    codyLLMConfig: { provider: 'sourcegraph', completionModel: '/claude-instant-1.2' },
                     expected: null,
                 },
 
                 // aws-bedrock
                 { codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'hello-world' }, expected: null },
                 {
-                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic.claude-instant-infill' },
-                    expected: { provider: 'anthropic', model: 'claude-instant-infill' },
+                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic.claude-instant-1.2' },
+                    expected: { provider: 'anthropic', model: 'claude-instant-1.2' },
                 },
                 {
                     codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic.' },
                     expected: null,
                 },
                 {
-                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic/claude-instant-infill' },
+                    codyLLMConfig: { provider: 'aws-bedrock', completionModel: 'anthropic/claude-instant-1.2' },
                     expected: null,
                 },
 
@@ -221,7 +221,7 @@ describe('createProviderConfig', () => {
                 // provider not defined (backward compat)
                 {
                     codyLLMConfig: { provider: undefined, completionModel: 'llama-code-7b' },
-                    expected: { provider: 'anthropic', model: 'claude-instant-infill' },
+                    expected: { provider: 'anthropic', model: 'claude-instant-1.2' },
                 },
             ]
 
@@ -248,6 +248,6 @@ describe('createProviderConfig', () => {
     it('returns anthropic provider config if no completions provider specified in VSCode settings or site config', async () => {
         const provider = await createProviderConfig(getVSCodeSettings(), dummyCodeCompletionsClient, {})
         expect(provider?.identifier).toBe('anthropic')
-        expect(provider?.model).toBe('claude-instant-infill')
+        expect(provider?.model).toBe('claude-instant-1.2')
     })
 })


### PR DESCRIPTION
Adds a new feature flag to test Claude Cyan (c.f. https://sourcegraph.slack.com/archives/C04D0GRD1GB/p1698383238134869)

The flag is evaluated after the starcoder one so if we set it to a `50/50` split it will only affect users that are not in the starcoder test group.

## Test plan

Manually changed the code to be inside the Claude Cyan group and ensure the right request is sent. The dotcom instance was already updated to support this.

<img width="1859" alt="Screenshot 2023-10-31 at 12 29 33" src="https://github.com/sourcegraph/cody/assets/458591/34a44034-4a88-4dee-99fd-b3f4840384b7">



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
