### PR TITLE
Integrating autocompletion with lookup manager

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -197,6 +197,14 @@ export class Agent extends MessageHandler {
                 return { items: [] }
             }
 
+            if (params.lookupElement !== undefined && document.content !== undefined && params.position !== undefined) {
+                const lookup = params.lookupElement
+                const lastPart = document.content.slice(params.offset, document.content.length)
+                const firstPart = document.content.slice(0, params.offset)
+                document.content = firstPart + lookup + lastPart
+                params.position.character = params.position.character + lookup.length
+            }
+
             const textDocument = new AgentTextDocument(document)
 
             try {
@@ -218,6 +226,21 @@ export class Agent extends MessageHandler {
                         : result.items.flatMap(({ insertText, range }) =>
                               typeof insertText === 'string' && range !== undefined ? [{ insertText, range }] : []
                           )
+
+                if (
+                    params.lookupElement !== undefined &&
+                    document.content !== undefined &&
+                    params.offset !== undefined &&
+                    params.position !== undefined
+                ) {
+                    const lastPart = document.content.slice(
+                        params.offset + params.lookupElement.length,
+                        document.content.length
+                    )
+                    const firstPart = document.content.slice(0, params.offset)
+                    document.content = firstPart + lastPart
+                }
+
                 return { items, completionEvent: (result as any)?.completionEvent }
             } catch (error) {
                 console.log('autocomplete failed', error)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -198,11 +198,10 @@ export class Agent extends MessageHandler {
             }
 
             if (params.lookupElement !== undefined && document.content !== undefined && params.position !== undefined) {
-                const lookup = params.lookupElement
-                const lastPart = document.content.slice(params.offset, document.content.length)
-                const firstPart = document.content.slice(0, params.offset)
-                document.content = firstPart + lookup + lastPart
-                params.position.character = params.position.character + lookup.length
+                const documentContentBeforeLookupElement = document.content.slice(0, params.offset)
+                const documentContentAfterLookupElement = document.content.slice(params.offset, document.content.length)
+                document.content = documentContentBeforeLookupElement + params.lookupElement + documentContentAfterLookupElement
+                params.position.character = params.position.character + params.lookupElement.length
             }
 
             const textDocument = new AgentTextDocument(document)

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -116,6 +116,7 @@ export interface AutocompleteParams {
     // triggered.
     triggerKind?: 'Automatic' | 'Invoke'
     lookupElement?: string
+    // Offset from the beginning of the document to caret position
     offset?: number
 }
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -115,6 +115,8 @@ export interface AutocompleteParams {
     // Defaults to 'Automatic' for autocompletions which were not explicitly
     // triggered.
     triggerKind?: 'Automatic' | 'Invoke'
+    lookupElement?: string
+    offset?: number
 }
 
 export interface AutocompleteResult {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -115,11 +115,13 @@ export interface AutocompleteParams {
     // Defaults to 'Automatic' for autocompletions which were not explicitly
     // triggered.
     triggerKind?: 'Automatic' | 'Invoke'
-    lookupElement?: string
-    // Offset from the beginning of the document to caret position
-    offset?: number
+    selectedCompletionInfo?: SelectedCompletionInfo
 }
 
+export interface SelectedCompletionInfo {
+    readonly range: Range
+    readonly text: string
+}
 export interface AutocompleteResult {
     items: AutocompleteItem[]
     completionEvent?: CompletionEvent


### PR DESCRIPTION
This is needed to fix [JetBrains: integrate autocomplete with lookup manager#57335](https://github.com/sourcegraph/sourcegraph/issues/57335).

It appends element from IntelliJ's lookup manager to the file in place of autocompletions, in order to generate completion including part from lookup manager.

## Test plan
Test requires changes on Jetbrains part so it is not possible at the moment. Those changes should not affect regular autocompletion behaviour.