### PR TITLE
Capture dependency download issues in Sentry

### DIFF
--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -7,6 +7,7 @@ import { MessageHandler } from '../../../../jsonrpc/jsonrpc'
 import { logDebug } from '../../../../log'
 import { Repository } from '../../../../repository/builtinGitExtension'
 import { gitAPI } from '../../../../repository/repositoryHelpers'
+import { captureException } from '../../../../services/sentry/sentry'
 import { ContextRetriever, ContextRetrieverOptions, ContextSnippet } from '../../../types'
 
 // This promise is only used for testing purposes. We don't await on the
@@ -26,6 +27,7 @@ export class BfgRetriever implements ContextRetriever {
         this.loadedBFG.then(
             () => {},
             error => {
+                captureException(error)
                 this.didFailLoading = true
                 logDebug('CodyEngine', 'failed to initialize', error)
             }
@@ -129,7 +131,10 @@ export class BfgRetriever implements ContextRetriever {
         return new Promise<MessageHandler>((resolve, reject) => {
             this.doLoadBFG(reject).then(
                 bfg => resolve(bfg),
-                error => reject(error)
+                error => {
+                    captureException(error)
+                    reject(error)
+                }
             )
         })
     }

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode'
 import { fileExists } from '../../local-context/download-symf'
 import { logDebug } from '../../log'
 import { getOSArch } from '../../os'
+import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 const defaultBfgVersion = '5.2.6637'
@@ -85,6 +86,7 @@ export async function downloadBfg(context: vscode.ExtensionContext): Promise<str
         )
         void removeOldBfgBinaries(bfgContainingDir, bfgFilename)
     } catch (error) {
+        captureException(error)
         void vscode.window.showErrorMessage(`Failed to download bfg from URL ${bfgURL}: ${error}`)
         return null
     }

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 
 import { logDebug } from '../log'
 import { getOSArch } from '../os'
+import { captureException } from '../services/sentry/sentry'
 
 const symfVersion = 'v0.0.2'
 
@@ -71,6 +72,7 @@ export async function getSymfPath(context: vscode.ExtensionContext): Promise<str
         )
         void removeOldSymfBinaries(symfContainingDir, symfFilename)
     } catch (error) {
+        captureException(error)
         void vscode.window.showErrorMessage(`Failed to download symf: ${error}`)
         return null
     }


### PR DESCRIPTION
## Test plan

Just adding a sentry callback to error handlers

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
