### PR TITLE
fix: chat history handling in ChatPanelProvider

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Edit: Fixed an issue where Cody would regularly include unrelated XML tags in the generated output. [pull/1789](https://github.com/sourcegraph/cody/pull/1789)
 - - Chat: Fixed an issue that caused Cody to be unable to locate active editors when running commands from the new chat panel. [pull/1793](https://github.com/sourcegraph/cody/pull/1793)
 - Chat: Replaced uses of deprecated getWorkspaceRootPath that caused Cody to be unable to determine the current workspace in the chat panel. [pull/1793](https://github.com/sourcegraph/cody/pull/1793)
+- Chat: Input history is now preserved between chat sessions. [pull/1826](https://github.com/sourcegraph/cody/pull/1826)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -183,12 +183,12 @@ export class ChatPanelProvider extends MessageProvider {
     /**
      * Update chat history in Tree View
      */
-    protected handleHistory(userHistory?: UserLocalHistory): void {
-        const history = userHistory || {
-            chat: MessageProvider.chatHistory,
-            input: MessageProvider.inputHistory,
-        }
-        this.treeView.updateTree(createCodyChatTreeItems(history))
+    protected handleHistory(userHistory: UserLocalHistory): void {
+        void this.webview?.postMessage({
+            type: 'history',
+            messages: userHistory,
+        })
+        this.treeView.updateTree(createCodyChatTreeItems(userHistory))
     }
 
     /**


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1827

Right now in the new chat UI, users cannot loop through their input history on UP arrow. This is because we are not sending the history back to the webview

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Start Cody from this build, and then press the `UP` arrow on your keyboard to loop through your input history/


### Before

Input history is not showing up on UP arrow press

![image](https://github.com/sourcegraph/cody/assets/68532117/d83ee2d2-be30-48a5-9a7f-d81ac1a46156)

### After

You can loop through input history on UP arrow

![image](https://github.com/sourcegraph/cody/assets/68532117/69df756e-47d0-4964-8c13-55febd25b5a9)
