### PR TITLE
Fix symf indexed dir

### DIFF
--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -228,9 +228,10 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
 
     private getIndexDir(scopeDir: string): { indexDir: string; tmpDir: string } {
         const absIndexedDir = path.resolve(scopeDir)
+        const encodedIndexedDir = Buffer.from(absIndexedDir).toString('base64url')
         return {
-            indexDir: path.join(this.indexRoot, absIndexedDir),
-            tmpDir: path.join(this.indexRoot, '.tmp', absIndexedDir),
+            indexDir: path.join(this.indexRoot, encodedIndexedDir),
+            tmpDir: path.join(this.indexRoot, '.tmp', encodedIndexedDir),
         }
     }
 


### PR DESCRIPTION
Code search with symf fails on Windows because `getIndexDir()` concatenates the `absIndexedDir` with the `indexRoot`. To solve this, I simply base64 encoded the indexed dir.