### PR TITLE
Edit: Fix `selectedCode` and `problemCode` appearing in edits

### DIFF
--- a/lib/shared/src/chat/recipes/helpers.test.ts
+++ b/lib/shared/src/chat/recipes/helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { contentSanitizer } from './helpers'
+
+const correctResponse = `export function getRerankWithLog(
+    chatClient: ChatClient
+): (query: string, results: ContextResult[]) => Promise<{ results: ContextResult[]; duration: number }> {
+    if (TestSupport.instance) {
+        const reranker = TestSupport.instance.getReranker()
+        return (query: string, results: ContextResult[]): Promise<{ results: ContextResult[]; duration: number }> => {
+            const start = Date.now()
+            const rerankedResults = reranker.rerank(query, results)
+            const duration = Date.now() - start
+            return { results: rerankedResults, duration }
+        }
+    }
+
+    const reranker = new LLMReranker(chatClient)
+    return async (
+        userQuery: string,
+        results: ContextResult[]
+    ): Promise<{ results: ContextResult[]; duration: number }> => {
+        const start = Date.now()
+        const rerankedResults = await reranker.rerank(userQuery, results)
+        const duration = Date.now() - start
+        logDebug('Reranker:rerank', JSON.stringify({ duration }))
+        return { results: rerankedResults, duration }
+    }
+}`
+
+describe('contentSanitizer', () => {
+    it('handles clean prompt correct', () => {
+        const sanitizedPrompt = contentSanitizer(correctResponse)
+        expect(sanitizedPrompt).toBe(correctResponse)
+    })
+
+    it('handles problematic prompt correct', () => {
+        const sanitizedPrompt = contentSanitizer('<selectedCode>' + correctResponse + '</selectedCode>')
+        expect(sanitizedPrompt).toBe(correctResponse)
+    })
+
+    it('handles partially problematic prompt correctly', () => {
+        const sanitizedPrompt = contentSanitizer('<problemCode>' + correctResponse)
+        expect(sanitizedPrompt).toBe(correctResponse)
+    })
+
+    it('handles problematic prompt correctly with whitespace', () => {
+        const sanitizedPrompt = contentSanitizer('   <fixup>' + correctResponse + '</fixup>   ')
+        expect(sanitizedPrompt).toBe(correctResponse)
+    })
+
+    it('handles problematic prompt correctly with whitespace across new lines', () => {
+        const sanitizedPrompt = contentSanitizer('\n   <selectedCode>' + correctResponse + '</selectedCode>   \n')
+        expect(sanitizedPrompt).toBe(correctResponse)
+    })
+})

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -72,7 +72,7 @@ export function getFileExtension(fileName: string): string {
 // ex. Remove  `tags:` that Cody sometimes include in the returned content
 // It also removes all spaces before a new line to keep the indentations
 export function contentSanitizer(text: string): string {
-    let output = text.replace(/<\/(fixup|selectedCode)>\s$/, '')
+    let output = text.replaceAll(/^<selectedCode>|<\/selectedCode>$/g, '')
     const tagsIndex = text.indexOf('tags:')
     if (tagsIndex !== -1) {
         // NOTE: 6 is the length of `tags:` + 1 space

--- a/lib/shared/src/chat/recipes/helpers.ts
+++ b/lib/shared/src/chat/recipes/helpers.ts
@@ -72,7 +72,7 @@ export function getFileExtension(fileName: string): string {
 // ex. Remove  `tags:` that Cody sometimes include in the returned content
 // It also removes all spaces before a new line to keep the indentations
 export function contentSanitizer(text: string): string {
-    let output = text.replaceAll(/^<selectedCode>|<\/selectedCode>$/g, '')
+    let output = text.replaceAll(/^\s*<(fixup|selectedCode|problemCode)>|<\/(fixup|selectedCode|problemCode)>\s*$/g, '')
     const tagsIndex = text.indexOf('tags:')
     if (tagsIndex !== -1) {
         // NOTE: 6 is the length of `tags:` + 1 space

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Autocomplete: Improved the multiline completions truncation logic. [pull/1709](https://github.com/sourcegraph/cody/pull/1709)
 - Autocomplete: Fix an issue where typing as suggested causes the completion to behave unexpectedly. [pull/1701](https://github.com/sourcegraph/cody/pull/1701)
 - Chat: Forbid style tags in DOMPurify config to prevent code block rendering issues. [pull/1747](https://github.com/sourcegraph/cody/pull/1747)
+- Edit: Fix `selectedCode` and `problemCode` sometimes being added to the document after an edit. [pull/1765](https://github.com/sourcegraph/cody/pull/1765)
 
 ### Changed
 


### PR DESCRIPTION
## Description

Due to the prompt, the LLM sometimes gets confused and adds some of the mentioned XML tags (`selectedCode`|`problemCode`) to the start and end of the text.

We were only removing this from the end previously. This will fix that

## Test plan

Create multiple edits. Check for `selectedCode`

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
