### PR TITLE
Agent: include product identifier for connected client

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,22 +1,7 @@
 {
   "version": "2.0.0",
   "tasks": [
-    {
-      "type": "typescript",
-      "tsconfig": "tsconfig.json",
-      "problemMatcher": ["$tsc-watch"],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "option": "watch",
-      "runOptions": { "runOn": "folderOpen", "instanceLimit": 1 },
-      "isBackground": true,
-      "presentation": {
-        "reveal": "never"
-      }
-    },
-    {
+   {
       "label": "Build VS Code Extension (Desktop)",
       "type": "npm",
       "path": "vscode",

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -148,6 +148,8 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return false
             case 'cody.codebase':
                 return connectionConfig?.codebase
+            case 'cody.advanced.agent.ide':
+                return connectionConfig?.connectedClient
             default:
                 return defaultValue
         }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -165,6 +165,9 @@ export interface ExtensionConfiguration {
     proxy?: string | null
     accessToken: string
     customHeaders: Record<string, string>
+
+    connectedClient: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
+
     autocompleteAdvancedProvider?: string
     autocompleteAdvancedServerEndpoint?: string | null
     autocompleteAdvancedModel?: string | null
@@ -173,8 +176,10 @@ export interface ExtensionConfiguration {
     verboseDebug?: boolean
     codebase?: string
 
-    /** When passed, the Agent will handle recording events.
-     * If not passed, client must send `graphql/logEvent` requests manually. **/
+    /**
+     * When passed, the Agent will handle recording events.
+     * If not passed, client must send `graphql/logEvent` requests manually.
+     */
     eventProperties?: EventProperties
 }
 


### PR DESCRIPTION
For querying from [Configuration](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/configuration.ts?L111:9) later when agent telemetry v2 is a thing

## Test plan

Much studying of the code: this gets set in the `initialize` request [here](https://sourcegraph.com/github.com/sourcegraph/cody@nsc/agent-connectedClient/-/blob/agent/src/agent.ts?L153), which calls [the following shim entry](https://sourcegraph.com/github.com/sourcegraph/cody@nsc/agent-connectedClient/-/blob/agent/src/agent.ts?L380) to set the global config variable [read here](https://github.com/sourcegraph/cody/compare/nsc/agent-connectedClient?expand=1#diff-9864a0013bb1fe8a7ef0d2be2beff9f8a24607cf55825ff9cccd4670ed6912a3R152)