### PR TITLE
fix: auto reload chat panel

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Replaced uses of deprecated getWorkspaceRootPath that caused Cody to be unable to determine the current workspace in the chat panel. [pull/1793](https://github.com/sourcegraph/cody/pull/1793)
 - Chat: Input history is now preserved between chat sessions. [pull/1826](https://github.com/sourcegraph/cody/pull/1826)
 - Chat: Fixed chat command selection behavior in chat input box. [pull/1828](https://github.com/sourcegraph/cody/pull/1828)
+- Chat: Fix issue with chat panel fails to load when multiple chat panels are opened simultaneously.
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -86,12 +86,6 @@ export class ChatPanelsManager implements vscode.Disposable {
      * Creates a new webview panel for chat.
      */
     public async createWebviewPanel(chatID?: string, chatQuestion?: string): Promise<ChatPanelProvider> {
-        if (this.activePanelProvider && !this.activePanelProvider?.webviewPanel?.active) {
-            this.activePanelProvider.webviewPanel?.reveal()
-            void vscode.window.showErrorMessage('Please wait for the current panel to load.')
-            return this.activePanelProvider
-        }
-
         if (chatID && this.panelProvidersMap.has(chatID)) {
             const provider = this.panelProvidersMap.get(chatID)
             if (provider) {
@@ -109,7 +103,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         this.panelProvidersMap.set(sessionID, provider)
 
         webviewPanel?.onDidChangeViewState(e => {
-            if (e.webviewPanel.visible) {
+            if (e.webviewPanel.visible && e.webviewPanel.active) {
                 this.activePanelProvider = provider
                 this.options.contextProvider.webview = provider.webview
                 void this.selectTreeItem(provider.sessionID)

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -191,7 +191,9 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         // This mean webview is not ready
         if (isWebviewReady && !authStatus && !config && !view) {
             setIsWebviewReady(false)
-            vscodeAPI.postMessage({ command: 'ready' })
+            setTimeout(() => {
+                vscodeAPI.postMessage({ command: 'ready' })
+            }, 2000)
         }
         return <LoadingPage />
     }


### PR DESCRIPTION
Follow up from https://github.com/sourcegraph/cody/pull/1835

Instead of checking if the current chat panel is active or not, this PR updates the webview to reload automatically when it failed to load after 2000ms so users can have multiple chat panels opened, where some of them might be stuck at the loading stuck when it was first opened, but they will reload automatically.

- Add delays before sending webview ready events to prevent premature sending.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

https://github.com/sourcegraph/cody/assets/68532117/37480645-0e71-4c2c-82a9-ab88d65834e1

