### PR TITLE
telemetry: log request_id per interaction

### DIFF
--- a/lib/shared/src/chat/prompts/utils.ts
+++ b/lib/shared/src/chat/prompts/utils.ts
@@ -21,14 +21,17 @@ export async function newInteraction(args: {
     assistantText?: string
     assistantDisplayText?: string
     source?: ChatEventSource
+    request_id?: string
 }): Promise<Interaction> {
-    const { text, displayText, contextMessages, assistantText, assistantDisplayText, source } = args
+    const { text, displayText, contextMessages, assistantText, assistantDisplayText, source, request_id } = args
     return Promise.resolve(
         new Interaction(
             { speaker: 'human', text, displayText, source },
             { speaker: 'assistant', text: assistantText, displayText: assistantDisplayText, source },
             Promise.resolve(contextMessages || []),
-            []
+            [],
+            [],
+            request_id
         )
     )
 }

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -36,7 +36,9 @@ export class ChatQuestion implements Recipe {
                     context.editor.getActiveTextEditorSelection() || null,
                     context.interactionID
                 ),
-                []
+                [],
+                [],
+                context.interactionID
             )
         )
     }

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -33,7 +33,8 @@ export class ChatQuestion implements Recipe {
                     context.firstInteraction,
                     context.intentDetector,
                     context.codebaseContext,
-                    context.editor.getActiveTextEditorSelection() || null
+                    context.editor.getActiveTextEditorSelection() || null,
+                    context.interactionID
                 ),
                 []
             )
