### PR TITLE
update: sort file results

### DIFF
--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -288,13 +288,25 @@ export class ChatPanelProvider extends MessageProvider {
 
         const debouncedContextFileQuery = debounce(async (query: string): Promise<void> => {
             try {
-                const MAX_RESULTS = 10
-                const fileResultsPromise = getFileContextFile(query, MAX_RESULTS)
+                const MAX_RESULTS = 20
+                const fileResultsPromise = getFileContextFile(query, 50)
                 const symbolResultsPromise = getSymbolContextFile(query, MAX_RESULTS)
 
                 const [fileResults, symbolResults] = await Promise.all([fileResultsPromise, symbolResultsPromise])
-                const context = [...new Set([...fileResults, ...symbolResults])]
-
+                // Sort results by alphabatic and the length of the director/file path
+                const sortedFileResults = fileResults
+                    .sort((a, b) => {
+                        if (a.fileName < b.fileName) {
+                            return -1
+                        }
+                        if (a.fileName > b.fileName) {
+                            return 1
+                        }
+                        return 0
+                    })
+                    .slice(0, MAX_RESULTS)
+                // Return the merged results
+                const context = [...new Set([...sortedFileResults, ...symbolResults])]
                 await this.webview?.postMessage({
                     type: 'userContextFiles',
                     context,


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1837

When we do a search using the VS Code API, it will always return the first n results found so the results could be different for the same keyword search. This caused confusion stated in the issue linked above. To  workaround that, this PR updated to get 50 results instead of 10 results from the API, and then sort the results alphabetically to get the first 20 results. This helps get the same set of results of the exact keyword search.

Summary:
- Increase max file search results from 10 to 20
- Increase max symbol search results from 10 to 50
- Sort file results alphabetically by path 
- Take top 20 sorted file results and merged symbol results

Here is an example of the results returned by the VS Code API for the same keyword search:
![Screenshot 2023-11-21 at 4 04 21 PM](https://github.com/sourcegraph/cody/assets/68532117/1857a7c8-0921-4637-a59d-822dfca07633)

Here is an example of the result `@lib` after the updated workaround:

![image](https://github.com/sourcegraph/cody/assets/68532117/7fd58ee0-3b04-4644-b29c-c7c050692c77)


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- Search for the same keyword multiple times, then results should come back in the same order

### DEMO

https://github.com/sourcegraph/cody/assets/68532117/ba02fd4c-e411-4ab5-b482-6458055167b2

