### PR TITLE
fix: prevent chat command selection from propagating event

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -275,6 +275,8 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             // Handles cycling through chat command suggestions using the up and down arrow keys
             if (displayCommands && formInput.startsWith('/')) {
                 if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+                    event.preventDefault()
+                    event.stopPropagation()
                     const commandsLength = displayCommands?.length
                     const curIndex = event.key === 'ArrowUp' ? selectedChatCommand - 1 : selectedChatCommand + 1
                     const newIndex = curIndex < 0 ? commandsLength - 1 : curIndex >= commandsLength - 1 ? 0 : curIndex

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -24,6 +24,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Focus chat input on mount even when notification for version update is shown. [pull/1556](https://github.com/sourcegraph/cody/pull/1556)
 - Commands: Commands selector in chat will now scroll to the selected item's viewport automatically. [pull/1556](https://github.com/sourcegraph/cody/pull/1556)
 - Edit: Errors are now shown separately to incoming edits, and will not be applied to the document. [pull/1376](https://github.com/sourcegraph/cody/pull/1376)
+- Chat: Prevent cursor from moving during chat command selection. [pull/1592](https://github.com/sourcegraph/cody/pull/1592)
 
 ### Changed
 


### PR DESCRIPTION
fix: prevent chat command selection from propagating event

Prevent the up/down arrow key events from propagating when cycling through chat command suggestions. This stops the cursor within the input box from moving up to the front when selecting a suggestion.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

#### Before 

Using arrow up in command selection box will move the cursor to the front

![image](https://github.com/sourcegraph/cody/assets/68532117/a93b5671-ffc0-4e48-8954-0f9d3a00e7db)

#### After

Moving up and down should not move the cursor position when the command selection box is showing. Cursor should stays in the back:

![image](https://github.com/sourcegraph/cody/assets/68532117/42eedc5a-7e5d-4590-86d4-d559cbd992fc)
