### PR TITLE
E2E: Assert against order of telemetry logs

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
     workers: 1,
     // Give failing tests a second chance
-    retries: 2,
+    retries: 0,
     testDir: 'test/e2e',
 })

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from '@playwright/test'
 export default defineConfig({
     workers: 1,
     // Give failing tests a second chance
-    retries: 0,
+    retries: 2,
     testDir: 'test/e2e',
 })

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test'
 
 import { loggedEvents, resetLoggedEvents, SERVER_URL, VALID_TOKEN } from '../fixtures/mock-server'
 
-import { assertEvents, signOut, test } from './helpers'
+import { signOut, test } from './helpers'
 
 const expectedEvents = ['CodyVSCodeExtension:logout:clicked']
 
@@ -41,5 +41,5 @@ test('requires a valid auth token and allows logouts', async ({ page, sidebar })
 
     await expect(sidebar.getByRole('button', { name: 'Sign In to Enterprise Instance' })).toBeVisible()
     await expect(sidebar.getByText('Invalid credentials')).not.toBeVisible()
-    await assertEvents(loggedEvents, expectedEvents)
+    await expect.poll(() => loggedEvents).toEqual(expectedEvents)
 })

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { assertEvents, test } from './helpers'
+import { test } from './helpers'
 
 const DECORATION_SELECTOR = 'div.view-overlays[role="presentation"] div[class*="TextEditorDecorationType"]'
 
@@ -72,5 +72,6 @@ test.skip('decorations from un-applied Cody changes appear', async ({ page, side
 
     // The decorations should change to conflict markers.
     await page.waitForSelector(`${DECORATION_SELECTOR}:not([class*="${decorationClassName}"])`)
-    await assertEvents(loggedEvents, expectedEvents)
+    // TODO: Fix flaky fixup telemetry logs.
+    await expect.poll(() => loggedEvents.slice().sort()).toEqual(expectedEvents.slice().sort())
 })

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtempSync, rmSync, writeFile } from 'fs'
 import { tmpdir } from 'os'
 import * as path from 'path'
 
-import { test as base, expect, Frame, Page } from '@playwright/test'
+import { test as base, Frame, Page } from '@playwright/test'
 import { _electron as electron } from 'playwright'
 import * as uuid from 'uuid'
 
