### PR TITLE
fix: remove extra call to loadChatHistory

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -657,7 +657,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Save chat history
      */
     private async saveChatHistory(): Promise<void> {
-        this.loadChatHistory()
         const userHistory = {
             chat: MessageProvider.chatHistory,
             input: MessageProvider.inputHistory,


### PR DESCRIPTION
fix: remove extra call to loadChatHistory()

This fixes issue where the last response from Cody is missing after starting a new chat session

This commit removes the extra unnecessary call, which avoids loading the old chat history before saving it in `saveChatHistory`.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Cody a question, and then restart your VS Code. Go back to your chat history for your last session.

#### Before 

Cody's response in the last chat was not stored

![image](https://github.com/sourcegraph/cody/assets/68532117/eef149ef-34f9-45ee-961f-30a0e19c376d)


#### After

Cody's response in the last chat was stored properly and can be seen in UI

![image](https://github.com/sourcegraph/cody/assets/68532117/049dddac-2740-4a1e-887f-df57778428b3)

