### PR TITLE
Fix: Chat spins forever after errors

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -50,6 +50,8 @@ export abstract class SourcegraphCompletionsClient {
                     if (!this.errorEncountered) {
                         cb.onComplete()
                     }
+                    // reset errorEncountered for next request
+                    this.errorEncountered = false                    
                     break
             }
         }


### PR DESCRIPTION
When a chat request errors a variable is set to capture that, so that when the done event arrives it will not call on complete.  However the chat client is reused for the next chat message leaving `errorEncountered` to true which would stop the promise from resolving unless it were to fail again.  

This change resets  `errorEncountered` back to false when receiving the done message for errored requests.

resolves https://github.com/sourcegraph/cody/issues/1830
## Test plan
Manual testing
Attempted a chat that would exceed token limit - got an error
Tried another chat and it was successful 
<img width="424" alt="Screenshot 2023-11-20 at 1 09 31 PM" src="https://github.com/sourcegraph/cody/assets/6098507/48588db7-0d0c-4a07-aa5b-fdec7c8e85a3">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
