### PR TITLE
Autocomplete: remove top level `charCount` from completion events

### DIFF
--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -63,7 +63,6 @@ describe('logger', () => {
         const shared = {
             id: expect.any(String),
             languageId: 'typescript',
-            lineCount: 1,
             source: 'Network',
             triggerKind: 'Automatic',
             type: 'inline',
@@ -73,7 +72,6 @@ describe('logger', () => {
             otherCompletionProviders: [],
             providerIdentifier: 'bfl',
             providerModel: 'blazing-fast-llm',
-            charCount: 3,
             contextSummary: {
                 retrieverStats: {},
                 strategy: 'none',

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -49,8 +49,6 @@ export interface CompletionEvent {
         languageId: string
         contextSummary?: any
         source?: InlineCompletionsResultSource
-        lineCount?: number
-        charCount?: number
         artificialDelay?: number
         // Mapping to a higher level abstractions of syntax nodes (e.g., function declaration body)
         completionIntent?: CompletionIntent

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -238,10 +238,6 @@ export function suggested(id: CompletionLogID, completion: InlineCompletionItemW
     }
 
     if (!event.suggestedAt) {
-        const { lineCount, charCount } = lineAndCharCount(completion)
-
-        event.params.lineCount = lineCount
-        event.params.charCount = charCount
         event.suggestedAt = performance.now()
 
         setTimeout(() => {


### PR DESCRIPTION
## Context

- Part of #1775 
- Based on [the Slack thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1700212920663709?thread_ts=1698983739.534099&cid=C05AGQYD528).

## Test plan

n/a
