### PR TITLE
Fixup: Fix error codelens being hidden

### DIFF
--- a/vscode/src/non-stop/FixupCodeLenses.ts
+++ b/vscode/src/non-stop/FixupCodeLenses.ts
@@ -39,7 +39,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider {
     }
 
     public didUpdateTask(task: FixupTask): void {
-        if (task.state === CodyTaskState.finished || task.state === CodyTaskState.error) {
+        if (task.state === CodyTaskState.finished) {
             this.removeLensesFor(task)
             return
         }


### PR DESCRIPTION
The new error handling logic was being hidden due to the codelens being removed.

It was already fixed this is just from a bad merge.

## Test plan

Force an error
Check code lens appears
Check code lens is functionality

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
