### PR TITLE
refactor: move codeblock and workspace actions

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -35,6 +35,7 @@ import { getAccessToken, secretStorage, VSCodeSecretStorage } from './services/S
 import { createStatusBar } from './services/StatusBar'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
+import { workspaceActionsOnConfigChange } from './services/utils/workspace-action'
 import { TestSupport } from './test-support'
 
 /**
@@ -197,6 +198,7 @@ const register = async (
                     symfRunner.setSourcegraphAuth(authStatus.endpoint, token)
                 })
                 .catch(() => {})
+            workspaceActionsOnConfigChange(editor.getWorkspaceRootUri(), authStatus.endpoint)
         } else {
             symfRunner?.setSourcegraphAuth(null, null)
         }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -8,9 +8,9 @@ import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
 
 import { getSmartSelection } from '../editor/utils'
 import { logDebug } from '../log'
-import { countCode } from '../services/InlineAssist'
 import { telemetryService } from '../services/telemetry'
 import { telemetryRecorder } from '../services/telemetry-v2'
+import { countCode } from '../services/utils/code-count'
 
 import { computeDiff, Diff } from './diff'
 import { FixupCodeLenses } from './FixupCodeLenses'

--- a/vscode/src/services/InlineAssist.test.ts
+++ b/vscode/src/services/InlineAssist.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from 'vitest'
 import * as vscode from 'vscode'
 
-import { countCode, editDocByUri, matchCodeSnippets, updateRangeOnDocChange } from './InlineAssist'
+import { editDocByUri, updateRangeOnDocChange } from './InlineAssist'
 
 describe('UpdateRangeOnDocChange returns a new selection range by calculating lines of code changed in current docs', () => {
     it('Returns current Range if change occurs after the current selected range', () => {
@@ -62,59 +62,5 @@ describe('editDocByUri returns a new selection range by calculating lines of cod
         const content = 'foo\nbar\nfoo\nbar\nfoo'
         const range = await editDocByUri(uri, lines, content)
         expect(range).toEqual(new vscode.Range(1, 0, 4, 0))
-    })
-})
-
-describe('countCode', () => {
-    it('counts lines correctly', () => {
-        const code = `line1
-  line2
-  line3`
-        const result = countCode(code)
-        expect(result.lineCount).toBe(3)
-    })
-
-    it('counts characters correctly', () => {
-        const code = 'foo bar'
-        const result = countCode(code)
-        expect(result.charCount).toBe(7)
-    })
-
-    it('handles windows line endings', () => {
-        const code = 'line1\r\nline2\r\nline3'
-        const result = countCode(code)
-        expect(result.lineCount).toBe(3)
-    })
-
-    it('handles empty string', () => {
-        const code = ''
-        const result = countCode(code)
-        expect(result.lineCount).toBe(1)
-        expect(result.charCount).toBe(0)
-    })
-})
-
-describe('matchCodeSnippets', () => {
-    it('returns false if either input is empty', () => {
-        expect(matchCodeSnippets('', 'foo')).toBe(false)
-        expect(matchCodeSnippets('foo', '')).toBe(false)
-    })
-
-    it('returns true if inputs match without whitespace', () => {
-        const copied = 'foo\nbar'
-        const changed = 'foobar'
-        expect(matchCodeSnippets(copied, changed)).toBe(true)
-    })
-
-    it('returns false if inputs do not match without whitespace', () => {
-        const copied = 'foo\nbar'
-        const changed = 'foobaz'
-        expect(matchCodeSnippets(copied, changed)).toBe(false)
-    })
-
-    it('handles trailing whitespace correctly', () => {
-        const copied = 'foo '
-        const changed = 'foo'
-        expect(matchCodeSnippets(copied, changed)).toBe(true)
     })
 })

--- a/vscode/src/services/InlineAssist.ts
+++ b/vscode/src/services/InlineAssist.ts
@@ -52,25 +52,3 @@ export async function editDocByUri(
     await vscode.workspace.applyEdit(edit)
     return new vscode.Range(lines.start, 0, lines.start + lineDiff, 0)
 }
-
-export function countCode(code: string): { lineCount: number; charCount: number } {
-    const lineCount = code.split(/\r\n|\r|\n/).length
-    const charCount = code.length
-    return { lineCount, charCount }
-}
-
-/**
- * Handle edge cases for code snippets where code is not pasted correctly
- * or code is multiline and the formatting is changed on paste
- */
-export function matchCodeSnippets(copiedText: string, changedText: string): boolean {
-    if (!changedText || !copiedText) {
-        return false
-    }
-    // Code can be multiline, so we need to remove all new lines and spaces
-    // from the copied code and changed text as formatting on paste may change the spacing
-    const copiedTextNoSpace = copiedText.replaceAll(/\s/g, '')
-    const changedTextNoSpace = changedText?.replace(/\s/g, '')
-    // check if the copied code is the same as the changed text without spaces
-    return copiedTextNoSpace === changedTextNoSpace
-}

