### PR TITLE
fix: stop sidebar from opening on panels switch

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 - Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
 - Command: Fixed an issue that opened a new chat window when running `/doc` and `/edit` commands from the command palette. [pull/1678](https://github.com/sourcegraph/cody/pull/1678)
+- Chat: Prevent sidebar from opening when switching editor chat panels.
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,7 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Fixup: Updated the fixup create task to just use the previous command text. [pull/1615](https://github.com/sourcegraph/cody/pull/1615)
 - Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
 - Command: Fixed an issue that opened a new chat window when running `/doc` and `/edit` commands from the command palette. [pull/1678](https://github.com/sourcegraph/cody/pull/1678)
-- Chat: Prevent sidebar from opening when switching editor chat panels.
+- Chat: Prevent sidebar from opening when switching editor chat panels. [pull/1691](https://github.com/sourcegraph/cody/pull/1691)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -116,9 +116,16 @@ export class ChatPanelsManager implements vscode.Disposable {
     }
 
     private selectTreeItem(chatID: ChatID): void {
+        // no op if tree view is not visible
+        if (!this.treeView.visible) {
+            return
+        }
+
+        // Highlights the chat item in tree view
+        // This will also open the tree view (sidebar)
         const chat = this.treeViewProvider.getTreeItemByID(chatID)
         if (chat) {
-            void this.treeView?.reveal(chat, { select: true })
+            void this.treeView?.reveal(chat, { select: true, focus: false })
         }
     }
 


### PR DESCRIPTION
fix: Prevent sidebar from opening when switching editor panels

The chat panel switching logic was incorrectly opening the sidebar. 

This fixes it by not revealing chat item in tree view when sidebar is not visible. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before


https://github.com/sourcegraph/cody/assets/68532117/36da179f-a87b-4002-be2a-b0072d575074



### After

https://github.com/sourcegraph/cody/assets/68532117/48ee4a96-c72b-495c-a05b-2f5abeb16434


