### PR TITLE
fix: open document side by side with chat panel

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
+- Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -297,7 +297,12 @@ export class ChatPanelProvider extends MessageProvider {
         }
         try {
             const doc = await vscode.workspace.openTextDocument(vscode.Uri.joinPath(rootUri, filePath))
-            await vscode.window.showTextDocument(doc)
+            // Check current webview panel location to open the doc side by side
+            const viewColumn =
+                this.webviewPanel?.viewColumn === vscode.ViewColumn.One
+                    ? vscode.ViewColumn.Beside
+                    : vscode.ViewColumn.One
+            await vscode.window.showTextDocument(doc, { viewColumn, preserveFocus: false })
         } catch {
             // Try to open the file in the sourcegraph view
             const sourcegraphSearchURL = new URL(

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -299,9 +299,7 @@ export class ChatPanelProvider extends MessageProvider {
             const doc = await vscode.workspace.openTextDocument(vscode.Uri.joinPath(rootUri, filePath))
             // Check current webview panel location to open the doc side by side
             const viewColumn =
-                this.webviewPanel?.viewColumn === vscode.ViewColumn.One
-                    ? vscode.ViewColumn.Beside
-                    : vscode.ViewColumn.One
+                this.webviewPanel?.viewColumn === vscode.ViewColumn.One ? vscode.ViewColumn.Two : vscode.ViewColumn.One
             await vscode.window.showTextDocument(doc, { viewColumn, preserveFocus: false })
         } catch {
             // Try to open the file in the sourcegraph view

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -297,9 +297,11 @@ export class ChatPanelProvider extends MessageProvider {
         }
         try {
             const doc = await vscode.workspace.openTextDocument(vscode.Uri.joinPath(rootUri, filePath))
-            // Check current webview panel location to open the doc side by side
-            const viewColumn =
-                this.webviewPanel?.viewColumn === vscode.ViewColumn.One ? vscode.ViewColumn.Two : vscode.ViewColumn.One
+            let viewColumn = vscode.ViewColumn.Beside
+            // Open file next to current webview panel column
+            if (this.webviewPanel?.viewColumn) {
+                viewColumn = this.webviewPanel.viewColumn - 1 || this.webviewPanel.viewColumn + 1
+            }
             await vscode.window.showTextDocument(doc, { viewColumn, preserveFocus: false })
         } catch {
             // Try to open the file in the sourcegraph view


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1699403470817339

fix: open document side by side with chat panel

Check current webview panel location before opening the document to show it side by side instead of replacing the chat panel.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

https://github.com/sourcegraph/cody/assets/68532117/bca885f8-8b09-4908-8500-707e5b3eeb91

