### PR TITLE
telemetry: add request_id field for code block actions

### DIFF
--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -57,6 +57,7 @@ export interface MyPromptsJSON {
 
 // The blueprint of a Cody Command
 export interface CodyPrompt {
+    request_id?: string
     description?: string
     prompt: string
     context?: CodyPromptContext

--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -57,7 +57,7 @@ export interface MyPromptsJSON {
 
 // The blueprint of a Cody Command
 export interface CodyPrompt {
-    request_id?: string
+    requestID?: string
     description?: string
     prompt: string
     context?: CodyPromptContext

--- a/lib/shared/src/chat/prompts/utils.ts
+++ b/lib/shared/src/chat/prompts/utils.ts
@@ -16,17 +16,35 @@ import { prompts } from './templates'
  */
 export async function newInteraction(args: {
     text?: string
-    displayText: string
+    displayText?: string
     contextMessages?: Promise<ContextMessage[]>
     assistantText?: string
     assistantDisplayText?: string
+    assistantPrefix?: string
     source?: ChatEventSource
+    requestID?: string
 }): Promise<Interaction> {
-    const { text, displayText, contextMessages, assistantText, assistantDisplayText, source } = args
+    const {
+        text,
+        displayText,
+        contextMessages,
+        assistantText,
+        assistantDisplayText,
+        assistantPrefix,
+        source,
+        requestID,
+    } = args
+    const metadata = { source, requestID }
     return Promise.resolve(
         new Interaction(
-            { speaker: 'human', text, displayText, source },
-            { speaker: 'assistant', text: assistantText, displayText: assistantDisplayText, source },
+            { speaker: 'human', text, displayText, metadata },
+            {
+                speaker: 'assistant',
+                text: assistantText,
+                displayText: assistantDisplayText,
+                prefix: assistantPrefix,
+                metadata,
+            },
             Promise.resolve(contextMessages || []),
             []
         )

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -25,8 +25,8 @@ export class ChatQuestion implements Recipe {
 
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: truncatedText, displayText: humanChatInput, source },
-                { speaker: 'assistant', source },
+                { speaker: 'human', text: truncatedText, displayText: humanChatInput, metadata: { source } },
+                { speaker: 'assistant', metadata: { source } },
                 this.getContextMessages(
                     truncatedText,
                     context.editor,

--- a/lib/shared/src/chat/recipes/code-question.ts
+++ b/lib/shared/src/chat/recipes/code-question.ts
@@ -25,11 +25,11 @@ export class CodeQuestion implements Recipe {
 
         return Promise.resolve(
             new Interaction(
-                { speaker: 'human', text: truncatedText, displayText: humanChatInput, source },
+                { speaker: 'human', text: truncatedText, displayText: humanChatInput, metadata: { source } },
                 {
                     speaker: 'assistant',
                     text: `\`\`\`${getFileExtension(context.editor.getActiveTextEditorSelection()?.fileName ?? '')}\n`,
-                    source,
+                    metadata: { source },
                 },
                 this.getContextMessages(
                     truncatedText,

--- a/lib/shared/src/chat/recipes/context-search.ts
+++ b/lib/shared/src/chat/recipes/context-search.ts
@@ -45,13 +45,13 @@ export class ContextSearch implements Recipe {
                 speaker: 'human',
                 text: '',
                 displayText: query,
-                source,
+                metadata: { source },
             },
             {
                 speaker: 'assistant',
                 text: '',
                 displayText: await this.displaySearchResults(truncatedText, context.codebaseContext, workspaceRootUri),
-                source,
+                metadata: { source },
             },
             new Promise(resolve => resolve([])),
             []

--- a/lib/shared/src/chat/recipes/explain-code-detailed.ts
+++ b/lib/shared/src/chat/recipes/explain-code-detailed.ts
@@ -1,5 +1,6 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -25,17 +26,17 @@ export class ExplainCodeDetailed implements Recipe {
         const promptMessage = `Please explain the following ${languageName} code. Be very detailed and specific, and indicate when it is not clear to you what is going on. Format your response as an ordered list.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`
         const displayText = `Explain the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            { speaker: 'assistant', source },
-            getContextMessagesFromSelection(
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            contextMessages: getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection,
                 context.codebaseContext
             ),
-            []
-        )
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/explain-code-high-level.ts
+++ b/lib/shared/src/chat/recipes/explain-code-high-level.ts
@@ -1,5 +1,6 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -25,17 +26,17 @@ export class ExplainCodeHighLevel implements Recipe {
         const promptMessage = `Explain the following ${languageName} code at a high level. Only include details that are essential to an overall understanding of what's happening in the code.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`
         const displayText = `Explain the following code at a high level:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            { speaker: 'assistant', source },
-            getContextMessagesFromSelection(
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            contextMessages: getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection,
                 context.codebaseContext
             ),
-            []
-        )
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/find-code-smells.ts
+++ b/lib/shared/src/chat/recipes/find-code-smells.ts
@@ -1,5 +1,6 @@
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH, MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { getNormalizedLanguageName } from './helpers'
@@ -34,16 +35,12 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
         const displayText = `Find code smells in the following code: \n\`\`\`\n${selection.selectedText}\n\`\`\``
 
         const assistantResponsePrefix = ''
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-                source,
-            },
-            new Promise(resolve => resolve([])),
-            []
-        )
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -3,6 +3,7 @@ import { VsCodeFixupTaskRecipeData } from '../../editor'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
 import { populateCodeContextTemplate, populateCurrentEditorDiagnosticsTemplate } from '../../prompt/templates'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection } from './helpers'
@@ -39,19 +40,11 @@ export class Fixup implements Recipe {
         const promptText = this.getPrompt(fixupTask, intent)
         const quarterFileContext = Math.floor(MAX_CURRENT_FILE_TOKENS / 4)
 
-        return Promise.resolve(
-            new Interaction(
-                {
-                    speaker: 'human',
-                    text: promptText,
-                },
-                {
-                    speaker: 'assistant',
-                },
-                this.getContextFromIntent(intent, fixupTask, quarterFileContext, context),
-                []
-            )
-        )
+        return newInteraction({
+            text: promptText,
+            source: this.id,
+            contextMessages: this.getContextFromIntent(intent, fixupTask, quarterFileContext, context),
+        })
     }
 
     public getPrompt(task: VsCodeFixupTaskRecipeData, intent: FixupIntent): string {

--- a/lib/shared/src/chat/recipes/generate-docstring.ts
+++ b/lib/shared/src/chat/recipes/generate-docstring.ts
@@ -1,5 +1,6 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -49,22 +50,19 @@ export class GenerateDocstring implements Recipe {
         const displayText = `Generate documentation for the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``
 
         const assistantResponsePrefix = `Here is the generated documentation:\n\`\`\`${extension}\n${docStart}`
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-                source,
-            },
-            getContextMessagesFromSelection(
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+            contextMessages: getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection,
                 context.codebaseContext
             ),
-            []
-        )
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/generate-pr-description.ts
+++ b/lib/shared/src/chat/recipes/generate-pr-description.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -52,17 +53,13 @@ export class PrDescription implements Recipe {
 
         if (!gitCommitOutput) {
             const emptyGitCommitMessage = 'No commits history found in the current branch.'
-            return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText, source },
-                {
-                    speaker: 'assistant',
-                    prefix: emptyGitCommitMessage,
-                    text: emptyGitCommitMessage,
-                    source,
-                },
-                Promise.resolve([]),
-                []
-            )
+            return newInteraction({
+                text: rawDisplayText,
+                displayText: rawDisplayText,
+                source,
+                assistantPrefix: emptyGitCommitMessage,
+                assistantText: emptyGitCommitMessage,
+            })
         }
 
         const truncatedGitCommitOutput = truncateText(gitCommitOutput, MAX_RECIPE_INPUT_TOKENS)
@@ -73,15 +70,12 @@ export class PrDescription implements Recipe {
 
         const promptMessage = `Summarise these changes:\n${gitCommitOutput}\n\n made while working in the current git branch.\nUse this pull request template to ${prTemplateContent} generate a pull request description based on the committed changes.\nIf the PR template mentions a requirement to check the contribution guidelines, then just summarise the changes in bulletin format.\n If it mentions a test plan for the changes use N/A\n.`
         const assistantResponsePrefix = `Here is the PR description for the work done in your current branch:\n${truncatedCommitMessage}`
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-            },
-            Promise.resolve([]),
-            []
-        )
+        return newInteraction({
+            text: promptMessage,
+            displayText: rawDisplayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/generate-release-notes.ts
+++ b/lib/shared/src/chat/recipes/generate-release-notes.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'child_process'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -66,17 +67,13 @@ export class ReleaseNotes implements Recipe {
 
         if (!gitLogOutput) {
             const emptyGitLogMessage = 'No recent changes found to generate release notes.'
-            return new Interaction(
-                { speaker: 'human', displayText: rawDisplayText, source },
-                {
-                    speaker: 'assistant',
-                    prefix: emptyGitLogMessage,
-                    text: emptyGitLogMessage,
-                    source,
-                },
-                Promise.resolve([]),
-                []
-            )
+            return newInteraction({
+                text: rawDisplayText,
+                displayText: rawDisplayText,
+                source,
+                assistantPrefix: emptyGitLogMessage,
+                assistantText: emptyGitLogMessage,
+            })
         }
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
@@ -88,15 +85,12 @@ export class ReleaseNotes implements Recipe {
 
         const promptMessage = `Generate release notes by summarising these commits:\n${truncatedGitLogOutput}\n\nUse proper heading format for the release notes.\n\n${tagsPromptText}.Do not include other changes and dependency updates.`
         const assistantResponsePrefix = `Here is the generated release notes for ${selectedLabel}\n${truncatedLogMessage}`
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-            },
-            Promise.resolve([]),
-            []
-        )
+        return newInteraction({
+            text: promptMessage,
+            displayText: rawDisplayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/generate-test.ts
+++ b/lib/shared/src/chat/recipes/generate-test.ts
@@ -1,5 +1,6 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -33,22 +34,19 @@ export class GenerateTest implements Recipe {
 
         const displayText = `Generate a unit test for the following code:\n\`\`\`${extension}\n${selection.selectedText}\n\`\`\``
 
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-                source,
-            },
-            getContextMessagesFromSelection(
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+            contextMessages: getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection,
                 context.codebaseContext
             ),
-            []
-        )
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/git-log.ts
+++ b/lib/shared/src/chat/recipes/git-log.ts
@@ -3,6 +3,7 @@ import path from 'path'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -80,16 +81,12 @@ export class GitHistory implements Recipe {
 
         const promptMessage = `Summarize these commits:\n${truncatedGitLogOutput}\n\nProvide your response in the form of a bulleted list. Do not mention the commit hashes.`
         const assistantResponsePrefix = `Here is a summary of recent changes:\n${truncatedLogMessage}`
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText: rawDisplayText, source },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-                source,
-            },
-            Promise.resolve([]),
-            []
-        )
+        return newInteraction({
+            text: promptMessage,
+            displayText: rawDisplayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/improve-variable-names.ts
+++ b/lib/shared/src/chat/recipes/improve-variable-names.ts
@@ -1,5 +1,6 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -32,23 +33,19 @@ export class ImproveVariableNames implements Recipe {
         const languageName = getNormalizedLanguageName(selection.fileName)
         const promptMessage = `Improve the variable names in this ${languageName} code by replacing the variable names with new identifiers which succinctly capture the purpose of the variable. We want the new code to be a drop-in replacement, so do not change names bound outside the scope of this code, like function names or members defined elsewhere. Only change the names of local variables and parameters:\n\n\`\`\`${extension}\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`
         const assistantResponsePrefix = `Here is the improved code:\n\`\`\`${extension}\n`
-
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-                source,
-            },
-            getContextMessagesFromSelection(
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+            contextMessages: getContextMessagesFromSelection(
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
                 selection,
                 context.codebaseContext
             ),
-            []
-        )
+        })
     }
 }

--- a/lib/shared/src/chat/recipes/inline-chat.ts
+++ b/lib/shared/src/chat/recipes/inline-chat.ts
@@ -3,6 +3,7 @@ import { ContextMessage } from '../../codebase-context/messages'
 import { ActiveTextEditorSelection, Editor } from '../../editor'
 import { MAX_HUMAN_INPUT_TOKENS, MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { ChatQuestion } from './chat-question'
@@ -49,19 +50,12 @@ export class InlineChat implements Recipe {
         // Text display in UI fpr human that includes the selected code
         const displayText = humanChatInput + InlineChat.displayPrompt.replace('{selectedText}', selection.selectedText)
 
-        return Promise.resolve(
-            new Interaction(
-                {
-                    speaker: 'human',
-                    text: promptText,
-                    displayText,
-                    source,
-                },
-                { speaker: 'assistant', source },
-                this.getContextMessages(truncatedText, context.codebaseContext, selection, context.editor),
-                []
-            )
-        )
+        return newInteraction({
+            text: promptText,
+            displayText,
+            source,
+            contextMessages: this.getContextMessages(truncatedText, context.codebaseContext, selection, context.editor),
+        })
     }
 
     // Prompt Templates

--- a/lib/shared/src/chat/recipes/next-questions.ts
+++ b/lib/shared/src/chat/recipes/next-questions.ts
@@ -5,6 +5,7 @@ import { IntentDetector } from '../../intent-detector'
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH, MAX_CURRENT_FILE_TOKENS } from '../../prompt/constants'
 import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { numResults } from './helpers'
@@ -26,19 +27,19 @@ export class NextQuestions implements Recipe {
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedText}\n\`\`\`\n\n${promptSuffix}`
 
         const assistantResponsePrefix = 'Sure, here are great follow-up discussion topics and learning ideas:\n\n - '
-        return Promise.resolve(
-            new Interaction(
-                { speaker: 'human', text: promptMessage, source },
-                {
-                    speaker: 'assistant',
-                    prefix: assistantResponsePrefix,
-                    text: assistantResponsePrefix,
-                    source,
-                },
-                this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext),
-                []
-            )
-        )
+        return newInteraction({
+            text: promptMessage,
+            displayText: promptMessage,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+            contextMessages: this.getContextMessages(
+                truncatedText,
+                context.editor,
+                context.intentDetector,
+                context.codebaseContext
+            ),
+        })
     }
 
     private async getContextMessages(

--- a/lib/shared/src/chat/recipes/translate.ts
+++ b/lib/shared/src/chat/recipes/translate.ts
@@ -1,5 +1,6 @@
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
+import { newInteraction } from '../prompts/utils'
 import { Interaction } from '../transcript/interaction'
 
 import { languageMarkdownID, languageNames } from './langs'
@@ -34,16 +35,12 @@ export class TranslateToLanguage implements Recipe {
         const markdownID = languageMarkdownID[toLanguage] || ''
         const assistantResponsePrefix = `Here is the code translated to ${toLanguage}:\n\`\`\`${markdownID}\n`
 
-        return new Interaction(
-            { speaker: 'human', text: promptMessage, displayText, source },
-            {
-                speaker: 'assistant',
-                prefix: assistantResponsePrefix,
-                text: assistantResponsePrefix,
-                source,
-            },
-            Promise.resolve([]),
-            []
-        )
+        return newInteraction({
+            text: promptMessage,
+            displayText,
+            source,
+            assistantPrefix: assistantResponsePrefix,
+            assistantText: assistantResponsePrefix,
+        })
     }
 }

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -1,6 +1,6 @@
 import { ContextFile, ContextMessage, PreciseContext } from '../../codebase-context/messages'
 
-import { ChatMessage, InteractionMessage } from './messages'
+import { ChatMessage, ChatMetadata, InteractionMessage } from './messages'
 
 export interface InteractionJSON {
     humanMessage: InteractionMessage
@@ -24,12 +24,11 @@ export class Interaction {
         public readonly timestamp: string = new Date().toISOString()
     ) {}
 
-    public request_id: string | undefined = undefined
-
-    public setRequestId(request_id: string): void {
-        this.request_id = request_id
-        this.humanMessage.request_id = request_id
-        this.assistantMessage.request_id = request_id
+    private metadata?: ChatMetadata
+    public setMetadata(metadata: ChatMetadata): void {
+        this.metadata = metadata
+        this.humanMessage.metadata = this.metadata
+        this.assistantMessage.metadata = this.metadata
     }
 
     public getAssistantMessage(): InteractionMessage {
@@ -37,8 +36,7 @@ export class Interaction {
     }
 
     public setAssistantMessage(assistantMessage: InteractionMessage): void {
-        const source = assistantMessage.source || this.assistantMessage.source
-        this.assistantMessage = { ...assistantMessage, source, request_id: this.request_id }
+        this.assistantMessage = { ...assistantMessage, metadata: this.metadata }
     }
 
     public getHumanMessage(): InteractionMessage {

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -24,13 +24,21 @@ export class Interaction {
         public readonly timestamp: string = new Date().toISOString()
     ) {}
 
+    public request_id: string | undefined = undefined
+
+    public setRequestId(request_id: string): void {
+        this.request_id = request_id
+        this.humanMessage.request_id = request_id
+        this.assistantMessage.request_id = request_id
+    }
+
     public getAssistantMessage(): InteractionMessage {
         return { ...this.assistantMessage }
     }
 
     public setAssistantMessage(assistantMessage: InteractionMessage): void {
         const source = assistantMessage.source || this.assistantMessage.source
-        this.assistantMessage = { ...assistantMessage, source }
+        this.assistantMessage = { ...assistantMessage, source, request_id: this.request_id }
     }
 
     public getHumanMessage(): InteractionMessage {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -17,16 +17,19 @@ export interface ChatMessage extends Message {
     preciseContext?: PreciseContext[]
     buttons?: ChatButton[]
     data?: any
-    source?: ChatEventSource
-    request_id?: string
+    metadata?: ChatMetadata
 }
 
 export interface InteractionMessage extends Message {
     displayText?: string
     prefix?: string
     error?: string
+    metadata?: ChatMetadata
+}
+
+export interface ChatMetadata {
     source?: ChatEventSource
-    request_id?: string
+    requestID?: string
 }
 
 export interface UserLocalHistory {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -18,6 +18,7 @@ export interface ChatMessage extends Message {
     buttons?: ChatButton[]
     data?: any
     source?: ChatEventSource
+    request_id?: string
 }
 
 export interface InteractionMessage extends Message {
@@ -25,6 +26,7 @@ export interface InteractionMessage extends Message {
     prefix?: string
     error?: string
     source?: ChatEventSource
+    request_id?: string
 }
 
 export interface UserLocalHistory {

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { ChatButton, ChatContextStatus, ChatMessage, CodyPrompt, isDefined } from '@sourcegraph/cody-shared'
 
+import { CodeBlockMeta } from './chat/CodeBlocks'
 import { FileLinkProps } from './chat/ContextFiles'
 import { ChatInputContext } from './chat/inputContext/ChatInputContext'
 import { SymbolLinkProps } from './chat/PreciseContext'
@@ -106,8 +107,8 @@ export interface FeedbackButtonsProps {
 }
 
 export interface CodeBlockActionsProps {
-    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', source?: string, requestID?: string) => void
-    insertButtonOnSubmit: (text: string, newFile?: boolean, source?: string, requestID?: string) => void
+    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', metadata?: CodeBlockMeta) => void
+    insertButtonOnSubmit: (text: string, newFile?: boolean, metadata?: CodeBlockMeta) => void
 }
 
 export interface ChatCommandsProps {

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -106,8 +106,8 @@ export interface FeedbackButtonsProps {
 }
 
 export interface CodeBlockActionsProps {
-    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', source?: string) => void
-    insertButtonOnSubmit: (text: string, newFile?: boolean, source?: string) => void
+    copyButtonOnSubmit: (text: string, event?: 'Keydown' | 'Button', source?: string, requestID?: string) => void
+    insertButtonOnSubmit: (text: string, newFile?: boolean, source?: string, requestID?: string) => void
 }
 
 export interface ChatCommandsProps {

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -24,6 +24,7 @@ interface CodeBlocksProps {
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 
     source?: string // the name of the executed command that generated the code
+    requestID?: string // id of the request that generated the code
 }
 
 function createButtons(
@@ -32,7 +33,8 @@ function createButtons(
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit'],
     insertButtonClassName?: string,
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit'],
-    source?: string
+    source?: string,
+    requestID?: string
 ): HTMLElement {
     const container = document.createElement('div')
     container.className = styles.container
@@ -71,7 +73,8 @@ function createButtons(
                 InsertCodeBlockIcon,
                 codeBlockActions,
                 insertButtonClassName,
-                source
+                source,
+                requestID
             )
         )
 
@@ -83,7 +86,8 @@ function createButtons(
                 SaveCodeBlockIcon,
                 codeBlockActions,
                 insertButtonClassName,
-                source
+                source,
+                requestID
             )
         )
     }
@@ -95,7 +99,6 @@ function createButtons(
 
 /**
  * Creates a button to perform an action on a code block.
- *
  * @returns The button element.
  */
 function createCodeBlockActionButton(
@@ -108,7 +111,8 @@ function createCodeBlockActionButton(
         insert?: CodeBlockActionsProps['insertButtonOnSubmit']
     },
     className?: string,
-    source?: string
+    source?: string,
+    requestID?: string
 ): HTMLElement {
     const button = document.createElement('button')
 
@@ -152,6 +156,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
     insertButtonClassName,
     insertButtonOnSubmit,
     source,
+    requestID,
 }) {
     const rootRef = useRef<HTMLDivElement>(null)
 
@@ -170,7 +175,8 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                     copyButtonOnSubmit,
                     insertButtonClassName,
                     insertButtonOnSubmit,
-                    source
+                    source,
+                    requestID
                 )
 
                 // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
@@ -192,6 +198,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
         copyButtonOnSubmit,
         insertButtonOnSubmit,
         source,
+        requestID,
     ])
 
     return useMemo(

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -59,7 +59,8 @@ function createButtons(
         CopyCodeBlockIcon,
         codeBlockActions,
         copyButtonClassName,
-        source
+        source,
+        requestID
     )
     buttons.append(copyButton)
 
@@ -127,7 +128,7 @@ function createCodeBlockActionButton(
             button.innerHTML = CheckCodeBlockIcon
             navigator.clipboard.writeText(text).catch(error => console.error(error))
             button.className = classNames(styleClass, className)
-            codeBlockActions.copy(text, 'Button', source)
+            codeBlockActions.copy(text, 'Button', source, requestID)
             setTimeout(() => (button.innerHTML = iconSvg), 5000)
         })
     }
@@ -139,10 +140,10 @@ function createCodeBlockActionButton(
 
     switch (type) {
         case 'insert':
-            button.addEventListener('click', () => insertOnSubmit(text, false, source))
+            button.addEventListener('click', () => insertOnSubmit(text, false, source, requestID))
             break
         case 'new':
-            button.addEventListener('click', () => insertOnSubmit(text, true, source))
+            button.addEventListener('click', () => insertOnSubmit(text, true, source, requestID))
             break
     }
 
@@ -185,7 +186,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                 // capture copy events (right click or keydown) on code block
                 preElement.addEventListener('copy', () => {
                     if (copyButtonOnSubmit) {
-                        copyButtonOnSubmit(preText, 'Keydown')
+                        copyButtonOnSubmit(preText, 'Keydown', source, requestID)
                     }
                 })
             }

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -180,8 +180,8 @@ export const TranscriptItem: React.FunctionComponent<
                             copyButtonOnSubmit={copyButtonOnSubmit}
                             insertButtonClassName={codeBlocksInsertButtonClassName}
                             insertButtonOnSubmit={insertButtonOnSubmit}
-                            source={message.source}
-                            requestID={message.request_id}
+                            metadata={message.metadata}
+                            inProgress={inProgress}
                         />
                     )
                 ) : inProgress ? (

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -181,6 +181,7 @@ export const TranscriptItem: React.FunctionComponent<
                             insertButtonClassName={codeBlocksInsertButtonClassName}
                             insertButtonOnSubmit={insertButtonOnSubmit}
                             source={message.source}
+                            requestID={message.request_id}
                         />
                     )
                 ) : inProgress ? (

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -656,7 +656,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     ): Promise<void> {
         const customInteraction = await newInteraction(args)
         const updatedInteraction = interaction || customInteraction
-        updatedInteraction.setMetadata({ requestID: this.sessionID, source: args.source })
+        updatedInteraction.setMetadata({ requestID: this.currentRequestID, source: args.source })
         this.transcript.addInteraction(updatedInteraction)
         this.sendTranscript()
         await this.saveTranscriptToChatHistory()

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -423,7 +423,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             }
         }
 
-        const args = { ...contextSummary, ...{ request_id } }
+        const args = { ...contextSummary, request_id }
         telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, args, { hasV2Event: true })
         telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: { ...args } })
     }

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -425,7 +425,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
 
         const args = { ...contextSummary, request_id }
         telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, args, { hasV2Event: true })
-        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: { ...args } })
+        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: args })
     }
 
     protected async runRecipeForSuggestion(recipeId: RecipeID, humanChatInput: string = ''): Promise<void> {

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -423,9 +423,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             }
         }
 
