### PR TITLE
fix: forbid `<style>` tags in DOMPurify config

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -49,6 +49,7 @@ const DOMPURIFY_CONFIG = {
         // Disallow heading ids, or any ids
         'id',
     ],
+    FORBID_TAGS: ['style'],
 }
 
 /**

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -25,6 +25,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Prevent `"command 'cody.chat'panel.new' not found"` error when the new chat panel UI is disabled. [pull/1696](https://github.com/sourcegraph/cody/pull/1696)
 - Autocomplete: Improved the multiline completions truncation logic. [pull/1709](https://github.com/sourcegraph/cody/pull/1709)
 - Autocomplete: Fix an issue where typing as suggested causes the completion to behave unexpectedly. [pull/1701](https://github.com/sourcegraph/cody/pull/1701)
+- Chat: Forbid style tags in DOMPurify config to prevent code block rendering issues. [pull/1747](https://github.com/sourcegraph/cody/pull/1747)
 
 ### Changed
 


### PR DESCRIPTION
Currently the `<style>` tag is breaking Cody as reported in https://sourcegraph.slack.com/archives/C03CSAER9LK/p1698893918877999:

This PR adds 'style' to the FORBID_TAGS array in the DOMPurify config to prevent style tags from being allowed.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Ask Cody :

Where is the styling defined for the code below?
```
<?xml version="1.0" encoding="utf-8"?>
<!-- Generator: Adobe Illustrator 27.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
<style type="text/css">
	.st0{fill:none;stroke:#231F20;stroke-width:1.5;stroke-linecap:round;stroke-miterlimit:10;}
</style>
<path class="st0" d="M4,5.6h2.5"/>
<path class="st0" d="M11,3.8v2.5"/>
<path class="st0" d="M3.2,9.7c0,0,1.1,2.5,4.8,2.5s4.8-2.5,4.8-2.5"/>
</svg>

```

##### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/6e4d4a27-613d-4cc3-a41b-ef38f7c1e5e2)


##### After: 

![image](https://github.com/sourcegraph/cody/assets/68532117/6e6c1db9-3fa3-48d0-b1cd-6a2d31b528f5)

