### PR TITLE
Return 'cody.advanced.agent.ide' from ClientInfo.name

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -3,6 +3,8 @@ import { execSync } from 'child_process'
 
 import type * as vscode from 'vscode'
 
+import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+
 // <VERY IMPORTANT - PLEASE READ>
 // This file must not import any module that transitively imports from 'vscode'.
 // It's only OK to `import type` from vscode. We can't depend on any vscode APIs
@@ -110,6 +112,17 @@ const configuration: vscode.WorkspaceConfiguration = {
         return true
     },
     get: (section, defaultValue?: any) => {
+        const clientNameToIDE = (value: string): Configuration['agentIDE'] | undefined => {
+            return (
+                {
+                    vscode: 'VSCode',
+                    jetbrains: 'JetBrains',
+                    emacs: 'Emacs',
+                    neovim: 'Neovim',
+                } as const
+            )[value.toLowerCase()]
+        }
+
         const fromCustomConfiguration = customConfiguration[section]
         if (fromCustomConfiguration) {
             return fromCustomConfiguration
@@ -148,6 +161,8 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return false
             case 'cody.codebase':
                 return connectionConfig?.codebase
+            case 'cody.advanced.agent.ide':
+                return clientNameToIDE(clientInfo?.name ?? '')
             default:
                 return defaultValue
         }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -173,8 +173,10 @@ export interface ExtensionConfiguration {
     verboseDebug?: boolean
     codebase?: string
 
-    /** When passed, the Agent will handle recording events.
-     * If not passed, client must send `graphql/logEvent` requests manually. **/
+    /**
+     * When passed, the Agent will handle recording events.
+     * If not passed, client must send `graphql/logEvent` requests manually.
+     */
     eventProperties?: EventProperties
 }
 


### PR DESCRIPTION
## Test plan

Checked for existing values of `ClientInfo.name` for editors:
1. [neovim](https://sourcegraph.com/github.com/sourcegraph/sg.nvim/-/blob/lua/sg/cody/rpc.lua?L281) 
2. [jetbrains](https://sourcegraph.com/github.com/sourcegraph/jetbrains/-/blob/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt?L69)
3. [emacs](https://sourcegraph.com/github.com/sourcegraph/emacs-cody/-/blob/cody.el?L311:24)