### PR TITLE
fix: select first command on slash

### DIFF
--- a/lib/shared/src/chat/prompts/vscode-context.ts
+++ b/lib/shared/src/chat/prompts/vscode-context.ts
@@ -390,43 +390,49 @@ export async function getContextMessageFromFiles(files: vscode.Uri[]): Promise<C
  */
 export async function getEditorOpenTabsContext(skipDirectory?: string): Promise<ContextMessage[]> {
     const contextMessages: ContextMessage[] = []
+    try {
+        // Get open tabs
+        const tabGroups = vscode.window.tabGroups.all
+        const openTabs = tabGroups.flatMap(group => group.tabs.map(tab => tab.input)) as vscode.TabInputText[]
 
-    // Get open tabs
-    const tabGroups = vscode.window.tabGroups.all
-    const openTabs = tabGroups.flatMap(group => group.tabs.map(tab => tab.input)) as vscode.TabInputText[]
+        for (const tab of openTabs) {
+            // Skip non-file URIs
+            if (tab.uri?.scheme !== 'file') {
+                continue
+            }
 
-    for (const tab of openTabs) {
-        // Skip non-file URIs
-        if (tab.uri.scheme !== 'file') {
-            continue
+            // Skip tabs in skipDirectory
+            if (skipDirectory && tab.uri.fsPath.includes(skipDirectory)) {
+                continue
+            }
+
+            // Get context using file path for files not in the current workspace
+            if (!isInWorkspace(tab.uri)) {
+                const contextMessage = await getFilePathContext(tab.uri.fsPath)
+                contextMessages.push(...contextMessage)
+                continue
+            }
+
+            // Get file name and extract context from current workspace file
+            const fileUri = tab.uri
+            const fileName = createVSCodeRelativePath(fileUri.fsPath)
+            const fileText = await getCurrentVSCodeDocTextByURI(fileUri)
+
+            // Truncate file text
+            const truncatedText = truncateText(fileText, MAX_CURRENT_FILE_TOKENS)
+
+            // Create context message
+            const message = getContextMessageWithResponse(
+                populateCurrentEditorContextTemplate(truncatedText, fileName),
+                {
+                    fileName,
+                }
+            )
+
+            contextMessages.push(...message)
         }
-
-        // Skip tabs in skipDirectory
-        if (skipDirectory && tab.uri.fsPath.includes(skipDirectory)) {
-            continue
-        }
-
-        // Get context using file path for files not in the current workspace
-        if (!isInWorkspace(tab.uri)) {
-            const contextMessage = await getFilePathContext(tab.uri.fsPath)
-            contextMessages.push(...contextMessage)
-            continue
-        }
-
-        // Get file name and extract context from current workspace file
-        const fileUri = tab.uri
-        const fileName = createVSCodeRelativePath(fileUri.fsPath)
-        const fileText = await getCurrentVSCodeDocTextByURI(fileUri)
-
-        // Truncate file text
-        const truncatedText = truncateText(fileText, MAX_CURRENT_FILE_TOKENS)
-
-        // Create context message
-        const message = getContextMessageWithResponse(populateCurrentEditorContextTemplate(truncatedText, fileName), {
-            fileName,
-        })
-
-        contextMessages.push(...message)
+    } catch {
+        // no ops
     }
 
     return contextMessages

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -291,15 +291,15 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             }
             if (inputValue === '/') {
                 setDisplayCommands(chatCommands)
-                setSelectedChatCommand(chatCommands.length)
+                setSelectedChatCommand(0)
                 return
             }
             if (inputValue.startsWith('/')) {
                 const filteredCommands = filterChatCommands
                     ? filterChatCommands(chatCommands, inputValue)
-                    : chatCommands.filter(([_, prompt]) => prompt.slashCommand?.startsWith(inputValue))
+                    : chatCommands.filter(command => command[1].slashCommand?.startsWith(inputValue))
                 setDisplayCommands(filteredCommands)
-                setSelectedChatCommand(0)
+                // setSelectedChatCommand(0)
                 return
             }
             setDisplayCommands(null)
@@ -406,28 +406,24 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             if (displayCommands && formInput.startsWith('/')) {
                 if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
                     event.preventDefault()
-                    event.stopPropagation()
                     const commandsLength = displayCommands?.length
                     const curIndex = event.key === 'ArrowUp' ? selectedChatCommand - 1 : selectedChatCommand + 1
-                    const newIndex = curIndex < 0 ? commandsLength - 1 : curIndex >= commandsLength - 1 ? 0 : curIndex
+                    const newIndex = curIndex < 0 ? commandsLength - 1 : curIndex > commandsLength - 1 ? 0 : curIndex
                     setSelectedChatCommand(newIndex)
                     const newInput = displayCommands?.[newIndex]?.[1]?.slashCommand
                     setFormInput(newInput || formInput)
+                    return
                 }
                 // close the chat command suggestions on escape key
                 if (event.key === 'Escape') {
                     setDisplayCommands(null)
                     setSelectedChatCommand(-1)
                     setFormInput('')
+                    return
                 }
                 // tab/enter to complete
-                if (
-                    (event.key === 'Tab' || event.key === 'Enter') &&
-                    selectedChatCommand > -1 &&
-                    displayCommands.length
-                ) {
+                if ((event.key === 'Tab' || event.key === 'Enter') && displayCommands.length) {
                     event.preventDefault()
-                    event.stopPropagation()
                     const selectedCommand = displayCommands?.[selectedChatCommand]?.[1]
                     if (formInput.startsWith(selectedCommand?.slashCommand)) {
                         // submit message if the input has slash command already completed

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - - Chat: Fixed an issue that caused Cody to be unable to locate active editors when running commands from the new chat panel. [pull/1793](https://github.com/sourcegraph/cody/pull/1793)
 - Chat: Replaced uses of deprecated getWorkspaceRootPath that caused Cody to be unable to determine the current workspace in the chat panel. [pull/1793](https://github.com/sourcegraph/cody/pull/1793)
 - Chat: Input history is now preserved between chat sessions. [pull/1826](https://github.com/sourcegraph/cody/pull/1826)
+- Chat: Fixed chat command selection behavior in chat input box. [pull/1828](https://github.com/sourcegraph/cody/pull/1828)
 
 ### Changed
 

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -35,9 +35,15 @@ export class CommandRunner implements vscode.Disposable {
         const commandKey = command.slashCommand
         this.kind = command.type === 'default' ? commandKey.replace('/', '') : 'custom'
 
+        if (instruction?.startsWith('/edit ')) {
+            command.mode = 'edit'
+        } else {
+            command.mode = command.mode || 'ask'
+        }
+
         // Log commands usage
         telemetryService.log(`CodyVSCodeExtension:command:${this.kind}:executed`, {
-            mode: command.mode || 'ask',
+            mode: command.mode,
             useCodebaseContex: !!command.context?.codebase,
             useShellCommand: !!command.context?.command,
             requestID: command.requestID,
@@ -47,7 +53,7 @@ export class CommandRunner implements vscode.Disposable {
 
         // Commands only work in active editor / workspace unless context specifies otherwise
         this.editor = getActiveEditor()
-        if (!this.editor && command.context?.none && command.slashCommand !== '/ask') {
+        if (!this.editor && !command.context?.none && command.slashCommand !== '/ask') {
             const errorMsg = 'Failed to create command: No active text editor found.'
             logDebug('CommandRunner:int:fail', errorMsg)
             void vscode.window.showErrorMessage(errorMsg)

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -131,7 +131,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         this.lastUsedCommands.add(command.slashCommand)
 
         // Fixup request will be taken care by the fixup recipe in the CommandRunner
-        if (isFixupRequest || command.mode === 'inline') {
+        if (isFixupRequest || command.mode !== 'ask') {
             return ''
         }
 

--- a/vscode/src/editor/EditorCodeLenses.ts
+++ b/vscode/src/editor/EditorCodeLenses.ts
@@ -108,8 +108,8 @@ export class EditorCodeLenses implements vscode.CodeLensProvider {
 
         // Add code lenses for each symbol
         if (symbols) {
-            for (let i = 0; i < symbols.length; i++) {
-                const range = symbols[i].location.range
+            for (const symbol of symbols) {
+                const range = symbol.location.range
                 const selection = new vscode.Selection(range.start, range.end)
                 codeLenses.push(
                     new vscode.CodeLens(range, {
@@ -125,7 +125,7 @@ export class EditorCodeLenses implements vscode.CodeLensProvider {
                         })
                     )
                 }
-                codeLensesMap.set(i.toString(), range)
+                codeLensesMap.set(symbol.location.range.start.line.toString(), range)
             }
         }
 

--- a/vscode/webviews/ChatCommands.tsx
+++ b/vscode/webviews/ChatCommands.tsx
@@ -15,22 +15,24 @@ export const ChatCommandsComponent: React.FunctionComponent<React.PropsWithChild
     setSelectedChatCommand,
     onSubmit,
 }) => {
+    const commands = chatCommands?.filter(([key]) => key !== 'separator')
+
     const commandRef = useRef<HTMLButtonElement>(null)
 
     useEffect(() => {
-        const container = commandRef.current?.parentElement
+        const selectedContainer = commandRef.current
 
-        // If selected command is first, scroll to top. Otherwise, scroll to bottom
-        if (container) {
-            if (selectedChatCommand === chatCommands?.length || selectedChatCommand === 0) {
-                container.scrollTop = 0
-            } else {
-                container.scrollTop = container.scrollHeight - container.clientHeight
-            }
+        if (selectedContainer) {
+            selectedContainer.scrollIntoView({ block: 'nearest' })
         }
+    }, [selectedChatCommand])
 
-        commandRef.current?.focus()
-    }, [chatCommands, chatCommands?.length, selectedChatCommand, setFormInput])
+    useEffect(() => {
+        // Set the selected to the first item whenever the length changes
+        if (commands?.length) {
+            setSelectedChatCommand(0)
+        }
+    }, [commands?.length, setSelectedChatCommand])
 
     const onCommandClick = (slashCommand: string): void => {
         if (!slashCommand) {
@@ -41,7 +43,6 @@ export const ChatCommandsComponent: React.FunctionComponent<React.PropsWithChild
         setSelectedChatCommand(-1)
     }
 
-    const commands = chatCommands?.filter(([key]) => key !== 'separator')
     if (!commands?.length || selectedChatCommand === undefined || selectedChatCommand < 0) {
         return null
     }


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/cody/issues/1813

- Fixed issues described in https://github.com/sourcegraph/cody/issues/1813
- Fixed issue where errors from getting open tabs context would cause commands to be stuck
- Updated Editor Code Lenses to show up once only using `SET`

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Follow the instruction in https://github.com/sourcegraph/cody/issues/1813 and try to reproduce it in this branch build.

## DEMO

- [x] Can hit enter to select first item after typing /
- [x] Can go to second item by pressing down after typing /

https://github.com/sourcegraph/cody/assets/68532117/9f956ef0-5668-4a8c-8110-01829982eb95


- [x] Navigating down just goes one item at a time, and brings the item into view at the bottom or top (same as the @ file selector)


https://github.com/sourcegraph/cody/assets/68532117/6b797c2d-86bb-46ad-88e8-dcff24d7231e

