### PR TITLE
Autocomplete: use streaming truncation for all completion requests

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -26,7 +26,6 @@ export enum FeatureFlag {
     CodyAutocompleteProviderLatency = 'cody-autocomplete-provider-latency',
     CodyAutocompleteDisableNetworkCache = 'cody-autocomplete-disable-network-cache',
     CodyAutocompleteDisableRecyclingOfPreviousRequests = 'cody-autocomplete-disable-recycling-of-previous-requests',
-    CodyAutocompleteDisableStreamingTruncation = 'cody-autocomplete-disable-streaming-truncation',
     CodyAutocompleteLowPerformanceDebounce = 'cody-autocomplete-low-performance-debounce',
 }
 

--- a/vscode/src/completions/can-use-partial-completion.ts
+++ b/vscode/src/completions/can-use-partial-completion.ts
@@ -34,12 +34,7 @@ export function canUsePartialCompletion(
     }
 
     // The last line might not be complete yet, so we discard it
-    const item = parseAndTruncateCompletion(partialResponse.slice(0, lastNewlineIndex), {
-        ...params,
-        // The tree-sitter-based truncation is disabled until the next-new-sibling approach is implemented.
-        // See: https://github.com/sourcegraph/cody/issues/1402
-        useTreeSitter: false,
-    })
+    const item = parseAndTruncateCompletion(partialResponse.slice(0, lastNewlineIndex), params)
 
     if (params.multiline) {
         return (item.lineTruncatedCount || 0) > 0 ? item : null

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -42,7 +42,6 @@ export interface InlineCompletionsParams {
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
-    disableStreamingTruncation?: boolean
 
     // Callbacks to accept completions
     handleDidAcceptCompletionItem?: (
@@ -163,7 +162,6 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         setIsLoading,
         abortSignal,
         tracer,
-        disableStreamingTruncation = false,
         handleDidAcceptCompletionItem,
         handleDidPartiallyAcceptCompletionItem,
     } = params
@@ -259,7 +257,6 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         triggerKind,
         providerConfig,
         docContext,
-        disableStreamingTruncation,
     })
     tracer?.({ completers: completionProviders.map(({ options }) => options) })
 
