### PR TITLE
change: set ignoreFocusOut to false for custom commands

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Changed
 
 - Chat: Updated the design and location for the `chat submit` button and `stop generating` button. [pull/1782](https://github.com/sourcegraph/cody/pull/1782)
+- Commands: The Custom Commands Menu now closes on click outside of the menu. [pull/1854](https://github.com/sourcegraph/cody/pull/1854)
 
 ## [0.16.0]
 

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -138,7 +138,7 @@ export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<Qui
         quickPick.items = items
         quickPick.title = CustomCommandsMenuOptions.title
         quickPick.placeholder = CustomCommandsMenuOptions.placeHolder
-        quickPick.ignoreFocusOut = true
+        quickPick.ignoreFocusOut = false
 
         quickPick.buttons = [menu_buttons.back]
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1816

The `ignoreFocusOut` property for the Custom Commands menu is now set to true. This allows user to close the quick pick menu on focus out. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- [x] Start the Custom Commands menu
- [x] Click somewhere outside of the Custom Commands menu
- [x] The Custom Commands menu will be closed automatically 

https://github.com/sourcegraph/cody/assets/68532117/457aa1a9-ed9c-4b4d-8853-e47e1950683c