@@ -46,7 +47,8 @@ export class ChatQuestion implements Recipe {
         firstInteraction: boolean,
         intentDetector: IntentDetector,
         codebaseContext: CodebaseContext,
-        selection: ActiveTextEditorSelection | null
+        selection: ActiveTextEditorSelection | null,
+        interactionID?: string
     ): Promise<ContextMessage[]> {
         const contextMessages: ContextMessage[] = []
         // If input is less than 2 words, it means it's most likely a statement or a follow-up question that does not require additional context
@@ -60,7 +62,8 @@ export class ChatQuestion implements Recipe {
 
         this.debug('ChatQuestion:getContextMessages', 'isCodebaseContextRequired', isCodebaseContextRequired)
         if (isCodebaseContextRequired) {
-            const codebaseContextMessages = await codebaseContext.getCombinedContextMessages(text, numResults)
+            const options = { ...numResults, interactionID }
+            const codebaseContextMessages = await codebaseContext.getCombinedContextMessages(text, options)
             contextMessages.push(...codebaseContextMessages)
         }
 

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -107,7 +107,8 @@ export class CustomPrompt implements Recipe {
         codebaseContext: CodebaseContext,
         promptContext: CodyPromptContext,
         selection?: ActiveTextEditorSelection | null,
-        commandOutput?: string | null
+        commandOutput?: string | null,
+        interactionID?: string
     ): Promise<ContextMessage[]> {
         const contextMessages: ContextMessage[] = []
         const workspaceRootUri = editor.getWorkspaceRootUri()
@@ -118,7 +119,8 @@ export class CustomPrompt implements Recipe {
         }
 
         if (promptContext.codebase) {
-            const codebaseMessages = await codebaseContext.getContextMessages(text, numResults)
+            const options = { ...numResults, interactionID }
+            const codebaseMessages = await codebaseContext.getCombinedContextMessages(text, options)
             contextMessages.push(...codebaseMessages)
         }
         if (promptContext.openTabs) {

--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -73,7 +73,9 @@ export class Fixup implements Recipe {
                     speaker: 'assistant',
                 },
                 this.getContextFromIntent(intent, fixupTask, quarterFileContext, context),
-                []
+                [],
+                [],
+                context.interactionID
             )
         )
     }
@@ -127,6 +129,7 @@ export class Fixup implements Recipe {
                     .getContextMessages(task.instruction, {
                         numCodeResults: 4,
                         numTextResults: 0,
+                        interactionID: context.interactionID,
                     })
                     .then(messages =>
                         messages.concat(

--- a/lib/shared/src/chat/recipes/recipe.ts
+++ b/lib/shared/src/chat/recipes/recipe.ts
@@ -11,6 +11,7 @@ export interface RecipeContext {
     codebaseContext: CodebaseContext
     responseMultiplexer: BotResponseMultiplexer
     firstInteraction: boolean
+    interactionID?: string
 }
 
 export type RecipeID =

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -21,8 +21,12 @@ export class Interaction {
         private fullContext: Promise<ContextMessage[]>,
         private usedContextFiles: ContextFile[],
         private usedPreciseContext: PreciseContext[] = [],
+        private readonly request_id?: string,
         public readonly timestamp: string = new Date().toISOString()
-    ) {}
+    ) {
+        this.humanMessage.request_id = this.request_id
+        this.assistantMessage.request_id = this.request_id
+    }
 
     public getAssistantMessage(): InteractionMessage {
         return { ...this.assistantMessage }

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -49,5 +49,6 @@ export type ChatEventSource =
     | 'custom-commands'
     | 'test'
     | 'code-lens'
+    | 'suggestion'
     | CodyDefaultCommands
     | RecipeID

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -18,6 +18,7 @@ export interface ChatMessage extends Message {
     buttons?: ChatButton[]
     data?: any
     source?: ChatEventSource
+    request_id?: string
 }
 
 export interface InteractionMessage extends Message {
@@ -25,6 +26,7 @@ export interface InteractionMessage extends Message {
     prefix?: string
     error?: string
     source?: ChatEventSource
+    request_id?: string
 }
 
 export interface UserLocalHistory {

--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -23,6 +23,7 @@ import { ContextFile, ContextFileSource, ContextMessage, getContextMessageWithRe
 export interface ContextSearchOptions {
     numCodeResults: number
     numTextResults: number
+    interactionID?: string
 }
 
 export class CodebaseContext {
@@ -226,7 +227,11 @@ export class CodebaseContext {
         if (!this.keywords) {
             return []
         }
-        const results = await this.keywords.getContext(query, options.numCodeResults + options.numTextResults)
+        const results = await this.keywords.getContext(
+            query,
+            options.numCodeResults + options.numTextResults,
+            options.interactionID
+        )
         return results
     }
 
@@ -234,7 +239,11 @@ export class CodebaseContext {
         if (!this.filenames) {
             return []
         }
-        const results = await this.filenames.getContext(query, options.numCodeResults + options.numTextResults)
+        const results = await this.filenames.getContext(
+            query,
+            options.numCodeResults + options.numTextResults,
+            options.interactionID
+        )
         return results
     }
 

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -6,12 +6,12 @@ export interface ContextResult {
 }
 
 export interface KeywordContextFetcher {
-    getContext(query: string, numResults: number): Promise<ContextResult[]>
-    getSearchContext(query: string, numResults: number): Promise<ContextResult[]>
+    getContext(query: string, numResults: number, interactionID?: string): Promise<ContextResult[]>
+    getSearchContext(query: string, numResults: number, interactionID?: string): Promise<ContextResult[]>
 }
 
 export interface FilenameContextFetcher {
-    getContext(query: string, numResults: number): Promise<ContextResult[]>
+    getContext(query: string, numResults: number, interactionID?: string): Promise<ContextResult[]>
 }
 
 export interface Point {

--- a/lib/shared/src/telemetry-v2/index.ts
+++ b/lib/shared/src/telemetry-v2/index.ts
@@ -68,6 +68,7 @@ export type EventFeature =
     | 'cody.messageProvider.chatResponse.edit'
     | 'cody.messageProvider.chatResponse.explain'
     | 'cody.messageProvider.chatResponse.smell'
+    | 'cody.messageProvider.chatResponse.suggestion'
     | 'cody.messageProvider.chatResponse.reset'
     | 'cody.messageProvider.chatReset'
     | 'cody.messageProvider.clearChatHistoryButton'

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -106,8 +106,8 @@ export interface FeedbackButtonsProps {
 }
 
 export interface CodeBlockActionsProps {
-    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', source?: string) => void
-    insertButtonOnSubmit: (text: string, newFile?: boolean, source?: string) => void
+    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', source?: string, request_id?: string) => void
+    insertButtonOnSubmit: (text: string, newFile?: boolean, source?: string, request_id?: string) => void
 }
 
 export interface ChatCommandsProps {

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -24,6 +24,7 @@ interface CodeBlocksProps {
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 
     source?: string // the name of the executed command that generated the code
+    request_id?: string // the id of the request that generated the code
 }
 
 function createButtons(
@@ -32,7 +33,8 @@ function createButtons(
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit'],
     insertButtonClassName?: string,
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
-    source?: string
+    source?: string,
+    request_id?: string
 ): HTMLElement {
     const container = document.createElement('div')
     container.className = styles.container
@@ -57,7 +59,8 @@ function createButtons(
         CopyCodeBlockIcon,
         codeBlockActions,
         copyButtonClassName,
-        source
+        source,
+        request_id
     )
     buttons.append(copyButton)
 
@@ -71,7 +74,8 @@ function createButtons(
                 InsertCodeBlockIcon,
                 codeBlockActions,
                 insertButtonClassName,
-                source
+                source,
+                request_id
             )
         )
 
@@ -83,7 +87,8 @@ function createButtons(
                 SaveCodeBlockIcon,
                 codeBlockActions,
                 insertButtonClassName,
-                source
+                source,
+                request_id
             )
         )
     }
@@ -95,7 +100,6 @@ function createButtons(
 
 /**
  * Creates a button to perform an action on a code block.
- *
  * @returns The button element.
  */
 function createCodeBlockActionButton(
@@ -108,7 +112,8 @@ function createCodeBlockActionButton(
         insert?: CodeBlockActionsProps['insertButtonOnSubmit']
     },
     className?: string,
-    source?: string
+    source?: string,
+    request_id?: string
 ): HTMLElement {
     const button = document.createElement('button')
 
@@ -123,7 +128,7 @@ function createCodeBlockActionButton(
             button.innerHTML = CheckCodeBlockIcon
             navigator.clipboard.writeText(text).catch(error => console.error(error))
             button.className = classNames(styleClass, className)
-            codeBlockActions.copy(text, 'Button', source)
+            codeBlockActions.copy(text, 'Button', source, request_id)
             setTimeout(() => (button.innerHTML = iconSvg), 5000)
         })
     }
@@ -135,10 +140,10 @@ function createCodeBlockActionButton(
 
     switch (type) {
         case 'insert':
-            button.addEventListener('click', () => insertOnSubmit(text, false, source))
+            button.addEventListener('click', () => insertOnSubmit(text, false, source, request_id))
             break
         case 'new':
-            button.addEventListener('click', () => insertOnSubmit(text, true, source))
+            button.addEventListener('click', () => insertOnSubmit(text, true, source, request_id))
             break
     }
 
@@ -152,6 +157,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
     insertButtonClassName,
     insertButtonOnSubmit,
     source,
+    request_id,
 }) {
     const rootRef = useRef<HTMLDivElement>(null)
 
@@ -170,7 +176,8 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                     copyButtonOnSubmit,
                     insertButtonClassName,
                     insertButtonOnSubmit,
-                    source
+                    source,
+                    request_id
                 )
 
                 // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
@@ -192,6 +199,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
         copyButtonOnSubmit,
         insertButtonOnSubmit,
         source,
+        request_id,
     ])
 
     return useMemo(

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -181,6 +181,7 @@ export const TranscriptItem: React.FunctionComponent<
                             insertButtonClassName={codeBlocksInsertButtonClassName}
                             insertButtonOnSubmit={insertButtonOnSubmit}
                             source={message.source}
+                            request_id={message.request_id}
                         />
                     )
                 ) : inProgress ? (

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -623,6 +623,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         const customInteraction = await newInteraction({
             displayText: humanInput,
             assistantDisplayText: assistantResponse,
+            request_id: this.currentInteractionID,
         })
         this.transcript.addInteraction(interaction || customInteraction)
         this.sendTranscript()

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -783,7 +783,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         return DEFAULT_MAX_TOKENS - solutionLimit
     }
 
-    public logTelemetryService(eventName: string, properties?: any, hasVSEvent = true): void {
+    public logTelemetryService(eventName: string, properties?: Record<string, unknown>, hasVSEvent = true): void {
         const request_id = this.currentInteractionID
         telemetryService.log(eventName, { ...properties, request_id }, { hasV2Event: hasVSEvent })
     }

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -34,9 +34,9 @@ export type WebviewMessage =
           range?: { startLine: number; startCharacter: number; endLine: number; endCharacter: number }
       }
     | { command: 'edit'; text: string }
-    | { command: 'insert'; text: string; source?: string }
-    | { command: 'newFile'; text: string; source?: string }
-    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; source?: string }
+    | { command: 'insert'; text: string; source?: string; request_id?: string }
+    | { command: 'newFile'; text: string; source?: string; request_id?: string }
+    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; source?: string; request_id?: string }
     | {
           command: 'auth'
           type:

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -98,13 +98,12 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
     /**
      * Returns pieces of context relevant for the given query. Uses a keyword-search-based
      * approach.
-     *
      * @param query user query
      * @param numResults the number of context results to return
      * @returns a list of context results, sorted in *reverse* order (that is,
      * the most important result appears at the bottom)
      */
-    public async getContext(query: string, numResults: number): Promise<ContextResult[]> {
+    public async getContext(query: string, numResults: number, request_id?: string): Promise<ContextResult[]> {
         const startTime = performance.now()
         const rootPath = this.editor.getWorkspaceRootPath()
         if (!rootPath) {
@@ -128,7 +127,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
             })
         )
         const searchDuration = performance.now() - startTime
-        telemetryService.log('CodyVSCodeExtension:keywordContext:searchDuration', { searchDuration })
+        telemetryService.log('CodyVSCodeExtension:keywordContext:searchDuration', { searchDuration, request_id })
         logDebug('LocalKeywordContextFetcher:getContext', JSON.stringify({ searchDuration }))
 
         return messagePairs.reverse().flat()

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -57,7 +57,7 @@ export class InlineController implements VsCodeInlineController {
     private codeLenses: Map<string, CodeLensProvider> = new Map()
 
     // Track acceptance of generated code by Cody in Inline Chat
-    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '' }
+    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '', request_id: '' }
     private insertInProgress = false
     private lastClipboardText = ''
 
@@ -138,7 +138,7 @@ export class InlineController implements VsCodeInlineController {
         // Track paste event - it checks if the copied text is part of the text string
         vscode.workspace.onDidChangeTextDocument(async e => {
             const changedText = e.contentChanges[0]?.text
-            const { code, lineCount, charCount, eventName, source } = this.lastCopiedCode
+            const { code, lineCount, charCount, eventName, source, request_id } = this.lastCopiedCode
             const clipboardText = await vscode.env.clipboard.readText()
             // Skip if the document is not a file or if the copied text is from insert
             if (!code || !changedText || e.document.uri.scheme !== 'file') {
@@ -159,6 +159,7 @@ export class InlineController implements VsCodeInlineController {
                     lineCount,
                     charCount,
                     source,
+                    request_id,
                 })
             }
         })
@@ -328,18 +329,19 @@ export class InlineController implements VsCodeInlineController {
     public setLastCopiedCode(
         code: string,
         eventName: string,
-        source = ''
-    ): { code: string; lineCount: number; charCount: number; eventName: string; source?: string } {
+        source = '',
+        request_id = ''
+    ): { code: string; lineCount: number; charCount: number; eventName: string; source?: string; request_id?: string } {
         // All non-copy events are considered as insertions since we don't need to listen for paste events
         this.insertInProgress = !eventName.startsWith('copy')
         const { lineCount, charCount } = countCode(code)
-        const codeCount = { code, lineCount, charCount, eventName, source }
+        const codeCount = { code, lineCount, charCount, eventName, source, request_id }
         this.lastCopiedCode = codeCount
 
         // Currently supported events are: copy, insert, save
         const op = eventName.includes('copy') ? 'copy' : eventName.startsWith('insert') ? 'insert' : 'save'
 
-        const args = { op, charCount, lineCount, source }
+        const args = { op, charCount, lineCount, source, request_id }
         telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
         return codeCount
     }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -105,24 +105,24 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 
     const onCopyBtnClick = useCallback(
-        (text: string, eventType: 'Button' | 'Keydown' = 'Button', source?: string) => {
+        (text: string, eventType: 'Button' | 'Keydown' = 'Button', source?: string, request_id?: string) => {
             const op = 'copy'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, source })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, source, request_id })
         },
         [vscodeAPI]
     )
 
     const onInsertBtnClick = useCallback(
-        (text: string, newFile = false, source?: string) => {
+        (text: string, newFile = false, source?: string, request_id?: string) => {
             const op = newFile ? 'newFile' : 'insert'
             const eventType = 'Button'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, source })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, source, request_id })
         },
         [vscodeAPI]
     )


