### PR TITLE
move cody.search webview position in sidebar

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -224,13 +224,6 @@
           "when": "(!cody.activated && config.cody.experimental.chatPanel) || !config.cody.experimental.chatPanel"
         },
         {
-          "type": "webview",
-          "id": "cody.search",
-          "name": "Search (experimental)",
-          "visibility": "visible",
-          "when": "cody.activated && config.cody.experimental.newSearch"
-        },
-        {
           "id": "cody.fixup.tree.view",
           "name": "Fixups",
           "when": "cody.nonstop.fixups.enabled && cody.activated && !config.cody.experimental.chatPanel",
@@ -241,6 +234,13 @@
           "id": "cody.commands.tree.view",
           "name": "Commands",
           "when": "cody.activated && config.cody.experimental.chatPanel"
+        },
+        {
+          "type": "webview",
+          "id": "cody.search",
+          "name": "Search (experimental)",
+          "visibility": "visible",
+          "when": "cody.activated && config.cody.experimental.newSearch"
         },
         {
           "id": "cody.chat.tree.view",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -236,16 +236,16 @@
           "when": "cody.activated && config.cody.experimental.chatPanel"
         },
         {
+          "id": "cody.chat.tree.view",
+          "name": "Chats",
+          "when": "cody.activated && config.cody.experimental.chatPanel"
+        },
+        {
           "type": "webview",
           "id": "cody.search",
           "name": "Search (experimental)",
           "visibility": "visible",
           "when": "cody.activated && config.cody.experimental.newSearch"
-        },
-        {
-          "id": "cody.chat.tree.view",
-          "name": "Chats",
-          "when": "cody.activated && config.cody.experimental.chatPanel"
         },
         {
           "id": "cody.support.tree.view",


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1812

Move the "cody.search" webview definition to appear after the "cody.commands" webview in the sidebar viewContainers array.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Search view should now show up under Commands for new users:

<img width="2000" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/98808520-5a2a-48b9-b70c-587ae8521129">

