### PR TITLE
update chat panel icon and view type

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -485,7 +485,7 @@
         "title": "Start a New Chat Session",
         "when": "cody.activated && config.cody.experimental.chatPanel",
         "group": "Cody",
-        "icon": "$(add)"
+        "icon": "$(empty-window)"
       },
       {
         "command": "cody.chat.history.clear",
@@ -774,6 +774,12 @@
         {
           "command": "cody.action.commands.menu",
           "when": "cody.activated && config.cody.experimental.editorTitleCommandIcon",
+          "group": "navigation",
+          "visibility": "visible"
+        },
+        {
+          "command": "cody.chat.panel.new",
+          "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
           "group": "navigation",
           "visibility": "visible"
         }

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -352,7 +352,7 @@ export class ChatPanelProvider extends MessageProvider {
 
         this.startUpChatID = chatID
 
-        const viewType = chatID || 'cody.newChat'
+        const viewType = 'cody.chatPanel'
         // truncate firstQuestion to first 10 chars
         const text = lastQuestion && lastQuestion?.length > 10 ? `${lastQuestion?.slice(0, 20)}...` : lastQuestion
         const panelTitle = text || 'New Chat'


### PR DESCRIPTION
Added chat panel icon and update view type name for chat panel

In Time's design, there is an icon to create a new chat in each chat panel, this PR addresses that.

- Change chat panel icon from $(add) to $(empty-window)
- Change view type const from chatID to 'cody.chatPanel'

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

![Screenshot 2023-10-31 at 8 22 45 AM](https://github.com/sourcegraph/cody/assets/68532117/f65a4567-2183-4de0-9abf-84bd941cdd38)