### PR DESCRIPTION
add interactionID to codebaseContext and recipes

- Pass interactionID to codebaseContext getContextMessages
- Add interactionID to RecipeContext
- Add interactionID parameter to relevant recipe methods
- Log interactionID as request_id for each chat question submitted


A new interactionID is assigned whenever executeRecipe is run, which allows tracing in individual webview/view.  

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Submit a question in chat, you should see all the logEvents has the same `request_id` for each chat question submitted.

I wanted to create an id for each interaction, but an interaction is not created until context is fetched so that didn't work out.

Example: 

Question 1
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:keywordContext:searchDuration {"properties":{"searchDuration":839.5423329919577,"request_id":"d6fd00bd-7559-456c-8bea-ae58b197a95c"}}
█ logEvent (telemetry disabled): CodyVSCodeExtension:recipe:chat-question:executed {"properties":{"contextSummary":{"embeddings":0,"local":7},"request_id":"d6fd00bd-7559-456c-8bea-ae58b197a95c"},"opts":{"hasV2Event":true}}
```

Question 2:
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:keywordContext:searchDuration {"properties":{"searchDuration":900.0559170097113,"request_id":"b5e1f00b-96d1-470a-9b0d-d9238550af71"}}
█ logEvent (telemetry disabled): CodyVSCodeExtension:recipe:chat-question:executed {"properties":{"contextSummary":{"embeddings":0,"local":8},"request_id":"b5e1f00b-96d1-470a-9b0d-d9238550af71"},"opts":{"hasV2Event":true}}
```

When paste a insert a code block:
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"properties":{"op":"insert","charCount":98,"lineCount":5,"source":"chat-question","request_id":"b5e1f00b-96d1-470a-9b0d-d9238550af71"}}
``