### PR TITLE
fix: adjust width and height of provider logo

### DIFF
--- a/vscode/webviews/Components/ChatModelDropdownMenu.module.css
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.module.css
@@ -8,17 +8,17 @@
 }
 
 .dropdown-container {
-    width: 95%;
+    width: 100%;
     padding: 0.5rem;
 }
 
 .header-logo {
     width: 1.5rem;
-    height: 1.5rem;
+    height: 1rem;
     margin-right: 0.5em;
     flex-shrink: 0;
+    padding: 0.25rem 0rem 0.25rem 0.25rem;
 }
-
 .logo {
     width: 0.8rem;
     height: 0.8rem;


### PR DESCRIPTION
fix: adjust width and height of header logo

Minor UI change: Reduced height of header logo and adjusted styling to fit dropdown container width.

- The width of the dropdown container was increased to 100% to take up full width. 
- The height of the header logo was reduced from 1.5rem to 1rem to better fit the container. 
- The logo width was also reduced and padding added.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Minor UI change:

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/b3f99949-e0b3-46dc-89f1-f8b778a61120)


#### After

![image](https://github.com/sourcegraph/cody/assets/68532117/e862c9e3-f9aa-4680-a4fe-61cd2e8428cf)
