### PR TITLE
Chat/Commands: Remove LLM reranker for repos without embeddings

### DIFF
--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -16,7 +16,6 @@ import { getFullConfig } from '../configuration'
 import { VSCodeEditor } from '../editor/vscode-editor'
 import { PlatformContext } from '../extension.common'
 import { logDebug } from '../log'
-import { getRerankWithLog } from '../logged-rerank'
 import { repositoryRemoteUrl } from '../repository/repositoryHelpers'
 import { AuthProvider } from '../services/AuthProvider'
 import { secretStorage } from '../services/SecretStorageProvider'
@@ -332,7 +331,6 @@ async function getCodebaseContext(
         rgPath ? platform.createFilenameContextFetcher?.(rgPath, editor, chatClient) ?? null : null,
         new GraphContextProvider(editor),
         symf,
-        undefined,
-        getRerankWithLog(chatClient)
+        undefined
     )
 }

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -14,7 +14,6 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 import { CodeCompletionsClient, createClient as createCodeCompletionsClint } from './completions/client'
 import { PlatformContext } from './extension.common'
 import { logDebug, logger } from './log'
-import { getRerankWithLog } from './logged-rerank'
 
 interface ExternalServices {
     intentDetector: IntentDetector
@@ -75,8 +74,7 @@ export async function configureExternalServices(
         rgPath ? platform.createFilenameContextFetcher?.(rgPath, editor, chatClient) ?? null : null,
         null,
         symf,
-        undefined,
-        getRerankWithLog(chatClient)
+        undefined
     )
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient)


### PR DESCRIPTION
Part of https://github.com/sourcegraph/cody/issues/1544
Part of https://github.com/sourcegraph/cody/issues/1464

## Description

The LLM reranker adds a significant amount of latency to reranking any fetched context. This applies to all commands, chat and edits. The latency is typically between 2-5 seconds.

This PR just disables the reranker for now.

I think this is worth doing as:
- The added latency from the reranker is not worth the possible benefit right now. It still can sometimes rerank poorly and doesn't provide enough value to justify waiting that long.
- Context doesn't have a constant value, in many cases context will provide little value (e.g. simple fixups) in some cases, like chat, context would provide a lot more value. We don't have a way of determining that right now, so we're often adding lots of latency for no good reason.

I created an issue here: https://github.com/sourcegraph/cody/issues/1721 to evaluate a different or improved approach. Possible details there on how we could improve this.
 
## Test plan

On a repository without embeddings, run:
- Chat
- Commands
- Edits

Review results and context included.