### PR TITLE
Autocomplete: Shift range when last candidate match is calculated

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -17,7 +17,8 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         lastTriggerSelectedCompletionInfo?: {
             text: string
             range: vscode.Range
-        }
+        },
+        range?: vscode.Range
     ): LastInlineCompletionCandidate {
         const { document, position } = documentAndPosition(code)
         const lastDocContext = getCurrentDocContext({
@@ -39,7 +40,9 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             result: {
                 logId: '1' as CompletionLogID,
                 source: InlineCompletionsResultSource.Network,
-                items: Array.isArray(insertText) ? insertText.map(insertText => ({ insertText })) : [{ insertText }],
+                items: Array.isArray(insertText)
+                    ? insertText.map(insertText => ({ insertText }))
+                    : [{ insertText, range }],
             },
             lastTriggerDocContext: lastDocContext,
         }
@@ -55,6 +58,18 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             )
         ).toEqual<V>({
             items: [{ insertText: '23' }],
+            source: InlineCompletionsResultSource.LastCandidate,
+        }))
+
+    it('updates the insertion range when typing forward as suggested', async () =>
+        expect(
+            await getInlineCompletions(
+                params('\nconst x = 1█;', [], {
+                    lastCandidate: lastCandidate('\nconst x = █;', '123', undefined, range(1, 10, 1, 10)),
+                })
+            )
+        ).toEqual<V>({
+            items: [{ insertText: '23', range: range(1, 11, 1, 11) }],
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -90,6 +90,20 @@ export function reuseLastCandidate({
                 lastCompletion.startsWith(currentLinePrefix) && position.isAfterOrEqual(lastTriggerPosition)
             if (isTypingAsSuggested) {
                 const remaining = lastCompletion.slice(currentLinePrefix.length)
+                const alreadyInsertedText = item.insertText.slice(0, -remaining.length)
+
+                // Shift the range by the already inserted characters to the right
+                const prevRange = item.range
+                let newRange
+                if (prevRange) {
+                    const rangeShift = alreadyInsertedText.length
+                    newRange = new vscode.Range(
+                        prevRange.start.line,
+                        prevRange.start.character + rangeShift,
+                        prevRange.end.line,
+                        prevRange.end.character + rangeShift
+                    )
+                }
 
                 // When the remaining text is empty, the user has forward-typed the full text of the
                 // completion. We mark this as an accepted completion.
@@ -116,7 +130,7 @@ export function reuseLastCandidate({
                     )
                 }
 
-                return { ...item, insertText: remaining }
+                return { ...item, insertText: remaining, range: newRange }
             }
 
             // Allow reuse if only the indentation (leading whitespace) has changed.


### PR DESCRIPTION
This fixes an issue where the insertion range was invalid when typing as suggested on a completion that has a same line suffix. 

The issue can be reproduced like this:

https://github.com/sourcegraph/cody/assets/458591/b40693ff-715c-4a2f-9893-76dcc37735c6

When typing new characters and reusing the last candidate, we have to shift the completion insertion range to match the new location.

This is not an issue with the indentation change logic when I tried it.

## Test plan


https://github.com/sourcegraph/cody/assets/458591/044f0f36-5738-4f7f-88d8-39b2b6f8ca3d




<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
