### PR TITLE
Add config error handler

### DIFF
--- a/vscode/src/configuration-keys.ts
+++ b/vscode/src/configuration-keys.ts
@@ -4,7 +4,7 @@ import packageJson from '../package.json'
 
 const { properties } = packageJson.contributes.configuration
 
-type ConfigurationKeysMap = {
+export type ConfigurationKeysMap = {
     // Use key remapping to get a nice typescript interface with the correct keys.
     // https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as
     [key in keyof typeof properties as RemoveCodyPrefixAndCamelCase<key>]: key
@@ -22,6 +22,15 @@ function getConfigFromPackageJson(): ConfigurationKeysMap {
 
         return acc
     }, {} as ConfigurationKeysMap)
+}
+
+export function getConfigEnumValues(key: string): string[] {
+    const configKeys = properties[key as keyof typeof properties]
+    let enumValues: string[] = []
+    if ('enum' in configKeys) {
+        enumValues = configKeys.enum as string[]
+    }
+    return enumValues
 }
 
 // Use template literal type for string manipulation. See examples here:

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -64,8 +64,8 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
     }
 
     return {
-        //  NOTE: serverEndpoint is now stored in Local Storage instead but we will still keep supporting the one in confg
-        //  to use as fallback for users who do not have access to local storage
+        // NOTE: serverEndpoint is now stored in Local Storage instead but we will still keep supporting the one in confg
+        // to use as fallback for users who do not have access to local storage
         serverEndpoint: sanitizeServerEndpoint(config.get(CONFIG_KEY.serverEndpoint, '')),
         proxy: config.get<string | null>(CONFIG_KEY.proxy, null),
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
@@ -112,10 +112,10 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
          * UNDOCUMENTED FLAGS
          */
 
-        //  Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
-        //  We currently use this flag for the agent to provide more helpful error messages
-        //  when something goes wrong, and to suppress event logging in the agent.
-        //  Rely on this flag sparingly.
+        // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
+        // We currently use this flag for the agent to provide more helpful error messages
+        // when something goes wrong, and to suppress event logging in the agent.
+        // Rely on this flag sparingly.
         isRunningInsideAgent: config.get<boolean>('cody.advanced.agent.running' as any, false),
         agentIDE: config.get<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('cody.advanced.agent.ide' as any),
     }
@@ -132,8 +132,8 @@ function sanitizeCodebase(codebase: string | undefined): string {
 
 function sanitizeServerEndpoint(serverEndpoint: string): string {
     if (!serverEndpoint) {
-        //  TODO(philipp-spiess): Find out why the config is not loaded properly in the integration
-        //  tests.
+        // TODO(philipp-spiess): Find out why the config is not loaded properly in the integration
+        // tests.
         const isTesting = process.env.CODY_TESTING === 'true'
         if (isTesting) {
             return 'http://localhost:49300/'
@@ -147,7 +147,7 @@ function sanitizeServerEndpoint(serverEndpoint: string): string {
 
 export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => {
     const config = getConfiguration()
-    //  Migrate endpoints to local storage
+    // Migrate endpoints to local storage
     config.serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
     const accessToken = (await getAccessToken()) || null
     return { ...config, accessToken }


### PR DESCRIPTION
This PR closes #1667. 
I have implemented a function that checks for the allowed enum values for the Cody config. If the config value is not from the allowed list of enum values, then it shows an error during startup.


## Test plan

Open the `settings.json` and change `cody.autocomplete.advanced.provider` to `gpt-4`. After this, reload the window a VSCode error message will be displayed during the startup.