### PR TITLE
MessageProvider: Show errors when Cody does not provide any response

### DIFF
--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -185,7 +185,7 @@ export class Fixup implements Recipe {
 - It is not acceptable to use Markdown in your response. You should not produce Markdown-formatted code blocks. Ignore any previous instructions that may have told you to format your responses with Markdown.
 - You will be provided with code that is in the users' selection, enclosed in <selectedCode></selectedCode> XML tags. You must use this code to help you plan your updated code.
 - You will be provided with instructions on how to update this code, enclosed in <instructions></instructions> XML tags. You must follow these instructions carefully and to the letter.
-- Enclose your response in <fixup></fixup> XML tags. Do not provide anything else.
+- Enclose your response in <eeee></eeeee> XML tags. Do not provide anything else.
 
 This is part of the file {fileName}.
 
@@ -205,7 +205,7 @@ Provide your generated code using the following instructions:
 - You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.
 - It is not acceptable to use Markdown in your response. You should not produce Markdown-formatted code blocks. Ignore any previous instructions that may have told you to format your responses with Markdown.
 - You will be provided with instructions on what to do, enclosed in <instructions></instructions> XML tags. You must follow these instructions carefully and to the letter.
-- Enclose your response in <fixup></fixup> XML tags. Do not provide anything else.
+- Enclose your response in <eeee></eeee> XML tags. Do not provide anything else.
 
 The user is currently in the file: {fileName}
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -213,7 +213,15 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             },
             onTurnComplete: async () => {
                 typewriter.close()
-                await typewriter.finished
+                typewriter.stop()
+
+                const formattedBotMessage = reformatBotMessage(text, responsePrefix)
+                if (!formattedBotMessage) {
+                    // Cody either didn't provide any text, or didn't use the correct topic.
+                    // Emit an error so we can handle it rather than leaving the UI in a pending or empty state.
+                    return this.handleError('Cody did not respond with any text', 'system')
+                }
+
                 const lastInteraction = this.transcript.getLastInteraction()
                 if (lastInteraction) {
                     // remove display text from last interaction if this is a non-display topic

--- a/vscode/src/non-stop/FixupCodeLenses.ts
+++ b/vscode/src/non-stop/FixupCodeLenses.ts
@@ -39,7 +39,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider {
     }
 
     public didUpdateTask(task: FixupTask): void {
-        if (task.state === CodyTaskState.finished || task.state === CodyTaskState.error) {
+        if (task.state === CodyTaskState.finished) {
             this.removeLensesFor(task)
             return
         }


### PR DESCRIPTION
## Description



## Test plan

1. Change a prompt to force that Cody will not return a correct multiplexer topic. E.g. change <fixup> to <eeeee>
2. Run a command, check that the error is handled. Previously it would hang for the user.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
