### PR TITLE
Fix scip-typescript upload job

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -31,20 +31,19 @@ jobs:
             ${{ runner.os }}-pnpm-store-
       - run: pnpm install --frozen-lockfile
       - run: pnpm dlx @sourcegraph/scip-typescript index --pnpm-workspaces --no-global-caches
-      - run: yarn global add @sourcegraph/src
       - name: Upload SCIP to Cloud
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.com/
       - name: Upload SCIP to S2
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
+        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress
         env:
           SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
       - name: Upload lsif to Dogfood
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://k8s.sgdev.org/
       - name: Upload lsif to Demo
-        run: src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
+        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:
           SRC_ENDPOINT: https://demo.sourcegraph.com/

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -292,6 +292,7 @@ export class Agent extends MessageHandler {
                 if (params.triggerKind === 'Invoke') {
                     await provider.manuallyTriggerCompletion()
                 }
+
                 const result = await provider.provideInlineCompletionItems(
                     textDocument,
                     new vscode.Position(params.position.line, params.position.character),


### PR DESCRIPTION
The scip-typescript job was failing with this error
```
error This project's package.json defines "packageManager": "yarn@pnpm@8.6.7". However the current global version of Yarn is 1.22.21.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
```

## Test plan
Green scip-typescript CI job
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
