### PR TITLE
BFG: correctly load git repositories

### DIFF
--- a/agent/src/bfg/BfgContextFetcher.test.ts
+++ b/agent/src/bfg/BfgContextFetcher.test.ts
@@ -9,11 +9,10 @@ import * as rimraf from 'rimraf'
 import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
-import { BfgRetriever } from '../../../vscode/src/completions/context/retrievers/bfg/bfg-retriever'
+import { bfgIndexingPromise, BfgRetriever } from '../../../vscode/src/completions/context/retrievers/bfg/bfg-retriever'
 import { getCurrentDocContext } from '../../../vscode/src/completions/get-current-doc-context'
 import { initTreeSitterParser } from '../../../vscode/src/completions/test-helpers'
-import { Agent, initializeVscodeExtension } from '../agent'
-import { MessageHandler } from '../jsonrpc-alias'
+import { initializeVscodeExtension, newEmbeddedAgentClient } from '../agent'
 import * as vscode_shim from '../vscode-shim'
 
 const exec = util.promisify(child_process.exec)
@@ -55,35 +54,38 @@ describe('BfgRetriever', async () => {
     afterAll(async () => {
         if (shouldCreateGitDir) {
             await rimraf.rimraf(gitdir)
-            // rimraf.rimrafSync(tmpDir)
         }
     })
 
-    const agent = new Agent()
-
-    const debugHandler = new MessageHandler()
-    debugHandler.registerNotification('debug/message', params => console.log(`${params.channel}: ${params.message}`))
-    debugHandler.messageEncoder.pipe(agent.messageDecoder)
-    agent.messageEncoder.pipe(debugHandler.messageDecoder)
+    const rootUri = vscode.Uri.from({ scheme: 'file', path: gitdir })
+    vscode_shim.addGitRepository(rootUri, 'asdf')
+    const agent = await newEmbeddedAgentClient({
+        name: 'BfgContextFetcher',
+        version: '0.1.0',
+        workspaceRootUri: rootUri.toString(),
+    })
+    const client = agent.clientForThisInstance()
 
     const filePath = path.join(dir, testFile)
     const content = await fspromises.readFile(filePath, 'utf8')
     const CURSOR = '/*CURSOR*/'
     it('returns non-empty context', async () => {
-        const gitdirUri = vscode.Uri.from({ scheme: 'file', path: gitdir })
         if (bfgCratePath) {
             const bfgBinary = path.join(bfgCratePath, '..', '..', 'target', 'debug', 'bfg')
             vscode_shim.customConfiguration['cody.experimental.bfg.path'] = bfgBinary
         }
         const extensionContext: Partial<vscode.ExtensionContext> = {
+            subscriptions: [],
             globalStorageUri: vscode.Uri.from({ scheme: 'file', path: tmpDir }),
         }
-        agent.workspace.addDocument({
+        client.notify('textDocument/didOpen', {
             filePath,
             content: content.replace(CURSOR, ''),
         })
 
-        const bfg = new BfgRetriever(extensionContext as vscode.ExtensionContext, () => gitdirUri)
+        const bfg = new BfgRetriever(extensionContext as vscode.ExtensionContext)
+
+        await bfgIndexingPromise
 
         const document = agent.workspace.agentTextDocument({ filePath })
         assert(document.getText().length > 0)
@@ -99,19 +101,14 @@ describe('BfgRetriever', async () => {
 
         expect(actual).toMatchInlineSnapshot([
             {
-                content: 'distance(a: Point, b: Point)',
-                fileName: 'Point.ts',
-                symbol: 'scip-ctags . . . distance().',
-            },
-            {
-                content: "import { distance } from './Point'",
-                fileName: 'main.ts',
-                symbol: 'scip-ctags . . . distance.',
+                content: 'function distance(a: Point, b: Point): number  { ... }',
+                fileName: 'src/Point.ts',
+                symbol: 'scip-ctags . . . src/`Point.ts`/distance().',
             },
             {
                 content: 'interface Point {\n    x: number\n    y: number\n}',
-                fileName: 'Point.ts',
-                symbol: 'scip-ctags . . . Point#',
+                fileName: 'src/Point.ts',
+                symbol: 'scip-ctags . . . src/`Point.ts`/Point#',
             },
         ])
     })

--- a/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
@@ -85,7 +85,7 @@ export const evaluateAutocompleteCommand = new Command('evaluate-autocomplete')
         }
 
         const workspaceRootUri = Uri.from({ scheme: 'file', path: workspace })
-        const client = await newEmbeddedAgentClient({
+        const agent = await newEmbeddedAgentClient({
             name: 'evaluate-autocomplete',
             version: '0.1.0',
             workspaceRootUri: workspaceRootUri.toString(),
@@ -95,6 +95,7 @@ export const evaluateAutocompleteCommand = new Command('evaluate-autocomplete')
                 customHeaders: {},
             },
         })
+        const client = agent.clientForThisInstance()
         try {
             await runEvalution(client, options, workspace)
         } catch (error) {
@@ -187,6 +188,8 @@ async function runEvalution(
             const input = new Input(filePath, content)
             const snapshot = formatSnapshot(input, document)
             await fspromises.writeFile(outputPath, snapshot)
+        } else if (options.snapshotDirectory) {
+            console.error(`Empty autocomplete: ${document.relative_path}`)
         }
     }
 }

--- a/agent/src/cli/root.ts
+++ b/agent/src/cli/root.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander'
 
-import { evaluateAutocompleteCommand } from './evaluate-autocomplete/evalaute-autocomplete'
+import { evaluateAutocompleteCommand } from './evaluate-autocomplete/evaluate-autocomplete'
 import { jsonrpcCommand } from './jsonrpc'
 
 export const rootCommand = new Command()

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -232,6 +232,7 @@ export function setAgent(newAgent: Agent): void {
 }
 
 const _window: Partial<typeof vscode.window> = {
+    createTreeView: () => ({ visible: false }) as any,
     tabGroups,
     registerCustomEditorProvider: () => emptyDisposable,
     registerFileDecorationProvider: () => emptyDisposable,
@@ -305,6 +306,28 @@ const _window: Partial<typeof vscode.window> = {
 }
 
 export const window = _window as typeof vscode.window
+const gitRepositories: Repository[] = []
+export function addGitRepository(uri: vscode.Uri, headCommit: string): void {
+    const repository: Partial<Repository> = {
+        rootUri: uri,
+        ui: {} as any,
+        state: {
+            refs: [],
+            indexChanges: [],
+            mergeChanges: [],
+            onDidChange: emptyEvent(),
+            remotes: [],
+            submodules: [],
+            workingTreeChanges: [],
+            rebaseCommit: undefined,
+            HEAD: {
+                type: /* RefType.Head */ 0, // Can't reference RefType.Head because it's from a d.ts file
+                commit: headCommit,
+            },
+        },
+    }
+    gitRepositories.push(repository as Repository)
+}
 
 const gitExtension: Partial<vscode.Extension<GitExtension>> = {
     isActive: true,
@@ -313,6 +336,11 @@ const gitExtension: Partial<vscode.Extension<GitExtension>> = {
         onDidChangeEnablement: emptyEvent(),
         getAPI(version) {
             const api: Partial<API> = {
+                repositories: gitRepositories,
+                onDidChangeState: emptyEvent(),
+                onDidCloseRepository: emptyEvent(),
+                onDidOpenRepository: emptyEvent(),
+                onDidPublish: emptyEvent(),
                 getRepository(uri) {
                     const cwd = workspaceDocuments?.workspaceRootUri?.fsPath
                     if (!cwd) {

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -5,18 +5,22 @@ import * as vscode from 'vscode'
 import { downloadBfg } from '../../../../graph/bfg/download-bfg'
 import { MessageHandler } from '../../../../jsonrpc/jsonrpc'
 import { logDebug } from '../../../../log'
+import { Repository } from '../../../../repository/builtinGitExtension'
+import { gitAPI } from '../../../../repository/repositoryHelpers'
 import { ContextRetriever, ContextRetrieverOptions, ContextSnippet } from '../../../types'
+
+// This promise is only used for testing purposes. We don't await on the
+// indexing request during autocomplete because we want autocomplete to respond
+// quickly even while BFG is indexing.
+export let bfgIndexingPromise = Promise.resolve<void>(undefined)
 
 export class BfgRetriever implements ContextRetriever {
     public identifier = 'bfg'
     private loadedBFG: Promise<MessageHandler>
     private didFailLoading = false
-    private latestRepoIndexing: Promise<void[]> = Promise.resolve([])
-    private indexedGitDirectories = new Set<string>()
-    constructor(
-        private context: vscode.ExtensionContext,
-        private gitDirectoryUri: (uri: vscode.Uri) => vscode.Uri | undefined
-    ) {
+    // Keys are repository URIs, values are revisions (commit hashes).
+    private indexedRepositoryRevisions = new Map<string, string>()
+    constructor(private context: vscode.ExtensionContext) {
         this.loadedBFG = this.loadBFG()
 
         this.loadedBFG.then(
@@ -27,24 +31,36 @@ export class BfgRetriever implements ContextRetriever {
             }
         )
 
-        this.latestRepoIndexing = Promise.all(
-            vscode.window.visibleTextEditors.map(textEditor => this.didOpenDocumentUri(textEditor.document.uri))
-        )
-        vscode.workspace.onDidOpenTextDocument(document => this.didOpenDocumentUri(document.uri))
+        bfgIndexingPromise = this.indexOpenGitRepositories()
     }
 
-    private async didOpenDocumentUri(uri: vscode.Uri): Promise<void> {
-        if (this.didFailLoading) {
+    private async indexOpenGitRepositories(): Promise<void> {
+        const git = gitAPI()
+        if (!git) {
             return
         }
-        const gitdir = this.gitDirectoryUri(uri)?.toString()
-        if (gitdir && !this.indexedGitDirectories.has(gitdir)) {
-            this.indexedGitDirectories.add(gitdir)
-            const bfg = await this.loadedBFG
-            const indexingStartTime = Date.now()
-            await bfg.request('bfg/gitRevision/didChange', { gitDirectoryUri: gitdir })
-            logDebug('BFG', `indexing time ${Date.now() - indexingStartTime}ms`)
+        for (const repository of git.repositories) {
+            await this.onDidChangeRepository(repository)
         }
+        this.context.subscriptions.push(git.onDidOpenRepository(repository => this.onDidChangeRepository(repository)))
+        // TODO: handle closed repositories
+    }
+
+    private async onDidChangeRepository(repository: Repository): Promise<void> {
+        const uri = repository.rootUri.toString()
+        const head = repository?.state?.HEAD?.commit
+        if (head !== this.indexedRepositoryRevisions.get(uri)) {
+            this.indexedRepositoryRevisions.set(uri, head ?? '')
+            await this.indexRepository(repository)
+        }
+    }
+
+    private async indexRepository(repository: Repository): Promise<void> {
+        const bfg = await this.loadedBFG
+        const indexingStartTime = Date.now()
+        // TODO: include commit?
+        await bfg.request('bfg/gitRevision/didChange', { gitDirectoryUri: repository.rootUri.toString() })
+        logDebug('BFG', `indexing time ${Date.now() - indexingStartTime}ms`)
     }
 
     public async retrieve({
@@ -61,7 +77,6 @@ export class BfgRetriever implements ContextRetriever {
             logDebug('BFG', 'BFG is not alive')
             return []
         }
-        await this.latestRepoIndexing
 
         const responses = await bfg.request('bfg/contextAtPosition', {
             uri: document.uri.toString(),
@@ -143,9 +158,6 @@ export class BfgRetriever implements ContextRetriever {
         child.stdout.pipe(bfg.messageDecoder)
         bfg.messageEncoder.pipe(child.stdin)
         await bfg.request('bfg/initialize', { clientName: 'vscode' })
-        for (const folder of vscode.workspace.workspaceFolders ?? []) {
-            await this.didOpenDocumentUri(folder.uri)
-        }
         return bfg
     }
 }

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -16,7 +16,6 @@ import { initializeNetworkAgent, setCustomAgent } from './fetch.node'
 import { FilenameContextFetcher } from './local-context/filename-context-fetcher'
 import { LocalKeywordContextFetcher } from './local-context/local-keyword-context-fetcher'
 import { SymfRunner } from './local-context/symf'
-import { gitDirectoryUri } from './repository/repositoryHelpers'
 import { getRgPath } from './rg'
 import { NodeSentryService } from './services/sentry/sentry.node'
 
@@ -34,7 +33,7 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
         createFilenameContextFetcher: (...args) => new FilenameContextFetcher(...args),
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createSymfRunner: (...args) => new SymfRunner(...args),
-        createBfgRetriever: () => new BfgRetriever(context, gitDirectoryUri),
+        createBfgRetriever: () => new BfgRetriever(context),
         createSentryService: (...args) => new NodeSentryService(...args),
 
         // Include additional recipes that require Node packages (such as `child_process`).

--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -26,7 +26,7 @@ function gitRepositoryRemoteUrl(uri: vscode.Uri): string | undefined {
     }
 }
 
-function gitAPI(): API | undefined {
+export function gitAPI(): API | undefined {
     const extension = vscode.extensions.getExtension<GitExtension>('vscode.git')
     if (!extension) {
         console.warn('Git extension not available')


### PR DESCRIPTION
Previously, we tried to infer the git repository based on open documents. This logic was brittle causing BFG to not pick up repositories when it should. This PR replaces this logic with direct calls to the git extension, which gives us access to this information directly.


## Test plan

See updated `BfgContextFetcher.test.ts`. I also manually tested that BFG is loaded when running the new autocomplete evaluation.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
