### PR TITLE
Completions: Fix duplicate InlineCompletionItemProvider bug

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -483,39 +483,43 @@ const register = async (
     let setupAutocompleteQueue = Promise.resolve() // Create a promise chain to avoid parallel execution
     disposables.push({ dispose: () => completionsProvider?.dispose() })
     const setupAutocomplete = (): void => {
-        setupAutocompleteQueue = setupAutocompleteQueue.then(async () => {
-            const config = getConfiguration(vscode.workspace.getConfiguration())
-            if (!config.autocomplete) {
-                completionsProvider?.dispose()
-                completionsProvider = null
-                if (config.isRunningInsideAgent) {
-                    throw new Error(
-                        'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
-                            'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
-                    )
+        setupAutocompleteQueue = setupAutocompleteQueue
+            .then(async () => {
+                const config = getConfiguration(vscode.workspace.getConfiguration())
+                if (!config.autocomplete) {
+                    completionsProvider?.dispose()
+                    completionsProvider = null
+                    if (config.isRunningInsideAgent) {
+                        throw new Error(
+                            'The setting `config.autocomplete` evaluated to `false`. It must be true when running inside the agent. ' +
+                                'To fix this problem, make sure that the setting cody.autocomplete.enabled has the value true.'
+                        )
+                    }
+                    return
                 }
-                return
-            }
 
-            if (completionsProvider !== null) {
-                // If completions are already initialized and still enabled, we
-                // need to reset the completion provider.
-                completionsProvider.dispose()
-            }
+                if (completionsProvider !== null) {
+                    // If completions are already initialized and still enabled, we
+                    // need to reset the completion provider.
+                    completionsProvider.dispose()
+                }
 
-            completionsProvider = await createInlineCompletionItemProvider(
-                {
-                    config,
-                    client: codeCompletionsClient,
-                    statusBar,
-                    contextProvider,
-                    authProvider,
-                    triggerNotice: notice => chatManager.triggerNotice(notice),
-                },
-                context,
-                platform
-            )
-        })
+                completionsProvider = await createInlineCompletionItemProvider(
+                    {
+                        config,
+                        client: codeCompletionsClient,
+                        statusBar,
+                        contextProvider,
+                        authProvider,
+                        triggerNotice: notice => chatManager.triggerNotice(notice),
+                    },
+                    context,
+                    platform
+                )
+            })
+            .catch(error => {
+                console.error('Error creating inline completion item provider:', error)
+            })
     }
 
     // Reload autocomplete if either the configuration changes or the auth status is updated


### PR DESCRIPTION
## Description

We often call `setupAutocomplete` multiple times, which throws a VS Code error and possibly causes other unintended behavior.

![image](https://github.com/sourcegraph/cody/assets/9516420/93728209-0d2a-4499-a581-a83081da97b9)

This change queues the calls so we don't attempt to create parallel completion providers.

## Test plan

Tested locally:
- Open a fresh VS Code window with the Cody sidebar already open
- Confirm no errors like `[sourcegraph.cody-ai]command 'cody.autocomplete.manual-trigger' already exists` are shown in dev tools

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
