### PR TITLE
Autocomplete: make javascript completion intent queries more precise

### DIFF
--- a/vscode/src/tree-sitter/queries.ts
+++ b/vscode/src/tree-sitter/queries.ts
@@ -18,6 +18,7 @@ export const intentPriority = [
     'arguments',
     'import.source',
     'comment',
+    'pair.value',
     'argument',
     'parameter',
     'parameters',

--- a/vscode/src/tree-sitter/queries/javascript.ts
+++ b/vscode/src/tree-sitter/queries/javascript.ts
@@ -44,15 +44,49 @@ const JS_INTENTS_QUERY = dedent`
     ; Atomic intents
     ;--------------------------------
 
+    (comment) @comment!
     (import_statement
         source: (string) @import.source!)
 
-    (comment) @comment!
-    (arguments (_) @argument!)
+    (pair
+        value: [
+            (string (_)*)
+            (template_string)
+            (number)
+            (identifier)
+            (true)
+            (false)
+            (null)
+            (undefined)
+        ] @pair.value!)
+
+    (arguments
+        [
+            (string (_)*)
+            (template_string)
+            (number)
+            (identifier)
+            (true)
+            (false)
+            (null)
+            (undefined)
+        ] @argument!)
+
     (formal_parameters) @parameters!
     (formal_parameters (_) @parameter!)
+
     (return_statement) @return_statement!
-    (return_statement (_) @return_statement.value!)
+    (return_statement
+        [
+            (string (_)*)
+            (template_string)
+            (number)
+            (identifier)
+            (true)
+            (false)
+            (null)
+            (undefined)
+        ] @return_statement.value!)
 `
 
 const JSX_INTENTS_QUERY = dedent`

--- a/vscode/src/tree-sitter/query-tests/test-data/intents.snap.ts
+++ b/vscode/src/tree-sitter/query-tests/test-data/intents.snap.ts
@@ -173,3 +173,41 @@
 // Nodes types:
 // arguments[1]: arguments
 
+// ------------------------------------
+
+  const object = {
+      key: "value"
+//         ^^^^^^^ pair.value[1]
+//         █
+  }
+
+// Nodes types:
+// pair.value[1]: string
+
+// ------------------------------------
+
+  returnStatementValue("value", () => {
+//                                    ^ start function.body[1]
+//                                    █
+      const value = "value"
+  })
+//^ end function.body[1]
+
+// Nodes types:
+// function.body[1]: statement_block
+
+// ------------------------------------
+
+  returnStatementValue("value", {key: value})
+//                                    ^^^^^ pair.value[1]
+//                                    █
+
+// Nodes types:
+// pair.value[1]: identifier
+
+// ------------------------------------
+
+returnStatementValue("value", () => {
+    const value = "value"
+   //             |
+})

--- a/vscode/src/tree-sitter/query-tests/test-data/intents.ts
+++ b/vscode/src/tree-sitter/query-tests/test-data/intents.ts
@@ -95,3 +95,29 @@ returnStatementValue("value", false)
 
 returnStatementValue()
 //                  |
+
+// ------------------------------------
+
+const object = {
+    key: "value"
+    //   |
+}
+
+// ------------------------------------
+
+returnStatementValue("value", () => {
+    //                              |
+    const value = "value"
+})
+
+// ------------------------------------
+
+returnStatementValue("value", {key: value})
+//                                  |
+
+// ------------------------------------
+
+returnStatementValue("value", () => {
+    const value = "value"
+   //             |
+})


### PR DESCRIPTION
## Context

- JS completion intent queries are too broad because of the "any" matches used in queries: `(arguments (_) @argument)`. It leads to misleading completion intent analytics results. E.g., too many node type combos fall into the "argument" completion intent even though they are deeply nested inside the `arguments` node. This PR limits the `argument` completion intent query to a few popular node types. We can expand the list later based on the analytics data.

Example of the misleading match for the `argument` completion intent:
```ts
myFunction(() => {
  const value = {
    █
  }
```

- Adds a query for the `pair.value` completion intent.
- Part of https://github.com/sourcegraph/cody/issues/1455

## Test plan

Updated snapshot tests.
