### PR TITLE
Agent: add support for fixtures with `evaluate-autocomplete`

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -81,7 +81,7 @@ export async function newAgentClient(clientInfo: ClientInfo): Promise<MessageHan
         args.push('jsonrpc')
         const child = spawn(process.argv[0], args, { env: { ENABLE_SENTRY: 'false' } })
         child.stderr.on('data', chunk => {
-            console.error(`agent stderr ${chunk}`)
+            console.error(`------agent stderr------\n${chunk}\n------------------------`)
         })
         child.on('disconnect', () => reject())
         child.on('close', () => reject())
@@ -90,7 +90,7 @@ export async function newAgentClient(clientInfo: ClientInfo): Promise<MessageHan
             serverHandler.exit()
             reject(code)
         })
-        child.stderr.pipe(process.stdout)
+        child.stderr.pipe(process.stderr)
         child.stdout.pipe(serverHandler.messageDecoder)
         serverHandler.messageEncoder.pipe(child.stdin)
         serverHandler.registerNotification('debug/message', params => {

--- a/agent/src/bfg/BfgContextFetcher.test.ts
+++ b/agent/src/bfg/BfgContextFetcher.test.ts
@@ -72,7 +72,12 @@ describe('BfgRetriever', async () => {
     it('returns non-empty context', async () => {
         if (bfgCratePath) {
             const bfgBinary = path.join(bfgCratePath, '..', '..', 'target', 'debug', 'bfg')
-            vscode_shim.customConfiguration['cody.experimental.bfg.path'] = bfgBinary
+            vscode_shim.setConnectionConfig({
+                accessToken: '',
+                serverEndpoint: '',
+                customHeaders: {},
+                customConfiguration: { 'cody.experimental.bfg.path': bfgBinary },
+            })
         }
         const extensionContext: Partial<vscode.ExtensionContext> = {
             subscriptions: [],

--- a/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
@@ -277,7 +277,7 @@ async function evaluateBfgStrategy(
                     }
                     try {
                         await triggerAutocomplete({ content, filePath, capture, client, document })
-                    } catch (error) {
+                    } catch {
                         // const message = error instanceof Error ? error.message : `${error}`
                         // TODO: push error occurrence
                         // const range

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -105,8 +105,6 @@ export function isAuthenticationChange(newConfig: ExtensionConfiguration): boole
     )
 }
 
-export const customConfiguration: Record<string, any> = {}
-
 const configuration: vscode.WorkspaceConfiguration = {
     has(section) {
         return true
@@ -123,8 +121,8 @@ const configuration: vscode.WorkspaceConfiguration = {
             )[value.toLowerCase()]
         }
 
-        const fromCustomConfiguration = customConfiguration[section]
-        if (fromCustomConfiguration) {
+        const fromCustomConfiguration = connectionConfig?.customConfiguration?.[section]
+        if (fromCustomConfiguration !== undefined) {
             return fromCustomConfiguration
         }
         switch (section) {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -44,6 +44,12 @@ export interface Configuration {
     autocompleteExperimentalGraphContext: 'lsp-light' | 'bfg' | 'bfg-mixed' | null
     isRunningInsideAgent?: boolean
     agentIDE?: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
+    autocompleteTimeouts: AutocompleteTimeouts
+}
+
+export interface AutocompleteTimeouts {
+    multiline?: number
+    singleline?: number
 }
 
 export interface ConfigurationWithAccessToken extends Configuration {

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -160,7 +160,7 @@ export class BfgRetriever implements ContextRetriever {
             bfg.exit()
             reject(code)
         })
-        child.stderr.pipe(process.stdout)
+        child.stderr.pipe(process.stderr)
         child.stdout.pipe(bfg.messageDecoder)
         bfg.messageEncoder.pipe(child.stdin)
         await bfg.request('bfg/initialize', { clientName: 'vscode' })

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -43,6 +43,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocompleteCompleteSuggestWidgetSelection: false,
     autocompleteExperimentalSyntacticPostProcessing: false,
     autocompleteExperimentalGraphContext: null,
+    autocompleteTimeouts: {},
 }
 
 const getVSCodeSettings = (config: Partial<Configuration> = {}): Configuration => ({

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -35,6 +35,7 @@ export async function createProviderConfig(
                     client,
                     model: config.autocompleteAdvancedModel ?? model ?? null,
                     starcoderExtendedTokenWindow,
+                    timeouts: config.autocompleteTimeouts,
                 })
             }
             case 'anthropic': {
@@ -82,6 +83,7 @@ export async function createProviderConfig(
             case 'fireworks':
                 return createFireworksProviderConfig({
                     client,
+                    timeouts: config.autocompleteTimeouts,
                     model: model ?? null,
                 })
             case 'aws-bedrock':

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -45,6 +45,7 @@ describe('getConfiguration', () => {
             autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: null,
+            autocompleteTimeouts: {},
         })
     })
 
@@ -109,6 +110,10 @@ describe('getConfiguration', () => {
                         return 'starcoder-32b'
                     case 'cody.autocomplete.advanced.accessToken':
                         return 'foobar'
+                    case 'cody.autocomplete.advanced.timeout.multiline':
+                        return undefined
+                    case 'cody.autocomplete.advanced.timeout.singleline':
+                        return undefined
                     case 'cody.autocomplete.completeSuggestWidgetSelection':
                         return false
                     case 'cody.autocomplete.experimental.syntacticPostProcessing':
@@ -149,7 +154,7 @@ describe('getConfiguration', () => {
             inlineChat: true,
             codeActions: true,
             isRunningInsideAgent: false,
-            agentIde: undefined,
+            agentIDE: undefined,
             experimentalNonStop: true,
             debugEnable: true,
             debugVerbose: true,
@@ -162,6 +167,7 @@ describe('getConfiguration', () => {
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalGraphContext: 'lsp-light',
+            autocompleteTimeouts: {},
         })
     })
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -118,6 +118,13 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         // Rely on this flag sparingly.
         isRunningInsideAgent: config.get<boolean>('cody.advanced.agent.running' as any, false),
         agentIDE: config.get<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('cody.advanced.agent.ide' as any),
+        autocompleteTimeouts: {
+            multiline: config.get<number | undefined>('cody.autocomplete.advanced.timeout.multiline' as any, undefined),
+            singleline: config.get<number | undefined>(
+                'cody.autocomplete.advanced.timeout.singleline' as any,
+                undefined
+            ),
+        },
     }
 }
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -208,6 +208,8 @@ export interface ExtensionConfiguration {
      * @deprecated This is only used for the legacy logEvent - use `telemetry` instead.
      */
     eventProperties?: EventProperties
+
+    customConfiguration?: Record<string, any>
 }
 
 /**

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -160,6 +160,9 @@ class MessageDecoder extends Writable {
                         }
                         this.callback(null, data)
                     } catch (error: any) {
+                        console.log(
+                            `jsonrpc.ts: JSON parse error against input '${this.contentBuffer}'. Error:\n${error}`
+                        )
                         if (tracePath) {
                             appendFileSync(tracePath, '<- ' + JSON.stringify({ error }, null, 4) + '\n')
                         }


### PR DESCRIPTION
Previously, we only supported evaluating one concrete fixture (set of
    config options). For example, this meant that we could evaluate BFG
in isolation but we couldn't compare it against non-BFG. This PR fixes the problem by adding the notion of "fixuture", which is a set of configuration options.


## Test plan

Manually tested with the command

```
❯ pnpm agent evaluate-autocomplete --evaluation-config ~/dev/sourcegraph/bfg-evaluation/evaluation.json --test-count 400
```

Resulted in this chart, which is the first time we see an actual difference between BFG vs non-BFG.
<img width="1137" alt="CleanShot 2023-11-16 at 16 29 54@2x" src="https://github.com/sourcegraph/cody/assets/1408093/bb6c1c59-b82a-485d-879f-f897444f6117">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
