### PR TITLE
Edit: Fix recursive diff expansion

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Changed
 
+- Edit: Fixed an issue where the diff for an edit could expand recursively each time it is viewed. [pull/1621](https://github.com/sourcegraph/cody/pull/1621)
+
 ## [0.14.4]
 
 ### Added

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -845,8 +845,11 @@ export class FixupController
         }
         // show diff view between the current document and replacement
         // Add replacement content to the temp document
-        await this.contentStore.set(task.id, task.fixupFile.uri)
-        const tempDocUri = vscode.Uri.parse(`cody-fixup:${task.fixupFile.uri.fsPath}#${task.id}`)
+
+        // Ensure each diff is fresh so there is no chance of diffing an already diffed file.
+        const diffId = `${task.id}-${Date.now()}`
+        await this.contentStore.set(diffId, task.fixupFile.uri)
+        const tempDocUri = vscode.Uri.parse(`cody-fixup:${task.fixupFile.uri.fsPath}#${diffId}`)
         const doc = await vscode.workspace.openTextDocument(tempDocUri)
         const edit = new vscode.WorkspaceEdit()
         const range = task.editedRange || task.selectionRange


### PR DESCRIPTION
## Description

We use a temp document to provide a "before" version of the edited fixup file. There is an edge case where, if we are adding new code (thus deleting from the temp document), we can reuse the already diffed temp document. This leads to the diff expanding every time it is triggered, as we delete more code from the selection.

We now ensure each diff has its own unique ID, so it always uses a fresh "temp" document. 

### Before

https://github.com/sourcegraph/cody/assets/9516420/c584f8a5-e21c-468f-bb82-c9eece29cc38


### After

https://github.com/sourcegraph/cody/assets/9516420/20eb4fd5-b318-47d2-b66c-c9a3b9d076c1


## Test plan

Tested locally:
- Diff for edits that expand ranges
- Diff for an edit where the doc has been changed elsewhere after it was applied

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
