### PR TITLE
Autocomplete: do not trigger the partial response callback when the request is aborted

### DIFF
--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -131,6 +131,10 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
 
                 for await (const chunk of iterator) {
                     if (chunk.event === 'completion') {
+                        if (signal?.aborted) {
+                            break // Stop processing the already received chunks.
+                        }
+
                         lastResponse = JSON.parse(chunk.data) as CompletionResponse
                         onPartialResponse?.(lastResponse)
                     }


### PR DESCRIPTION
## Context

- There's no need to process the already received completion chunks if the signal is aborted (it means we already received the completion that we can show to the user).

## Test plan

CI
