### PR TITLE
Autocomplete: Remove recursion from lsp light

### DIFF
--- a/vscode/src/completions/context/lsp-light-graph-cache.test.ts
+++ b/vscode/src/completions/context/lsp-light-graph-cache.test.ts
@@ -94,14 +94,12 @@ describe('LSPLightGraphCache', () => {
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(0, 0, 0, 19),
-            expect.anything(),
-            0 // no recursion
+            expect.anything()
         )
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(1, 0, 1, 11),
-            expect.anything(),
-            1 // recurse 1 layer
+            expect.anything()
         )
     })
 
@@ -116,14 +114,12 @@ describe('LSPLightGraphCache', () => {
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(0, 0, 0, 19),
-            expect.anything(),
-            0 // no recursion
+            expect.anything()
         )
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(1, 0, 1, 11),
-            expect.anything(),
-            1 // recurse 1 layer
+            expect.anything()
         )
 
         getGraphContextFromRange.mockClear()
@@ -152,14 +148,12 @@ describe('LSPLightGraphCache', () => {
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(0, 0, 0, 19),
-            expect.anything(),
-            0 // no recursion
+            expect.anything()
         )
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(1, 0, 1, 11),
-            expect.anything(),
-            1 // recurse 1 layer
+            expect.anything()
         )
         getGraphContextFromRange.mockClear()
 
@@ -182,8 +176,7 @@ describe('LSPLightGraphCache', () => {
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(0, 0, 0, 19),
-            expect.anything(),
-            0 // no recursion
+            expect.anything()
         )
     })
 
@@ -204,14 +197,12 @@ describe('LSPLightGraphCache', () => {
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(0, 0, 0, 19),
-            expect.anything(),
-            0 // no recursion
+            expect.anything()
         )
         expect(getGraphContextFromRange).toHaveBeenCalledWith(
             testDocuments.document1,
             range(1, 0, 1, 11),
-            expect.anything(),
-            1 // recurse 1 layer
+            expect.anything()
         )
         getGraphContextFromRange.mockClear()
 

--- a/vscode/src/testutils/test.ts
+++ b/vscode/src/testutils/test.ts
@@ -1,0 +1,3 @@
+import { wrapVSCodeTextDocument } from './textDocument'
+
+wrapVSCodeTextDocument()

--- a/vscode/src/testutils/test.ts
+++ b/vscode/src/testutils/test.ts
@@ -1,3 +1,0 @@
-import { wrapVSCodeTextDocument } from './textDocument'
-
-wrapVSCodeTextDocument()


### PR DESCRIPTION
Closes #1506

The recursion doesn't work well and there's no ned for improving it right now. Better test a stupider version that is less prone to have perf issues before we roll out the bigger changes.

## Test plan

- Enable `lsp-light` context
- Open the trace view
- Trigger a completion and see that nothing but the hover information is added

<img width="2098" alt="Screenshot 2023-10-31 at 17 04 07" src="https://github.com/sourcegraph/cody/assets/458591/845331c7-7a2d-4540-b90b-9b919230a5af">




<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