@@ -300,17 +297,15 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 interface GetCompletionProvidersParams
     extends Pick<InlineCompletionsParams, 'document' | 'position' | 'triggerKind' | 'providerConfig'> {
     docContext: DocumentContext
-    disableStreamingTruncation?: boolean
 }
 
 function getCompletionProviders(params: GetCompletionProvidersParams): Provider[] {
-    const { document, position, triggerKind, providerConfig, docContext, disableStreamingTruncation } = params
+    const { document, position, triggerKind, providerConfig, docContext } = params
 
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
         docContext,
         document,
         position,
-        disableStreamingTruncation: Boolean(disableStreamingTruncation),
     }
 
     if (docContext.multilineTrigger) {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -233,16 +233,10 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
 
         // We start feature flag requests early so that we have a high chance of getting a response
         // before we need it.
-        const [
-            isIncreasedDebounceTimeEnabledPromise,
-            syntacticTriggersPromise,
-            lowPerformanceDebouncePromise,
-            disableStreamingTruncation,
-        ] = [
+        const [isIncreasedDebounceTimeEnabledPromise, syntacticTriggersPromise, lowPerformanceDebouncePromise] = [
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteIncreasedDebounceTimeEnabled),
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteSyntacticTriggers),
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLowPerformanceDebounce),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDisableStreamingTruncation),
         ]
 
         const minLatencyFlagsPromises = {
@@ -333,7 +327,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 selectedCompletionInfo: context.selectedCompletionInfo,
                 docContext,
                 providerConfig: this.config.providerConfig,
-                disableStreamingTruncation: await disableStreamingTruncation,
                 contextMixer: this.contextMixer,
                 requestManager: this.requestManager,
                 lastCandidate: this.lastCandidate,

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -185,14 +185,12 @@ export class AnthropicProvider extends Provider {
                 const result = await client.complete(
                     params,
                     (incompleteResponse: CompletionResponse) => {
-                        if (!this.options.disableStreamingTruncation) {
-                            const processedCompletion = this.postProcess(incompleteResponse.completion)
-                            const completion = canUsePartialCompletion(processedCompletion, this.options)
+                        const processedCompletion = this.postProcess(incompleteResponse.completion)
+                        const completion = canUsePartialCompletion(processedCompletion, this.options)
 
-                            if (completion) {
-                                resolve({ ...completion, stopReason: 'streaming-truncation' })
-                                abortController.abort()
-                            }
+                        if (completion) {
+                            resolve({ ...completion, stopReason: 'streaming-truncation' })
+                            abortController.abort()
                         }
                     },
                     abortController.signal

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -232,14 +232,12 @@ ${intro}${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}
                 const result = await client.complete(
                     params,
                     (incompleteResponse: CompletionResponse) => {
-                        if (!this.options.disableStreamingTruncation) {
-                            const processedCompletion = this.postProcess(incompleteResponse.completion)
-                            const completion = canUsePartialCompletion(processedCompletion, this.options)
+                        const processedCompletion = this.postProcess(incompleteResponse.completion)
+                        const completion = canUsePartialCompletion(processedCompletion, this.options)
 
-                            if (completion) {
-                                resolve({ ...completion, stopReason: 'streaming-truncation' })
-                                abortController.abort()
-                            }
+                        if (completion) {
+                            resolve({ ...completion, stopReason: 'streaming-truncation' })
+                            abortController.abort()
                         }
                     },
                     abortController.signal

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -62,9 +62,6 @@ export interface ProviderOptions {
     multiline: boolean
     // Number of parallel LLM requests per completion.
     n: number
-
-    // Use indentation-based or tree-sitter-based truncation strategies to stop streaming early.
-    disableStreamingTruncation?: boolean
 }
 
 export abstract class Provider {

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -144,14 +144,12 @@ ${OPENING_CODE_TAG}${infillBlock}`
                 const result = await client.complete(
                     params,
                     (incompleteResponse: CompletionResponse) => {
-                        if (!this.options.disableStreamingTruncation) {
-                            const processedCompletion = this.postProcess(incompleteResponse.completion)
-                            const completion = canUsePartialCompletion(processedCompletion, this.options)
+                        const processedCompletion = this.postProcess(incompleteResponse.completion)
+                        const completion = canUsePartialCompletion(processedCompletion, this.options)
 
-                            if (completion) {
-                                resolve({ ...completion, stopReason: 'streaming-truncation' })
-                                abortController.abort()
-                            }
+                        if (completion) {
+                            resolve({ ...completion, stopReason: 'streaming-truncation' })
+                            abortController.abort()
                         }
                     },
                     abortController.signal

--- a/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
+++ b/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
@@ -12,7 +12,6 @@ export interface ParseAndTruncateParams {
     position: Position
     docContext: DocumentContext
     multiline: boolean
-    useTreeSitter?: boolean
 }
 
 export function parseAndTruncateCompletion(
@@ -24,7 +23,6 @@ export function parseAndTruncateCompletion(
         multiline,
         docContext,
         docContext: { prefix },
-        useTreeSitter = true,
     } = params
 
     const insertTextBeforeTruncation = multiline ? normalizeStartLine(completion, prefix) : completion
@@ -44,7 +42,6 @@ export function parseAndTruncateCompletion(
             parsed,
             document,
             docContext,
-            useTreeSitter,
         })
 
         const initialLineCount = insertTextBeforeTruncation.split('\n').length
@@ -62,7 +59,6 @@ interface TruncateMultilineBlockParams {
     parsed: ParsedCompletion
     docContext: DocumentContext
     document: TextDocument
-    useTreeSitter: boolean
 }
 
 interface TruncateMultilineBlockResult {
@@ -71,9 +67,9 @@ interface TruncateMultilineBlockResult {
 }
 
 export function truncateMultilineBlock(params: TruncateMultilineBlockParams): TruncateMultilineBlockResult {
-    const { parsed, docContext, document, useTreeSitter } = params
+    const { parsed, docContext, document } = params
 
-    if (useTreeSitter && parsed.tree) {
+    if (parsed.tree) {
         return {
             truncatedWith: 'tree-sitter',
             insertText: truncateParsedCompletionByNextSibling({

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.ts
@@ -70,7 +70,7 @@ export function truncateParsedCompletionByNextSibling(context: CompletionContext
 
     const { insertText, points } = completion
 
-    const queryStart = points?.trigger || points?.start
+    const queryStart = points?.trigger || points.start
     const nodeToInsert = findChildBeforeTheNewSibling(
         parsedFirstLine.tree.rootNode,
         completion.tree.rootNode,
@@ -112,6 +112,12 @@ function findChildBeforeTheNewSibling(
 
     for (let i = 0; i < PARENTS_TO_CHECK; i++) {
         if (!currentNode?.parent || !prevNode?.parent) {
+            // If we are already at the tip of the tree, check if the current node
+            // has the updated number of children.
+            if (prevNode?.childCount !== currentNode?.childCount) {
+                return currentNode
+            }
+
             break
         }
 


### PR DESCRIPTION
## Context 

- Removed the `cody-autocomplete-disable-streaming-truncation` feature flag.
- Changed the multiline truncation cache, which enhances performance by eliminating the need to re-parse the first line for each new line received in a completion.
- Follow-up for https://github.com/sourcegraph/cody/pull/1709/
- Part of https://github.com/sourcegraph/cody/issues/1402

## Test plan

Unit tests + local manual testing.
