### PR TITLE
Fixup: Use editor `tabSize` and `insertSpaces` when available

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+- Edit: Fixed formatting issues with some editor formatters that required explict indendation configuration. [pull/1620](https://github.com/sourcegraph/cody/pull/1620)
+
 ## [0.14.4]
 
 ### Added

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -24,7 +24,7 @@ import { FixupTask, taskID } from './FixupTask'
 import { FixupTypingUI } from './FixupTypingUI'
 import { FixupFileCollection, FixupIdleTaskRunner, FixupTaskFactory, FixupTextChanged } from './roles'
 import { FixupTaskTreeItem, TaskViewProvider } from './TaskViewProvider'
-import { CodyTaskState } from './utils'
+import { CodyTaskState, getEditorInsertSpaces, getEditorTabSize } from './utils'
 
 // This class acts as the factory for Fixup Tasks and handles communication between the Tree View and editor
 export class FixupController
@@ -479,7 +479,10 @@ export class FixupController
             (await vscode.commands.executeCommand<vscode.TextEdit[]>(
                 'vscode.executeFormatDocumentProvider',
                 document.uri,
-                {}
+                {
+                    tabSize: getEditorTabSize(),
+                    insertSpaces: getEditorInsertSpaces(),
+                }
             )) || []
 
         const formattingChangesInRange = formattingChanges.filter(change => rangeToFormat.contains(change.range))

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -480,8 +480,8 @@ export class FixupController
                 'vscode.executeFormatDocumentProvider',
                 document.uri,
                 {
-                    tabSize: getEditorTabSize(),
-                    insertSpaces: getEditorInsertSpaces(),
+                    tabSize: getEditorTabSize(document.uri),
+                    insertSpaces: getEditorInsertSpaces(document.uri),
                 }
             )) || []
 

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode'
+
 export enum CodyTaskState {
     'idle' = 1,
     'working' = 2,
@@ -66,4 +68,38 @@ export function getFileNameAfterLastDash(filePath: string): string {
         return filePath
     }
     return filePath.slice(lastDashIndex + 1)
+}
+
+export function getEditorInsertSpaces(): boolean {
+    if (!vscode.window.activeTextEditor) {
+        // Default to the same as VS Code default
+        return true
+    }
+
+    const { insertSpaces } = vscode.window.activeTextEditor.options
+
+    // This should never happen: "When getting a text editor's options, this property will always be a boolean (resolved)."
+    if (typeof insertSpaces === 'string' || insertSpaces === undefined) {
+        console.error('Unexpected value when getting "insertSpaces" for the current editor.')
+        return true
+    }
+
+    return insertSpaces
+}
+
+export function getEditorTabSize(): number {
+    if (!vscode.window.activeTextEditor) {
+        // Default to the same as VS Code default
+        return 4
+    }
+
+    const { tabSize } = vscode.window.activeTextEditor.options
+
+    // This should never happen: "When getting a text editor's options, this property will always be a number (resolved)."
+    if (typeof tabSize === 'string' || tabSize === undefined) {
+        console.error('Unexpected value when getting "tabSize" for the current editor.')
+        return 4
+    }
+
+    return tabSize
 }

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -70,13 +70,14 @@ export function getFileNameAfterLastDash(filePath: string): string {
     return filePath.slice(lastDashIndex + 1)
 }
 
-export function getEditorInsertSpaces(): boolean {
-    if (!vscode.window.activeTextEditor) {
+export function getEditorInsertSpaces(uri: vscode.Uri): boolean {
+    const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri === uri)
+    if (!editor) {
         // Default to the same as VS Code default
         return true
     }
 
-    const { insertSpaces } = vscode.window.activeTextEditor.options
+    const { insertSpaces } = editor.options
 
     // This should never happen: "When getting a text editor's options, this property will always be a boolean (resolved)."
     if (typeof insertSpaces === 'string' || insertSpaces === undefined) {
@@ -87,13 +88,14 @@ export function getEditorInsertSpaces(): boolean {
     return insertSpaces
 }
 
-export function getEditorTabSize(): number {
-    if (!vscode.window.activeTextEditor) {
+export function getEditorTabSize(uri: vscode.Uri): number {
+    const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri === uri)
+    if (!editor) {
         // Default to the same as VS Code default
         return 4
     }
 
-    const { tabSize } = vscode.window.activeTextEditor.options
+    const { tabSize } = editor.options
 
     // This should never happen: "When getting a text editor's options, this property will always be a number (resolved)."
     if (typeof tabSize === 'string' || tabSize === undefined) {


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/1552

## Description

It appears that VS Code doesn't use these automatically, and some formatters expect that they are provided.

Related issue: https://github.com/sourcegraph/cody/issues/1552

## Test plan

Tested with different formatters
Tested with `Python Black Formatter` which was erroring previously

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
