### PR TITLE
Agent: support multiple workspaces with `evaluate-autocomplete`

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'child_process'
 import * as fspromises from 'fs/promises'
 import path from 'path'
 
@@ -66,6 +67,40 @@ export function initializeVscodeExtension(workspaceRoot: vscode.Uri): void {
         globalStorageUri: vscode.Uri.file(paths.data),
         storagePath: {} as any,
         globalStoragePath: vscode.Uri.file(paths.data).fsPath,
+    })
+}
+
+export async function newAgentClient(clientInfo: ClientInfo): Promise<MessageHandler> {
+    const asyncHandler = async (reject: (reason?: any) => void): Promise<MessageHandler> => {
+        const serverHandler = new MessageHandler()
+        const args = process.argv0.endsWith('node') ? process.argv.slice(1, 2) : []
+        args.push('jsonrpc')
+        const child = spawn(process.argv[0], args, { env: { ENABLE_SENTRY: 'false' } })
+        child.stderr.on('data', chunk => {
+            console.error(`agent stderr ${chunk}`)
+        })
+        child.on('disconnect', () => reject())
+        child.on('close', () => reject())
+        child.on('error', error => reject(error))
+        child.on('exit', code => {
+            serverHandler.exit()
+            reject(code)
+        })
+        child.stderr.pipe(process.stdout)
+        child.stdout.pipe(serverHandler.messageDecoder)
+        serverHandler.messageEncoder.pipe(child.stdin)
+        serverHandler.registerNotification('debug/message', params => {
+            console.error(`${params.channel}: ${params.message}`)
+        })
+        await serverHandler.request('initialize', clientInfo)
+        serverHandler.notify('initialized', null)
+        return serverHandler
+    }
+    return new Promise<MessageHandler>((resolve, reject) => {
+        asyncHandler(reject).then(
+            handler => resolve(handler),
+            error => reject(error)
+        )
     })
 }
 

--- a/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
@@ -76,7 +76,7 @@ async function loadEvaluationConfig(options: EvaluateAutocompleteOptions): Promi
     return result
 }
 
