### PR TITLE
Add hanging-process to vscode Vite config

### DIFF
--- a/vscode/vite.config.ts
+++ b/vscode/vite.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
         include: ['src/**/*.test.ts?(x)'],
         setupFiles: ['src/testutils/vscode.ts'],
         reporters: [
-            'default',
             // fixme(toolmantim): Remove this when flakiness is gone
             //
             // Enable the hanging-process reporter to try to spot why sometimes unit tests are timing out on exit:
@@ -17,7 +16,8 @@ export default defineConfig({
             //   You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters
             //
             // https://vitest.dev/guide/reporters.html#hanging-process-reporter
-            'hanging-process'
+            'hanging-process',
+            'default'
         ]
     }
 })

--- a/vscode/vite.config.ts
+++ b/vscode/vite.config.ts
@@ -6,5 +6,18 @@ export default defineConfig({
     test: {
         include: ['src/**/*.test.ts?(x)'],
         setupFiles: ['src/testutils/vscode.ts'],
-    },
+        reporters: [
+            'default',
+            // fixme(toolmantim): Remove this when flakiness is gone
+            //
+            // Enable the hanging-process reporter to try to spot why sometimes unit tests are timing out on exit:
+            //   close timed out after 10000ms
+            //   Failed to terminate worker while running /home/runner/work/cody/cody/lib/shared/src/common/markdown/markdown.test.ts.
+            //   Tests closed successfully but something prevents Vite server from exiting
+            //   You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters
+            //
+            // https://vitest.dev/guide/reporters.html#hanging-process-reporter
+            'hanging-process'
+        ]
+    }
 })

--- a/vscode/vite.config.ts
+++ b/vscode/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
             //
             // https://vitest.dev/guide/reporters.html#hanging-process-reporter
             'hanging-process',
-            'default'
-        ]
-    }
+            'default',
+        ],
+    },
 })


### PR DESCRIPTION
Going to run GitHub Action over and over on this branch in order to try to spot why test units would fail to exit cleanly.

## Test plan

- n/a