### PR TITLE
Autocomplete: reuse the last candidate if the user types forward as suggested despite the updated completion info

### DIFF
--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -163,3 +163,9 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
         }),
     }
 }
+
+export function getCurrentLinePrefixWithoutInjectedPrefix(docContext: DocumentContext): string {
+    const { currentLinePrefix, injectedPrefix } = docContext
+
+    return injectedPrefix ? currentLinePrefix.slice(0, -injectedPrefix.length) : currentLinePrefix
+}

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -310,11 +310,37 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                             range: range(0, 8, 0, 8),
                         },
                         completeSuggestWidgetSelection: true,
+                        takeSuggestWidgetSelectionIntoAccount: true,
                     })
                 )
             ).toEqual<V>({
                 items: [],
                 source: InlineCompletionsResultSource.Network,
+            }))
+
+        it('is reused when typing forward as suggested and the selected item info differs', async () =>
+            // The user types `export c`, sees the context menu pop up `class` and receives a completion for
+            // the first item. They now type fotward as suggested and reach the next word of the completion `Agent`.
+            // The context menu pop up shows a different suggestion `Agent` but the original ghost text can be
+            // reused because user continues to type as suggested.
+            expect(
+                await getInlineCompletions(
+                    params('export class A█', [], {
+                        lastCandidate: lastCandidate('export c█', 'lass Agent {', {
+                            text: 'class',
+                            range: range(0, 8, 0, 8),
+                        }),
+                        selectedCompletionInfo: {
+                            text: 'Agent',
+                            range: range(0, 8, 0, 8),
+                        },
+                        completeSuggestWidgetSelection: true,
+                        takeSuggestWidgetSelectionIntoAccount: true,
+                    })
+                )
+            ).toEqual<V>({
+                items: [{ insertText: 'gent {' }],
+                source: InlineCompletionsResultSource.LastCandidate,
             }))
 
         it('does not repeat injected suffix information when content is inserted', async () =>

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -95,10 +95,10 @@ export class RequestManager {
             providers.map(provider => provider.generateCompletions(request.abortController.signal, context, tracer))
         )
             .then(res => res.flat())
-            .then(completions =>
+            .then(completions => {
                 // Shared post-processing logic
-                processInlineCompletions(completions, params)
-            )
+                return processInlineCompletions(completions, params)
+            })
             .then(processedCompletions => {
                 if (!this.disableNetworkCache) {
                     // Cache even if the request was aborted or already fulfilled.

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -56,6 +56,10 @@ function processCompletion(completion: ParsedCompletion, params: ProcessItemPara
     const { prefix, suffix, currentLineSuffix, multilineTrigger } = docContext
     let { insertText } = completion
 
+    if (completion.insertText.length === 0) {
+        return completion
+    }
+
     if (docContext.injectedPrefix) {
         insertText = docContext.injectedPrefix + completion.insertText
     }


### PR DESCRIPTION
## Context

- Reuse the last candidate if the user types forward as suggested despite the updated completion info.
- See the new added test with the inline description for the use-case. 

## Test plan

Updated unit tests