-function intOption(value: string) {
+function intOption(value: string): number {
     const parsedValue = Number.parseInt(value, 10)
     if (isNaN(parsedValue)) {
         throw new commander.InvalidArgumentError('Not a number.')

--- a/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process'
 import * as fspromises from 'fs/promises'
 import * as path from 'path'
 
-import { Command, Option } from 'commander'
+import * as commander from 'commander'
 import { calcPatch } from 'fast-myers-diff'
 import { minimatch } from 'minimatch'
 import { rimraf } from 'rimraf'
@@ -11,99 +11,166 @@ import { QueryCapture } from 'web-tree-sitter'
 
 import { Input } from '@sourcegraph/scip-typescript/src/Input'
 import * as scip from '@sourcegraph/scip-typescript/src/scip'
-import { formatSnapshot } from '@sourcegraph/scip-typescript/src/SnapshotTesting'
 
 import { getParseLanguage } from '../../../../vscode/src/completions/tree-sitter/grammars'
 import { createParser } from '../../../../vscode/src/completions/tree-sitter/parser'
-import { newEmbeddedAgentClient } from '../../agent'
+import { newAgentClient } from '../../agent'
 import { AgentTextDocument } from '../../AgentTextDocument'
-import { InProcessClient } from '../../jsonrpc-alias'
+import { MessageHandler } from '../../jsonrpc-alias'
 import { getLanguageForFileName } from '../../language'
 import { AutocompleteResult } from '../../protocol-alias'
 import * as vscode_shim from '../../vscode-shim'
 
+import { formatSnapshot } from './formatSnapshot'
 import { Queries } from './Queries'
 
 interface EvaluateAutocompleteOptions {
     workspace: string
     treeSitterGrammars: string
-    queries: string
-    testCount: string
-    includePattern: string
-    excludePattern: string
+    queriesDirectory: string
+    testCount: number
+    includeWorkspace: string[]
+    excludeWorkspace: string[]
+    includeFilepath?: string[]
+    excludeFilepath?: string[]
     srcAccessToken: string
     srcEndpoint: string
+    evaluationConfig: string
     snapshotDirectory: string
     bfgBinary?: string
+    installCommands?: string[]
+    testCommands?: string[]
 }
 
-export const evaluateAutocompleteCommand = new Command('evaluate-autocomplete')
+interface EvaluationConfig extends Partial<EvaluateAutocompleteOptions> {
+    tests: EvaluateAutocompleteOptions[]
+}
+
+async function loadEvaluationConfig(options: EvaluateAutocompleteOptions): Promise<EvaluateAutocompleteOptions[]> {
+    if (!options?.evaluationConfig) {
+        return [options]
+    }
+    const configBuffer = await fspromises.readFile(options.evaluationConfig)
+    const config = JSON.parse(configBuffer.toString()) as EvaluationConfig
+    const result: EvaluateAutocompleteOptions[] = []
+    for (const test of config?.tests ?? []) {
+        if (!test.workspace) {
+            console.error(`skipping test, missing required property 'workspace': ${JSON.stringify(test)}`)
+            continue
+        }
+        const rootDir = path.dirname(options.evaluationConfig)
+        const workspace = path.normalize(path.join(rootDir, test.workspace))
+        const queriesDirectory = test.queriesDirectory
+            ? path.join(rootDir, test.queriesDirectory)
+            : config.queriesDirectory
+            ? path.join(rootDir, config.queriesDirectory)
+            : options.queriesDirectory
+        const snapshotDirectory = test.snapshotDirectory
+            ? path.join(rootDir, test.snapshotDirectory, test.workspace)
+            : config.snapshotDirectory
+            ? path.join(rootDir, config.snapshotDirectory, test.workspace)
+            : options.snapshotDirectory
+        result.push({ ...options, ...config, ...test, workspace, queriesDirectory, snapshotDirectory })
+    }
+
+    return result
+}
+
+function intOption(value: string) {
+    const parsedValue = Number.parseInt(value, 10)
+    if (isNaN(parsedValue)) {
+        throw new commander.InvalidArgumentError('Not a number.')
+    }
+    return parsedValue
+}
+
+function collect<T>(value: T, previous: T[]): T[] {
+    return previous.concat([value])
+}
+
+export const evaluateAutocompleteCommand = new commander.Command('evaluate-autocomplete')
     .description('Evaluate Cody autocomplete by running the Agent in headless mode')
     .option('--workspace <path>', 'The workspace directory where to run the autocomplete evaluation', process.cwd())
-    .option('--test-count <number>', 'The number of autocomplete requests to run in this evaluation', '10')
+    .option('--test-count <number>', 'The number of autocomplete requests to run in this evaluation', intOption)
+    .option('--evaluation-config <path>', 'Path to a JSON with configuration for this evaluation', '')
     .option(
         '--snapshot-directory <path>',
         'Directory where to write snapshot files to document autocomplete results',
         ''
     )
     .addOption(
-        new Option('--src-access-token <token>', 'The Sourcegraph access token to use for authentication').env(
-            'SRC_ACCESS_TOKEN'
-        )
+        new commander.Option(
+            '--src-access-token <token>',
+            'The Sourcegraph access token to use for authentication'
+        ).env('SRC_ACCESS_TOKEN')
     )
     .addOption(
-        new Option('--src-endpoint <url>', 'The Sourcegraph URL endpoint to use for authentication').env('SRC_ENDPOINT')
+        new commander.Option('--src-endpoint <url>', 'The Sourcegraph URL endpoint to use for authentication').env(
+            'SRC_ENDPOINT'
+        )
     )
     .option(
-        '--include-pattern <glob>',
-        'A glob pattern to determine what file paths to include in the evaluation',
-        '**'
+        '--include-workspace <glob>',
+        'A glob pattern to determine what workspace paths to include in the evaluation',
+        collect as any,
+        []
     )
-    .option('--exclude-pattern <glob>', 'A glob pattern to determine what file paths to exclude in the evaluation', '')
-    .addOption(new Option('--bfg-binary <path>', 'Optional path to a BFG binary').env('BFG_BINARY'))
+    .option(
+        '--exclude-workspace <glob>',
+        'A glob pattern to determine what workspace paths to exclude in the evaluation',
+        collect as any,
+        []
+    )
+    .addOption(new commander.Option('--bfg-binary <path>', 'Optional path to a BFG binary').env('BFG_BINARY'))
     .option(
         '--tree-sitter-grammars <path>',
         'Path to a directory containing tree-sitter grammars',
         path.resolve(__dirname, '../../vscode/dist')
     )
-    .option('--queries <path>', 'Path to a directory containing tree-sitter queries')
+    .option('--queries-directory <path>', 'Path to a directory containing tree-sitter queries')
     .action(async (options: EvaluateAutocompleteOptions) => {
-        // canonicalize and make path absolute
-        const workspace = path.normalize(options.workspace)
-
-        if (!options.queries) {
-            console.log('missing required options: --queries')
-            process.exit(1)
-        }
-        if (!options.srcAccessToken) {
-            console.log('environment variable SRC_ACCESS_TOKEN must be non-empty')
-            process.exit(1)
-        }
-        if (!options.srcEndpoint) {
-            console.log('environment variable SRC_ENDPOINT must be non-empty')
-            process.exit(1)
-        }
-
-        const workspaceRootUri = Uri.from({ scheme: 'file', path: workspace })
-        const agent = await newEmbeddedAgentClient({
-            name: 'evaluate-autocomplete',
-            version: '0.1.0',
-            workspaceRootUri: workspaceRootUri.toString(),
-            extensionConfiguration: {
-                accessToken: options.srcAccessToken,
-                serverEndpoint: options.srcEndpoint,
-                customHeaders: {},
-            },
-        })
-        const client = agent.clientForThisInstance()
-        try {
-            await runEvalution(client, options, workspace)
-        } catch (error) {
-            console.error('unexpected error running evaluate-autocomplete', error)
-        }
-        await client.request('shutdown', null)
-        client.notify('exit', null)
+        const testOptions = await loadEvaluationConfig(options)
+        const workspacesToRun = testOptions.filter(testOptions =>
+            matchesGlobPatterns(options.includeWorkspace, options.excludeWorkspace, testOptions.workspace)
+        )
+        await Promise.all(workspacesToRun.map(workspace => evaluateWorkspace(workspace)))
     })
+
+async function evaluateWorkspace(options: EvaluateAutocompleteOptions): Promise<void> {
+    const workspace = path.normalize(options.workspace)
+
+    if (!options.queriesDirectory) {
+        console.error('missing required options: --queries-directory')
+        process.exit(1)
+    }
+    if (!options.srcAccessToken) {
+        console.error('environment variable SRC_ACCESS_TOKEN must be non-empty')
+        process.exit(1)
+    }
+    if (!options.srcEndpoint) {
+        console.error('environment variable SRC_ENDPOINT must be non-empty')
+        process.exit(1)
+    }
+
+    const workspaceRootUri = Uri.from({ scheme: 'file', path: workspace })
+    const client = await newAgentClient({
+        name: 'evaluate-autocomplete',
+        version: '0.1.0',
+        workspaceRootUri: workspaceRootUri.toString(),
+        extensionConfiguration: {
+            accessToken: options.srcAccessToken,
+            serverEndpoint: options.srcEndpoint,
+            customHeaders: {},
+        },
+    })
+    try {
+        await evaluateWorkspaceOrCrash(client, options, workspace)
+    } catch (error) {
+        console.error('unexpected error running evaluate-autocomplete', error)
+    }
+    await client.request('shutdown', null)
+    client.notify('exit', null)
+}
 
 /**
  * Runs autocomplete evaluation. The current logic is specifically optimized
@@ -111,8 +178,8 @@ export const evaluateAutocompleteCommand = new Command('evaluate-autocomplete')
  * code. Eventually, we could make the logic configurable via command-line
  * flags so that we can reuse this command for different kinds of evaluations.
  */
-async function runEvalution(
-    client: InProcessClient,
+async function evaluateWorkspaceOrCrash(
+    client: MessageHandler,
     options: EvaluateAutocompleteOptions,
     workspace: string
 ): Promise<void> {
@@ -123,18 +190,16 @@ async function runEvalution(
     if (options.bfgBinary) {
         vscode_shim.customConfiguration['cody.experimental.cody-engine.path'] = options.bfgBinary
     }
-    const queries = new Queries(options.queries)
+    const queries = new Queries(options.queriesDirectory)
     const grammarDirectory = path.normalize(options.treeSitterGrammars)
     const files = execSync('git ls-files', { cwd: workspace }).toString().split('\n')
-    let remainingTests = Number.parseInt(options.testCount, 10)
+    files.sort()
+    let remainingTests = options.testCount
     if (options.snapshotDirectory) {
         await rimraf(options.snapshotDirectory)
     }
     for (const file of files) {
-        if (!minimatch(file, options.includePattern)) {
-            continue
-        }
-        if (options.excludePattern && minimatch(file, options.excludePattern)) {
+        if (!matchesGlobPatterns(options.includeFilepath ?? [], options.excludeFilepath ?? [], file)) {
             continue
         }
         const filePath = path.join(workspace, file)
@@ -143,7 +208,8 @@ async function runEvalution(
             continue
         }
         const content = (await fspromises.readFile(filePath)).toString()
-        const language = getParseLanguage(getLanguageForFileName(file))
+        const languageid = getLanguageForFileName(file)
+        const language = getParseLanguage(languageid)
         if (!language) {
             continue
         }
@@ -155,7 +221,7 @@ async function runEvalution(
             continue
         }
 
-        const document = new scip.scip.Document({ relative_path: file })
+        const document = new scip.scip.Document({ relative_path: file, language: languageid })
         for (const match of query.matches(tree.rootNode)) {
             if (remainingTests <= 0) {
                 break
@@ -170,10 +236,8 @@ async function runEvalution(
                         continue
                     }
                     try {
-                        const result = await triggerAutocomplete({ content, filePath, capture, client, document })
-                        if (result.items.length > 0) {
-                            remainingTests--
-                        }
+                        await triggerAutocomplete({ content, filePath, capture, client, document })
+                        remainingTests--
                     } catch {
                         // ignore. Most common issue is that autocomplete times out.
                     }
@@ -188,8 +252,6 @@ async function runEvalution(
             const input = new Input(filePath, content)
             const snapshot = formatSnapshot(input, document)
             await fspromises.writeFile(outputPath, snapshot)
-        } else if (options.snapshotDirectory) {
-            console.error(`Empty autocomplete: ${document.relative_path}`)
         }
     }
 }
@@ -198,7 +260,7 @@ interface AutocompleteFixture {
     content: string
     filePath: string
     capture: QueryCapture
-    client: InProcessClient
+    client: MessageHandler
     document: scip.scip.Document
 }
 
@@ -213,6 +275,7 @@ async function triggerAutocomplete(fixture: AutocompleteFixture): Promise<Autoco
         '()',
         content.slice(capture.node.endIndex),
     ].join('')
+    const removedContent = content.slice(capture.node.startIndex, capture.node.endIndex)
     client.notify('textDocument/didChange', { filePath, content: modifiedContent })
     const result = await client.request('autocomplete/execute', {
         filePath,
@@ -222,6 +285,19 @@ async function triggerAutocomplete(fixture: AutocompleteFixture): Promise<Autoco
         },
     })
     const textDocument = new AgentTextDocument({ filePath, content: modifiedContent })
+    const pushText = (text: string): void => {
+        const scipRange = [
+            capture.node.startPosition.row,
+            capture.node.startPosition.column,
+            capture.node.endPosition.column,
+        ]
+        const occurrence = new scip.scip.Occurrence({
+            symbol: text,
+            range: scipRange,
+            symbol_roles: 0,
+        })
+        document.occurrences.push(occurrence)
+    }
     for (const item of result.items) {
         const range = new Range(
             item.range.start.line,
@@ -236,18 +312,26 @@ async function triggerAutocomplete(fixture: AutocompleteFixture): Promise<Autoco
                 // TODO: handle non-insert patches
                 continue
             }
-            const scipRange = [
-                capture.node.startPosition.row,
-                capture.node.startPosition.column,
-                capture.node.endPosition.column,
-            ]
-            const occurrence = new scip.scip.Occurrence({
-                symbol: text,
-                range: scipRange,
-                symbol_roles: 0,
-            })
-            document.occurrences.push(occurrence)
+            if (['(', text, ')'].join('') === removedContent) {
+                pushText('EXACT_MATCH')
+            } else {
+                pushText(text)
+            }
         }
     }
+    if (result.items.length === 0) {
+        pushText(removedContent === '()' ? 'EXACT_MATCH' : 'EMPTY_RESULT')
+    }
     return result
+}
+
+function matchesGlobPatterns(includeGlobs: string[], excludeGlobs: string[], value: string): boolean {
+    const matchingIncludePattern =
+        includeGlobs.length > 0 ? !!includeGlobs.find(includePattern => minimatch(value, includePattern)) : true
+    if (!matchingIncludePattern) {
+        return false
+    }
+
+    const matchingExcludePatttern = excludeGlobs.find(excludePattern => minimatch(value, excludePattern))
+    return !matchingExcludePatttern
 }

--- a/agent/src/cli/evaluate-autocomplete/formatSnapshot.ts
+++ b/agent/src/cli/evaluate-autocomplete/formatSnapshot.ts
@@ -1,0 +1,78 @@
+import { Input } from '@sourcegraph/scip-typescript/src/Input'
+import { Range } from '@sourcegraph/scip-typescript/src/Range'
+import * as scip from '@sourcegraph/scip-typescript/src/scip'
+
+const lsiftyped = scip.scip
+
+function commentSyntaxForLanguage(languageid: string): string {
+    switch (languageid) {
+        case 'haskell':
+        case 'lua':
+            return '--'
+        case 'python':
+        case 'ruby':
+        case 'yaml':
+        case 'dockerfile':
+        case 'toml':
+        case 'perl':
+        case 'perl6':
+            return '#'
+        default:
+            return '//'
+    }
+}
+
+// This function is copy/pasted from the scip-typescript repository so that we
+// can customize rendering for the `evaluate-autocomplete` command. For example,
+// we will need to come up with a good solution for multi-line completions that may not
+// be relevant for scip-typescript.
+export function formatSnapshot(input: Input, document: scip.scip.Document): string {
+    const commentSyntax = commentSyntaxForLanguage(document.language)
+    const out: string[] = []
+    document.occurrences.sort(occurrencesByLine)
+    const symbolTable = new Map<string, scip.scip.SymbolInformation>()
+    for (const symbolInfo of document.symbols) {
+        symbolTable.set(symbolInfo.symbol, symbolInfo)
+    }
+    let occurrenceIndex = 0
+    for (const [lineNumber, line] of input.lines.entries()) {
+        out.push(' '.repeat(commentSyntax.length))
+        out.push(line.replace('\t', ' '))
+        out.push('\n')
+        while (
+            occurrenceIndex < document.occurrences.length &&
+            document.occurrences[occurrenceIndex].range[0] === lineNumber
+        ) {
+            const occurrence = document.occurrences[occurrenceIndex]
+            occurrenceIndex++
+            if (occurrence.range.length > 3) {
+                // Skip multiline occurrences for now.
+                continue
+            }
+            const range = Range.fromLsif(occurrence.range)
+            out.push(commentSyntax)
+            out.push(' '.repeat(range.start.character))
+            const length = range.end.character - range.start.character
+            if (length < 0) {
+                throw new Error(input.format(range, 'negative length occurrence!'))
+            }
+            out.push('^'.repeat(length))
+            out.push(' ')
+            const isDefinition = (occurrence.symbol_roles & lsiftyped.SymbolRole.Definition) > 0
+            out.push(isDefinition ? 'definition' : 'AUTOCOMPLETE')
+            out.push(' ')
+            out.push(occurrence.symbol)
+            const info = symbolTable.get(occurrence.symbol)
+            if (!isDefinition || !info) {
+                out.push('\n')
+                continue
+            }
+            out.push('\n')
+        }
+    }
+    return out.join('')
+}
+
+function occurrencesByLine(a: scip.scip.Occurrence, b: scip.scip.Occurrence): number {
+    return Range.fromLsif(a.range).compare(Range.fromLsif(b.range))
+}


### PR DESCRIPTION
Previously, `evaluate-autocomplete` required all the arguments to be passed from the command-line and it was only able to evaluate a single workspace at a time (with no parallelization!). Now, you can evaluate multiple workspaces in parallel based on JSON configuration inside a file. This makes it easy to run evaluations on a cron job to track progress.


## Test plan

I've been iterating with a command like this

```
pnpm agent evaluate-autocomplete --evaluation-config ~/dev/sourcegraph/bfg-evaluation/evaluation.json --include-workspace '**/flask' --test-count 1
```
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
