### PR TITLE
fix about value in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/prd-issue.md
+++ b/.github/ISSUE_TEMPLATE/prd-issue.md
@@ -1,6 +1,6 @@
 ---
 name: PRD Issue
-description: User story for completing items on the PRD
+about: User story for completing items on the PRD
 title: 'PRD-Issue: Example user story from PRD'
 labels: prd-issue
 assignees: ''


### PR DESCRIPTION
github didn't update docs when they changed the value of `description` to `about` and it broke the template 😢 

## Test plan
n/a
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
