### PR TITLE
Update the FixUp retry instruction text

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,6 +19,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Chat: Fixed an issue where multiple action buttons were appended to each Code Block per chat message. [pull/1617](https://github.com/sourcegraph/cody/pull/1617)
+- Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 
 ### Changed
 
@@ -44,7 +45,6 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Commands: Commands selector in chat will now scroll to the selected item's viewport automatically. [pull/1556](https://github.com/sourcegraph/cody/pull/1556)
 - Edit: Errors are now shown separately to incoming edits, and will not be applied to the document. [pull/1376](https://github.com/sourcegraph/cody/pull/1376)
 - Chat: Prevent cursor from moving during chat command selection. [pull/1592](https://github.com/sourcegraph/cody/pull/1592)
-- Fixup: Updated the retry instruction to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Added
 
 ### Fixed
+
 - Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 
 ### Changed

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -25,6 +25,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Commands: Commands selector in chat will now scroll to the selected item's viewport automatically. [pull/1556](https://github.com/sourcegraph/cody/pull/1556)
 - Edit: Errors are now shown separately to incoming edits, and will not be applied to the document. [pull/1376](https://github.com/sourcegraph/cody/pull/1376)
 - Chat: Prevent cursor from moving during chat command selection. [pull/1592](https://github.com/sourcegraph/cody/pull/1592)
+- Fixup: Updated the retry instruction to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Added
 
 ### Fixed
+- Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 
 ### Changed
 
@@ -19,7 +20,6 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Chat: Fixed an issue where multiple action buttons were appended to each Code Block per chat message. [pull/1617](https://github.com/sourcegraph/cody/pull/1617)
-- Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 
 ### Changed
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -149,7 +149,8 @@ export class FixupController
         source?: ChatEventSource
     ): FixupTask {
         const fixupFile = this.files.forUri(documentUri)
-        const task = new FixupTask(fixupFile, instruction, selectionRange, insertMode, source)
+        const fixupInstruction = instruction.replace(/^\/edit/, '').trim()
+        const task = new FixupTask(fixupFile, fixupInstruction, selectionRange, insertMode, source)
         this.tasks.set(task.id, task)
         this.setTaskState(task, CodyTaskState.working)
         return task
@@ -877,11 +878,11 @@ export class FixupController
             return
         }
         const previousRange = task.selectionRange
-        const previousInstruction = task.instruction.replace(/^\/edit/, '')
+        const previousInstruction = task.instruction
         const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
 
         // Prompt the user for a new instruction, and create a new fixup
-        const instruction = (await this.typingUI.getInstructionFromQuickPick({ value: previousInstruction })).trim()
+        const instruction = await this.typingUI.getInstructionFromQuickPick({ value: previousInstruction })
 
         // Revert and remove the previous task
         await this.undoTask(task)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -877,7 +877,7 @@ export class FixupController
             return
         }
         const previousRange = task.selectionRange
-        const previousInstruction = task.instruction
+        const previousInstruction = task.instruction.replace(/^\/edit/, '')
         const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
 
         // Prompt the user for a new instruction, and create a new fixup

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -149,8 +149,7 @@ export class FixupController
         source?: ChatEventSource
     ): FixupTask {
         const fixupFile = this.files.forUri(documentUri)
-        const fixupInstruction = instruction.replace(/^\/edit/, '').trim()
-        const task = new FixupTask(fixupFile, fixupInstruction, selectionRange, insertMode, source)
+        const task = new FixupTask(fixupFile, instruction, selectionRange, insertMode, source)
         this.tasks.set(task.id, task)
         this.setTaskState(task, CodyTaskState.working)
         return task

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -42,6 +42,7 @@ export class FixupTask {
         public source?: ChatEventSource
     ) {
         this.id = Date.now().toString(36).replaceAll(/\d+/g, '')
+        this.instruction = instruction.replace(/^\/edit/, '').trim()
     }
 
     /**


### PR DESCRIPTION
The retry instruction text has the command attached, which recursively adds to each retry. This PR fixes this issue that in case of any fixup task, only the previous instruction is used/shown in the quick pick. 

## Test plan

- Tested manually.

Before behaviour:

https://github.com/sourcegraph/cody/assets/44617923/70daecc9-bf38-4dd5-bca9-271367f4441c

After:

https://github.com/sourcegraph/cody/assets/44617923/1916df2e-b616-4f1c-96a6-c7144844759d

