### PR TITLE
fix: handle @ files with start line 0

### DIFF
--- a/lib/shared/src/chat/prompts/display-text.test.ts
+++ b/lib/shared/src/chat/prompts/display-text.test.ts
@@ -43,6 +43,14 @@ describe('replaceFileNameWithMarkdownLink', () => {
         expect(result).toEqual('Error in [_@test.js_](vscode://file/path/test.js:10)')
     })
 
+    it('handles edge case where start line at 0 - exclude start line in markdown link', () => {
+        const text = 'Error in @test.js'
+
+        const result = replaceFileNameWithMarkdownLink(text, '@test.js', '/path/test.js', 0)
+
+        expect(result).toEqual('Error in [_@test.js_](vscode://file/path/test.js)')
+    })
+
     it('handles names that showed up more than once', () => {
         const text = 'Compare and explain @foo.js and @bar.js. What does @foo.js do?'
 

--- a/lib/shared/src/chat/prompts/display-text.ts
+++ b/lib/shared/src/chat/prompts/display-text.ts
@@ -37,7 +37,7 @@ export function createDisplayTextWithFileSelection(
     const displayText = `${humanInput} @${fileName}`
     const fsPath = selection?.fileUri?.fsPath
     const startLine = selection?.selectionRange?.start?.line
-    if (!fsPath || !startLine) {
+    if (!fsPath || !selection?.selectionRange?.end?.line) {
         return displayText
     }
 
@@ -60,10 +60,7 @@ export function replaceFileNameWithMarkdownLink(
     const fileLink = `vscode://file${fsPath}${range}`
     const markdownText = `[_${fileName.trim()}_](${fileLink})`
 
-    // Escape special characters in fileName for regex
-    const escapedFileName = fileName.replaceAll(/[$()*+./?[\\\]^{|}-]/g, '\\$&')
-
-    // Updated regex to match the file name with optional line number, range, and symbol name
-    const textToBeReplaced = new RegExp(`(${escapedFileName})(:\\d+(-\\d+)?(#\\S+)?)?(?!\\S)`, 'g')
-    return humanInput.replaceAll(textToBeReplaced, markdownText).trim()
+    // Use regex to makes sure the file name is surrounded by spaces and not a substring of another file name
+    const textToBeReplaced = new RegExp(`\\s*${fileName.replaceAll(/[$()*+./?[\\\]^{|}-]/g, '\\$&')}(?!\\S)`, 'g')
+    return humanInput.replaceAll(textToBeReplaced, ` ${markdownText}`).trim()
 }


### PR DESCRIPTION
The file link markdown generation was previously erroring when the start line was 0. This fixes it by checking for a valid end line instead of start line.

Also simplifies the regex used to replace the file name with a markdown link.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Added new test for  edge case error when generating markdown links for selections starting at line 0.