### PR TITLE
feat: add restart chat btn to new chat panel

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Added
 
 - Chat: A new chat model selection dropdown that allows selecting between different chat models when connected to the sourcegraph.com instance. [pull/1676](https://github.com/sourcegraph/cody/pull/1676)
+- Chat: New button in editor title for restarting chat session in current chat panel. [pull/1687](https://github.com/sourcegraph/cody/pull/1687)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -539,6 +539,14 @@
         "title": "Update search indices for all workspace folders",
         "icon": "$(sync)",
         "when": "cody.activated && config.cody.experimental.new-search"
+      },
+      {
+        "command": "cody.chat.restart",
+        "category": "Cody",
+        "title": "Restart Chat Session",
+        "group": "Cody",
+        "icon": "$(refresh)",
+        "when": "cody.activated && cody.hasChatHistory && config.cody.experimental.chatPanel"
       }
     ],
     "keybindings": [
@@ -828,6 +836,12 @@
         },
         {
           "command": "cody.chat.panel.new",
+          "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
+          "group": "navigation",
+          "visibility": "visible"
+        },
+        {
+          "command": "cody.chat.restart",
           "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
           "group": "navigation",
           "visibility": "visible"

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -166,8 +166,11 @@ export class ChatManager implements vscode.Disposable {
      * Clears the current chat session and restarts it, creating a new chat ID.
      */
     public async clearAndRestartSession(): Promise<void> {
-        const chatProvider = await this.getChatProvider()
-        await chatProvider.clearAndRestartSession()
+        if (!this.chatPanelsManager) {
+            return this.sidebarChat.clearAndRestartSession()
+        }
+
+        await this.chatPanelsManager.clearAndRestartSession()
     }
 
     public async restoreSession(chatID: string): Promise<void> {

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -145,9 +145,9 @@ export class ChatPanelProvider extends MessageProvider {
             isMessageInProgress,
         })
 
-        // Update webview panel title
-        const text = this.transcript.getLastInteraction()?.getHumanMessage()?.displayText
-        if (text && this.webviewPanel) {
+        // Update / reset webview panel title
+        const text = this.transcript.getLastInteraction()?.getHumanMessage()?.displayText || 'New Chat'
+        if (this.webviewPanel) {
             this.webviewPanel.title = text.length > 10 ? `${text?.slice(0, 20)}...` : text
         }
     }

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -172,6 +172,13 @@ export class ChatPanelsManager implements vscode.Disposable {
 
     public async clearAndRestartSession(): Promise<void> {
         logDebug('ChatPanelsManager', 'clearAndRestartSession')
+        // Clear and restart chat session in current panel
+        if (this.activePanelProvider) {
+            await this.activePanelProvider.clearAndRestartSession()
+            return
+        }
+
+        // Create and restart in new panel
         const chatProvider = await this.getChatPanel()
         await chatProvider.clearAndRestartSession()
     }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -350,6 +350,12 @@ const register = async (
             return result
         }),
         // Commands
+        vscode.commands.registerCommand('cody.chat.restart', async () => {
+            await chatManager.clearAndRestartSession()
+            telemetryService.log('CodyVSCodeExtension:chatTitleButton:clicked', { name: 'clear' }, { hasV2Event: true })
+            telemetryRecorder.recordEvent('cody.interactive.clear', 'clicked', { privateMetadata: { name: 'clear' } })
+        }),
+        // TODO remove cody.interactive.clear when we remove the old chat
         vscode.commands.registerCommand('cody.interactive.clear', async () => {
             await chatManager.clearAndRestartSession()
             await chatManager.setWebviewView('chat')


### PR DESCRIPTION
Added reset current chat button in editor title when new cody chat panel is active

![image](https://github.com/sourcegraph/cody/assets/68532117/20ff48b4-1501-4c47-90ab-b3a2d382c716)

- Add new "cody.chat.restart" command to restart the chat session
- Update ChatManager to call clearAndRestartSession() on active chat panel
- Update ChatPanelsManager to handle chat reset in current panel
- Add command registration in main.ts

https://github.com/sourcegraph/cody/assets/68532117/99d17032-d27a-4a39-b088-418123128469

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Start a chat session in the new Chat UI, and then click the new reset button

![image](https://github.com/sourcegraph/cody/assets/68532117/71c58d13-e372-4769-9493-30f4b380461e)

Nothing is affected in the old chat UI
