### PR TITLE
fix: do not open chat for doc/edit commands

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,7 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 - Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
-- Command: Fixed an issue that opens a new chat window when running `/doc` and `/edit` commands from the command palette.
+- Command: Fixed an issue that opened a new chat window when running `/doc` and `/edit` commands from the command palette. [pull/1678](https://github.com/sourcegraph/cody/pull/1678)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 - Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
+- Command: Fixed an issue that opens a new chat window when running `/doc` and `/edit` commands from the command palette.
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -102,12 +102,14 @@ export class ChatManager implements vscode.Disposable {
             return
         }
 
-        // If chat view is not needed, run the recipe via sidebar chat
-        if (!openChatView) {
+        // If chat view is not needed, run the recipe via sidebar chat without creating a new panel
+        const isDefaultEditCommands = ['/doc', '/edit'].includes(humanChatInput)
+        if (!openChatView || isDefaultEditCommands) {
             await this.sidebarChat.executeRecipe(recipeId, humanChatInput, source)
             return
         }
 
+        // Else, open a new chanel panel and run the command in the new panel
         const chatProvider = await this.getChatProvider()
         if (!openChatView || !this.chatPanelsManager) {
             await this.sidebarChat.executeRecipe(recipeId, humanChatInput, source)


### PR DESCRIPTION
Reported in https://sourcegraph.slack.com/archives/C05AGQYD528/p1699400897961909

fix: do not open chat for doc/edit commands

The `/doc` and `/edit` commands were incorrectly opening a new chat panel. This fixes it to not creating any new chat panel or opening existing chat window  when running the `/doc` and `/edit` commands.

## Demo

https://github.com/sourcegraph/cody/assets/68532117/0b365a6d-f380-4093-91a9-fdf01efb588b


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

First, close the cody sidebar

Then try running the `/doc` command from:
- [ ] chat
- [ ] command palette
- [ ] right click context menu

#### before

An empty chat window will pop up

#### after

All chat windows remains closed (when closed)