--- a/vscode/src/services/InlineController.ts
+++ b/vscode/src/services/InlineController.ts
@@ -8,8 +8,14 @@ import { getActiveEditor } from '../editor/active-editor'
 import { CodyTaskState } from '../non-stop/utils'
 
 import { CodeLensProvider } from './CodeLensProvider'
-import { countCode, editDocByUri, getIconPath, matchCodeSnippets, updateRangeOnDocChange } from './InlineAssist'
+import { editDocByUri, getIconPath, updateRangeOnDocChange } from './InlineAssist'
 import { telemetryService } from './telemetry'
+import {
+    isLastStoredCode,
+    onTextDocumentChange,
+    setLastStoredCode,
+    setLastTextFromClipboard,
+} from './utils/codeblock-action-tracker'
 
 const initPost = new vscode.Position(0, 0)
 const initRange = new vscode.Range(initPost, initPost)
@@ -55,11 +61,6 @@ export class InlineController implements VsCodeInlineController {
     // If a task is in progress, the editor will use the selection range tracked by the controller
     public isInProgress = false
     private codeLenses: Map<string, CodeLensProvider> = new Map()
-
-    // Track acceptance of generated code by Cody in Inline Chat
-    private lastCopiedCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '', requestID: '' }
-    private insertInProgress = false
-    private lastClipboardText = ''
 
     constructor(private extensionPath: string) {
         this.codyIcon = getIconPath('cody', this.extensionPath)
@@ -135,33 +136,14 @@ export class InlineController implements VsCodeInlineController {
             }
         })
 
-        // Track paste event - it checks if the copied text is part of the text string
+        // Track paste event for inline chat - it checks if the copied text is part of the text string
         vscode.workspace.onDidChangeTextDocument(async e => {
             const changedText = e.contentChanges[0]?.text
-            const { code, lineCount, charCount, eventName, source, requestID } = this.lastCopiedCode
-            const clipboardText = await vscode.env.clipboard.readText()
             // Skip if the document is not a file or if the copied text is from insert
-            if (!code || !changedText || e.document.uri.scheme !== 'file') {
+            if (!changedText || e.document.uri.scheme !== 'file') {
                 return
             }
-            // Skip logging paste even when the change event was triggered by insert
-            if (this.insertInProgress) {
-                this.insertInProgress = false
-                return
-            }
-            // the copied code should be the same as the clipboard text
-            if (matchCodeSnippets(code, clipboardText) && matchCodeSnippets(code, changedText)) {
-                const op = 'paste'
-                const eventType = eventName.startsWith('inlineChat') ? 'inlineChat' : 'keyDown'
-                // 'CodyVSCodeExtension:inlineChat:Paste:clicked' or 'CodyVSCodeExtension:keyDown:Paste:clicked'
-                telemetryService.log(`CodyVSCodeExtension:${eventType}:Paste:clicked`, {
-                    op,
-                    lineCount,
-                    charCount,
-                    source,
-                    requestID,
-                })
-            }
+            await onTextDocumentChange(changedText)
         })
 
         // Track clipboard text before a new inline chat is created
@@ -174,7 +156,7 @@ export class InlineController implements VsCodeInlineController {
             // get the last editor from the event list
             const editor = e.at(-1)
             if (editor?.document?.uri?.scheme === 'comment') {
-                this.lastClipboardText = await vscode.env.clipboard.readText()
+                await setLastTextFromClipboard()
             }
         })
 
