### PR TITLE
fix: error from new chat shortcut

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,7 +16,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
 - Command: Fixed an issue that opened a new chat window when running `/doc` and `/edit` commands from the command palette. [pull/1678](https://github.com/sourcegraph/cody/pull/1678)
 - Chat: Prevent sidebar from opening when switching editor chat panels. [pull/1691](https://github.com/sourcegraph/cody/pull/1691)
-- Chat: Prevent `"command 'cody.chat'panel.new' not found"` error when the new chat panel UI is disabled. [pull/1691](https://github.com/sourcegraph/cody/pull/1691)
+- Chat: Prevent `"command 'cody.chat'panel.new' not found"` error when the new chat panel UI is disabled. [pull/1696](https://github.com/sourcegraph/cody/pull/1696)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Opening files from the new chat panel will now show up beside the chat panel instead of on top of the chat panel. [pull/1677](https://github.com/sourcegraph/cody/pull/1677)
 - Command: Fixed an issue that opened a new chat window when running `/doc` and `/edit` commands from the command palette. [pull/1678](https://github.com/sourcegraph/cody/pull/1678)
 - Chat: Prevent sidebar from opening when switching editor chat panels. [pull/1691](https://github.com/sourcegraph/cody/pull/1691)
+- Chat: Prevent `"command 'cody.chat'panel.new' not found"` error when the new chat panel UI is disabled. [pull/1691](https://github.com/sourcegraph/cody/pull/1691)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -550,12 +550,12 @@
       {
         "command": "cody.chat.tree.view.focus",
         "key": "alt+f1",
-        "enablement": "cody.activated && config.cody.experimental.chatPanel"
+        "when": "cody.activated && config.cody.experimental.chatPanel"
       },
       {
         "command": "cody.chat.panel.new",
         "key": "alt+/",
-        "enablement": "cody.activated && config.cody.experimental.chatPanel"
+        "when": "cody.activated && config.cody.experimental.chatPanel"
       },
       {
         "command": "cody.command.edit-code",


### PR DESCRIPTION
fix: prevent "command not found" error when chat panel disabled

Update the keybinding enablement conditions to avoid invoking the command when the chat panel config is disabled. This fixes the "command not found" error that currently shows when invoking the keybinding while `cody.experimental.chatPanel` is false.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

#### Before

In the old chat UI, focus on the chat input box, and then press `alt` + `/` - you will see an error message pops up:

![image](https://github.com/sourcegraph/cody/assets/68532117/c2cfca0c-b533-4c68-a0ad-4659cf447f87)

#### After

Do the same thing as described above - you should not see the error message pop up again.