### PR TITLE
Agent: get tests running again

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -266,11 +266,15 @@ export class Agent extends MessageHandler {
 
             await this.logEvent(`recipe:${data.id}`, 'executed', 'dotcom-only')
             this.agentTelemetryRecorderProvider.getRecorder().recordEvent(`cody.recipe.${data.id}`, 'executed')
-            await client.executeRecipe(data.id, {
-                signal: abortController.signal,
-                humanChatInput: data.humanChatInput,
-                data: data.data,
-            })
+            try {
+                await client.executeRecipe(data.id, {
+                    signal: abortController.signal,
+                    humanChatInput: data.humanChatInput,
+                    data: data.data,
+                })
+            } catch {
+                // ignore, can happen when the client cancels the request
+            }
             return null
         })
         this.registerRequest('autocomplete/execute', async (params, token) => {

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -359,14 +359,18 @@ const gitExtension: Partial<vscode.Extension<GitExtension>> = {
                     if (!cwd) {
                         return null
                     }
-                    const toplevel = execSync('git rev-parse --show-toplevel', { cwd }).toString().trim()
-                    const repository: Partial<Repository> = {
-                        rootUri: Uri.file(toplevel),
-                        state: {
-                            remotes: [],
-                        } as any,
+                    try {
+                        const toplevel = execSync('git rev-parse --show-toplevel', { cwd }).toString().trim()
+                        const repository: Partial<Repository> = {
+                            rootUri: Uri.file(toplevel),
+                            state: {
+                                remotes: [],
+                            } as any,
+                        }
+                        return repository as Repository
+                    } catch {
+                        return null
                     }
-                    return repository as Repository
                 },
             }
             return api as API

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -81,20 +81,25 @@ export class BfgRetriever implements ContextRetriever {
             return []
         }
 
-        const responses = await bfg.request('bfg/contextAtPosition', {
-            uri: document.uri.toString(),
-            content: (await vscode.workspace.openTextDocument(document.uri)).getText(),
-            position: { line: position.line, character: position.character },
-            maxChars: hints.maxChars, // ignored by BFG server for now
-            contextRange: getContextRange(document, docContext),
-        })
+        try {
+            const responses = await bfg.request('bfg/contextAtPosition', {
+                uri: document.uri.toString(),
+                content: (await vscode.workspace.openTextDocument(document.uri)).getText(),
+                position: { line: position.line, character: position.character },
+                maxChars: hints.maxChars, // ignored by BFG server for now
+                contextRange: getContextRange(document, docContext),
+            })
 
-        // Just in case, handle non-object results
-        if (typeof responses !== 'object') {
+            // Just in case, handle non-object results
+            if (typeof responses !== 'object') {
+                return []
+            }
+
+            return [...(responses?.symbols || []), ...(responses?.files || [])]
+        } catch (error) {
+            logDebug('CodyEngine:error', `${error}`)
             return []
         }
-
-        return [...(responses?.symbols || []), ...(responses?.files || [])]
     }
 
     public isSupportedForLanguageId(languageId: string): boolean {
@@ -130,6 +135,7 @@ export class BfgRetriever implements ContextRetriever {
         // This is implemented as a custom promise instead of async/await so that we can reject
         // the promise in the 'exit' handler if we fail to start the bfg process for some reason.
         return new Promise<MessageHandler>((resolve, reject) => {
+            logDebug('CodyEngine', 'loading bfg')
             this.doLoadBFG(reject).then(
                 bfg => resolve(bfg),
                 error => {
@@ -149,7 +155,13 @@ export class BfgRetriever implements ContextRetriever {
             )
         }
         const isVerboseDebug = vscode.workspace.getConfiguration().get<boolean>('cody.debug.verbose', false)
-        const child = child_process.spawn(codyrpc, { stdio: 'pipe', env: { VERBOSE_DEBUG: `${isVerboseDebug}` } })
+        const child = child_process.spawn(codyrpc, {
+            stdio: 'pipe',
+            env: {
+                VERBOSE_DEBUG: `${isVerboseDebug}`,
+                RUST_BACKTRACE: isVerboseDebug ? '1' : '0',
+            },
+        })
         child.stderr.on('data', chunk => {
             logDebug('CodyEngine', 'stderr', chunk.toString())
         })

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -62,10 +62,10 @@ class JsonrpcError extends Error {
     public toString(): string {
         return `${this.name}: ${this.message}`
     }
-    get name(): string {
+    public get name(): string {
         return ErrorCode[this.info.code]
     }
-    get message(): string {
+    public get message(): string {
         if (typeof this.info?.data === 'string') {
             try {
                 const data = JSON.parse(this.info.data)
@@ -254,7 +254,7 @@ export class MessageHandler {
     private cancelTokens: Map<Id, vscode.CancellationTokenSource> = new Map()
     private notificationHandlers: Map<NotificationMethodName, NotificationCallback<any>> = new Map()
     private alive = true
-    private processExitedError = () => new Error('Process has exited')
+    private processExitedError: () => Error = () => new Error('Process has exited')
     private responseHandlers: Map<
         Id,
         {

--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -15,7 +15,7 @@ function gitRepositoryRemoteUrl(uri: vscode.Uri): string | undefined {
         const git = gitAPI()
         const repository = git?.getRepository(uri)
         if (!repository) {
-            console.warn('No Git repository for URI', uri)
+            console.warn(`No Git repository for URI ${uri}`)
             return undefined
         }
 


### PR DESCRIPTION
Previously, the agent e2e tests were failing after the recent introduction of BFG support. This PR fixes the regressions so that the e2e tests are working against. To get the tests passing again, I had to update our JSON-RPC bindings to correctly handle error respones from the server, which required fixing how `recipes/execute` handles errors.


## Test plan

```
src login
cd agent
pnpm run test src/index.test.ts
```
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
