### PR TITLE
Autocomplete: log partial acceptance events on every word instead of every char

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -219,15 +219,15 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             expect(handleDidPartiallyAcceptCompletionItem).not.toHaveBeenCalled()
 
             // Now we did
-            await getInlineCompletions(params('console█', [], args))
-            expect(handleDidPartiallyAcceptCompletionItem).toHaveBeenCalledWith(expect.anything(), expect.anything(), 7)
+            await getInlineCompletions(params('console.█', [], args))
+            expect(handleDidPartiallyAcceptCompletionItem).toHaveBeenCalledWith(expect.anything(), expect.anything(), 8)
 
             // Subsequent keystrokes should continue updating the partial acceptance
-            await getInlineCompletions(params('console.log█', [], args))
+            await getInlineCompletions(params('console.log(█', [], args))
             expect(handleDidPartiallyAcceptCompletionItem).toHaveBeenCalledWith(
                 expect.anything(),
                 expect.anything(),
-                11
+                12
             )
         })
     })

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { isDefined } from '@sourcegraph/cody-shared/src/common'
 
-import { DocumentContext, getCurrentLinePrefixWithoutInjectedPrefix } from './get-current-doc-context'
+import { DocumentContext } from './get-current-doc-context'
 import {
     InlineCompletionsParams,
     InlineCompletionsResult,

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { isDefined } from '@sourcegraph/cody-shared/src/common'
 
-import { DocumentContext } from './get-current-doc-context'
+import { DocumentContext, getCurrentLinePrefixWithoutInjectedPrefix } from './get-current-doc-context'
 import {
     InlineCompletionsParams,
     InlineCompletionsResult,
@@ -140,8 +140,11 @@ function isWhitespace(s: string): boolean {
 }
 
 // Count a completion as partially accepted, when at least one word of the completion was typed
+// To avoid sending partial completion events on every keystroke after the first word, we only
+// return true here after every completed word.
 function isPartialAcceptance(insertText: string, insertedLength: number): boolean {
-    const match = insertText.match(/(\w+)/)
+    const insertedText = insertText.slice(0, insertedLength)
+    const match = insertedText.match(/(\w+)\W+$/)
     const endOfFirstWord = match?.index === undefined ? null : match.index + match[0]!.length
     if (endOfFirstWord === null) {
         return false


### PR DESCRIPTION
## Context

- Log partial acceptance events on every word instead of every char to reduce the volume of the partial acceptance event being sent.

## Test plan

Updated unit tests
