### PR TITLE
fix ssh url parse (E2E run)

### DIFF
--- a/lib/shared/src/utils.test.ts
+++ b/lib/shared/src/utils.test.ts
@@ -9,6 +9,12 @@ describe('convertGitCloneURLToCodebaseName', () => {
         )
     })
 
+    test('converts GitHub SSH URL with different user', () => {
+        expect(convertGitCloneURLToCodebaseName('jdsbcnuqwew@github.com:sourcegraph/sourcegraph.git')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
+        )
+    })
+
     test('converts GitHub SSH URL with the port number', () => {
         expect(convertGitCloneURLToCodebaseName('ssh://git@gitlab-my-company.net:20022/path/repo.git')).toEqual(
             'gitlab-my-company.net/path/repo'

--- a/lib/shared/src/utils.ts
+++ b/lib/shared/src/utils.ts
@@ -11,15 +11,15 @@ export function convertGitCloneURLToCodebaseName(cloneURL: string): string | nul
         return null
     }
     try {
-        const uri = new URL(cloneURL.replace('git@', ''))
         // Handle common Git SSH URL format
-        const match = cloneURL.match(/git@([^:]+):([\w-]+)\/([\w-]+)(\.git)?/)
-        if (cloneURL.startsWith('git@') && match) {
+        const match = cloneURL.match(/^[\w-]+@([^:]+):([\w-]+)\/([\w-]+)(\.git)?$/)
+        if (match) {
             const host = match[1]
             const owner = match[2]
             const repo = match[3]
             return `${host}/${owner}/${repo}`
         }
+        const uri = new URL(cloneURL)
         // Handle GitHub URLs
         if (uri.protocol.startsWith('github') || uri.href.startsWith('github')) {
             return `github.com/${uri.pathname.replace('.git', '')}`


### PR DESCRIPTION
## Description

E2E run for https://github.com/sourcegraph/cody/pull/1574

## Test plan

E2e pass

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