@@ -307,41 +289,19 @@ export class InlineController implements VsCodeInlineController {
         // check if the text is copied from the code block on document change
         vscode.window.onDidChangeTextEditorSelection(async e => {
             const documentUri = e.textEditor.document.uri
-            const lastClipboardText = this.lastClipboardText
             if (e && documentUri?.fsPath === this.thread?.uri.fsPath) {
-                // check if the current range is within the selection range of the thread
                 const clipboardText = await vscode.env.clipboard.readText()
-                if (clipboardText === this.lastCopiedCode.code || clipboardText === lastClipboardText) {
+                if (isLastStoredCode(clipboardText)) {
                     return
                 }
                 // check if the clipboard text is part of the text string
                 if (groupedText.includes(clipboardText)) {
-                    this.lastClipboardText = clipboardText
+                    await setLastTextFromClipboard(clipboardText)
                     const eventName = 'inlineChat:Copy'
-                    this.setLastCopiedCode(clipboardText, eventName, 'inline-chat', commentID)
+                    setLastStoredCode(clipboardText, eventName, 'inline-chat', commentID)
                 }
             }
         })
-    }
-
-    public setLastCopiedCode(
-        code: string,
-        eventName: string,
-        source = '',
-        requestID = ''
-    ): { code: string; lineCount: number; charCount: number; eventName: string; source?: string; requestID?: string } {
-        // All non-copy events are considered as insertions since we don't need to listen for paste events
-        this.insertInProgress = !eventName.startsWith('copy')
-        const { lineCount, charCount } = countCode(code)
-        const codeCount = { code, lineCount, charCount, eventName, source, requestID }
-        this.lastCopiedCode = codeCount
-
-        // Currently supported events are: copy, insert, save
-        const op = eventName.includes('copy') ? 'copy' : eventName.startsWith('insert') ? 'insert' : 'save'
-
-        const args = { op, charCount, lineCount, source, requestID }
-        telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
-        return codeCount
     }
 
     public abort(): void {

--- a/vscode/src/services/utils/code-count.test.ts
+++ b/vscode/src/services/utils/code-count.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { countCode, matchCodeSnippets } from './code-count'
+
+describe('countCode', () => {
+    it('counts lines correctly', () => {
+        const code = `line1
+  line2
+  line3`
+        const result = countCode(code)
+        expect(result.lineCount).toBe(3)
+    })
+
+    it('counts characters correctly', () => {
+        const code = 'foo bar'
+        const result = countCode(code)
+        expect(result.charCount).toBe(7)
+    })
+
+    it('handles windows line endings', () => {
+        const code = 'line1\r\nline2\r\nline3'
+        const result = countCode(code)
+        expect(result.lineCount).toBe(3)
+    })
+
+    it('handles empty string', () => {
+        const code = ''
+        const result = countCode(code)
+        expect(result.lineCount).toBe(1)
+        expect(result.charCount).toBe(0)
+    })
+})
+
+describe('matchCodeSnippets', () => {
+    it('returns false if either input is empty', () => {
+        expect(matchCodeSnippets('', 'foo')).toBe(false)
+        expect(matchCodeSnippets('foo', '')).toBe(false)
+    })
+
+    it('returns true if inputs match without whitespace', () => {
+        const copied = 'foo\nbar'
+        const changed = 'foobar'
+        expect(matchCodeSnippets(copied, changed)).toBe(true)
+    })
+
+    it('returns false if inputs do not match without whitespace', () => {
+        const copied = 'foo\nbar'
+        const changed = 'foobaz'
+        expect(matchCodeSnippets(copied, changed)).toBe(false)
+    })
+
+    it('handles trailing whitespace correctly', () => {
+        const copied = 'foo '
+        const changed = 'foo'
+        expect(matchCodeSnippets(copied, changed)).toBe(true)
+    })
+})

--- a/vscode/src/services/utils/code-count.ts
+++ b/vscode/src/services/utils/code-count.ts
@@ -1,0 +1,21 @@
+export function countCode(code: string): { lineCount: number; charCount: number } {
+    const lineCount = code.split(/\r\n|\r|\n/).length
+    const charCount = code.length
+    return { lineCount, charCount }
+}
+
+/**
+ * Handle edge cases for code snippets where code is not pasted correctly
+ * or code is multiline and the formatting is changed on paste
+ */
+export function matchCodeSnippets(copiedText: string, text: string): boolean {
+    if (!text || !copiedText) {
+        return false
+    }
+    // Code can be multiline, so we need to remove all new lines and spaces
+    // from the copied code and changed text as formatting on paste may change the spacing
+    const copiedTextNoSpace = copiedText.replaceAll(/\s/g, '')
+    const textNoSpace = text?.replace(/\s/g, '')
+    // check if the copied code is the same as the changed text without spaces
+    return copiedTextNoSpace === textNoSpace
+}

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -1,0 +1,139 @@
+import * as vscode from 'vscode'
+
+import { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
+
+import { getActiveEditor } from '../../editor/active-editor'
+import { telemetryService } from '../telemetry'
+
+import { countCode, matchCodeSnippets } from './code-count'
+
+/**
+ * It tracks the last stored code snippet and metadata like lines, chars, event, source etc.
+ * This is used to track acceptance of generated code by Cody for Chat and Commands
+ */
+let lastStoredCode = { code: 'init', lineCount: 0, charCount: 0, eventName: '', source: '', requestID: '' }
+let insertInProgress = false
+let lastClipboardText = ''
+
+/**
+ * Sets the last stored code snippet and associated metadata.
+ *
+ * This is used to track code generation events in VS Code.
+ */
+export function setLastStoredCode(
+    code: string,
+    eventName: string,
+    source = 'chat',
+    requestID = ''
+): { code: string; lineCount: number; charCount: number; eventName: string; source?: string; requestID?: string } {
+    // All non-copy events are considered as insertions since we don't need to listen for paste events
+    insertInProgress = !eventName.includes('copy')
+    const { lineCount, charCount } = countCode(code)
+    const codeCount = { code, lineCount, charCount, eventName, source, requestID }
+
+    lastStoredCode = codeCount
+
+    // Currently supported events are: copy, insert, save
+    const op = eventName.includes('copy') ? 'copy' : eventName.startsWith('insert') ? 'insert' : 'save'
+    const args = { op, charCount, lineCount, source, requestID }
+
+    telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, args)
+
+    return codeCount
+}
+
+export async function setLastTextFromClipboard(clipboardText?: string): Promise<void> {
+    lastClipboardText = clipboardText || (await vscode.env.clipboard.readText())
+}
+
+/**
+ * Handles insert event to insert text from code block at cursor position
+ * Replace selection if there is one and then log insert event
+ * Note: Using workspaceEdit instead of 'editor.action.insertSnippet' as the later reformats the text incorrectly
+ */
+export async function handleCodeFromInsertAtCursor(text: string, meta?: CodeBlockMeta): Promise<void> {
+    const selectionRange = getActiveEditor()?.selection
+    const editor = getActiveEditor()
+    if (!editor || !selectionRange) {
+        throw new Error('No editor or selection found to insert text')
+    }
+
+    const edit = new vscode.WorkspaceEdit()
+    // trimEnd() to remove new line added by Cody
+    edit.insert(editor.document.uri, selectionRange.start, text + '\n')
+    await vscode.workspace.applyEdit(edit)
+
+    // Log insert event
+    const op = 'insert'
+    const eventName = op + 'Button'
+    setLastStoredCode(text, eventName, meta?.source, meta?.requestID)
+}
+
+/**
+ * Handles insert event to insert text from code block to new file
+ */
+export function handleCodeFromSaveToNewFile(text: string, meta?: CodeBlockMeta): void {
+    const eventName = 'saveButton'
+    setLastStoredCode(text, eventName, meta?.source, meta?.requestID)
+}
+
+/**
+ * Handles copying code and detecting a paste event.
+ */
+export async function handleCopiedCode(text: string, isButtonClickEvent: boolean, meta?: CodeBlockMeta): Promise<void> {
+    // If it's a Button event, then the text is already passed in from the whole code block
+    const copiedCode = isButtonClickEvent ? text : await vscode.env.clipboard.readText()
+    const eventName = isButtonClickEvent ? 'copyButton' : 'keyDown:Copy'
+    // Set for tracking
+    if (copiedCode) {
+        setLastStoredCode(copiedCode, eventName, meta?.source, meta?.requestID)
+    }
+}
+
+/**
+ * Checks if the provided code matches the last code stored from copy events.
+ */
+export function isLastStoredCode(code: string): boolean {
+    return code === lastStoredCode.code || code === lastClipboardText
+}
+
+/**
+ * Checks if the provided code matches the last code stored from copy events.
+ */
+export function matchCodeInStore(code: string): boolean {
+    if (insertInProgress) {
+        insertInProgress = false
+        return false
+    }
+    return matchCodeSnippets(code, lastClipboardText) && matchCodeSnippets(code, lastStoredCode.code)
+}
+
+// For tracking paste events for inline-chat
+export async function onTextDocumentChange(newCode: string): Promise<void> {
+    const { code, lineCount, charCount, source, requestID } = lastStoredCode
+
+    if (!code) {
+        return
+    }
+
+    if (insertInProgress) {
+        insertInProgress = false
+        return
+    }
+
+    await setLastTextFromClipboard()
+
+    // the copied code should be the same as the clipboard text
+    if (matchCodeSnippets(code, lastClipboardText) && matchCodeSnippets(code, newCode)) {
+        const op = 'paste'
+        const eventType = source.startsWith('inline') ? 'inlineChat' : 'keyDown'
+        // 'CodyVSCodeExtension:inlineChat:Paste:clicked' or 'CodyVSCodeExtension:keyDown:Paste:clicked'
+        telemetryService.log(`CodyVSCodeExtension:${eventType}:Paste:clicked`, {
+            op,
+            lineCount,
+            charCount,
+            source,
+            requestID,
+        })
+    }
+}

--- a/vscode/src/services/utils/workspace-action.ts
+++ b/vscode/src/services/utils/workspace-action.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode'
+
+let workspaceRootUri = vscode.workspace.workspaceFolders?.[0].uri
+let serverEndpoint = ''
+
+export function workspaceActionsOnConfigChange(workspaceUri: vscode.Uri | null, endpoint?: string | null): void {
+    if (workspaceUri) {
+        workspaceRootUri = workspaceUri
+    }
+    if (endpoint) {
+        serverEndpoint = endpoint
+    }
+}
+
+/**
+ * Open file in editor or in sourcegraph
+ */
+export async function openFilePath(filePath: string, currentViewColumn?: vscode.ViewColumn): Promise<void> {
+    void vscode.commands.executeCommand('vscode.open', filePath)
+    if (!workspaceRootUri) {
+        throw new Error('Failed to open file: missing workspace')
+    }
+
+    try {
+        const workspaceFileUri = vscode.Uri.joinPath(workspaceRootUri, filePath)
+        const doc = await vscode.workspace.openTextDocument(workspaceFileUri)
+
+        // Open file next to current webview panel column
+        let viewColumn = vscode.ViewColumn.Beside
+        if (currentViewColumn) {
+            viewColumn = currentViewColumn - 1 || currentViewColumn + 1
+        }
+
+        await vscode.window.showTextDocument(doc, { viewColumn, preserveFocus: false })
+    } catch {
+        // Try to open the file in the sourcegraph view
+        const sourcegraphSearchURL = new URL(`/search?q=context:global+file:${filePath}`, serverEndpoint).href
+        return openExternalLinks(sourcegraphSearchURL)
+    }
+}
+
+/**
+ * Open file in editor (assumed filePath is absolute) and optionally reveal a specific range
+ */
+export async function openLocalFileWithRange(filePath: string, range?: CodeRange): Promise<void> {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(filePath))
+    const selection = range
+        ? new vscode.Range(range.startLine, range.startCharacter, range.endLine, range.endCharacter)
+        : range
+    await vscode.window.showTextDocument(doc, { selection })
+}
+
+/**
+ * Open external links
+ */
+export async function openExternalLinks(uri: string): Promise<void> {
+    try {
+        await vscode.env.openExternal(vscode.Uri.parse(uri))
+    } catch (error) {
+        throw new Error(`Failed to open file: ${error}`)
+    }
+}
+
+interface CodeRange {
+    startLine: number
+    startCharacter: number
+    endLine: number
+    endCharacter: number
+}


### PR DESCRIPTION
refactor: move codeblock and workspace actions out of view providers (SidebaChatProvider and ChatPanelProvider)

This separates code block action and workspace files action handling from the SidebaChatProvider and ChatPanelProvider.

Currently they are duplicated.

Move codeblock action and workspace files handling to separate utils files. 
- Handle insert at cursor in `handleCodeFromInsertAtCursor`
- Handle save to new file in `handleCodeFromSaveToNewFile` 
- Handle copied code in `handleCopiedCode`

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Only move the handling to separate files. This should not change any existing functions or features.

- [ ] Confirm all code block actions are working
- [ ] Confirm all workspace actions are working