### PR TITLE
feat: enable editor title icon by default

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -30,7 +30,7 @@ export interface Configuration {
     experimentalChatPanel: boolean
     experimentalChatPredictions: boolean
     experimentalCommandLenses: boolean
-    experimentalEditorTitleCommandIcon: boolean
+    editorTitleCommandIcon: boolean
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
     experimentalLocalSymbols: boolean

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Edit: Fixed formatting issues with some editor formatters that required explict indendation configuration. [pull/1620](https://github.com/sourcegraph/cody/pull/1620)
 - Edit: Fixed an issue where the diff for an edit could expand recursively each time it is viewed. [pull/1621](https://github.com/sourcegraph/cody/pull/1621)
+- Editor Title Icon has been moved out of the experimental stage and is now enabled by default. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ## [0.14.4]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -789,7 +789,7 @@
       "editor/title": [
         {
           "command": "cody.action.commands.menu",
-          "when": "cody.activated && config.cody.experimental.editorTitleCommandIcon",
+          "when": "cody.activated && config.cody.editorTitleCommandIcon",
           "group": "navigation",
           "visibility": "visible"
         },
@@ -931,8 +931,14 @@
           "markdownDescription": "Enables asking questions and requesting code changes directly from within the code editor. Use the + button next to any line of code to start an inline chat.",
           "default": true
         },
-        "cody.experimental.chatPredictions": {
+        "cody.editorTitleCommandIcon": {
           "order": 7,
+          "type": "boolean",
+          "markdownDescription": "Adds a Cody icon to the editor title menu for quick access to Cody commands.",
+          "default": true
+        },
+        "cody.experimental.chatPredictions": {
+          "order": 8,
           "type": "boolean",
           "default": false,
           "markdownDescription": "Adds suggestions of possible relevant messages in the chat window."
@@ -941,12 +947,6 @@
           "order": 8,
           "type": "boolean",
           "markdownDescription": "[Experimental] Adds code lenses to current file for quick access to Cody commands.",
-          "default": false
-        },
-        "cody.experimental.editorTitleCommandIcon": {
-          "order": 8,
-          "type": "boolean",
-          "markdownDescription": "[Experimental] Adds an editor title menu icon for quick access to Cody commands.",
           "default": false
         },
         "cody.experimental.guardrails": {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -42,7 +42,7 @@ export type Config = Pick<
     | 'experimentalChatPredictions'
     | 'experimentalGuardrails'
     | 'experimentalCommandLenses'
-    | 'experimentalEditorTitleCommandIcon'
+    | 'editorTitleCommandIcon'
     | 'experimentalLocalSymbols'
     | 'inlineChat'
 >

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -22,7 +22,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocomplete: true,
     autocompleteLanguages: { '*': true, scminput: false },
     experimentalCommandLenses: false,
-    experimentalEditorTitleCommandIcon: false,
+    editorTitleCommandIcon: true,
     experimentalChatPanel: false,
     experimentalChatPredictions: false,
     experimentalGuardrails: false,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -23,7 +23,7 @@ describe('getConfiguration', () => {
                 scminput: false,
             },
             experimentalCommandLenses: false,
-            experimentalEditorTitleCommandIcon: false,
+            editorTitleCommandIcon: true,
             experimentalChatPanel: false,
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
@@ -74,7 +74,7 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.commandLenses':
                         return true
-                    case 'cody.experimental.editorTitleCommandIcon':
+                    case 'cody.editorTitleCommandIcon':
                         return true
                     case 'cody.experimental.guardrails':
                         return true
@@ -139,7 +139,7 @@ describe('getConfiguration', () => {
             experimentalChatPanel: true,
             experimentalChatPredictions: true,
             experimentalCommandLenses: true,
-            experimentalEditorTitleCommandIcon: true,
+            editorTitleCommandIcon: true,
             experimentalGuardrails: true,
             experimentalLocalSymbols: true,
             inlineChat: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -80,7 +80,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),
         experimentalLocalSymbols: config.get(CONFIG_KEY.experimentalLocalSymbols, false),
         experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
-        experimentalEditorTitleCommandIcon: config.get(CONFIG_KEY.experimentalEditorTitleCommandIcon, false),
+        editorTitleCommandIcon: config.get(CONFIG_KEY.editorTitleCommandIcon, true),
         autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(
             CONFIG_KEY.autocompleteAdvancedServerEndpoint,

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -94,6 +94,13 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.autocomplete
                 ),
                 createFeatureToggle(
+                    'Editor Title Icon',
+                    undefined,
+                    'Enable Cody to appear in editor title menu for quick access to Cody commands',
+                    'cody.editorTitleCommandIcon',
+                    c => c.editorTitleCommandIcon
+                ),
+                createFeatureToggle(
                     'Inline Chat',
                     undefined,
                     'Enable chatting and editing with Cody, directly in your code',
@@ -128,13 +135,6 @@ export function createStatusBar(): CodyStatusBar {
                     'Enable Code Lenses in documents for quick access to Cody commands',
                     'cody.experimental.commandLenses',
                     c => c.experimentalCommandLenses
-                ),
-                createFeatureToggle(
-                    'Editor Title Icon',
-                    'Experimental',
-                    'Enable Cody to appear in editor title menu for quick access to Cody commands',
-                    'cody.experimental.editorTitleCommandIcon',
-                    c => c.experimentalEditorTitleCommandIcon
                 ),
                 { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
                 {

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -133,7 +133,7 @@ export async function buildWorkSpaceSettings(workspaceDirectory: string): Promis
     const settings = {
         'cody.serverEndpoint': 'http://localhost:49300',
         'cody.experimental.commandLenses': true,
-        'cody.experimental.editorTitleCommandIcon': true,
+        'cody.editorTitleCommandIcon': true,
     }
     // create a temporary directory with settings.json and add to the workspaceDirectory
     const workspaceSettingsPath = path.join(workspaceDirectory, '.vscode', 'settings.json')


### PR DESCRIPTION
PART of https://github.com/sourcegraph/cody/issues/1521

feat: enable editor title icon by default

The editor title icon that provides quick access to Cody commands has been moved out of experimental and is now enabled by default.

This change:

- Updates the configuration property name from `experimentalEditorTitleCommandIcon` to `editorTitleCommandIcon`.
- Sets the default value to `true`.
- Removes the "[Experimental]" tag from the settings description.
- Updates references to the old config name.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

You should see the Cody icon in the editor title menu enabled by default when you first installed Cody.

![image](https://github.com/sourcegraph/cody/assets/68532117/928dac93-0cf5-4132-bfbc-27cc87cde7c2)