-        const args = { ...contextSummary, request_id }
-        telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, args, { hasV2Event: true })
-        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: args })
+        const args = { ...contextSummary, ...{ request_id } }
+        telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, contextSummary, { hasV2Event: true })
+        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: { ...args } })
     }
 
     protected async runRecipeForSuggestion(recipeId: RecipeID, humanChatInput: string = ''): Promise<void> {

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -423,9 +423,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             }
         }
 
-        const args = { ...contextSummary, ...{ request_id } }
         telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, contextSummary, { hasV2Event: true })
-        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: { ...args } })
+        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: { ...contextSummary } })
     }
 
     protected async runRecipeForSuggestion(recipeId: RecipeID, humanChatInput: string = ''): Promise<void> {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -95,7 +95,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         logDebug('ChatPanelsManager:createWebviewPanel', this.panelProvidersMap.size.toString())
         const provider = new ChatPanelProvider(this.options)
         const webviewPanel = await provider.createWebviewPanel(chatID, chatQuestion)
-        const sessionID = chatID || provider.currentChatID
+        const sessionID = chatID || provider.sessionID
         this.activePanelProvider = provider
         this.panelProvidersMap.set(sessionID, provider)
 
@@ -103,7 +103,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             if (e.webviewPanel.visible && e.webviewPanel.active) {
                 this.activePanelProvider = provider
                 this.options.contextProvider.webview = provider.webview
-                void this.selectTreeItem(provider.currentChatID)
+                void this.selectTreeItem(provider.sessionID)
             }
         })
 
