### PR TITLE
change chat panel view column to beside

### DIFF
--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -387,7 +387,7 @@ export class ChatPanelProvider extends MessageProvider {
         const panel = vscode.window.createWebviewPanel(
             viewType,
             panelTitle,
-            { viewColumn: vscode.ViewColumn.Two, preserveFocus: true },
+            { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
             {
                 enableScripts: true,
                 retainContextWhenHidden: true,


### PR DESCRIPTION
feat: change chat panel view column to beside

Change the default view column for the chat panel from Two to Beside.

This will always open the chat panel next to the current editor instead of panel two.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try creating a new chat panel, a new one should always opened next to your current active editor panel



https://github.com/sourcegraph/cody/assets/68532117/b07e3cc1-052b-4ea5-b6ce-1f7c4f881e35


