### PR TITLE
feat: add chat command to sidebar view

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -482,10 +482,18 @@
       {
         "command": "cody.chat.panel.new",
         "category": "Cody",
-        "title": "Start a New Chat Session",
+        "title": "Start a New Chat Panel",
         "when": "cody.activated && config.cody.experimental.chatPanel",
         "group": "Cody",
-        "icon": "$(empty-window)"
+        "icon": "$(comment)"
+      },
+      {
+        "command": "cody.chat.tree.view.focus",
+        "category": "Cody",
+        "title": "Open Cody Sidebar",
+        "group": "Cody",
+        "icon": "$(layout-sidebar-left)",
+        "when": "config.cody.experimental.chatPanel"
       },
       {
         "command": "cody.chat.history.clear",
@@ -516,7 +524,17 @@
       {
         "command": "cody.chat.focus",
         "key": "alt+/",
-        "mac": "alt+/"
+        "when": "!config.cody.experimental.chatPanel"
+      },
+      {
+        "command": "cody.chat.tree.view.focus",
+        "key": "alt+f1",
+        "enablement": "cody.activated && config.cody.experimental.chatPanel"
+      },
+      {
+        "command": "cody.chat.panel.new",
+        "key": "alt+/",
+        "enablement": "cody.activated && config.cody.experimental.chatPanel"
       },
       {
         "command": "cody.command.edit-code",

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -97,7 +97,7 @@ const commandsItems: CodySidebarTreeItem[] = [
     {
         title: 'Chat',
         icon: 'comment',
-        description: 'Start new chat',
+        description: 'Ask Cody a question',
         command: { command: 'cody.chat.panel.new' },
     },
     {
@@ -114,7 +114,7 @@ const commandsItems: CodySidebarTreeItem[] = [
     },
     {
         title: 'Explain',
-        icon: 'output',
+        icon: 'file-binary',
         command: { command: 'cody.command.explain-code' },
         description: 'Explain code',
     },

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -95,6 +95,12 @@ const supportItems: CodySidebarTreeItem[] = [
 
 const commandsItems: CodySidebarTreeItem[] = [
     {
+        title: 'Chat',
+        icon: 'comment',
+        description: 'Start new chat',
+        command: { command: 'cody.chat.panel.new' },
+    },
+    {
         title: 'Document',
         icon: 'book',
         description: 'Add code documentation',


### PR DESCRIPTION

![image](https://github.com/sourcegraph/cody/assets/68532117/96b322ed-a7f8-4ea4-84f0-57f76b70def6)

Add a new 'Chat' item to the sidebar tree view commands. 

This will open a new chat panel when clicked.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- Click on the new `Chat` command in the new chat view
- The command should open a new chat panel for you