### PR TITLE
Autocomplete: log partial acceptance events only if the length increases

### DIFF
--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -157,4 +157,34 @@ describe('logger', () => {
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)
         expect(loggerItem3?.params.id).not.toBe(completionId)
     })
+
+    it('does not log partial accept events if the length is not increasing', () => {
+        const item = { insertText: 'export default class Agent' }
+
+        const id = CompletionLogger.create(defaultArgs)
+        CompletionLogger.start(id)
+        CompletionLogger.partiallyAccept(id, item, 5)
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'CodyVSCodeExtension:completion:partiallyAccepted',
+            expect.objectContaining({
+                acceptedLength: 5,
+                acceptedLengthDelta: 5,
+            })
+        )
+
+        CompletionLogger.partiallyAccept(id, item, 10)
+
+        expect(logSpy).toHaveBeenCalledWith(
+            'CodyVSCodeExtension:completion:partiallyAccepted',
+            expect.objectContaining({
+                acceptedLength: 10,
+                acceptedLengthDelta: 5,
+            })
+        )
+
+        CompletionLogger.partiallyAccept(id, item, 5)
+        CompletionLogger.partiallyAccept(id, item, 8)
+        expect(logSpy).toHaveBeenCalledTimes(2)
+    })
 })

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -321,13 +321,20 @@ export function partiallyAccept(id: SuggestionID, completion: InlineCompletionIt
     }
 
     const loggedPartialAcceptedLength = completionEvent.loggedPartialAcceptedLength
+
+    // Do not log partial acceptances if the length of the accepted completion is not increasing
+    if (acceptedLength <= loggedPartialAcceptedLength) {
+        return
+    }
+
+    const acceptedLengthDelta = acceptedLength - loggedPartialAcceptedLength
     completionEvent.loggedPartialAcceptedLength = acceptedLength
 
     logCompletionEvent('partiallyAccepted', {
         ...getSharedParams(completionEvent),
         acceptedItem: { ...completionItemToItemInfo(completion) },
         acceptedLength,
-        acceptedLengthDelta: acceptedLength - loggedPartialAcceptedLength,
+        acceptedLengthDelta,
     })
 }
 


### PR DESCRIPTION
## Context

Log partial accept events only if the partial acceptance length increases to avoid overcounting the number of partially accepted chars.

## Test plan

Added a unit test.
