### PR TITLE
feat: new ui for enhanced context

### DIFF
--- a/lib/shared/src/chat/prompts/vscode-context.ts
+++ b/lib/shared/src/chat/prompts/vscode-context.ts
@@ -489,11 +489,16 @@ export async function getDirectoryFileListContext(
         const fileNames = directoryFiles.map(file => file[0])
         const truncatedFileNames = truncateText(fileNames.join(', '), MAX_CURRENT_FILE_TOKENS)
         const fsPath = fileName || 'root'
+        const relativePath = fileName || createVSCodeRelativePath(fileUri.fsPath)
+        const source = 'editor'
+
+        const file: ContextFile = { fileName: relativePath, source }
 
         return [
             {
                 speaker: 'human',
                 text: populateListOfFilesContextTemplate(truncatedFileNames, fsPath),
+                file,
             },
             {
                 speaker: 'assistant',

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -1,5 +1,5 @@
 import { CodebaseContext } from '../../codebase-context'
-import { ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
+import { ContextFile, ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
 import { ActiveTextEditorSelection, Editor } from '../../editor'
 import { IntentDetector } from '../../intent-detector'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
@@ -83,15 +83,19 @@ export class ChatQuestion implements Recipe {
         if (!visibleContent) {
             return []
         }
+        const visibleContext: ContextFile = visibleContent
+        visibleContext.source = 'editor'
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
             populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName, visibleContent.repoName),
-            visibleContent
+            visibleContext
         )
     }
 
     public static getEditorSelectionContext(selection: ActiveTextEditorSelection): ContextMessage[] {
         const truncatedContent = truncateText(selection.selectedText, MAX_CURRENT_FILE_TOKENS)
+        const selectionContext: ContextFile = selection
+        selectionContext.source = 'editor'
         return getContextMessageWithResponse(
             populateCurrentEditorSelectedContextTemplate(truncatedContent, selection.fileName, selection.repoName),
             selection

--- a/lib/shared/src/chat/recipes/code-question.ts
+++ b/lib/shared/src/chat/recipes/code-question.ts
@@ -1,5 +1,5 @@
 import { CodebaseContext } from '../../codebase-context'
-import { ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
+import { ContextFile, ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
 import { ActiveTextEditorSelection, Editor } from '../../editor'
 import { IntentDetector } from '../../intent-detector'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
@@ -88,17 +88,21 @@ export class CodeQuestion implements Recipe {
             return []
         }
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
+        const visibleContext: ContextFile = visibleContent
+        visibleContext.source = 'editor'
         return getContextMessageWithResponse(
             populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName, visibleContent.repoName),
-            visibleContent
+            visibleContext
         )
     }
 
     public static getEditorSelectionContext(selection: ActiveTextEditorSelection): ContextMessage[] {
         const truncatedContent = truncateText(selection.selectedText, MAX_CURRENT_FILE_TOKENS)
+        const selectionContext: ContextFile = selection
+        selectionContext.source = 'editor'
         return getContextMessageWithResponse(
             populateCurrentEditorSelectedContextTemplate(truncatedContent, selection.fileName, selection.repoName),
-            selection
+            selectionContext
         )
     }
 }

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -53,12 +53,15 @@ export async function getContextMessagesFromSelection(
         numTextResults: 0,
     })
 
+    const source = 'editor'
+
     return selectedTextContext.concat(
         [precedingText, followingText].flatMap(text =>
             getContextMessageWithResponse(populateCodeContextTemplate(text, fileName, repoName), {
                 fileName,
                 repoName,
                 revision,
+                source,
             })
         )
     )

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -63,12 +63,12 @@ export class Interaction {
      */
     public toChat(): ChatMessage[] {
         return [
-            this.humanMessage,
             {
-                ...this.assistantMessage,
+                ...this.humanMessage,
                 contextFiles: this.usedContextFiles,
                 preciseContext: this.usedPreciseContext,
             },
+            this.assistantMessage,
         ]
     }
 

--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -227,7 +227,10 @@ export class CodebaseContext {
             return []
         }
         const results = await this.keywords.getContext(query, options.numCodeResults + options.numTextResults)
-        return results
+        return results?.map(result => {
+            result.source = 'keyword'
+            return result
+        })
     }
 
     private async getFilenameSearchResults(query: string, options: ContextSearchOptions): Promise<ContextResult[]> {
@@ -235,7 +238,10 @@ export class CodebaseContext {
             return []
         }
         const results = await this.filenames.getContext(query, options.numCodeResults + options.numTextResults)
-        return results
+        return results?.map(result => {
+            result.source = 'filename'
+            return result
+        })
     }
 
     public async getGraphContextMessages(): Promise<ContextMessage[]> {

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -5,7 +5,7 @@ import { Message } from '../sourcegraph-api'
 //
 // For now we just track "embeddings" since that is the main driver for
 // understanding if it is being useful.
-export type ContextFileSource = 'embeddings'
+export type ContextFileSource = 'embeddings' | 'keyword' | 'filename' | 'editor'
 
 export interface ContextFile {
     fileName: string

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -1,8 +1,12 @@
+import { ContextFileSource } from '../codebase-context/messages'
+
 export interface ContextResult {
     repoName?: string
     revision?: string
     fileName: string
     content: string
+
+    source?: ContextFileSource
 }
 
 export interface KeywordContextFetcher {

--- a/lib/ui/src/chat/ContextFiles.tsx
+++ b/lib/ui/src/chat/ContextFiles.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { mdiFileDocumentOutline, mdiMagnify } from '@mdi/js'
-
 import { ContextFile, pluralize } from '@sourcegraph/cody-shared'
 
 import { TranscriptAction } from './actions/TranscriptAction'
@@ -17,6 +15,10 @@ export const ContextFiles: React.FunctionComponent<{
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
     className?: string
 }> = React.memo(function ContextFilesContent({ contextFiles, fileLinkComponent: FileLink, className }) {
+    if (!contextFiles.length) {
+        return
+    }
+
     const uniqueFiles = new Set<string>()
     const filteredFiles = contextFiles.filter(file => {
         if (uniqueFiles.has(file.fileName)) {
@@ -28,13 +30,15 @@ export const ContextFiles: React.FunctionComponent<{
 
     return (
         <TranscriptAction
-            title={{ verb: 'Read', object: `${filteredFiles.length} ${pluralize('file', filteredFiles.length)}` }}
+            title={{
+                verb: 'Enhanced Context',
+                object: `${filteredFiles.length} ${pluralize('file', filteredFiles.length)}`,
+            }}
             steps={[
-                { verb: 'Searched', object: 'entire codebase for relevant files', icon: mdiMagnify },
+                { verb: '✨', object: '' },
                 ...filteredFiles.map(file => ({
                     verb: '',
                     object: <FileLink path={file.fileName} repoName={file.repoName} revision={file.revision} />,
-                    icon: mdiFileDocumentOutline,
                 })),
             ]}
             className={className}

--- a/lib/ui/src/chat/ContextFiles.tsx
+++ b/lib/ui/src/chat/ContextFiles.tsx
@@ -35,7 +35,6 @@ export const ContextFiles: React.FunctionComponent<{
                 object: `${filteredFiles.length} ${pluralize('file', filteredFiles.length)}`,
             }}
             steps={[
-                { verb: '✨', object: '' },
                 ...filteredFiles.map(file => ({
                     verb: '',
                     object: <FileLink path={file.fileName} repoName={file.repoName} revision={file.revision} />,

--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -29,14 +29,13 @@
     background-image: linear-gradient(to bottom, #b200f8, #ff5543, #00cbec);
 }
 
-.row:hover>.header-container {
+.row:hover > .header-container {
     visibility: visible;
 }
 
 .actions {
     display: flex;
-    flex-direction: column;
-    padding: 0 0 var(--spacing) 0;
+    padding: 0;
 }
 
 .content {
@@ -53,7 +52,12 @@
     overflow-x: auto;
 }
 
-.content h1, .content h2, .content h3, .content h4, .content h5, .content h6 {
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
     margin: 1.2em 0;
 }
 
@@ -72,7 +76,9 @@
     font-weight: 700;
 }
 
-.content h4, .content h5, .content h6 {
+.content h4,
+.content h5,
+.content h6 {
     font-size: inherit;
     font-weight: 600;
 }

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -147,24 +147,6 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </header>
             )}
-            {message.contextFiles && message.contextFiles.length > 0 && (
-                <div className={styles.actions}>
-                    <ContextFiles
-                        contextFiles={message.contextFiles}
-                        fileLinkComponent={fileLinkComponent}
-                        className={transcriptActionClassName}
-                    />
-                </div>
-            )}
-            {message.preciseContext && message.preciseContext.length > 0 && (
-                <div className={styles.actions}>
-                    <PreciseContexts
-                        preciseContexts={message.preciseContext}
-                        symbolLinkComponent={symbolLinkComponent}
-                        className={transcriptActionClassName}
-                    />
-                </div>
-            )}
             <div
                 className={classNames(
                     styles.contentPadding,
@@ -190,6 +172,24 @@ export const TranscriptItem: React.FunctionComponent<
             </div>
             {message.buttons?.length && ChatButtonComponent && (
                 <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>
+            )}
+            {message.speaker === 'human' && message.contextFiles && message.contextFiles.length > 0 && (
+                <div className={styles.actions}>
+                    <ContextFiles
+                        contextFiles={message.contextFiles.filter(f => f.source !== 'editor')}
+                        fileLinkComponent={fileLinkComponent}
+                        className={transcriptActionClassName}
+                    />
+                </div>
+            )}
+            {message.speaker === 'human' && message.preciseContext && message.preciseContext.length > 0 && (
+                <div className={styles.actions}>
+                    <PreciseContexts
+                        preciseContexts={message.preciseContext}
+                        symbolLinkComponent={symbolLinkComponent}
+                        className={transcriptActionClassName}
+                    />
+                </div>
             )}
             {showFeedbackButtons &&
                 FeedbackButtonsContainer &&

--- a/lib/ui/src/chat/actions/TranscriptAction.module.css
+++ b/lib/ui/src/chat/actions/TranscriptAction.module.css
@@ -1,14 +1,13 @@
 .container {
     display: inline-block;
-    padding: 0.4rem;
     font-size: 0.9rem;
     min-width: calc(100% - 1.1rem);
+
+    background: unset !important;
 }
 .container-open {
     padding-bottom: 0.6rem;
     display: flex;
-    flex-direction: column;
-    align-self: stretch;
     gap: 0.5rem;
 }
 
@@ -34,16 +33,15 @@
 }
 
 .steps {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    display: inline-block;
+    align-items: center;
     list-style-type: none;
     margin: 0;
     padding: 0;
+    gap: 0.5em;
 }
 
 .step {
-    display: flex;
     align-items: center;
 }
 .step-icon {

--- a/lib/ui/src/chat/actions/TranscriptAction.module.css
+++ b/lib/ui/src/chat/actions/TranscriptAction.module.css
@@ -38,7 +38,7 @@
     list-style-type: none;
     margin: 0;
     padding: 0;
-    gap: 0.5em;
+    gap: 1em;
 }
 
 .step {
@@ -52,6 +52,7 @@
     margin-right: 0.3rem;
 }
 .step-object {
+    background: rgba(166, 172, 205, 0.3);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/lib/ui/src/chat/actions/TranscriptAction.tsx
+++ b/lib/ui/src/chat/actions/TranscriptAction.tsx
@@ -25,6 +25,7 @@ export const TranscriptAction: React.FunctionComponent<{
     return (
         <div className={classNames(className, styles.container, styles.containerOpen)}>
             <div className={styles.steps}>
+                ✨
                 {steps.map((step, index) => (
                     // eslint-disable-next-line react/no-array-index-key
                     <span key={index} className={styles.step}>

--- a/lib/ui/src/chat/actions/TranscriptAction.tsx
+++ b/lib/ui/src/chat/actions/TranscriptAction.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react'
+import React from 'react'
 
-import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Icon } from '../../utils/Icon'
@@ -13,7 +12,6 @@ export interface TranscriptActionStep {
 
     /**
      * The SVG path of an icon.
-     *
      * @example mdiSearchWeb
      */
     icon?: string
@@ -24,37 +22,19 @@ export const TranscriptAction: React.FunctionComponent<{
     steps: TranscriptActionStep[]
     className?: string
 }> = ({ title, steps, className }) => {
-    const [open, setOpen] = useState(false)
-
     return (
-        <div className={classNames(className, styles.container, open && styles.containerOpen)}>
-            <button type="button" onClick={() => setOpen(!open)} className={styles.openCloseButton}>
-                {typeof title === 'string' ? (
-                    title
-                ) : (
-                    <span>
-                        {title.verb} <strong>{title.object}</strong>
+        <div className={classNames(className, styles.container, styles.containerOpen)}>
+            <div className={styles.steps}>
+                {steps.map((step, index) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <span key={index} className={styles.step}>
+                        {step.icon && <Icon svgPath={step.icon} className={styles.stepIcon} />}{' '}
+                        <span className={styles.stepObject}>
+                            {step.verb} {step.object}
+                        </span>
                     </span>
-                )}
-                <Icon
-                    aria-hidden={true}
-                    svgPath={open ? mdiChevronUp : mdiChevronDown}
-                    className={styles.openCloseIcon}
-                />
-            </button>
-            {open && (
-                <ol className={styles.steps}>
-                    {steps.map((step, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <li key={index} className={styles.step}>
-                            {step.icon && <Icon svgPath={step.icon} className={styles.stepIcon} />}{' '}
-                            <span className={styles.stepObject}>
-                                {step.verb} {step.object}
-                            </span>
-                        </li>
-                    ))}
-                </ol>
-            )}
+                ))}
+            </div>
         </div>
     )
 }

--- a/lib/ui/src/chat/fixtures.ts
+++ b/lib/ui/src/chat/fixtures.ts
@@ -21,14 +21,14 @@ export const FIXTURE_TRANSCRIPT: Record<string, ChatMessage[]> = {
             speaker: 'human',
             displayText:
                 "Explain the following code at a high level:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
-        },
-        {
-            speaker: 'assistant',
-            displayText: 'This code generates a random 32-character string (nonce) using characters A-Z, a-z, and 0-9.',
             contextFiles: [
                 { fileName: 'vscode/src/chat/ChatViewProvider.ts' },
                 { fileName: 'lib/shared/src/timestamp.ts' },
             ],
+        },
+        {
+            speaker: 'assistant',
+            displayText: 'This code generates a random 32-character string (nonce) using characters A-Z, a-z, and 0-9.',
         },
         {
             speaker: 'human',

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -297,7 +297,8 @@ export class ChatPanelProvider extends MessageProvider {
         }
         try {
             const doc = await vscode.workspace.openTextDocument(vscode.Uri.joinPath(rootUri, filePath))
-            await vscode.window.showTextDocument(doc)
+            // open doc next to current view
+            await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.Beside, preserveFocus: false })
         } catch {
             // Try to open the file in the sourcegraph view
             const sourcegraphSearchURL = new URL(

--- a/vscode/test/integration/commands.test.ts
+++ b/vscode/test/integration/commands.test.ts
@@ -30,6 +30,7 @@ suite('Commands', function () {
         // Check the chat transcript contains markdown
         const humanMessage = await getTranscript(0)
         assert.match(humanMessage.displayText || '', /^\/explain/)
+        assert.match(humanMessage.contextFiles?.[0]?.source || '', /editor/)
 
         await waitUntil(async () => assistantRegex.test((await getTranscript(1)).displayText || ''))
     })
@@ -43,6 +44,7 @@ suite('Commands', function () {
         // Check the chat transcript contains markdown
         const humanMessage = await getTranscript(0)
         assert.match(humanMessage.displayText || '', /^\/smell/)
+        assert.match(humanMessage.contextFiles?.[0]?.source || '', /editor/)
 
         await waitUntil(async () => assistantRegex.test((await getTranscript(1)).displayText || ''))
     })
@@ -56,6 +58,7 @@ suite('Commands', function () {
         // Check the chat transcript contains markdown
         const humanMessage = await getTranscript(0)
         assert.match(humanMessage.displayText || '', /^\/test/)
+        assert.match(humanMessage.contextFiles?.[0]?.source || '', /editor/)
 
         await waitUntil(async () => assistantRegex.test((await getTranscript(1)).displayText || ''))
     })

--- a/vscode/webviews/FileLink.module.css
+++ b/vscode/webviews/FileLink.module.css
@@ -1,7 +1,7 @@
 .link-button {
     background: none;
     border: none;
-    color: var(--vscode-button-secondaryForeground);
+    color: var(--vscode-textLink-foreground);
     cursor: pointer;
     font-size: inherit;
     text-decoration: underline;

--- a/vscode/webviews/FileLink.tsx
+++ b/vscode/webviews/FileLink.tsx
@@ -15,6 +15,6 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({ path }) => (
         }}
         title={path}
     >
-        {path}
+        {`@${path}`}
     </button>
 )

--- a/web/src/Chat.tsx
+++ b/web/src/Chat.tsx
@@ -93,5 +93,5 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({ classN
     </button>
 )
 
-const FileLink: React.FunctionComponent<FileLinkProps> = ({ path }) => <>{path}</>
+const FileLink: React.FunctionComponent<FileLinkProps> = ({ path }) => <>{`@${path}`}</>
 const SymbolLink: React.FunctionComponent<SymbolLinkProps> = ({ symbol }) => <>{symbol}</>


### PR DESCRIPTION
# MOVED TO PR/1706

https://github.com/sourcegraph/cody/pull/1706

CLOSE: https://github.com/sourcegraph/cody/issues/1525

This PR replaces the current Context File widget with a new UI widget for displaying context files used for a chat question as shown in @toolmantim 's figma design:

![image](https://github.com/sourcegraph/cody/assets/68532117/b018d7c1-68de-40ee-a103-4bc089830727)

Also add a new `source` field to Context File for identifying purpose, which only supports 'embeddings' currently.

Updated all the context message building functions to include context source.

Added 'keyword' as source to results returned by keyword search.

Added 'filename' as source to results returned by filename search.

Related tests are also updated.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Ask Cody a question, e.g. `What's the entry file for the cody vs code extension?`

Enhanced context will be displayed as following:

![image](https://github.com/sourcegraph/cody/assets/68532117/502f1e40-5b37-4380-8f6f-9380c3c4861c)

Run a command, e.g. Explain, that use editor context and not enhanced context (e.g. embeddings or local keyword search), the editor context will not show up as enhanced context (displayed with sprinkles in the front):

![image](https://github.com/sourcegraph/cody/assets/68532117/cad7b65e-f18c-4496-9c1e-ebc41f9776fb)

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/460a345a-b22c-4d1d-ba5e-5f5b415cc992)
