### PR TITLE
fix: context files always display 0 lines

### DIFF
--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -101,6 +101,7 @@ export class EventLogger {
                 inline: this.config.inlineChat,
                 nonStop: this.config.experimentalNonStop,
                 guardrails: this.config.experimentalGuardrails,
+                newChatUI: this.config.experimentalChatPanel,
             },
             version: this.extensionDetails.version, // for backcompat
             hasV2Event,

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -41,16 +41,19 @@ export const EnhancedContext: React.FunctionComponent<{
 
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
-    const lines = filteredFiles.reduce(
+    const lineCount = filteredFiles.reduce(
         (total, file) => total + (file.range ? file.range?.end?.line - file.range?.start?.line + 1 : 0),
         0
     )
-    const files = filteredFiles.length
+    const fileCount = filteredFiles.length
+    const lines = `${lineCount} line` + (lineCount > 1 ? 's' : '')
+    const files = `${fileCount} file` + (fileCount > 1 ? 's' : '')
+    const title = lineCount ? `✨ ${lines} from ${files}` : `✨ snippets from ${files}`
 
     return (
         <TranscriptAction
             title={{
-                verb: `✨ ${lines} lines from ${files} files`,
+                verb: title,
                 object: '',
                 tooltip: 'Related code automatically included as context',
             }}

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -413,6 +413,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         const contextSummary = {
             embeddings: 0,
             local: 0,
+            user: 0, // context added by user with @ command
         }
 
         // Check whether or not to connect to LLM backend for responses
@@ -442,8 +443,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 await this.saveTranscriptToChatHistory()
 
                 contextFiles.map(file => {
-                    if (file.source) {
+                    if (file.source === 'embeddings') {
                         contextSummary.embeddings++
+                    } else if (file.source === 'user') {
+                        contextSummary.user++
                     } else {
                         contextSummary.local++
                     }

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -13,7 +13,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({ path, range, 
         <button
             className={styles.linkButton}
             type="button"
-            title={`${pathWithRange} included via ${source}`}
+            title={source ? `${pathWithRange} included via ${source}` : pathWithRange}
             onClick={() => {
                 getVSCodeAPI().postMessage({ command: 'openFile', filePath: path, range })
             }}


### PR DESCRIPTION
Some minor cleanup for the things I noticed when running the main build for 0.16.0:

Chat UI:

 the new context files display widget does not work well with conversation from old chat history, where lines will always be 0:

![image](https://github.com/sourcegraph/cody/assets/68532117/e9957051-11e5-4e16-b973-35cd06babffe)

After:

![image](https://github.com/sourcegraph/cody/assets/68532117/b6f743f7-76bb-45c5-924e-00e6bd44f943)


Other housekeeping items:
- log numbers of context added by users via @ command
- log  usage of the new chat UI

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Start Cody and check your chat history.