@@ -162,8 +162,4 @@ export async function signOut(page: Page): Promise<void> {
 export async function submitChat(sidebar: Frame, text: string): Promise<void> {
     await sidebar.getByRole('textbox', { name: 'Chat message' }).fill(text)
     await sidebar.getByTitle('Send Message').click()
-}
-
-export async function assertEvents(loggedEvents: string[], expectedEvents: string[]): Promise<void> {
-    await expect.poll(() => loggedEvents.slice().sort()).toEqual(expectedEvents.slice().sort())
 }

--- a/vscode/test/e2e/inline-assist-inline-touch.test.ts
+++ b/vscode/test/e2e/inline-assist-inline-touch.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { loggedEvents, loggedV2Events, resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { assertEvents, test } from './helpers'
+import { test } from './helpers'
 
 const expectedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
@@ -47,8 +47,8 @@ test.skip('start a fixup job from inline chat with valid auth', async ({ page, s
 
     // Check if a new file called index.cody.html is created
     await expect(page.getByText('index.cody.html')).toBeVisible()
-    await assertEvents(loggedEvents, expectedEvents)
-    await assertEvents(loggedV2Events, ['cody.fixup.apply/succeeded'])
+    await expect.poll(() => loggedEvents).toEqual(expectedEvents)
+    await expect.poll(() => loggedV2Events).toEqual(['cody.fixup.apply/succeeded'])
 
     // TODO check if content is correct. Currently blocked by ability to highlight in test
 })

--- a/vscode/test/e2e/inline-assist.test.ts
+++ b/vscode/test/e2e/inline-assist.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { loggedEvents, loggedV2Events, resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { assertEvents, test } from './helpers'
+import { test } from './helpers'
 
 const expectedEvents = [
     'CodyVSCodeExtension:command:edit:executed',
@@ -53,12 +53,15 @@ test('start a fixup job from inline chat with valid auth', async ({ page, sideba
     // Click 'Done' to complete the fixup
     await page.getByRole('button', { name: 'Done' }).click()
 
-    await assertEvents(loggedEvents, expectedEvents)
-    await assertEvents(loggedV2Events, [
-        'cody.auth/failed',
-        'cody.auth/connected',
-        'cody.command.edit/executed',
-        'cody.recipe.fixup/executed',
-        'cody.fixup.apply/succeeded',
-    ])
+    // TODO: Fix flaky fixup telemetry logs.
+    await expect.poll(() => loggedEvents.slice().sort()).toEqual(expectedEvents.slice().sort())
+    await expect
+        .poll(() => loggedV2Events)
+        .toEqual([
+            'cody.auth/failed',
+            'cody.auth/connected',
+            'cody.command.edit/executed',
+            'cody.recipe.fixup/executed',
+            'cody.fixup.apply/succeeded',
+        ])
 })

--- a/vscode/test/e2e/inline-chat.test.ts
+++ b/vscode/test/e2e/inline-chat.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { assertEvents, test } from './helpers'
+import { test } from './helpers'
 
 const expectedEvents = [
     'CodyVSCodeExtension:keywordContext:searchDuration',
@@ -38,5 +38,5 @@ test('start a fixup job from inline chat with valid auth', async ({ page, sideba
 
     // Make sure the < and > characters were not escaped
     await expect(page.locator('[id="workbench\\.parts\\.editor"]').getByText('what is a <div> tag?``')).toBeVisible()
-    await assertEvents(loggedEvents, expectedEvents)
+    await expect.poll(() => loggedEvents).toEqual(expectedEvents)
 })

--- a/vscode/test/e2e/inline-completion.test.ts
+++ b/vscode/test/e2e/inline-completion.test.ts
@@ -3,7 +3,7 @@ import { expect, Locator, Page } from '@playwright/test'
 import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { assertEvents, test } from './helpers'
+import { test } from './helpers'
 
 test.beforeEach(() => {
     resetLoggedEvents()
@@ -53,7 +53,7 @@ test('shows chat sidebar completion onboarding notice on first completion accept
     await acceptInlineCompletion(page)
     await expect(otherAcceptedCompletion).toBeVisible()
     await expect(notice).not.toBeVisible()
-    await assertEvents(loggedEvents, expectedEvents)
+    await expect.poll(() => loggedEvents).toEqual(expectedEvents)
 })
 
 test('inline completion onboarding notice on first completion accept', async ({ page, sidebar }) => {
@@ -105,7 +105,7 @@ test('inline completion onboarding notice on first completion accept', async ({ 
     await acceptInlineCompletion(page)
     await expect(otherAcceptedCompletion).toBeVisible()
     await expect(decoration).not.toBeVisible()
-    await assertEvents(loggedEvents, expectedEvents)
+    await expect.poll(() => loggedEvents).toEqual(expectedEvents)
 })
 
 async function triggerInlineCompletionAfter(page: Page, afterElement: Locator): Promise<void> {

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { loggedEvents, loggedV2Events, resetLoggedEvents } from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { assertEvents, test } from './helpers'
+import { test } from './helpers'
 
 const expectedEvents = [
     'CodyVSCodeExtension:command:edit:executed',
@@ -75,12 +75,15 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     // Collapse the task tree view
     await page.getByRole('button', { name: 'Fixups Section' }).click()
     await expect(page.getByText('No pending Cody fixups')).not.toBeVisible()
-    await assertEvents(loggedEvents, expectedEvents)
-    await assertEvents(loggedV2Events, [
-        'cody.auth/failed',
-        'cody.auth/connected',
-        'cody.command.edit/executed',
-        'cody.recipe.fixup/executed',
-        'cody.fixup.apply/succeeded',
-    ])
+    // TODO: Fix flaky fixup telemetry logs.
+    await expect.poll(() => loggedEvents.slice().sort()).toEqual(expectedEvents.slice().sort())
+    await expect
+        .poll(() => loggedV2Events)
+        .toEqual([
+            'cody.auth/failed',
+            'cody.auth/connected',
+            'cody.command.edit/executed',
+            'cody.recipe.fixup/executed',
+            'cody.fixup.apply/succeeded',
+        ])
 })


### PR DESCRIPTION
## Description

Reverts some of the changes from https://github.com/sourcegraph/cody/pull/1561

The order of telemetry events does actually provide value here, and can help us catch some bugs. We have some race conditions when sending events for commands, but we can handle these separately. (I thought that we might not actually care about the order of these events being sent but I think it's actually valuable)

## Test plan

E2E tests pass with no flakes.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
