### PR TITLE
Autocomplete: Move decision which StarCoder model to use to the server

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -12,8 +12,6 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
-    // This flag is only used when `CodyAutocompleteStarCoderHybrid` is also true
-    CodyAutocompleteStarCoderHybridSourcegraph = 'cody-autocomplete-default-starcoder-hybrid-sourcegraph',
     CodyAutocompleteLlamaCode7B = 'cody-autocomplete-default-llama-code-7b',
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-default-llama-code-13b',
     CodyAutocompleteContextLspLight = 'cody-autocomplete-context-lsp-light',

--- a/vscode/src/completions/providers/createProvider.ts
+++ b/vscode/src/completions/providers/createProvider.ts
@@ -121,7 +121,6 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(configuredPr
         starCoder7b,
         starCoder16b,
         starCoderHybrid,
-        starCoderHybridSourcegraph,
         llamaCode7b,
         llamaCode13b,
         starcoderExtendedTokenWindow,
@@ -130,7 +129,6 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(configuredPr
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder7B),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybridSourcegraph),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode7B),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderExtendedTokenWindow),
@@ -143,9 +141,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(configuredPr
             : starCoder16b
             ? 'starcoder-16b'
             : starCoderHybrid
-            ? starCoderHybridSourcegraph
-                ? 'starcoder-hybrid-sourcegraph'
-                : 'starcoder-hybrid'
+            ? 'starcoder-hybrid'
             : llamaCode7b
             ? 'llama-code-7b'
             : 'llama-code-13b'

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -37,10 +37,11 @@ const EOT_LLAMA_CODE = ' <EOT>'
 // Model identifiers can be found in https://docs.fireworks.ai/explore/ and in our internal
 // conversations
 const MODEL_MAP = {
-    'starcoder-16b': 'fireworks/accounts/fireworks/models/starcoder-16b-w8a16',
-    'starcoder-16b-sourcegraph': 'fireworks/accounts/sourcegraph/models/starcoder-16b',
-    'starcoder-7b': 'fireworks/accounts/fireworks/models/starcoder-7b-w8a16',
-    'starcoder-7b-sourcegraph': 'fireworks/accounts/sourcegraph/models/starcoder-7b',
+    // Models in production
+    'starcoder-16b': 'fireworks/starcoder-16b',
+    'starcoder-7b': 'fireworks/starcoder-7b',
+
+    // Models in evaluation
     'starcoder-3b': 'fireworks/accounts/fireworks/models/starcoder-3b-w8a16',
     'starcoder-1b': 'fireworks/accounts/fireworks/models/starcoder-1b-w8a16',
     'wizardcoder-15b': 'fireworks/accounts/fireworks/models/wizardcoder-15b',
@@ -54,12 +55,10 @@ type FireworksModel =
     | keyof typeof MODEL_MAP
     // `starcoder-hybrid` uses the 16b model for multiline requests and the 7b model for single line
     | 'starcoder-hybrid'
-    | 'starcoder-hybrid-sourcegraph'
 
 function getMaxContextTokens(model: FireworksModel, starcoderExtendedTokenWindow?: boolean): number {
     switch (model) {
         case 'starcoder-hybrid':
-        case 'starcoder-hybrid-sourcegraph':
         case 'starcoder-16b':
         case 'starcoder-7b':
         case 'starcoder-3b':
@@ -164,8 +163,6 @@ export class FireworksProvider extends Provider {
         const model =
             this.model === 'starcoder-hybrid'
                 ? MODEL_MAP[multiline ? 'starcoder-16b' : 'starcoder-7b']
-                : this.model === 'starcoder-hybrid-sourcegraph'
-                ? MODEL_MAP[multiline ? 'starcoder-16b-sourcegraph' : 'starcoder-7b-sourcegraph']
                 : MODEL_MAP[this.model]
 
         const timeoutMs: number = multiline
@@ -289,8 +286,6 @@ export function createProviderConfig({
             ? 'starcoder-hybrid'
             : model === 'starcoder-hybrid'
             ? 'starcoder-hybrid'
-            : model === 'starcoder-hybrid-sourcegraph'
-            ? 'starcoder-hybrid-sourcegraph'
             : Object.prototype.hasOwnProperty.call(MODEL_MAP, model)
             ? (model as keyof typeof MODEL_MAP)
             : null


### PR DESCRIPTION
Follow up to sourcegraph/sourcegraph#58404

This PR moves the client logic of picking the right StarCoder model to the server.

## Test plan

<img width="1258" alt="Screenshot 2023-11-21 at 13 24 21" src="https://github.com/sourcegraph/cody/assets/458591/ec5dab09-c41c-4d04-b759-38864ab50cf8">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
