### PR TITLE
Autocomplete: log `insertText` for DotCom users

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -61,6 +61,8 @@ describe('[getInlineCompletions] completion event', () => {
                 "items": [
                   {
                     "charCount": 30,
+                    "insertText": "console.log(bar)
+              return false}",
                     "lineCount": 2,
                     "lineTruncatedCount": 0,
                     "nodeTypes": {
@@ -112,6 +114,7 @@ describe('[getInlineCompletions] completion event', () => {
                 "items": [
                   {
                     "charCount": 5,
+                    "insertText": "\\"foo\\"",
                     "lineCount": 1,
                     "lineTruncatedCount": undefined,
                     "nodeTypes": {

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -82,6 +82,7 @@ describe('logger', () => {
                 {
                     charCount: 3,
                     lineCount: 1,
+                    insertText: 'foo',
                     lineTruncatedCount: undefined,
                     nodeTypes: undefined,
                     parseErrorCount: undefined,

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -504,11 +504,9 @@ function getSharedParams(event: CompletionEvent): TelemetryEventProperties {
 function completionItemToItemInfo(item: InlineCompletionItemWithAnalytics, isDotComUser = false): CompletionItemInfo {
     const { lineCount, charCount } = lineAndCharCount(item)
 
-    return {
+    const completionItemInfo: CompletionItemInfo = {
         lineCount,
         charCount,
-        // 🚨 SECURITY: included only for DotCom users.
-        insertText: isDotComUser ? item.insertText : undefined,
         stopReason: item.stopReason,
         parseErrorCount: item.parseErrorCount,
         lineTruncatedCount: item.lineTruncatedCount,
@@ -516,6 +514,13 @@ function completionItemToItemInfo(item: InlineCompletionItemWithAnalytics, isDot
         nodeTypes: item.nodeTypes,
         nodeTypesWithCompletion: item.nodeTypesWithCompletion,
     }
+
+    if (isDotComUser) {
+        // 🚨 SECURITY: included only for DotCom users.
+        completionItemInfo.insertText = item.insertText
+    }
+
+    return completionItemInfo
 }
 
 const otherCompletionProviders = [


### PR DESCRIPTION
## Context

- Adds `insertText` to analytics events for DotCom users only.
- Adds a unit test to check that the `insertText` is only included for DotCom users.

## Test plan

CI
