### PR TITLE
fix: code block actions event handlers

### DIFF
--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -169,20 +169,22 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
         }
 
         const preElements = rootRef.current?.querySelectorAll('pre')
-        if (!preElements?.length) {
+        if (!preElements?.length || !copyButtonOnSubmit) {
             return
         }
 
         for (const preElement of preElements) {
             const preText = preElement.textContent
             if (preText?.trim() && preElement.parentNode) {
+                const eventMetadata = { requestID: metadata?.requestID, source: metadata?.source }
+
                 const buttons = createButtons(
                     preText,
                     copyButtonClassName,
                     copyButtonOnSubmit,
                     insertButtonClassName,
                     insertButtonOnSubmit,
-                    metadata
+                    eventMetadata
                 )
 
                 // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
@@ -191,7 +193,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                 // capture copy events (right click or keydown) on code block
                 preElement.addEventListener('copy', () => {
                     if (copyButtonOnSubmit) {
-                        copyButtonOnSubmit(preText, 'Keydown', metadata)
+                        copyButtonOnSubmit(preText, 'Keydown', eventMetadata)
                     }
                 })
             }
@@ -203,7 +205,8 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
         rootRef,
         copyButtonOnSubmit,
         insertButtonOnSubmit,
-        metadata,
+        metadata?.requestID,
+        metadata?.source,
         inProgress,
     ])
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,16 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+## [0.14.4]
+
+### Added
+
+### Fixed
+
+- Chat: Fixed an issue where multiple action buttons were appended to each Code Block per chat message. [pull/1617](https://github.com/sourcegraph/cody/pull/1617)
+
+### Changed
+
 ## [0.14.3]
 
 ### Added


### PR DESCRIPTION
Pass requestID and source metadata to copy button event handlers directly instead of through dependencies.

Using metadata as a dependency caused useEffect to keep re-rendering and append multiple copy buttons on mount. Passing the metadata directly to the event handler fixes this issue.

#### Fix

By constructing the metadata object inside the callback and passing it directly, the metadata gets passed to the buttons without causing re-renders from useEffect.

This avoids the issue of useEffect appending multiple buttons on each render.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

To reproduce:

1. Ask Cody a question that generate code: `What does a button looks like in html?`
2. in the same Window, send Cody another question, e.g. `Hello`


### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/da08ff58-e580-4b10-9fb5-b9b49408e00f)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/a5b98d88-d7b1-4df3-b0de-3193c06bbeb7)
