### PR TITLE
fix: race condition on new panel creation

### DIFF
--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -41,7 +41,9 @@ export class ChatManager implements vscode.Disposable {
         this.disposables.push(
             vscode.commands.registerCommand('cody.chat.history.export', async () => this.exportHistory()),
             vscode.commands.registerCommand('cody.chat.history.clear', async () => this.clearHistory()),
-            vscode.commands.registerCommand('cody.chat.history.delete', async item => this.clearHistory(item))
+            vscode.commands.registerCommand('cody.chat.history.delete', async item => this.clearHistory(item)),
+            vscode.commands.registerCommand('cody.chat.panel.new', async () => this.createNewWebviewPanel()),
+            vscode.commands.registerCommand('cody.chat.panel.restore', async (id, chat) => this.restorePanel(id, chat))
         )
 
         // Register config change listener
@@ -225,6 +227,19 @@ export class ChatManager implements vscode.Disposable {
         this.options.authProvider.webview = this.sidebarChat.webview
         this.chatPanelsManager?.dispose()
         this.chatPanelsManager = undefined
+    }
+
+    // For registering the commands for chat panels in advance
+    private async createNewWebviewPanel(): Promise<void> {
+        if (this.chatPanelsManager) {
+            await this.chatPanelsManager?.createWebviewPanel()
+        }
+    }
+
+    private async restorePanel(chatID: string, chatQuestion?: string): Promise<void> {
+        if (this.chatPanelsManager) {
+            await this.chatPanelsManager?.restorePanel(chatID, chatQuestion)
+        }
     }
 
     public dispose(): void {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -87,7 +87,8 @@ export class ChatPanelsManager implements vscode.Disposable {
      */
     public async createWebviewPanel(chatID?: string, chatQuestion?: string): Promise<ChatPanelProvider> {
         if (this.activePanelProvider && !this.activePanelProvider?.webviewPanel?.active) {
-            void vscode.window.showInformationMessage(
+            this.activePanelProvider.webviewPanel?.reveal()
+            void vscode.window.showErrorMessage(
                 'Please wait for the current panel to be activated before opening a new one.'
             )
             return this.activePanelProvider

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -88,9 +88,7 @@ export class ChatPanelsManager implements vscode.Disposable {
     public async createWebviewPanel(chatID?: string, chatQuestion?: string): Promise<ChatPanelProvider> {
         if (this.activePanelProvider && !this.activePanelProvider?.webviewPanel?.active) {
             this.activePanelProvider.webviewPanel?.reveal()
-            void vscode.window.showErrorMessage(
-                'Please wait for the current panel to load.'
-            )
+            void vscode.window.showErrorMessage('Please wait for the current panel to load.')
             return this.activePanelProvider
         }
 

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -45,12 +45,6 @@ export class ChatPanelsManager implements vscode.Disposable {
             vscode.window.registerTreeDataProvider('cody.commands.tree.view', new TreeViewProvider('command'))
         )
 
-        // Register Commands
-        this.disposables.push(
-            vscode.commands.registerCommand('cody.chat.panel.new', async () => this.createWebviewPanel()),
-            vscode.commands.registerCommand('cody.chat.panel.restore', async (id, chat) => this.restorePanel(id, chat))
-        )
-
         // Register config change listener
         this.onConfigurationChange = options.contextProvider.configurationChangeEvent.event(async () => {
             // When chat.chatPanel is set to true, the sidebar chat view will never be shown
@@ -92,6 +86,22 @@ export class ChatPanelsManager implements vscode.Disposable {
      * Creates a new webview panel for chat.
      */
     public async createWebviewPanel(chatID?: string, chatQuestion?: string): Promise<ChatPanelProvider> {
+        if (this.activePanelProvider && !this.activePanelProvider?.webviewPanel?.active) {
+            void vscode.window.showInformationMessage(
+                'Please wait for the current panel to be activated before opening a new one.'
+            )
+            return this.activePanelProvider
+        }
+
+        if (chatID && this.panelProvidersMap.has(chatID)) {
+            const provider = this.panelProvidersMap.get(chatID)
+            if (provider) {
+                provider.webviewPanel?.reveal()
+                void this.selectTreeItem(chatID)
+                return provider
+            }
+        }
+
         logDebug('ChatPanelsManager:createWebviewPanel', this.panelProvidersMap.size.toString())
         const provider = new ChatPanelProvider(this.options)
         const webviewPanel = await provider.createWebviewPanel(chatID, chatQuestion)
@@ -100,7 +110,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         this.panelProvidersMap.set(sessionID, provider)
 
         webviewPanel?.onDidChangeViewState(e => {
-            if (e.webviewPanel.visible && e.webviewPanel.active) {
+            if (e.webviewPanel.visible) {
                 this.activePanelProvider = provider
                 this.options.contextProvider.webview = provider.webview
                 void this.selectTreeItem(provider.sessionID)
@@ -192,15 +202,19 @@ export class ChatPanelsManager implements vscode.Disposable {
     }
 
     public async restorePanel(chatID: string, chatQuestion?: string): Promise<void> {
-        logDebug('ChatPanelsManager', 'restorePanel')
-        // Panel already exists, just reveal it
-        const provider = this.panelProvidersMap.get(chatID)
-        if (provider) {
-            provider.webviewPanel?.reveal()
-            return
-        }
+        try {
+            logDebug('ChatPanelsManager', 'restorePanel')
+            // Panel already exists, just reveal it
+            const provider = this.panelProvidersMap.get(chatID)
+            if (provider) {
+                provider.webviewPanel?.reveal()
+                return
+            }
 
-        await this.createWebviewPanel(chatID, chatQuestion)
+            await this.createWebviewPanel(chatID, chatQuestion)
+        } catch (error) {
+            console.error(error, 'errored restoring panel')
+        }
     }
 
     public triggerNotice(notice: { key: string }): void {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -89,7 +89,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         if (this.activePanelProvider && !this.activePanelProvider?.webviewPanel?.active) {
             this.activePanelProvider.webviewPanel?.reveal()
             void vscode.window.showErrorMessage(
-                'Please wait for the current panel to be activated before opening a new one.'
+                'Please wait for the current panel to load.'
             )
             return this.activePanelProvider
         }

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -39,7 +39,13 @@ export function createCodyChatTreeItems(userHistory: UserLocalHistory): CodySide
     chatHistoryEntries.forEach(([id, entry]) => {
         const lastHumanMessage = entry?.interactions?.findLast(interaction => interaction?.humanMessage)
         if (lastHumanMessage?.humanMessage.displayText && lastHumanMessage?.humanMessage.text) {
-            const title = lastHumanMessage.humanMessage.displayText.split('\n')[0]
+            let title = lastHumanMessage.humanMessage.displayText.split('\n')[0]
+
+            // Display command key only
+            if (title.startsWith('/')) {
+                title = title.split(' ')[0]
+            }
+
             chatTreeItems.push({
                 id,
                 title,

--- a/vscode/test/e2e/inline-assist.test.ts
+++ b/vscode/test/e2e/inline-assist.test.ts
@@ -56,6 +56,7 @@ test('start a fixup job from inline chat with valid auth', async ({ page, sideba
     await assertEvents(loggedEvents, expectedEvents)
     await assertEvents(loggedV2Events, [
         'cody.auth/failed',
+        'cody.auth/failed',
         'cody.auth/connected',
         'cody.command.edit/executed',
         'cody.recipe.fixup/executed',

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -78,6 +78,7 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     await assertEvents(loggedEvents, expectedEvents)
     await assertEvents(loggedV2Events, [
         'cody.auth/failed',
+        'cody.auth/failed',
         'cody.auth/connected',
         'cody.command.edit/executed',
         'cody.recipe.fixup/executed',

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -184,6 +184,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
 
     if (!view || !authStatus || !config) {
+        vscodeAPI.postMessage({ command: 'ready' })
         return <LoadingPage />
     }
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1809

This PR  moves the command registration step to chat manager, and new condition to check if the current panel has been activated or not. If it's not activated, display a warning and ask users to wait for the current panel to be activated before opening a new one to prevent race condition described in the issue https://github.com/sourcegraph/cody/issues/1809

### DEMO

https://github.com/sourcegraph/cody/assets/68532117/1619b1de-bc5b-40e9-9598-66c708d53f5e

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try to reproduce the steps described in the original issue to confirm.

RE: https://github.com/sourcegraph/cody/issues/1757

I also cannot reproduce the issue mentioned in https://github.com/sourcegraph/cody/issues/1757 with this build

https://github.com/sourcegraph/cody/assets/68532117/cbb9d307-3946-48c9-87d8-d3faa2df8e93