@@ -195,7 +195,7 @@ export class ChatPanelsManager implements vscode.Disposable {
     }
 
     private disposeProvider(chatID: string): void {
-        if (chatID === this.activePanelProvider?.currentChatID) {
+        if (chatID === this.activePanelProvider?.sessionID) {
             this.activePanelProvider.webviewPanel?.dispose()
             this.activePanelProvider.dispose()
             this.activePanelProvider = undefined

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -214,19 +214,12 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
     }
 
     private async onHumanMessageSubmitted(text: string, submitType: 'user' | 'suggestion' | 'example'): Promise<void> {
-        logDebug('SidebarChatProvider:onHumanMessageSubmitted', 'sidebar', { verbose: { text, submitType } })
+        logDebug('SidebarChatProvider:onHumanMessageSubmitted', 'chat', { verbose: { text, submitType } })
+        MessageProvider.inputHistory.push(text)
+        await this.executeRecipe('chat-question', text, 'chat')
         if (submitType === 'suggestion') {
             telemetryService.log('CodyVSCodeExtension:chatPredictions:used', undefined, { hasV2Event: true })
         }
-        if (text === '/') {
-            void vscode.commands.executeCommand('cody.action.commands.menu', true)
-            return
-        }
-        MessageProvider.inputHistory.push(text)
-        if (this.contextProvider.config.experimentalChatPredictions) {
-            void this.runRecipeForSuggestion('next-questions', text)
-        }
-        await this.executeRecipe('chat-question', text, 'chat')
     }
 
     /**

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { CodyPrompt, CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
 
 import { View } from '../../../webviews/NavBar'
 import { getActiveEditor } from '../../editor/active-editor'
@@ -103,13 +104,13 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
                 await vscode.commands.executeCommand(`cody.auth.${message.type}`)
                 break
             case 'insert':
-                await this.handleInsertAtCursor(message.text, message.source)
+                await this.handleInsertAtCursor(message.text, message.metadata)
                 break
             case 'newFile':
-                await this.handleSaveToNewFile(message.text, message.source)
+                await this.handleSaveToNewFile(message.text, message.metadata)
                 break
             case 'copy':
-                await this.handleCopiedCode(message.text, message.eventType, message.source)
+                await this.handleCopiedCode(message.text, message.eventType, message.metadata)
                 break
             case 'event':
                 telemetryService.log(message.eventName, message.properties)
@@ -280,7 +281,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
      * Replace selection if there is one and then log insert event
      * Note: Using workspaceEdit instead of 'editor.action.insertSnippet' as the later reformats the text incorrectly
      */
-    private async handleInsertAtCursor(text: string, source?: string): Promise<void> {
+    private async handleInsertAtCursor(text: string, meta?: CodeBlockMeta): Promise<void> {
         const selectionRange = getActiveEditor()?.selection
         const editor = getActiveEditor()
         if (!editor || !selectionRange) {
@@ -296,17 +297,17 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
         // Log insert event
         const op = 'insert'
         const eventName = op + 'Button'
-        this.editor.controllers.inline?.setLastCopiedCode(text, eventName, source)
+        this.editor.controllers.inline?.setLastCopiedCode(text, eventName, meta?.source, meta?.requestID)
     }
 
     /**
      * Handles insert event to insert text from code block to new file
      */
-    private async handleSaveToNewFile(text: string, source?: string): Promise<void> {
+    private async handleSaveToNewFile(text: string, meta?: CodeBlockMeta): Promise<void> {
         // Log insert event
         const op = 'save'
         const eventName = op + 'Button'
-        this.editor.controllers.inline?.setLastCopiedCode(text, eventName, source)
+        this.editor.controllers.inline?.setLastCopiedCode(text, eventName, meta?.source, meta?.requestID)
 
         await this.editor.createWorkspaceFile(text)
     }
@@ -316,13 +317,13 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
      * @param text - The text from code block when copy event is triggered
      * @param eventType - Either 'Button' or 'Keydown'
      */
-    private async handleCopiedCode(text: string, eventType: 'Button' | 'Keydown', source?: string): Promise<void> {
+    private async handleCopiedCode(text: string, eventType: 'Button' | 'Keydown', meta?: CodeBlockMeta): Promise<void> {
         // If it's a Button event, then the text is already passed in from the whole code block
         const copiedCode = eventType === 'Button' ? text : await vscode.env.clipboard.readText()
         const eventName = eventType === 'Button' ? 'copyButton' : 'keyDown:Copy'
         // Send to Inline Controller for tracking
         if (copiedCode) {
-            this.editor.controllers.inline?.setLastCopiedCode(copiedCode, eventName, source)
+            this.editor.controllers.inline?.setLastCopiedCode(copiedCode, eventName, meta?.source, meta?.requestID)
         }
     }
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -34,9 +34,9 @@ export type WebviewMessage =
           range?: { startLine: number; startCharacter: number; endLine: number; endCharacter: number }
       }
     | { command: 'edit'; text: string }
-    | { command: 'insert'; text: string; source?: string }
-    | { command: 'newFile'; text: string; source?: string }
-    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; source?: string }
+    | { command: 'insert'; text: string; source?: string; requestID?: string }
+    | { command: 'newFile'; text: string; source?: string; requestID?: string }
+    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; source?: string; requestID?: string }
     | {
           command: 'auth'
           type:

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -5,6 +5,7 @@ import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import type { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
+import { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
 
 import { View } from '../../webviews/NavBar'
 
@@ -34,9 +35,9 @@ export type WebviewMessage =
           range?: { startLine: number; startCharacter: number; endLine: number; endCharacter: number }
       }
     | { command: 'edit'; text: string }
-    | { command: 'insert'; text: string; source?: string; requestID?: string }
-    | { command: 'newFile'; text: string; source?: string; requestID?: string }
-    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; source?: string; requestID?: string }
+    | { command: 'insert'; text: string; metadata?: CodeBlockMeta }
+    | { command: 'newFile'; text: string; metadata?: CodeBlockMeta }
+    | { command: 'copy'; eventType: 'Button' | 'Keydown'; text: string; metadata?: CodeBlockMeta }
     | {
           command: 'auth'
           type:

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -40,6 +40,7 @@ export class CommandRunner implements vscode.Disposable {
             mode: command.mode || 'ask',
             useCodebaseContex: !!command.context?.codebase,
             useShellCommand: !!command.context?.command,
+            request_id: command.request_id,
         })
 
         logDebug('CommandRunner:init', this.kind)

--- a/vscode/src/custom-prompts/CommandRunner.ts
+++ b/vscode/src/custom-prompts/CommandRunner.ts
@@ -40,7 +40,7 @@ export class CommandRunner implements vscode.Disposable {
             mode: command.mode || 'ask',
             useCodebaseContex: !!command.context?.codebase,
             useShellCommand: !!command.context?.command,
-            request_id: command.request_id,
+            requestID: command.requestID,
         })
 
         logDebug('CommandRunner:init', this.kind)

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -83,12 +83,12 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      * If found, creates a new Cody command runner instance for that prompt and input.
      * Returns the ID of the created runner, or 'invalid' if not found.
      */
-    public async addCommand(key: string, input = '', request_id?: string): Promise<string> {
+    public async addCommand(key: string, input = '', requestID?: string): Promise<string> {
         const command = this.default.get(key)
         if (!command) {
             return 'invalid'
         }
-        command.request_id = request_id
+        command.requestID = requestID
         return this.createCodyCommand(command, input)
     }
 

--- a/vscode/src/custom-prompts/CommandsController.ts
+++ b/vscode/src/custom-prompts/CommandsController.ts
@@ -83,11 +83,12 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      * If found, creates a new Cody command runner instance for that prompt and input.
      * Returns the ID of the created runner, or 'invalid' if not found.
      */
-    public async addCommand(key: string, input?: string): Promise<string> {
+    public async addCommand(key: string, input = '', request_id?: string): Promise<string> {
         const command = this.default.get(key)
         if (!command) {
             return 'invalid'
         }
+        command.request_id = request_id
         return this.createCodyCommand(command, input)
     }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -290,7 +290,7 @@ const register = async (
             // Ensure that the sidebar view is open if not already
             await chatManager.setWebviewView('chat')
             // The inline chat is already saved in history, we just need to tell the sidebar chat to restore it
-            await chatManager.restoreSession(inlineChatProvider.currentChatID)
+            await chatManager.restoreSession(inlineChatProvider.sessionID)
             // Remove the inline chat
             inlineChatManager.removeProviderForThread(thread)
             telemetryService.log('CodyVSCodeExtension:inline-assist:openInSidebarButton:clicked', undefined, {

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -57,7 +57,7 @@ export class InlineController implements VsCodeInlineController {
     private codeLenses: Map<string, CodeLensProvider> = new Map()
 
     // Track acceptance of generated code by Cody in Inline Chat
-    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '', request_id: '' }
+    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '', requestID: '' }
     private insertInProgress = false
     private lastClipboardText = ''
 
@@ -138,7 +138,7 @@ export class InlineController implements VsCodeInlineController {
         // Track paste event - it checks if the copied text is part of the text string
         vscode.workspace.onDidChangeTextDocument(async e => {
             const changedText = e.contentChanges[0]?.text
-            const { code, lineCount, charCount, eventName, source, request_id } = this.lastCopiedCode
+            const { code, lineCount, charCount, eventName, source, requestID } = this.lastCopiedCode
             const clipboardText = await vscode.env.clipboard.readText()
             // Skip if the document is not a file or if the copied text is from insert
             if (!code || !changedText || e.document.uri.scheme !== 'file') {
@@ -159,7 +159,7 @@ export class InlineController implements VsCodeInlineController {
                     lineCount,
                     charCount,
                     source,
-                    request_id,
+                    requestID,
                 })
             }
         })
@@ -328,18 +328,18 @@ export class InlineController implements VsCodeInlineController {
         code: string,
         eventName: string,
         source = '',
-        request_id = ''
-    ): { code: string; lineCount: number; charCount: number; eventName: string; source?: string; request_id?: string } {
+        requestID = ''
+    ): { code: string; lineCount: number; charCount: number; eventName: string; source?: string; requestID?: string } {
         // All non-copy events are considered as insertions since we don't need to listen for paste events
         this.insertInProgress = !eventName.startsWith('copy')
         const { lineCount, charCount } = countCode(code)
-        const codeCount = { code, lineCount, charCount, eventName, source, request_id }
+        const codeCount = { code, lineCount, charCount, eventName, source, requestID }
         this.lastCopiedCode = codeCount
 
         // Currently supported events are: copy, insert, save
         const op = eventName.includes('copy') ? 'copy' : eventName.startsWith('insert') ? 'insert' : 'save'
 
-        const args = { op, charCount, lineCount, source, request_id }
+        const args = { op, charCount, lineCount, source, requestID }
         telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
         return codeCount
     }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -105,24 +105,24 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 
     const onCopyBtnClick = useCallback(
-        (text: string, eventType: 'Button' | 'Keydown' = 'Button', source?: string) => {
+        (text: string, eventType: 'Button' | 'Keydown' = 'Button', source?: string, requestID?: string) => {
             const op = 'copy'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, source })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, source, requestID })
         },
         [vscodeAPI]
     )
 
     const onInsertBtnClick = useCallback(
-        (text: string, newFile = false, source?: string) => {
+        (text: string, newFile = false, source?: string, requestID?: string) => {
             const op = newFile ? 'newFile' : 'insert'
             const eventType = 'Button'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, source })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, source, requestID })
         },
         [vscodeAPI]
     )

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -16,6 +16,7 @@ import {
     EditButtonProps,
     FeedbackButtonsProps,
 } from '@sourcegraph/cody-ui/src/Chat'
+import { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
 import { SubmitSvg } from '@sourcegraph/cody-ui/src/utils/icons'
 
 import { CODY_FEEDBACK_URL } from '../src/chat/protocol'
@@ -105,24 +106,24 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 
     const onCopyBtnClick = useCallback(
-        (text: string, eventType: 'Button' | 'Keydown' = 'Button', source?: string, requestID?: string) => {
+        (text: string, eventType: 'Button' | 'Keydown' = 'Button', metadata?: CodeBlockMeta) => {
             const op = 'copy'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, source, requestID })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, metadata })
         },
         [vscodeAPI]
     )
 
     const onInsertBtnClick = useCallback(
-        (text: string, newFile = false, source?: string, requestID?: string) => {
+        (text: string, newFile = false, metadata?: CodeBlockMeta) => {
             const op = newFile ? 'newFile' : 'insert'
             const eventType = 'Button'
             // remove the additional /n added by the text area at the end of the text
             const code = eventType === 'Button' ? text.replace(/\n$/, '') : text
             // Log the event type and text to telemetry in chat view
-            vscodeAPI.postMessage({ command: op, eventType, text: code, source, requestID })
+            vscodeAPI.postMessage({ command: op, eventType, text: code, metadata })
         },
         [vscodeAPI]
     )


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C05AGQYD528/p1698355247771849?thread_ts=1697738493.299929&cid=C05AGQYD528

From @chenkc805 

> For a "chatID", I'd like to be able to link specific chain of events together:
chat/command executed --> chat/command response --> code copied --> code pasted

This PR adds request_id to each Interaction so that when we display the code block in the UI, we will be able to refer back to the request when the code was generated:

- add requestID parameter to copy and insert callback functions 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Cody a question that generates a code block, and then copy the code. they should have the same request id as the request that generated the code

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:recipe:chat-question:executed {"properties":{"embeddings":15,"local":1,"request_id":"2c951818-f4fe-4105-9113-0c055d8b264c"},"opts":{"hasV2Event":true}}
█ logEvent (telemetry disabled): CodyVSCodeExtension:chatResponse:hasCode {"properties":{"lineCount":1,"charCount":25,"source":"chat-question","request_id":"2c951818-f4fe-4105-9113-0c055d8b264c"},"opts":{"hasV2Event":true}}
█ logEvent (telemetry disabled): CodyVSCodeExtension:insertButton:clicked {"properties":{"op":"insert","charCount":25,"lineCount":1,"source":"chat-question","request_id":"2c951818-f4fe-4105-9113-0c055d8b264c"}}
█ logEvent (telemetry disabled): CodyVSCodeExtension:copyButton:clicked {"properties":{"op":"copy","charCount":25,"lineCount":1,"source":"chat-question","request_id":"2c951818-f4fe-4105-9113-0c055d8b264c"}}
█ logEvent (telemetry disabled): CodyVSCodeExtension:keyDown:Paste:clicked {"properties":{"op":"paste","lineCount":1,"charCount":25,"source":"chat-question","request_id":"2c951818-f4fe-4105-9113-0c055d8b264c"}}
```