### PR TITLE
Fixup: Add formatting codelens and the option to skip

### DIFF
--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -30,6 +30,7 @@ export class FixupTask {
     public spinCount = 0
     // The edited range of the applied replacement
     public editedRange: vscode.Range | undefined
+    public formattingResolver: ((value: boolean) => void) | null = null
 
     constructor(
         public readonly fixupFile: FixupFile,

--- a/vscode/src/non-stop/codelenses.ts
+++ b/vscode/src/non-stop/codelenses.ts
@@ -18,6 +18,11 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
             const title = getApplyingLens(codeLensRange)
             return [title]
         }
+        case CodyTaskState.formatting: {
+            const title = getFormattingLens(codeLensRange)
+            const skip = getFormattingSkipLens(codeLensRange, task.id)
+            return [title, skip]
+        }
         case CodyTaskState.applied: {
             const title = getAppliedLens(codeLensRange, task.id)
             const retry = getRetryLens(codeLensRange, task.id)
@@ -60,6 +65,25 @@ function getApplyingLens(codeLensRange: vscode.Range): vscode.CodeLens {
     lens.command = {
         title: '$(sync~spin) Applying...',
         command: 'cody.focus',
+    }
+    return lens
+}
+
+function getFormattingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
+        title: '$(sync~spin) Formatting...',
+        command: 'cody.focus',
+    }
+    return lens
+}
+
+function getFormattingSkipLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
+        title: 'Skip',
+        command: 'cody.fixup.codelens.skip-formatting',
+        arguments: [id],
     }
     return lens
 }

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -2,9 +2,10 @@ export enum CodyTaskState {
     'idle' = 1,
     'working' = 2,
     'applying' = 3,
-    'applied' = 4,
-    'finished' = 5,
-    'error' = 6,
+    'formatting' = 4,
+    'applied' = 5,
+    'finished' = 6,
+    'error' = 7,
 }
 
 export type CodyTaskList = {
@@ -33,6 +34,11 @@ export const fixupTaskList: CodyTaskList = {
         id: 'applying',
         icon: 'pencil',
         description: 'The edit is being applied to the document',
+    },
+    [CodyTaskState.formatting]: {
+        id: 'formatting',
+        icon: 'pencil',
+        description: 'The edit is being formatted in the document',
     },
     [CodyTaskState.applied]: {
         id: 'applied',


### PR DESCRIPTION
## Description

Adds a codelens state for the formatting part, as this could take a noticeable amount of time depending on the users' formatter.

Also added the ability to skip formatting if it's taking a long time:


https://github.com/sourcegraph/cody/assets/9516420/b0c06318-b8da-465f-bccd-9e661ee7fe38



## Test plan

Tested locally with different formatters.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
