### PR TITLE
fix: show edit button on last user message

### DIFF
--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -144,16 +144,15 @@ export const Transcript: React.FunctionComponent<
             if (!message?.displayText) {
                 return null
             }
+            const offsetIndex = index + offset === earlierMessages.length
             return (
                 <TranscriptItem
                     key={index + offset}
                     message={message}
                     inProgress={
-                        index + offset === earlierMessages.length &&
-                        messageInProgress?.speaker === 'assistant' &&
-                        !messageInProgress?.displayText
+                        offsetIndex && messageInProgress?.speaker === 'assistant' && !messageInProgress?.displayText
                     }
-                    beingEdited={index > 0 && transcript.length - index === 2 && messageBeingEdited}
+                    beingEdited={messageBeingEdited && offsetIndex}
                     setBeingEdited={setMessageBeingEdited}
                     fileLinkComponent={fileLinkComponent}
                     symbolLinkComponent={symbolLinkComponent}
@@ -166,7 +165,7 @@ export const Transcript: React.FunctionComponent<
                     textAreaComponent={textAreaComponent}
                     EditButtonContainer={EditButtonContainer}
                     editButtonOnSubmit={editButtonOnSubmit}
-                    showEditButton={index > 0 && transcript.length - index === 2}
+                    showEditButton={offsetIndex && !messageInProgress?.speaker && !message.displayText.startsWith('/')}
                     FeedbackButtonsContainer={FeedbackButtonsContainer}
                     feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                     copyButtonOnSubmit={copyButtonOnSubmit}

--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -106,12 +106,27 @@
     visibility: hidden;
 }
 
-.editing-container {
-    position: absolute;
-    right: var(--spacing);
-    top: var(--spacing);
+.transcript-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
+    margin-bottom: 0.2em;
+}
+
+.editing-container {
     visibility: visible;
+}
+
+.editing-button-container {
+    visibility: visible;
+    position: absolute;
+
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+
+    align-self: center;
 }
 
 .editing-label {

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -86,7 +86,7 @@ export const TranscriptItem: React.FunctionComponent<
     ChatButtonComponent,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
-    const textarea =
+    const EditTextArea =
         TextArea && beingEdited && editButtonOnSubmit && SubmitButton ? (
             <div className={styles.textAreaContainer}>
                 <TextArea
@@ -132,21 +132,17 @@ export const TranscriptItem: React.FunctionComponent<
                 message.speaker === 'human' ? humanTranscriptItemClassName : styles.assistantRow
             )}
         >
-            {/* display edit buttons on last user message, feedback buttons on last assistant message only */}
-            {EditButtonContainer && beingEdited && <p className={classNames(styles.editingLabel)}>Editing...</p>}
             {showEditButton && EditButtonContainer && editButtonOnSubmit && TextArea && message.speaker === 'human' && (
-                <header
-                    className={classNames(
-                        beingEdited ? styles.editingContainer : styles.headerContainer,
-                        transcriptItemParticipantClassName
-                    )}
-                >
-                    <EditButtonContainer
-                        className={styles.FeedbackEditButtonsContainer}
-                        messageBeingEdited={beingEdited}
-                        setMessageBeingEdited={setBeingEdited}
-                    />
-                </header>
+                <div className={beingEdited ? styles.editingContainer : styles.editingButtonContainer}>
+                    <header className={classNames(styles.transcriptItemHeader, transcriptItemParticipantClassName)}>
+                        {beingEdited && <p className={classNames(styles.editingLabel)}>Editing...</p>}
+                        <EditButtonContainer
+                            className={styles.FeedbackEditButtonsContainer}
+                            messageBeingEdited={beingEdited}
+                            setMessageBeingEdited={setBeingEdited}
+                        />
+                    </header>
+                </div>
             )}
             {message.preciseContext && message.preciseContext.length > 0 && (
                 <div className={styles.actions}>
@@ -157,20 +153,24 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </div>
             )}
-            <div className={classNames(styles.contentPadding, textarea ? undefined : styles.content)}>
-                {message.displayText
-                    ? textarea ?? (
-                          <CodeBlocks
-                              displayText={message.displayText}
-                              copyButtonClassName={codeBlocksCopyButtonClassName}
-                              copyButtonOnSubmit={copyButtonOnSubmit}
-                              insertButtonClassName={codeBlocksInsertButtonClassName}
-                              insertButtonOnSubmit={insertButtonOnSubmit}
-                              metadata={message.metadata}
-                              inProgress={inProgress}
-                          />
-                      )
-                    : inProgress && <BlinkingCursor />}
+            <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
+                {message.displayText ? (
+                    EditTextArea ? (
+                        !inProgress && !message.displayText.startsWith('/') && EditTextArea
+                    ) : (
+                        <CodeBlocks
+                            displayText={message.displayText}
+                            copyButtonClassName={codeBlocksCopyButtonClassName}
+                            copyButtonOnSubmit={copyButtonOnSubmit}
+                            insertButtonClassName={codeBlocksInsertButtonClassName}
+                            insertButtonOnSubmit={insertButtonOnSubmit}
+                            metadata={message.metadata}
+                            inProgress={inProgress}
+                        />
+                    )
+                ) : (
+                    inProgress && <BlinkingCursor />
+                )}
             </div>
             {message.buttons?.length && ChatButtonComponent && (
                 <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -8,7 +8,7 @@
     font-family: var(--vscode-font-family);
     font-weight: var(--vscode-font-weight);
     border-color: var(--vscode-sideBarSectionHeader-border);
-    padding: 15px 15px 15px 20px;
+    padding: 1rem 1rem 1rem 1.25rem;
     color: var(--vscode-foreground);
 }
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -361,6 +361,7 @@ const EditButton: React.FunctionComponent<EditButtonProps> = ({
         <VSCodeButton
             className={classNames(styles.editButton)}
             appearance="icon"
+            title={messageBeingEdited ? 'cancel' : 'edit and resend your message'}
             type="button"
             onClick={() => setMessageBeingEdited(!messageBeingEdited)}
         >


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1655 && https://github.com/sourcegraph/cody/issues/1780

![image](https://github.com/sourcegraph/cody/assets/68532117/9d8295d8-f103-4e4b-8e28-18c777cc6cbb)


This PR fixes the issue where edit button was not showing up in Chat. 

Previously it was set to shown on the second to last message `transcript.length - index === 2` and only when speaker is "human",  but that did not factor in the fact the last message is handled separately, so transcript.length - index === 2 will always have the speaker as assistant instead of human, causing the edit button not showing up correctly.


Expected behavior:

- only the last user message can be edited
- you cannot edit a message that is a command, e.g. `/explain`
- 
![image](https://github.com/sourcegraph/cody/assets/68532117/a900221d-68a0-4ec0-8498-9bfc2755247d)


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try to submit a message and then edit the message once Cody has replied.


https://github.com/sourcegraph/cody/assets/68532117/586a66cf-2ee8-4532-b657-99673a0a3010

