### PR TITLE
Edit: Fix flickering code lens for users with autoSave enabled

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -29,6 +29,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Autocomplete: Fix an issue where typing as suggested causes the completion to behave unexpectedly. [pull/1701](https://github.com/sourcegraph/cody/pull/1701)
 - Chat: Forbid style tags in DOMPurify config to prevent code block rendering issues. [pull/1747](https://github.com/sourcegraph/cody/pull/1747)
 - Edit: Fix `selectedCode` and `problemCode` sometimes being added to the document after an edit. [pull/1765](https://github.com/sourcegraph/cody/pull/1765)
+- Edit: Fix the code lens containing options to diff, undo and retry being automatically dismissed for users who have `autoSave` enabled. [pull/1767](https://github.com/sourcegraph/cody/pull/1767)
 
 ### Changed
 


### PR DESCRIPTION
## Description

Fixes https://github.com/sourcegraph/cody/issues/1762

If a user has `autoSave` set to a value like `onFocusChange` or `afterDelay`, then it is possible that the edit code lens will immediately be dismissed.

The best thing we can do here is just to avoid dismissing on save for these cases. The code lens will still be dismissed when a user clicks "Done" or if a user manually changes some code in the selection.

## Test plan

1. Set `files.autoSave` to something other than the default value
2. Create a fixup and check the codelens doesn't immediately disappear

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
