### PR TITLE
fix: do not reset file matches on every key

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -142,7 +142,9 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     }, [view, vscodeAPI])
 
     useEffect(() => {
-        setContextSelection([])
+        if (formInput.endsWith(' ')) {
+            setContextSelection([])
+        }
         // Regex to check if input ends with the '@' tag format, always get the last @tag
         // pass: 'foo @bar.ts', '@bar.ts', '@foo.ts @bar', '@'
         // fail: 'foo ', '@foo.ts bar', '@ foo.ts', '@foo.ts '


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1754

Do not reset file matches on every key press.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before

The panel flashes on every input change

https://github.com/sourcegraph/cody/assets/68532117/d2ef0df2-94cf-428c-9462-9a4d0bb89ebb


### After

The panel gets updated in place


https://github.com/sourcegraph/cody/assets/68532117/6cf7321e-fc89-4f5f-89b3-4ff53fe64d9d

