### PR TITLE
Autocomplete: Remove enableExtendedTriggers flag

### DIFF
--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -13,13 +13,12 @@ import { execQueryWrapper } from './tree-sitter/query-sdk'
 interface DetectMultilineParams {
     docContext: Omit<DocumentContext, 'multilineTrigger'>
     document: TextDocument
-    enableExtendedTriggers: boolean
     syntacticTriggers?: boolean
     cursorPosition: Pick<Position, 'line' | 'character'>
 }
 
 export function detectMultiline(params: DetectMultilineParams): string | null {
-    const { syntacticTriggers, docContext, document, enableExtendedTriggers, cursorPosition } = params
+    const { syntacticTriggers, docContext, document, cursorPosition } = params
     const { prefix, prevNonEmptyLine, nextNonEmptyLine, currentLinePrefix, currentLineSuffix } = docContext
 
     const blockStart = getLanguageConfig(document.languageId)?.blockStart
@@ -48,7 +47,6 @@ export function detectMultiline(params: DetectMultilineParams): string | null {
 
     const openingBracketMatch = currentLinePrefix.match(OPENING_BRACKET_REGEX)
     if (
-        enableExtendedTriggers &&
         openingBracketMatch &&
         // Only trigger multiline suggestions when the next non-empty line is indented less
         // than the block start line (the newly created block is empty).

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -15,7 +15,6 @@ function testGetCurrentDocContext(code: string, context?: vscode.InlineCompletio
         position,
         maxPrefixLength: 100,
         maxSuffixLength: 100,
-        enableExtendedTriggers: true,
         context,
     })
 }
@@ -53,7 +52,7 @@ describe('getCurrentDocContext', () => {
         })
     })
 
-    it('returns correct multi-line trigger when `enableExtendedTriggers: true`', () => {
+    it('returns correct multi-line trigger', () => {
         const result = testGetCurrentDocContext('const arr = [█\n];')
 
         expect(result).toEqual({
@@ -191,7 +190,6 @@ describe('getCurrentDocContext', () => {
             position,
             maxPrefixLength: 140,
             maxSuffixLength: 60,
-            enableExtendedTriggers: true,
         })
         expect(docContext.contextRange).toMatchInlineSnapshot(`
           Range {

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -36,7 +36,6 @@ interface GetCurrentDocContextParams {
     position: vscode.Position
     maxPrefixLength: number
     maxSuffixLength: number
-    enableExtendedTriggers: boolean
     syntacticTriggers?: boolean
     context?: vscode.InlineCompletionContext
 }
@@ -49,17 +48,14 @@ interface GetCurrentDocContextParams {
  * The prefix and suffix are obtained by looking around the current position up to a max length
  * defined by `maxPrefixLength` and `maxSuffixLength` respectively. If the length of the entire
  * document content in either direction is smaller than these parameters, the entire content will be used.
- *
  * @param document - A `vscode.TextDocument` object, the document in which to find the context.
  * @param position - A `vscode.Position` object, the position in the document from which to find the context.
  * @param maxPrefixLength - A number representing the maximum length of the prefix to get from the document.
  * @param maxSuffixLength - A number representing the maximum length of the suffix to get from the document.
- *
  * @returns An object containing the current document context or null if there are no lines in the document.
  */
 export function getCurrentDocContext(params: GetCurrentDocContextParams): DocumentContext {
-    const { document, position, maxPrefixLength, maxSuffixLength, enableExtendedTriggers, context, syntacticTriggers } =
-        params
+    const { document, position, maxPrefixLength, maxSuffixLength, context, syntacticTriggers } = params
     const offset = document.offsetAt(position)
 
     // TODO(philipp-spiess): This requires us to read the whole document. Can we limit our ranges
@@ -157,7 +153,6 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
         multilineTrigger: detectMultiline({
             docContext,
             document,
-            enableExtendedTriggers,
             syntacticTriggers,
             cursorPosition: positionBeforeCursor,
         }),

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -80,7 +80,6 @@ export function params(
         position,
         maxPrefixLength: 1000,
         maxSuffixLength: 1000,
-        enableExtendedTriggers: providerConfig.enableExtendedMultilineTriggers,
         context: takeSuggestWidgetSelectionIntoAccount
             ? {
                   triggerKind: 0,

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -25,7 +25,6 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             position,
             maxPrefixLength: 100,
             maxSuffixLength: 100,
-            enableExtendedTriggers: true,
             context: lastTriggerSelectedCompletionInfo
                 ? {
                       triggerKind: vscode.InlineCompletionTriggerKind.Automatic,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -305,7 +305,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             position,
             maxPrefixLength: this.config.providerConfig.contextSizeHints.prefixChars,
             maxSuffixLength: this.config.providerConfig.contextSizeHints.suffixChars,
-            enableExtendedTriggers: this.config.providerConfig.enableExtendedMultilineTriggers,
             syntacticTriggers: await syntacticTriggersPromise,
             // We ignore the current context selection if completeSuggestWidgetSelection is not enabled
             context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -26,7 +26,6 @@ const defaultRequestParams: RequestParams = {
         position,
         maxPrefixLength: 100,
         maxSuffixLength: 100,
-        enableExtendedTriggers: true,
     }),
     selectedCompletionInfo: undefined,
 }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -252,7 +252,6 @@ export function createProviderConfig({
             return new AnthropicProvider(options, { maxContextTokens, model: definedModel, ...otherOptions })
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
-        enableExtendedMultilineTriggers: true,
         identifier: 'anthropic',
         model: definedModel,
     }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -267,7 +267,6 @@ export function createProviderConfig({
             return new FireworksProvider(options, { model: resolvedModel, maxContextTokens, ...otherOptions })
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
-        enableExtendedMultilineTriggers: true,
         identifier: PROVIDER_IDENTIFIER,
         model: resolvedModel,
     }

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -23,11 +23,6 @@ export interface ProviderConfig {
     contextSizeHints: ProviderContextSizeHints
 
     /**
-     * When set, multi-line completions will trigger more often. This is
-     */
-    enableExtendedMultilineTriggers: boolean
-
-    /**
      * A string identifier for the provider config used in event logs.
      */
     identifier: string

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -198,7 +198,6 @@ export function createProviderConfig({
             return new UnstableOpenAIProvider(options, { maxContextTokens, ...otherOptions })
         },
         contextSizeHints: standardContextSizeHints(maxContextTokens),
-        enableExtendedMultilineTriggers: false,
         identifier: PROVIDER_IDENTIFIER,
         model: model ?? 'gpt-35-turbo',
     }

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -49,7 +49,6 @@ function docState(prefix: string, suffix: string = ';'): RequestParams {
             position,
             maxPrefixLength: 100,
             maxSuffixLength: 100,
-            enableExtendedTriggers: true,
         }),
         selectedCompletionInfo: undefined,
     }


### PR DESCRIPTION
This was added specifically to opt-out of some multi-line completion triggers when using the CodeGen backend (as it would not honor the max tokens set and only return a single-line result).

Since we no longer have to support that backend, we don't need to branch off anymore based on this field. This fixes an issue where the OpenAI client has different multi-line behavior.

## Test plan

- Tests green
- TS happy

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
