### PR TITLE
add back `transcript` to cody feedback event data for dotcom users

### DIFF
--- a/lib/shared/src/sourcegraph-api/environments.ts
+++ b/lib/shared/src/sourcegraph-api/environments.ts
@@ -9,7 +9,7 @@ export function isLocalApp(url: string): boolean {
         return false
     }
 }
-
+// 🚨 SECURITY: This is used as a check for logging chatTranscript for dotcom users only, be extremely careful if modifying this function
 export function isDotCom(url: string): boolean {
     try {
         return new URL(url).origin === DOTCOM_URL.origin


### PR DESCRIPTION
The goal of this PR is to collect `transcript` again when a user submits feedback. IMPORTANT to note, that we only want to collect transcript for free community users that are connected to dotcom.

steps added:
- Add `isDotCom` check before setting `transcript` (only set if `isDotCom` endpoint)
- Stringify transcript before adding to eventData

## Test plan
Tested locally by connecting to S2 and ensuring no value is sent for `transcript` and when connected to sourcegraph, `transcript` value is populated
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
