### PR TITLE
Agent: add `evaluate-autocomplete` subcommand

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -24,9 +24,16 @@
   },
   "dependencies": {
     "@sourcegraph/cody-shared": "workspace:*",
+    "@sourcegraph/scip-typescript": "^0.3.9",
+    "commander": "^11.1.0",
+    "env-paths": "^3.0.0",
+    "fast-myers-diff": "^3.1.0",
+    "minimatch": "^9.0.3",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {
+    "@types/google-protobuf": "^3.15.6",
+    "@types/minimatch": "^5.1.2",
     "@types/vscode": "^1.80.0",
     "pkg": "^5.8.1",
     "rimraf": "^5.0.5"

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 
+import envPaths from 'env-paths'
 import * as vscode from 'vscode'
 
 import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/dist/utils'
@@ -14,16 +15,17 @@ import { AgentTextDocument } from './AgentTextDocument'
 import { newTextEditor } from './AgentTextEditor'
 import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
 import { AgentEditor } from './editor'
-import { MessageHandler } from './jsonrpc-alias'
+import { InProcessClient, MessageHandler } from './jsonrpc-alias'
 import { AutocompleteItem, ClientInfo, ExtensionConfiguration, RecipeInfo } from './protocol-alias'
 import * as vscode_shim from './vscode-shim'
 
 const secretStorage = new Map<string, string>()
 
-export function initializeVscodeExtension(): void {
+export function initializeVscodeExtension(workspaceRoot: vscode.Uri): void {
+    const paths = envPaths('Cody')
     activate({
         asAbsolutePath(relativePath) {
-            return path.resolve(process.cwd(), relativePath)
+            return path.resolve(workspaceRoot.fsPath, relativePath)
         },
         environmentVariableCollection: {} as any,
         extension: {} as any,
@@ -60,10 +62,25 @@ export function initializeVscodeExtension(): void {
         storageUri: {} as any,
         subscriptions: [],
         workspaceState: {} as any,
-        globalStorageUri: {} as any,
+        globalStorageUri: vscode.Uri.file(paths.data),
         storagePath: {} as any,
-        globalStoragePath: {} as any,
+        globalStoragePath: vscode.Uri.file(paths.data).fsPath,
     })
+}
+
+export async function newEmbeddedAgentClient(clientInfo: ClientInfo): Promise<InProcessClient> {
+    process.env.ENABLE_SENTRY = 'false'
+    const agent = new Agent()
+    const debugHandler = new MessageHandler()
+    debugHandler.registerNotification('debug/message', params => {
+        console.error(`${params.channel}: ${params.message}`)
+    })
+    debugHandler.messageEncoder.pipe(agent.messageDecoder)
+    agent.messageEncoder.pipe(debugHandler.messageDecoder)
+    const client = agent.clientForThisInstance()
+    await client.request('initialize', clientInfo)
+    client.notify('initialized', null)
+    return client
 }
 
 export class Agent extends MessageHandler {
@@ -81,10 +98,11 @@ export class Agent extends MessageHandler {
             process.stderr.write(
                 `Cody Agent: handshake with client '${clientInfo.name}' (version '${clientInfo.version}') at workspace root path '${clientInfo.workspaceRootUri}'\n`
             )
-            initializeVscodeExtension()
+            vscode_shim.setClientInfo(clientInfo)
             this.workspace.workspaceRootUri = clientInfo.workspaceRootUri
                 ? vscode.Uri.parse(clientInfo.workspaceRootUri)
                 : vscode.Uri.from({ scheme: 'file', path: clientInfo.workspaceRootPath })
+            initializeVscodeExtension(this.workspace.workspaceRootUri)
 
             if (clientInfo.extensionConfiguration) {
                 this.setClient(clientInfo.extensionConfiguration)

--- a/agent/src/bfg/BfgContextFetcher.test.ts
+++ b/agent/src/bfg/BfgContextFetcher.test.ts
@@ -40,7 +40,7 @@ describe('BfgRetriever', async () => {
     beforeAll(async () => {
         process.env.CODY_TESTING = 'true'
         await initTreeSitterParser()
-        initializeVscodeExtension()
+        initializeVscodeExtension(vscode.Uri.file(process.cwd()))
 
         if (shouldCreateGitDir) {
             await exec('git init', { cwd: dir })
@@ -94,6 +94,25 @@ describe('BfgRetriever', async () => {
         const maxChars = 1_000
         const maxMs = 100
 
-        expect(await bfg.retrieve({ document, position, docContext, hints: { maxChars, maxMs } })).toHaveLength(2)
+        const actual = await bfg.retrieve({ document, position, docContext, hints: { maxChars, maxMs } })
+        actual.sort((a, b) => a.content.localeCompare(b.content))
+
+        expect(actual).toMatchInlineSnapshot([
+            {
+                content: 'distance(a: Point, b: Point)',
+                fileName: 'Point.ts',
+                symbol: 'scip-ctags . . . distance().',
+            },
+            {
+                content: "import { distance } from './Point'",
+                fileName: 'main.ts',
+                symbol: 'scip-ctags . . . distance.',
+            },
+            {
+                content: 'interface Point {\n    x: number\n    y: number\n}',
+                fileName: 'Point.ts',
+                symbol: 'scip-ctags . . . Point#',
+            },
+        ])
     })
 })

--- a/agent/src/cli/evaluate-autocomplete/Queries.ts
+++ b/agent/src/cli/evaluate-autocomplete/Queries.ts
@@ -1,0 +1,79 @@
+import * as fspromises from 'fs/promises'
+import * as path from 'path'
+
+import Parser, { Query } from 'web-tree-sitter'
+
+import { SupportedLanguage } from '../../../../vscode/src/completions/tree-sitter/grammars'
+
+export type QueryName = 'context'
+
+/**
+ * Queries manages compilation of tree-sitter queries from a directory layout.
+ *
+ * Queries are written in a file structure like this: `LANGUAGE/QUERY_NAME.scm`
+ *
+ * This class caches compilation of queries so that we only read each query once from disk.
+ */
+export class Queries {
+    private cache: CompiledQuery[] = []
+    constructor(private queriesDirectory: string) {}
+    public async loadQuery(parser: Parser, language: SupportedLanguage, name: QueryName): Promise<Query | undefined> {
+        const fromCache = this.cache.find(compiled => compiled.language === language && compiled.queryName === name)
+        if (fromCache) {
+            return fromCache.compiledQuery
+        }
+        return this.compileQuery(parser, language, name)
+    }
+
+    private async compileQuery(
+        parser: Parser,
+        language: SupportedLanguage,
+        name: QueryName
+    ): Promise<Query | undefined> {
+        const languages = [language, ...(grammarInheritance[language] ?? [])]
+        const queryStrings: string[] = []
+        for (const queryLanguage of languages) {
+            const queryPath = path.join(this.queriesDirectory, queryLanguage, `${name}.scm`)
+            try {
+                const stat = await fspromises.stat(queryPath)
+                if (!stat.isFile()) {
+                    continue
+                }
+            } catch {
+                continue
+            }
+            const queryString = await fspromises.readFile(queryPath)
+            queryStrings.push(queryString.toString())
+        }
+        const uncompiled: UncompiledQuery = {
+            language,
+            queryName: name,
+            queryString: queryStrings.join('\n\n'),
+        }
+        const compiled = compileQuery(uncompiled, parser)
+        this.cache.push(compiled)
+        return compiled.compiledQuery
+    }
+}
+
+interface UncompiledQuery {
+    language: SupportedLanguage
+    queryName: QueryName
+    queryString: string
+}
+interface CompiledQuery extends UncompiledQuery {
+    compiledQuery: Query
+}
+
+function compileQuery(query: UncompiledQuery, parser: Parser): CompiledQuery {
+    return {
+        ...query,
+        compiledQuery: parser.getLanguage().query(query.queryString),
+    }
+}
+
+const grammarInheritance: Partial<Record<SupportedLanguage, SupportedLanguage[]>> = {
+    [SupportedLanguage.TypeScript]: [SupportedLanguage.JavaScript],
+    [SupportedLanguage.JSX]: [SupportedLanguage.JavaScript],
+    [SupportedLanguage.TSX]: [SupportedLanguage.TypeScript, SupportedLanguage.JavaScript],
+}

--- a/agent/src/cli/evaluate-autocomplete/evalaute-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evalaute-autocomplete.ts
@@ -1,0 +1,250 @@
+import { execSync } from 'child_process'
+import * as fspromises from 'fs/promises'
+import * as path from 'path'
+
+import { Command, Option } from 'commander'
+import { calcPatch } from 'fast-myers-diff'
+import { minimatch } from 'minimatch'
+import { rimraf } from 'rimraf'
+import { Range, Uri } from 'vscode'
+import { QueryCapture } from 'web-tree-sitter'
+
+import { Input } from '@sourcegraph/scip-typescript/src/Input'
+import * as scip from '@sourcegraph/scip-typescript/src/scip'
+import { formatSnapshot } from '@sourcegraph/scip-typescript/src/SnapshotTesting'
+
+import { getParseLanguage } from '../../../../vscode/src/completions/tree-sitter/grammars'
+import { createParser } from '../../../../vscode/src/completions/tree-sitter/parser'
+import { newEmbeddedAgentClient } from '../../agent'
+import { AgentTextDocument } from '../../AgentTextDocument'
+import { InProcessClient } from '../../jsonrpc-alias'
+import { getLanguageForFileName } from '../../language'
+import { AutocompleteResult } from '../../protocol-alias'
+import * as vscode_shim from '../../vscode-shim'
+
+import { Queries } from './Queries'
+
+interface EvaluateAutocompleteOptions {
+    workspace: string
+    treeSitterGrammars: string
+    queries: string
+    testCount: string
+    includePattern: string
+    excludePattern: string
+    srcAccessToken: string
+    srcEndpoint: string
+    snapshotDirectory: string
+    bfgBinary?: string
+}
+
+export const evaluateAutocompleteCommand = new Command('evaluate-autocomplete')
+    .description('Evaluate Cody autocomplete by running the Agent in headless mode')
+    .option('--workspace <path>', 'The workspace directory where to run the autocomplete evaluation', process.cwd())
+    .option('--test-count <number>', 'The number of autocomplete requests to run in this evaluation', '10')
+    .option(
+        '--snapshot-directory <path>',
+        'Directory where to write snapshot files to document autocomplete results',
+        ''
+    )
+    .addOption(
+        new Option('--src-access-token <token>', 'The Sourcegraph access token to use for authentication').env(
+            'SRC_ACCESS_TOKEN'
+        )
+    )
+    .addOption(
+        new Option('--src-endpoint <url>', 'The Sourcegraph URL endpoint to use for authentication').env('SRC_ENDPOINT')
+    )
+    .option(
+        '--include-pattern <glob>',
+        'A glob pattern to determine what file paths to include in the evaluation',
+        '**'
+    )
+    .option('--exclude-pattern <glob>', 'A glob pattern to determine what file paths to exclude in the evaluation', '')
+    .addOption(new Option('--bfg-binary <path>', 'Optional path to a BFG binary').env('BFG_BINARY'))
+    .option(
+        '--tree-sitter-grammars <path>',
+        'Path to a directory containing tree-sitter grammars',
+        path.resolve(__dirname, '../../vscode/dist')
+    )
+    .option('--queries <path>', 'Path to a directory containing tree-sitter queries')
+    .action(async (options: EvaluateAutocompleteOptions) => {
+        // canonicalize and make path absolute
+        const workspace = path.normalize(options.workspace)
+
+        if (!options.queries) {
+            console.log('missing required options: --queries')
+            process.exit(1)
+        }
+        if (!options.srcAccessToken) {
+            console.log('environment variable SRC_ACCESS_TOKEN must be non-empty')
+            process.exit(1)
+        }
+        if (!options.srcEndpoint) {
+            console.log('environment variable SRC_ENDPOINT must be non-empty')
+            process.exit(1)
+        }
+
+        const workspaceRootUri = Uri.from({ scheme: 'file', path: workspace })
+        const client = await newEmbeddedAgentClient({
+            name: 'evaluate-autocomplete',
+            version: '0.1.0',
+            workspaceRootUri: workspaceRootUri.toString(),
+            extensionConfiguration: {
+                accessToken: options.srcAccessToken,
+                serverEndpoint: options.srcEndpoint,
+                customHeaders: {},
+            },
+        })
+        try {
+            await runEvalution(client, options, workspace)
+        } catch (error) {
+            console.error('unexpected error running evaluate-autocomplete', error)
+        }
+        await client.request('shutdown', null)
+        client.notify('exit', null)
+    })
+
+/**
+ * Runs autocomplete evaluation. The current logic is specifically optimized
+ * to evaluate BFG.  The best way to customize the logic is by changing the
+ * code. Eventually, we could make the logic configurable via command-line
+ * flags so that we can reuse this command for different kinds of evaluations.
+ */
+async function runEvalution(
+    client: InProcessClient,
+    options: EvaluateAutocompleteOptions,
+    workspace: string
+): Promise<void> {
+    vscode_shim.customConfiguration['cody.autocomplete.experimental.graphContext'] = 'bfg'
+    vscode_shim.customConfiguration['cody.autocomplete.advanced.provider'] = 'fireworks'
+    vscode_shim.customConfiguration['cody.autocomplete.advanced.model'] = 'starcoder-7b'
+    vscode_shim.customConfiguration['cody.debug.verbose'] = 'true'
+    if (options.bfgBinary) {
+        vscode_shim.customConfiguration['cody.experimental.bfg.path'] = options.bfgBinary
+    }
+    const queries = new Queries(options.queries)
+    const grammarDirectory = path.normalize(options.treeSitterGrammars)
+    const files = execSync('git ls-files', { cwd: workspace }).toString().split('\n')
+    let remainingTests = Number.parseInt(options.testCount, 10)
+    if (options.snapshotDirectory) {
+        await rimraf(options.snapshotDirectory)
+    }
+    for (const file of files) {
+        if (!minimatch(file, options.includePattern)) {
+            continue
+        }
+        if (options.excludePattern && minimatch(file, options.excludePattern)) {
+            continue
+        }
+        const filePath = path.join(workspace, file)
+        const stat = await fspromises.stat(filePath)
+        if (!stat.isFile()) {
+            continue
+        }
+        const content = (await fspromises.readFile(filePath)).toString()
+        const language = getParseLanguage(getLanguageForFileName(file))
+        if (!language) {
+            continue
+        }
+        client.notify('textDocument/didOpen', { filePath, content })
+        const parser = await createParser({ language, grammarDirectory })
+        const tree = parser.parse(content)
+        const query = await queries.loadQuery(parser, language, 'context')
+        if (!query) {
+            continue
+        }
+
+        const document = new scip.scip.Document({ relative_path: file })
+        for (const match of query.matches(tree.rootNode)) {
+            if (remainingTests <= 0) {
+                break
+            }
+            for (const capture of match.captures) {
+                if (remainingTests <= 0) {
+                    break
+                }
+                if (capture.name === 'range') {
+                    if (capture.node.startPosition.row !== capture.node.endPosition.row) {
+                        // TODO: handle multi-line
+                        continue
+                    }
+                    try {
+                        const result = await triggerAutocomplete({ content, filePath, capture, client, document })
+                        if (result.items.length > 0) {
+                            remainingTests--
+                        }
+                    } catch {
+                        // ignore. Most common issue is that autocomplete times out.
+                    }
+                }
+            }
+        }
+
+        // Write snapshot file to disk we get non-empty autocomplete results.
+        if (options.snapshotDirectory && document.occurrences.length > 0) {
+            const outputPath = path.join(options.snapshotDirectory, file)
+            await fspromises.mkdir(path.dirname(outputPath), { recursive: true })
+            const input = new Input(filePath, content)
+            const snapshot = formatSnapshot(input, document)
+            await fspromises.writeFile(outputPath, snapshot)
+        }
+    }
+}
+
+interface AutocompleteFixture {
+    content: string
+    filePath: string
+    capture: QueryCapture
+    client: InProcessClient
+    document: scip.scip.Document
+}
+
+async function triggerAutocomplete(fixture: AutocompleteFixture): Promise<AutocompleteResult> {
+    const { content, filePath, capture, client, document } = fixture
+    // Modify the content by replacing the argument list to the call expression
+    // with an empty argument list. This evaluation is interesting because it
+    // allows us to test how good Cody is at inferring the original argument
+    // list.
+    const modifiedContent = [
+        content.slice(0, capture.node.startIndex),
+        '()',
+        content.slice(capture.node.endIndex),
+    ].join('')
+    client.notify('textDocument/didChange', { filePath, content: modifiedContent })
+    const result = await client.request('autocomplete/execute', {
+        filePath,
+        position: {
+            line: capture.node.startPosition.row,
+            character: capture.node.startPosition.column + 1,
+        },
+    })
+    const textDocument = new AgentTextDocument({ filePath, content: modifiedContent })
+    for (const item of result.items) {
+        const range = new Range(
+            item.range.start.line,
+            item.range.start.character,
+            item.range.end.line,
+            item.range.end.character
+        )
+        const original = textDocument.getText(range)
+        const completion = item.insertText
+        for (const [sx, ex, text] of calcPatch(original, completion)) {
+            if (sx !== ex) {
+                // TODO: handle non-insert patches
+                continue
+            }
+            const scipRange = [
+                capture.node.startPosition.row,
+                capture.node.startPosition.column,
+                capture.node.endPosition.column,
+            ]
+            const occurrence = new scip.scip.Occurrence({
+                symbol: text,
+                range: scipRange,
+                symbol_roles: 0,
+            })
+            document.occurrences.push(occurrence)
+        }
+    }
+    return result
+}

--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander'
+
+import { Agent } from '../agent'
+
+export const jsonrpcCommand = new Command('jsonrpc')
+    .description(
+        'Interact with the Agent using JSON-RPC via stdout/stdin. ' +
+            'This is the subcommand that is used by Cody clients like the JetBrains and Neovim plugins.'
+    )
+    .action(() => {
+        process.stderr.write('Starting Cody Agent...\n')
+
+        const agent = new Agent()
+
+        console.log = console.error
+
+        // Force the agent process to exit when stdin/stdout close as an attempt to
+        // prevent zombie agent processes. We experienced this problem when we
+        // forcefully exit the IntelliJ process during local `./gradlew :runIde`
+        // workflows. We manually confirmed that this logic makes the agent exit even
+        // when we forcefully quit IntelliJ
+        // https://github.com/sourcegraph/cody/pull/1439#discussion_r1365610354
+        process.stdout.on('close', () => process.exit(1))
+        process.stdin.on('close', () => process.exit(1))
+
+        process.stdin.pipe(agent.messageDecoder)
+        agent.messageEncoder.pipe(process.stdout)
+    })

--- a/agent/src/cli/root.ts
+++ b/agent/src/cli/root.ts
@@ -1,0 +1,14 @@
+import { Command } from 'commander'
+
+import { evaluateAutocompleteCommand } from './evaluate-autocomplete/evalaute-autocomplete'
+import { jsonrpcCommand } from './jsonrpc'
+
+export const rootCommand = new Command()
+    .name('cody-agent')
+    .version('0.1.0')
+    .description(
+        'Cody Agent supports running the Cody VS Code extension in headless mode and interact with it via JSON-RPC. ' +
+            'The Agent is used by editor clients like JetBrains and Neovim.'
+    )
+    .addCommand(jsonrpcCommand)
+    .addCommand(evaluateAutocompleteCommand)

--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -2,8 +2,9 @@ import assert from 'assert'
 import * as path from 'path'
 
 import { describe, expect, it } from 'vitest'
-import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
+
+import * as vscode from './vscode-shim'
 
 describe('vscode-shim', () => {
     describe('vscode.Uri', () => {

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -8,6 +8,6 @@
     "allowJs": true,
   },
   "include": ["**/*", ".*", "package.json", "src/language-file-extensions.json"],
-  "exclude": ["dist", "src/bfg/__tests__"],
+  "exclude": ["dist", "src/bfg/__tests__", "scip.ts"],
   "references": [{ "path": "../lib/shared" }, { "path": "../vscode" }],
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
+    "@types/google-protobuf": "^3.15.6",
     "@sourcegraph/eslint-config": "0.37.1",
     "@sourcegraph/prettierrc": "^3.0.3",
     "@sourcegraph/tsconfig": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@storybook/testing-library':
         specifier: ^0.0.14-next.2
         version: 0.0.14-next.2
+      '@types/google-protobuf':
+        specifier: ^3.15.6
+        version: 3.15.10
       '@types/node':
         specifier: 20.4.0
         version: 20.4.0
@@ -117,10 +120,31 @@ importers:
       '@sourcegraph/cody-shared':
         specifier: workspace:*
         version: link:../lib/shared
+      '@sourcegraph/scip-typescript':
+        specifier: ^0.3.9
+        version: 0.3.9
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
+      fast-myers-diff:
+        specifier: ^3.1.0
+        version: 3.1.0
+      minimatch:
+        specifier: ^9.0.3
+        version: 9.0.3
       vscode-uri:
         specifier: ^3.0.7
         version: 3.0.7
     devDependencies:
+      '@types/google-protobuf':
+        specifier: ^3.15.6
+        version: 3.15.10
+      '@types/minimatch':
+        specifier: ^5.1.2
+        version: 5.1.2
       '@types/vscode':
         specifier: ^1.80.0
         version: 1.80.0
@@ -5031,6 +5055,17 @@ packages:
     resolution: {integrity: sha512-FQ1/Ued4I02R0JkrHHofDN163juVxUnPALzfxPZrDZUHv+c3jHjfZhmTHEz+Wd+g3b7MFk0fkj36nZSnvPyU8A==}
     dev: true
 
+  /@sourcegraph/scip-typescript@0.3.9:
+    resolution: {integrity: sha512-0QY1Nxe+LF+SPG6OqVzFuUleQfa4xboVbhjNNmonYQSmcuav6ry+9iSNpEL8prsGw5tGXzqvqT9oiqCQ5a7bkw==}
+    hasBin: true
+    dependencies:
+      commander: 9.5.0
+      google-protobuf: 3.21.2
+      pretty-ms: 7.0.1
+      progress: 2.0.3
+      typescript: 4.9.5
+    dev: false
+
   /@sourcegraph/telemetry@0.11.0:
     resolution: {integrity: sha512-cOlkCwX3V5lVJO/F8w7VauhMZob3PrMbE4DApTKwasTMwm4+OxtT6+afC5wJTwZwNWc31V83sNjV2nBkEtFPZg==}
     dependencies:
@@ -6171,6 +6206,10 @@ packages:
       '@types/node': 20.5.7
     dev: true
 
+  /@types/google-protobuf@3.15.10:
+    resolution: {integrity: sha512-uiyKJCa8hbmPE4yxwjbkMOALaBAiOVcatW/yEGbjTqwAh4kzNgQPWRlJMNPXpB5CPUM66xsYufiSX9WKHZCE9g==}
+    dev: true
+
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
@@ -7085,6 +7124,7 @@ packages:
   /acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
+    hasBin: true
 
   /address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
@@ -8261,6 +8301,11 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
+  /commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+    dev: false
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -9015,6 +9060,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
   /envalid@7.3.1:
     resolution: {integrity: sha512-KL1YRwn8WcoF/Ty7t+yLLtZol01xr9ZJMTjzoGRM8NaSU+nQQjSWOQKKJhJP2P57bpdakJ9jbxqQX4fGTOicZg==}
     engines: {node: '>=8.12'}
@@ -9148,6 +9198,7 @@ packages:
   /esbuild@0.17.14:
     resolution: {integrity: sha512-vOO5XhmVj/1XQR9NQ1UPq6qvMYL7QFJU57J5fKBKBKxp17uDt5PgxFDb4A2nEiXhr1qQs4x0F5+66hVVw4ruNw==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       '@esbuild/android-arm': 0.17.14
@@ -9234,6 +9285,7 @@ packages:
   /esbuild@0.18.19:
     resolution: {integrity: sha512-ra3CaIKCzJp5bU5BDfrCc0FRqKj71fQi+gbld0aj6lN0ifuX2fWJYPgLVLGwPfA+ruKna+OWwOvf/yHj6n+i0g==}
     engines: {node: '>=12'}
+    hasBin: true
     requiresBuild: true
     optionalDependencies:
       '@esbuild/android-arm': 0.18.19
@@ -9971,6 +10023,10 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  /fast-myers-diff@3.1.0:
+    resolution: {integrity: sha512-nLOy4sU1cxU+95gGmIiyjAKTmB1Nxaj2UUv9LnSgEv9pVqo2O7TJwQQZCtUJ+x8R5+zrwVn7XFUReb3efFjB/g==}
+    dev: false
+
   /fast-text-encoding@1.0.6:
     resolution: {integrity: sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==}
     dev: true
@@ -10415,6 +10471,10 @@ packages:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
     dev: true
 
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
@@ -10532,6 +10592,7 @@ packages:
   /glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 2.3.6
@@ -10691,6 +10752,10 @@ packages:
     dependencies:
       node-forge: 1.3.1
     dev: true
+
+  /google-protobuf@3.21.2:
+    resolution: {integrity: sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==}
+    dev: false
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -12518,7 +12583,7 @@ packages:
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
     dependencies:
-      get-func-name: 2.0.0
+      get-func-name: 2.0.2
     dev: true
 
   /lowercase-keys@2.0.0:
@@ -13602,6 +13667,7 @@ packages:
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   /nanomatch@1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
@@ -14745,7 +14811,6 @@ packages:
   /progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /promise-inflight@1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -15531,6 +15596,7 @@ packages:
   /rollup@3.26.2:
     resolution: {integrity: sha512-6umBIGVz93er97pMgQO08LuH3m6PUb3jlDUUGFsNJB6VgTCUaDFpupf5JfU30529m/UKOgmiX+uY6Sx8cOYpLA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -16857,6 +16923,12 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
+  /typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: false
+
   /typescript@5.1.6:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
     engines: {node: '>=14.17'}
@@ -17252,6 +17324,7 @@ packages:
   /vite-node@0.28.5(@types/node@20.4.0):
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
     engines: {node: '>=v14.16.0'}
+    hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
@@ -17569,6 +17642,7 @@ packages:
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: true
@@ -17576,12 +17650,14 @@ packages:
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
     dependencies:
       isexe: 2.0.0
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
     engines: {node: '>=8'}
+    hasBin: true
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -9,56 +9,17 @@ import { ContextRetriever, ContextRetrieverOptions, ContextSnippet } from '../..
 
 const isTesting = process.env.CODY_TESTING === 'true'
 
-async function doLoadBFG(context: vscode.ExtensionContext, reject: (reason?: any) => void): Promise<MessageHandler> {
-    const bfg = new MessageHandler()
-    const codyrpc = await downloadBfg(context)
-    if (!codyrpc) {
-        throw new Error(
-            'Failed to download BFG binary. To fix this problem, set the "cody.experimental.bfg.path" configuration to the path of your BFG binary'
-        )
-    }
-    const child = child_process.spawn(codyrpc, { stdio: 'pipe' })
-    child.stderr.on('data', chunk => {
-        if (isTesting) {
-            console.log(chunk.toString())
-        } else {
-            logDebug('BFG', 'stderr output', chunk.toString())
-        }
-    })
-    child.on('disconnect', () => reject())
-    child.on('close', () => reject())
-    child.on('error', error => reject(error))
-    child.on('exit', code => {
-        bfg.exit()
-        reject(code)
-    })
-    child.stderr.pipe(process.stdout)
-    child.stdout.pipe(bfg.messageDecoder)
-    bfg.messageEncoder.pipe(child.stdin)
-    await bfg.request('bfg/initialize', { clientName: 'vscode' })
-    return bfg
-}
-
-// We lazily load BFG to allow the Cody extension finish activation as
-// quickly as possible.
-function loadBFG(context: vscode.ExtensionContext): Promise<MessageHandler> {
-    // This is implemented as a custom promise instead of async/await so that we can reject
-    // the promise in the 'exit' handler if we fail to start the bfg process for some reason.
-    return new Promise<MessageHandler>((resolve, reject) => {
-        doLoadBFG(context, reject).then(
-            bfg => resolve(bfg),
-            error => reject(error)
-        )
-    })
-}
-
 export class BfgRetriever implements ContextRetriever {
     public identifier = 'bfg'
     private loadedBFG: Promise<MessageHandler>
     private didFailLoading = false
     private latestRepoIndexing: Promise<void[]> = Promise.resolve([])
-    constructor(context: vscode.ExtensionContext, gitDirectoryUri: (uri: vscode.Uri) => vscode.Uri | undefined) {
-        this.loadedBFG = loadBFG(context)
+    private indexedGitDirectories = new Set<string>()
+    constructor(
+        private context: vscode.ExtensionContext,
+        private gitDirectoryUri: (uri: vscode.Uri) => vscode.Uri | undefined
+    ) {
+        this.loadedBFG = this.loadBFG()
 
         this.loadedBFG.then(
             () => {},
@@ -68,24 +29,24 @@ export class BfgRetriever implements ContextRetriever {
             }
         )
 
-        const indexedGitDirectories = new Set<string>()
-        const didOpenDocumentUri = async (uri: vscode.Uri): Promise<void> => {
-            if (this.didFailLoading) {
-                return
-            }
-            const gitdir = gitDirectoryUri(uri)?.toString()
-            if (gitdir && !indexedGitDirectories.has(gitdir)) {
-                indexedGitDirectories.add(gitdir)
-                const bfg = await this.loadedBFG
-                const indexingStartTime = Date.now()
-                await bfg.request('bfg/gitRevision/didChange', { gitDirectoryUri: gitdir })
-                logDebug('BFG', `indexing time ${Date.now() - indexingStartTime}ms`)
-            }
-        }
         this.latestRepoIndexing = Promise.all(
-            vscode.window.visibleTextEditors.map(textEditor => didOpenDocumentUri(textEditor.document.uri))
+            vscode.window.visibleTextEditors.map(textEditor => this.didOpenDocumentUri(textEditor.document.uri))
         )
-        vscode.workspace.onDidOpenTextDocument(document => didOpenDocumentUri(document.uri))
+        vscode.workspace.onDidOpenTextDocument(document => this.didOpenDocumentUri(document.uri))
+    }
+
+    private async didOpenDocumentUri(uri: vscode.Uri): Promise<void> {
+        if (this.didFailLoading) {
+            return
+        }
+        const gitdir = this.gitDirectoryUri(uri)?.toString()
+        if (gitdir && !this.indexedGitDirectories.has(gitdir)) {
+            this.indexedGitDirectories.add(gitdir)
+            const bfg = await this.loadedBFG
+            const indexingStartTime = Date.now()
+            await bfg.request('bfg/gitRevision/didChange', { gitDirectoryUri: gitdir })
+            logDebug('BFG', `indexing time ${Date.now() - indexingStartTime}ms`)
+        }
     }
 
     public async retrieve({
@@ -103,11 +64,12 @@ export class BfgRetriever implements ContextRetriever {
             return []
         }
         await this.latestRepoIndexing
+
         const responses = await bfg.request('bfg/contextAtPosition', {
             uri: document.uri.toString(),
             content: (await vscode.workspace.openTextDocument(document.uri)).getText(),
             position: { line: position.line, character: position.character },
-            maxChars: hints.maxChars, // ignored by BFG server for now
+            maxChars: hints.maxChars,
             contextRange: docContext.contextRange,
         })
 
@@ -144,5 +106,52 @@ export class BfgRetriever implements ContextRetriever {
             bfg => bfg.request('bfg/shutdown', null),
             () => {}
         )
+    }
+
+    // We lazily load BFG to allow the Cody extension to finish activation as
+    // quickly as possible.
+    private loadBFG(): Promise<MessageHandler> {
+        // This is implemented as a custom promise instead of async/await so that we can reject
+        // the promise in the 'exit' handler if we fail to start the bfg process for some reason.
+        return new Promise<MessageHandler>((resolve, reject) => {
+            this.doLoadBFG(reject).then(
+                bfg => resolve(bfg),
+                error => reject(error)
+            )
+        })
+    }
+
+    private async doLoadBFG(reject: (reason?: any) => void): Promise<MessageHandler> {
+        const bfg = new MessageHandler()
+        const codyrpc = await downloadBfg(this.context)
+        if (!codyrpc) {
+            throw new Error(
+                'Failed to download BFG binary. To fix this problem, set the "cody.experimental.bfg.path" configuration to the path of your BFG binary'
+            )
+        }
+        const isVerboseDebug = vscode.workspace.getConfiguration().get<boolean>('cody.debug.verbose', false)
+        const child = child_process.spawn(codyrpc, { stdio: 'pipe', env: { VERBOSE_DEBUG: `${isVerboseDebug}` } })
+        child.stderr.on('data', chunk => {
+            if (isTesting) {
+                console.log(chunk.toString())
+            } else {
+                logDebug('BFG', 'stderr output', chunk.toString())
+            }
+        })
+        child.on('disconnect', () => reject())
+        child.on('close', () => reject())
+        child.on('error', error => reject(error))
+        child.on('exit', code => {
+            bfg.exit()
+            reject(code)
+        })
+        child.stderr.pipe(process.stdout)
+        child.stdout.pipe(bfg.messageDecoder)
+        bfg.messageEncoder.pipe(child.stdin)
+        await bfg.request('bfg/initialize', { clientName: 'vscode' })
+        for (const folder of vscode.workspace.workspaceFolders ?? []) {
+            await this.didOpenDocumentUri(folder.uri)
+        }
+        return bfg
     }
 }

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -7,8 +7,6 @@ import { MessageHandler } from '../../../../jsonrpc/jsonrpc'
 import { logDebug } from '../../../../log'
 import { ContextRetriever, ContextRetrieverOptions, ContextSnippet } from '../../../types'
 
-const isTesting = process.env.CODY_TESTING === 'true'
-
 export class BfgRetriever implements ContextRetriever {
     public identifier = 'bfg'
     private loadedBFG: Promise<MessageHandler>
@@ -132,11 +130,7 @@ export class BfgRetriever implements ContextRetriever {
         const isVerboseDebug = vscode.workspace.getConfiguration().get<boolean>('cody.debug.verbose', false)
         const child = child_process.spawn(codyrpc, { stdio: 'pipe', env: { VERBOSE_DEBUG: `${isVerboseDebug}` } })
         child.stderr.on('data', chunk => {
-            if (isTesting) {
-                console.log(chunk.toString())
-            } else {
-                logDebug('BFG', 'stderr output', chunk.toString())
-            }
+            logDebug('BFG', 'stderr', chunk.toString())
         })
         child.on('disconnect', () => reject())
         child.on('close', () => reject())

--- a/vscode/src/custom-prompts/ToolsProvider.ts
+++ b/vscode/src/custom-prompts/ToolsProvider.ts
@@ -10,8 +10,8 @@ import { logDebug, logError } from '../log'
 import { UserWorkspaceInfo } from './utils'
 import { outputWrapper } from './utils/helpers'
 
-const rootPath = vscode.workspace.workspaceFolders?.[0].uri.fsPath
-const currentFilePath = getActiveEditor()?.document.uri.fsPath
+const rootPath: () => string | undefined = () => vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath
+const currentFilePath: () => string | undefined = () => getActiveEditor()?.document.uri.fsPath
 const homePath = os.homedir() || process.env.HOME || process.env.USERPROFILE || ''
 const _exec = promisify(exec)
 /**
@@ -36,8 +36,8 @@ export class ToolsProvider {
         const appRoot = vscode.env.appRoot
         return {
             homeDir: homePath,
-            workspaceRoot: rootPath,
-            currentFilePath,
+            workspaceRoot: rootPath(),
+            currentFilePath: currentFilePath(),
             appRoot,
         }
     }
@@ -53,7 +53,7 @@ export class ToolsProvider {
      * Open a folder in the file explorer
      */
     public async openFolder(): Promise<void> {
-        await vscode.commands.executeCommand('vscode.openFolder', rootPath)
+        await vscode.commands.executeCommand('vscode.openFolder', rootPath())
     }
 
     /**
@@ -69,7 +69,7 @@ export class ToolsProvider {
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${homeDir}`)
         try {
             const { stdout, stderr } = await _exec(filteredCommand, {
-                cwd: runFromWSRoot ? rootPath : currentFilePath,
+                cwd: runFromWSRoot ? rootPath() : currentFilePath(),
                 encoding: 'utf8',
             })
             const output = stdout || stderr

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -11,7 +11,7 @@ import { logDebug } from '../../log'
 import { getOSArch } from '../../os'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
-const defaultBfgVersion = '5.2.4257'
+const defaultBfgVersion = '5.2.6637'
 
 export async function downloadBfg(context: vscode.ExtensionContext): Promise<string | null> {
     const config = vscode.workspace.getConfiguration()
@@ -64,8 +64,8 @@ export async function downloadBfg(context: vscode.ExtensionContext): Promise<str
     try {
         await vscode.window.withProgress(
             {
-                location: vscode.ProgressLocation.Notification,
-                title: 'Downloading BFG code graph utility',
+                location: vscode.ProgressLocation.Window,
+                title: 'Downloading context engine',
                 cancellable: false,
             },
             async progress => {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -148,6 +148,7 @@ export interface ClientCapabilities {
     completions?: 'none'
     //  When 'streaming', handles 'chat/updateMessageInProgress' streaming notifications.
     chat?: 'none' | 'streaming'
+    git?: 'none' | 'disabled'
 }
 
 export interface ServerInfo {

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -378,7 +378,7 @@ export class MessageHandler {
 /**
  * A client for a JSON-RPC {@link MessageHandler} running in the same process.
  */
-class InProcessClient {
+export class InProcessClient {
     constructor(
         private readonly requestHandlers: Map<RequestMethodName, RequestCallback<any>>,
         private readonly notificationHandlers: Map<NotificationMethodName, NotificationCallback<any>>

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -30,8 +30,12 @@ export abstract class SentryService {
     private prepareReconfigure(): void {
         try {
             const isProd = process.env.NODE_ENV === 'production'
+
             // Used to enable Sentry reporting in the development environment.
             const isSentryEnabled = process.env.ENABLE_SENTRY === 'true'
+            if (!isSentryEnabled) {
+                return
+            }
 
             const options: SentryOptions = {
                 dsn: SENTRY_DSN,
@@ -48,7 +52,7 @@ export abstract class SentryService {
                 // Only send errors when connected to dotcom in the production build.
                 beforeSend: (event, hint) => {
                     if (
-                        (isProd || isSentryEnabled) &&
+                        isProd &&
                         isDotCom(this.config.serverEndpoint) &&
                         shouldErrorBeReported(hint.originalException)
                     ) {

--- a/vscode/src/services/utils/workspace-action.ts
+++ b/vscode/src/services/utils/workspace-action.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-let workspaceRootUri = vscode.workspace.workspaceFolders?.[0].uri
+let workspaceRootUri = vscode.workspace.workspaceFolders?.[0]?.uri
 let serverEndpoint = ''
 
 export function workspaceActionsOnConfigChange(workspaceUri: vscode.Uri | null, endpoint?: string | null): void {


### PR DESCRIPTION
Previously, I didn't have a good way to test BFG alongside Cody. I just
manually started a local build of the extension, waited for indexing to
finish and triggered autocomplete. This PR fixes this problem by making
it easy to run Cody autocomplete in batch mode against any codebase by
adding a new `evaluate-autocomplete` subcommand. This new command made
it much easier for me to debug BFG and implement critical fixes. It also
makes it much easier to compare the difference between BFG and non-BFG
context.

## Test plan

```
pnpm install
pnpm build
cd agent
pnpm agent evaluate-autocomplete --workspace ~/dev/sourcegraph/bfg-private --queries ~/dev/sourcegraph/bfg-private/crates/bfg/queries/ --include-pattern crates/bfg/snapshots/input/typescript/main.ts --test-count 1 --snapshot-directory ~/dev/snapshots/bfg-suite
cat ~/dev/snapshots/bfg-suite/crates/bfg/snapshots/input/typescript/main.ts

...
  import { sayHello, arrayHello, objectHello, optionalHello } from "./pog";

  sayHello();
  arrayHello();
  objectHello();
//           ^^ reference { cool: { val: 1, otherVal: "hello" } }
  optionalHello();
```

Notice that the `^^ reference` line shows that Cody autocomplete picked up the graph context from BFG.


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
