### PR TITLE
BFG: rename `bfg` binary name into `cody-engine`

### DIFF
--- a/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
@@ -121,7 +121,7 @@ async function runEvalution(
     vscode_shim.customConfiguration['cody.autocomplete.advanced.model'] = 'starcoder-7b'
     vscode_shim.customConfiguration['cody.debug.verbose'] = 'true'
     if (options.bfgBinary) {
-        vscode_shim.customConfiguration['cody.experimental.bfg.path'] = options.bfgBinary
+        vscode_shim.customConfiguration['cody.experimental.cody-engine.path'] = options.bfgBinary
     }
     const queries = new Queries(options.queries)
     const grammarDirectory = path.normalize(options.treeSitterGrammars)

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -27,7 +27,7 @@ export class BfgRetriever implements ContextRetriever {
             () => {},
             error => {
                 this.didFailLoading = true
-                logDebug('BFG', 'failed to initialize', error)
+                logDebug('CodyEngine', 'failed to initialize', error)
             }
         )
 
@@ -60,7 +60,7 @@ export class BfgRetriever implements ContextRetriever {
         const indexingStartTime = Date.now()
         // TODO: include commit?
         await bfg.request('bfg/gitRevision/didChange', { gitDirectoryUri: repository.rootUri.toString() })
-        logDebug('BFG', `indexing time ${Date.now() - indexingStartTime}ms`)
+        logDebug('CodyEngine', `indexing time ${Date.now() - indexingStartTime}ms`)
     }
 
     public async retrieve({
@@ -74,7 +74,7 @@ export class BfgRetriever implements ContextRetriever {
         }
         const bfg = await this.loadedBFG
         if (!bfg.isAlive()) {
-            logDebug('BFG', 'BFG is not alive')
+            logDebug('CodyEngine', 'not alive')
             return []
         }
 
@@ -139,13 +139,13 @@ export class BfgRetriever implements ContextRetriever {
         const codyrpc = await downloadBfg(this.context)
         if (!codyrpc) {
             throw new Error(
-                'Failed to download BFG binary. To fix this problem, set the "cody.experimental.bfg.path" configuration to the path of your BFG binary'
+                'Failed to download BFG binary. To fix this problem, set the "cody.experimental.cody-engine.path" configuration to the path of your BFG binary'
             )
         }
         const isVerboseDebug = vscode.workspace.getConfiguration().get<boolean>('cody.debug.verbose', false)
         const child = child_process.spawn(codyrpc, { stdio: 'pipe', env: { VERBOSE_DEBUG: `${isVerboseDebug}` } })
         child.stderr.on('data', chunk => {
-            logDebug('BFG', 'stderr', chunk.toString())
+            logDebug('CodyEngine', 'stderr', chunk.toString())
         })
         child.on('disconnect', () => reject())
         child.on('close', () => reject())


### PR DESCRIPTION
The name of the binary appears in activity monitors and we want to make it easy for users to trace it back to Cody. We still keep the "bfg" codename in the implementation (variable names, JSON-RPC protocol, etc.)
  because it requires non-trivial engineering effort to change the name
  everywhere and we don't think this is worth the effort at this early
  stage of the project.

I kept the `graphContext: 'bfg'` setting name because that is specifically about code graph. I'm open to changing that as well to `cody-engine` but I don't think it's necessary.

## Test plan

Ran extension manually and confirmed that the output channel doesn't print BFG-related messages. Also confirmed that the binary name is now named "cody-agent-*"
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
