### PR TITLE
Autocomplete: Implement top-k retrieval mixing and make section history a retriever

### DIFF
--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode'
 
-import { logDebug } from '../../log'
 import { DocumentContext } from '../get-current-doc-context'
 import { ContextRetriever, ContextSnippet } from '../types'
 
 import { BfgRetriever } from './retrievers/bfg/bfg-retriever'
 import { JaccardSimilarityRetriever } from './retrievers/jaccard-similarity/jaccard-similarity-retriever'
-import { LspLightGraphCache } from './retrievers/lsp-light/lsp-light-graph-cache'
+import { LspLightRetriever } from './retrievers/lsp-light/lsp-light-retriever'
+import { SectionHistoryRetriever } from './retrievers/section-history/section-history-retriever'
 
 export interface GetContextOptions {
     document: vscode.TextDocument
@@ -16,13 +16,33 @@ export interface GetContextOptions {
     maxChars: number
 }
 
-export type ContextSummary = Readonly<{
-    strategy: string
-    embeddings?: number
-    local?: number
-    graph?: number
+export interface ContextSummary {
+    /** Name of the strategy being used */
+    strategy: ContextStrategy
+    /** Total duration of the context retrieval phase */
     duration: number
-}>
+    /** Total characters of combined context snippets */
+    totalChars: number
+    /** Detailed information for each retriever that has run */
+    retrieverStats: {
+        [identifier: string]: {
+            /** Number of items that are ended up being suggested to be used by the context mixer */
+            suggestedItems: number
+            /** Number of total snippets */
+            retrievedItems: number
+            /** Duration of the individual retriever */
+            duration: number
+            /**
+             * A bitmap that indicates at which position in the result set an entry from the given
+             * retriever is included. It only includes information about the first 32 entries.
+             *
+             * The lowest bit indicates if the first entry is included, the second lowest bit
+             * indicates if the second entry is included, and so on.
+             */
+            positionBitmap: number
+        }
+    }
+}
 
 export interface GetContextResult {
     context: ContextSnippet[]
@@ -36,131 +56,154 @@ export class ContextMixer implements vscode.Disposable {
     private localRetriever: ContextRetriever | undefined
     private graphRetriever: ContextRetriever | undefined
 
-    constructor(contextStrategy: ContextStrategy, createBfgRetriever?: () => BfgRetriever) {
-        if (contextStrategy !== 'none') {
-            this.localRetriever = new JaccardSimilarityRetriever()
-            this.disposables.push(this.localRetriever)
-        }
-
-        if (contextStrategy === 'bfg' && createBfgRetriever) {
-            this.graphRetriever = createBfgRetriever()
-            this.disposables.push(this.graphRetriever)
-        } else if (contextStrategy === 'lsp-light') {
-            this.graphRetriever = LspLightGraphCache.createInstance()
-            this.disposables.push(this.graphRetriever)
+    constructor(
+        private contextStrategy: ContextStrategy,
+        createBfgRetriever?: () => BfgRetriever
+    ) {
+        switch (contextStrategy) {
+            case 'none':
+                break
+            case 'bfg':
+                // The bfg strategy uses jaccard similarity as a fallback if no results are found or
+                // the language is not supported.
+                this.localRetriever = new JaccardSimilarityRetriever()
+                this.disposables.push(this.localRetriever)
+                if (createBfgRetriever) {
+                    this.graphRetriever = createBfgRetriever()
+                    this.disposables.push(this.graphRetriever)
+                }
+                break
+            case 'lsp-light':
+                this.localRetriever = SectionHistoryRetriever.createInstance()
+                this.graphRetriever = new LspLightRetriever()
+                this.disposables.push(this.localRetriever, this.graphRetriever)
+                break
+            case 'jaccard-similarity':
+                this.localRetriever = new JaccardSimilarityRetriever()
+                this.disposables.push(this.localRetriever)
+                break
         }
     }
 
-    // TODO: Generalize the retriever concept more. For now we branch off based on graph context
-    // usage or not to support the existing configuration options
     public async getContext(options: GetContextOptions): Promise<GetContextResult> {
-        if (this.graphRetriever?.isSupportedForLanguageId(options.document.languageId)) {
-            return this.getGraphContext(options)
-        }
-        return this.getLocalContext(options)
-    }
+        const retrievers: ContextRetriever[] = []
 
-    public async getLocalContext(options: GetContextOptions): Promise<GetContextResult> {
-        const { maxChars } = options
         const start = performance.now()
 
-        const localMatches =
-            (await this.localRetriever?.retrieve({
-                ...options,
-                hints: {
-                    maxChars: options.maxChars,
-                    maxMs: 150,
+        switch (this.contextStrategy) {
+            case 'none': {
+                break
+            }
+
+            // The lsp-light strategy mixes local and graph based retrievers
+            case 'lsp-light': {
+                if (this.graphRetriever && this.graphRetriever.isSupportedForLanguageId(options.document.languageId)) {
+                    retrievers.push(this.graphRetriever)
+                }
+                if (this.localRetriever) {
+                    retrievers.push(this.localRetriever)
+                }
+                break
+            }
+
+            // The bfg strategy only uses the graph based retriever and falls through to the local
+            // retriever if the graph based retriever is not available for the requested language.
+            case 'bfg':
+                if (this.graphRetriever && this.graphRetriever.isSupportedForLanguageId(options.document.languageId)) {
+                    retrievers.push(this.graphRetriever)
+                    break
+                }
+
+            case 'jaccard-similarity': {
+                if (this.localRetriever) {
+                    retrievers.push(this.localRetriever)
+                }
+                break
+            }
+        }
+
+        if (retrievers.length === 0) {
+            return {
+                context: [],
+                logSummary: {
+                    strategy: 'none',
+                    totalChars: 0,
+                    duration: 0,
+                    retrieverStats: {},
                 },
-            })) ?? []
-
-        /**
-         * Iterate over matches and add them to the context.
-         * Discard editor matches for files with embedding matches.
-         */
-        const usedFilenames = new Set<string>()
-        const context: ContextSnippet[] = []
-        let totalChars = 0
-        function addMatch(match: ContextSnippet): boolean {
-            // TODO(@philipp-spiess): We should de-dupe on the snippet range and not
-            // the file name to allow for more than one snippet of the same file
-            if (usedFilenames.has(match.fileName)) {
-                return false
-            }
-            usedFilenames.add(match.fileName)
-
-            if (totalChars + match.content.length > maxChars) {
-                return false
-            }
-            context.push(match)
-            totalChars += match.content.length
-            return true
-        }
-
-        let includedLocalMatches = 0
-        for (const match of localMatches) {
-            if (addMatch(match)) {
-                includedLocalMatches++
             }
         }
 
-        return {
-            context,
-            logSummary: {
-                strategy: 'local',
-                ...(includedLocalMatches ? { local: includedLocalMatches } : {}),
-                duration: performance.now() - start,
-            },
-        }
-    }
+        const results = await Promise.all(
+            retrievers.map(async retriever => {
+                const retrieverStart = performance.now()
+                const snippets = await retriever.retrieve({
+                    ...options,
+                    hints: {
+                        maxChars: options.maxChars,
+                        maxMs: 150,
+                    },
+                })
 
-    public async getGraphContext(options: GetContextOptions): Promise<GetContextResult> {
-        const retriever = this.graphRetriever
-
-        if (!retriever) {
-            throw new Error('getGraphContext called with undefined graph retriever')
-        }
-
-        const start = performance.now()
-        const graphMatches = await retriever.retrieve({
-            ...options,
-            hints: {
-                maxChars: options.maxChars,
-                maxMs: 150,
-            },
-        })
-
-        // TODO: Run local and graph retrievers in parallel and mix the results
-        if (graphMatches.length <= 0) {
-            return this.getLocalContext(options)
-        }
-
-        const context: ContextSnippet[] = []
-        let totalChars = 0
-        let includedGraphMatches = 0
-        for (const match of graphMatches) {
-            if (totalChars + match.content.length > options.maxChars) {
-                continue
-            }
-            context.push(match)
-            totalChars += match.content.length
-            includedGraphMatches++
-        }
-
-        logDebug(
-            'GraphContext:autocomplete',
-            `Added ${includedGraphMatches} graph matches for ${options.document.fileName}`,
-            { verbose: graphMatches }
+                return {
+                    identifier: retriever.identifier,
+                    duration: performance.now() - retrieverStart,
+                    snippets,
+                }
+            })
         )
 
+        const mixedContext: ContextSnippet[] = []
+        const retrieverStats: ContextSummary['retrieverStats'] = {}
+
+        const maxMatches = Math.max(...[...results.values()].map(r => r.snippets.length))
+
+        let totalChars = 0
+        let position = 0
+        for (let i = 0; i < maxMatches; i++) {
+            for (const { identifier, duration, snippets } of results) {
+                if (i >= snippets.length) {
+                    continue
+                }
+                const snippet = snippets[i]
+                if (totalChars + snippet.content.length > options.maxChars) {
+                    continue
+                }
+
+                mixedContext.push(snippet)
+                totalChars += snippet.content.length
+
+                if (!retrieverStats[identifier]) {
+                    retrieverStats[identifier] = {
+                        suggestedItems: 0,
+                        positionBitmap: 0,
+                        retrievedItems: snippets.length ?? 0,
+                        duration,
+                    }
+                }
+
+                retrieverStats[identifier].suggestedItems++
+                if (position < 32) {
+                    retrieverStats[identifier].positionBitmap |= 1 << position
+                }
+
+                position++
+            }
+        }
+
+        const logSummary: ContextSummary = {
+            strategy: this.contextStrategy,
+            duration: performance.now() - start,
+            totalChars,
+            retrieverStats,
+        }
+
         return {
-            context,
-            logSummary: {
-                strategy: retriever.identifier,
-                graph: includedGraphMatches,
-                duration: performance.now() - start,
-            },
+            context: mixedContext,
+            logSummary,
         }
     }
+
     public dispose(): void {
         this.disposables.forEach(disposable => disposable.dispose())
     }

--- a/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.test.ts
@@ -7,7 +7,7 @@ import { Position } from '../../../../testutils/mocks'
 import { range, withPosixPaths } from '../../../../testutils/textDocument'
 import { document } from '../../../test-helpers'
 
-import { LspLightGraphCache } from './lsp-light-graph-cache'
+import { LspLightRetriever } from './lsp-light-retriever'
 
 const document1Uri = URI.file('/document1.ts')
 const document2Uri = URI.file('/document2.ts')
@@ -16,13 +16,13 @@ const disposable = {
     dispose: () => {},
 }
 
-describe('LSPLightGraphCache', () => {
+describe('LspLightRetriever', () => {
     let testDocuments: {
         document1: vscode.TextDocument
         document2: vscode.TextDocument
     }
 
-    let cache: LspLightGraphCache
+    let retriever: LspLightRetriever
     let onDidChangeTextEditorSelection: any
     let onDidChangeTextDocument: any
     let getGraphContextFromRange: Mock
@@ -66,7 +66,7 @@ describe('LSPLightGraphCache', () => {
             .mockImplementation(() =>
                 Promise.resolve([{ symbolName: 'foo', content: ['foo(): void'], uri: document1Uri.toString() }])
             )
-        cache = LspLightGraphCache.createInstance(
+        retriever = new LspLightRetriever(
             {
                 // Mock VS Code event handlers so we can fire them manually
                 onDidChangeTextEditorSelection: (_onDidChangeTextEditorSelection: any) => {
@@ -80,19 +80,17 @@ describe('LSPLightGraphCache', () => {
                     return disposable
                 },
             },
-            getGraphContextFromRange,
-            null
+            getGraphContextFromRange
         )
     })
     afterEach(() => {
-        cache.dispose()
+        retriever.dispose()
     })
 
     it('calls the LSP for context of the current and previous lines', async () => {
-        await cache.retrieve({
+        await retriever.retrieve({
             document: testDocuments.document1,
             position: new Position(1, 0),
-            docContext: {},
             hints: { maxChars: 100 },
         })
 
@@ -131,10 +129,9 @@ describe('LSPLightGraphCache', () => {
 
         expect(
             withPosixPaths(
-                await cache.retrieve({
+                await retriever.retrieve({
                     document: testDocuments.document1,
                     position: new Position(1, 0),
-                    docContext: {},
                     hints: { maxChars: 100 },
                 })
             )
@@ -177,10 +174,9 @@ describe('LSPLightGraphCache', () => {
 
         expect(
             withPosixPaths(
-                await cache.retrieve({
+                await retriever.retrieve({
                     document: testDocuments.document1,
                     position: new Position(1, 0),
-                    docContext: {},
                     hints: { maxChars: 100 },
                 })
             )

--- a/vscode/src/completions/context/retrievers/section-history/section-history-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/section-history/section-history-retriever.test.ts
@@ -3,7 +3,7 @@ import { URI } from 'vscode-uri'
 
 import { range } from '../../../../testutils/textDocument'
 
-import { SectionObserver } from './section-observer'
+import { SectionHistoryRetriever } from './section-history-retriever'
 
 const document1Uri = URI.file('/document1.ts')
 const document2Uri = URI.file('/document2.ts')
@@ -29,7 +29,7 @@ describe('GraphSectionObserver', () => {
     let onDidChangeTextEditorSelection: any
     let onDidChangeTextDocument: any
     let getDocumentSections: Mock
-    let sectionObserver: SectionObserver
+    let sectionObserver: SectionHistoryRetriever
     beforeEach(async () => {
         testDocuments = {
             document1: {
@@ -56,7 +56,7 @@ describe('GraphSectionObserver', () => {
             return doc?.sections ?? []
         })
 
-        sectionObserver = SectionObserver.createInstance(
+        sectionObserver = SectionHistoryRetriever.createInstance(
             {
                 // Mock VS Code event handlers so we can fire them manually
                 onDidChangeVisibleTextEditors: (_onDidChangeVisibleTextEditors: any) => {
@@ -211,13 +211,14 @@ describe('GraphSectionObserver', () => {
                 └ file:/document2.ts baz"
             `)
 
-            const context = await sectionObserver.getLastVisitedSections(
-                testDocuments.document1 as any,
-                {
+            const context = await sectionObserver.retrieve({
+                document: testDocuments.document1 as any,
+                position: {
                     line: 0,
                     character: 0,
-                } as any
-            )
+                } as any,
+                docContext: { contextRange: range(0, 0, 20, 0) },
+            })
 
             expect(context[0]).toEqual({
                 content: 'foo\nbar\nfoo',
@@ -246,14 +247,14 @@ describe('GraphSectionObserver', () => {
                 └ file:/document1.ts foo"
             `)
 
-            const context = await sectionObserver.getLastVisitedSections(
-                testDocuments.document1 as any,
-                {
+            const context = await sectionObserver.retrieve({
+                document: testDocuments.document1 as any,
+                position: {
                     line: 0,
                     character: 0,
                 } as any,
-                range(0, 0, 20, 0)
-            )
+                docContext: { contextRange: range(0, 0, 20, 0) },
+            })
 
             expect(context.length).toBe(0)
         })

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -84,7 +84,9 @@ describe('[getInlineCompletions] completion event', () => {
                 "params": {
                   "completionIntent": "function.body",
                   "contextSummary": {
-                    "strategy": "local",
+                    "retrieverStats": {},
+                    "strategy": "none",
+                    "totalChars": 0,
                   },
                   "id": "stable-uuid",
                   "languageId": "typescript",
@@ -132,7 +134,9 @@ describe('[getInlineCompletions] completion event', () => {
                 "params": {
                   "completionIntent": "return_statement",
                   "contextSummary": {
-                    "strategy": "local",
+                    "retrieverStats": {},
+                    "strategy": "none",
+                    "totalChars": 0,
                   },
                   "id": "stable-uuid",
                   "languageId": "typescript",

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -5,8 +5,8 @@ import { renderMarkdown } from '@sourcegraph/cody-shared/src/common/markdown'
 
 import {
     registerDebugListener as registerSectionObserverDebugListener,
-    SectionObserver,
-} from '../context/retrievers/lsp-light/section-observer'
+    SectionHistoryRetriever,
+} from '../context/retrievers/section-history/section-history-retriever'
 import { InlineCompletionsResultSource } from '../get-inline-completions'
 import { InlineCompletionItemProvider } from '../inline-completion-item-provider'
 import * as statistics from '../statistics'
@@ -181,7 +181,7 @@ ${
 
 ${markdownCodeBlock(data.error)}
 `,
-        SectionObserver.instance
+        SectionHistoryRetriever.instance
             ? `
 ## Document sections
 
@@ -211,10 +211,10 @@ function statisticSummary(): string {
 }
 
 function documentSections(): string {
-    if (!SectionObserver.instance) {
+    if (!SectionHistoryRetriever.instance) {
         return ''
     }
-    return `\`\`\`\n${SectionObserver.instance.debugPrint()}\n\`\`\``
+    return `\`\`\`\n${SectionHistoryRetriever.instance.debugPrint()}\n\`\`\``
 }
 
 function codeDetailsWithSummary(
@@ -248,10 +248,10 @@ function markdownCodeBlock(value: string): string {
     return '```\n' + value.replaceAll('`', '\\`') + '\n```\n'
 }
 
-function markdownList(object: { [key: string]: string | number | boolean }): string {
+function markdownList(object: { [key: string]: any }): string {
     return Object.keys(object)
         .sort()
-        .map(key => `- ${key}: ${JSON.stringify(object[key as keyof typeof object])}`)
+        .map(key => `- ${key}: ${JSON.stringify(object[key as keyof typeof object], null, 2)}`)
         .join('\n')
 }
 


### PR DESCRIPTION
Some more retrieval improvements!

- Section history now implements the retrieval strategy and is now longer called transitively by the lsp light retriever. This will allow us to mix it with other results soon.
- The context mixer now does top-k mixing (not sure if this is the right terminology?): If more than one retrieval strategy is used, it will pick the top most results from every strategy and then follow on with the second rank, etc. For now this is only used in the `lsp-light` strategy that isn't used but the idea is that it will contain the highest ranked  lsp light result followed by the highest ranked section history and then the second highest ranked lsp light etc.
  - This is only temporary and we'll add more advanced strategies shortly. Again this only affects `lsp-light` strategy which is not rolled out right now.
- Overhauls the `contextSummary` logging to include a ton more information like:
  - Execution time of each retrieval strategy
  - Number of retrieved items and number of items included in the suggested context set
  - A bitmap that can be used to know which types of snippets are included, more on this below.
  - Total number of characters suggested for the request context (this may NOT be the exact prompt length but it can be used as a proxy for it)

## Position bitmap

Okay maybe this is over engineering but I do think we need to understand how the top snippets are composed when we start to experiment with snippet mixing. To do that, we can use bitmaps and setting the bit according to the position in the result set for every type to express the order.

Here's an example of retrieval stats for an `lsp-light` request that contains a total of 5 items.

```json
{
  "lsp-light":{
    "suggestedItems":4,
    "positionBitmap":29,
    "retrievedItems":4,
    "duration":123
  },
  "section-history":{
    "suggestedItems":1,
    "positionBitmap":2,
    "retrievedItems":1,
    "duration":123
  }
}
```
 
In binary, the `positionBitmap` for each strategy look like this:

- lsp-light: `11101`
- section-history: `00010`

Since the result is read from the lowest bit to the highest, we can see that the first item (right most bit) is from the lsp light set, the second entry from the section history and the remaining three from the lsp light set again.

## Test plan

### Jaccard similliarty still works

<img width="1468" alt="Screenshot 2023-11-09 at 17 08 40" src="https://github.com/sourcegraph/cody/assets/458591/76d30fd3-cd7f-47c6-8a1f-54e4fdf41652">

### lsp light works

<img width="2053" alt="Screenshot 2023-11-09 at 18 12 56" src="https://github.com/sourcegraph/cody/assets/458591/26782928-a93f-42b4-8e0a-36320fa55ed3">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
