### PR TITLE
change: custom commands to beta

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -30,7 +30,7 @@ export interface Configuration {
     experimentalChatPanel: boolean
     experimentalChatPredictions: boolean
     experimentalSearchPanel: boolean
-    experimentalCommandLenses: boolean
+    commandCodeLenses: boolean
     editorTitleCommandIcon: boolean
     experimentalGuardrails: boolean
     experimentalNonStop: boolean

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Changed
 
 - Chat: Updated the design and location for the `chat submit` button and `stop generating` button. [pull/1782](https://github.com/sourcegraph/cody/pull/1782)
+- Commands: `Command Code Lenses` has been moved out of experimental feature and is now available to general. [pull/0000](https://github.com/sourcegraph/cody/pull/0000)
+- Commands: `Custom Commands` has been moved out of experimental and is now at Beta. [pull/0000](https://github.com/sourcegraph/cody/pull/0000)
 
 ## [0.16.0]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -971,11 +971,11 @@
           }
         },
         "cody.inlineChat.enabled": {
-          "order": 6,
+          "order": 10,
           "title": "Cody Inline Chat",
           "type": "boolean",
           "markdownDescription": "Enables asking questions and requesting code changes directly from within the code editor. Use the + button next to any line of code to start an inline chat.",
-          "default": true
+          "default": false
         },
         "cody.editorTitleCommandIcon": {
           "order": 7,
@@ -989,10 +989,10 @@
           "default": false,
           "markdownDescription": "Adds suggestions of possible relevant messages in the chat window."
         },
-        "cody.experimental.commandLenses": {
+        "cody.commandCodeLenses": {
           "order": 8,
           "type": "boolean",
-          "markdownDescription": "[Experimental] Adds code lenses to current file for quick access to Cody commands.",
+          "markdownDescription": "Adds code lenses to current file for quick access to Cody commands.",
           "default": false
         },
         "cody.experimental.guardrails": {
@@ -1014,7 +1014,7 @@
           "markdownDescription": "Experimental feature for internal use."
         },
         "cody.chat.preInstruction": {
-          "order": 10,
+          "order": 6,
           "type": "string",
           "markdownDescription": "An instruction to be included at the start of all chat messages sent to Cody. Extension reload required.",
           "examples": [

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -40,7 +40,7 @@ export type Config = Pick<
     | 'experimentalChatPanel'
     | 'experimentalChatPredictions'
     | 'experimentalGuardrails'
-    | 'experimentalCommandLenses'
+    | 'commandCodeLenses'
     | 'editorTitleCommandIcon'
     | 'experimentalLocalSymbols'
     | 'inlineChat'

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -129,7 +129,7 @@ export async function showCommandMenu(
 
 export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<QuickPickItem> {
     const CustomCommandsMenuOptions: QuickPickOptions = {
-        title: 'Cody: Custom Commands (Experimental)',
+        title: 'Cody: Custom Commands (Beta)',
         placeHolder: 'Search command to run...',
     }
 
@@ -162,7 +162,7 @@ export async function showCustomCommandMenu(items: QuickPickItem[]): Promise<Qui
  */
 export async function showCommandConfigMenu(): Promise<CustomCommandsItem> {
     const CustomCommandConfigMenuOptions = {
-        title: 'Cody: Configure Custom Commands (Experimental)',
+        title: 'Cody: Configure Custom Commands (Beta)',
         placeHolder: 'Choose an option',
     }
 

--- a/vscode/src/commands/utils/menu.ts
+++ b/vscode/src/commands/utils/menu.ts
@@ -6,7 +6,7 @@ import { CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { ContextOption } from '.'
 
 export const NewCustomCommandConfigMenuOptions = {
-    title: 'Cody Custom Commands (Experimental) - New User Command',
+    title: 'Cody Custom Commands (Beta) - New User Command',
 }
 
 export type QuickPickItemWithSlashCommand = QuickPickItem & { slashCommand: string }
@@ -33,7 +33,7 @@ const fixOption: QuickPickItemWithSlashCommand = {
 }
 // Seperators
 const commandsSeparator: QuickPickItem = { kind: -1, label: 'commands' }
-const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'custom commands (experimental)' }
+const customCommandsSeparator: QuickPickItem = { kind: -1, label: 'Custom Commands (Beta)' }
 const settingsSeparator: QuickPickItem = { kind: -1, label: 'settings' }
 const lastUsedSeparator: QuickPickItem = { kind: -1, label: 'last used' }
 // Common options

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -21,7 +21,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     useContext: 'embeddings',
     autocomplete: true,
     autocompleteLanguages: { '*': true, scminput: false },
-    experimentalCommandLenses: false,
+    commandCodeLenses: false,
     editorTitleCommandIcon: true,
     experimentalChatPanel: false,
     experimentalChatPredictions: false,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -22,7 +22,7 @@ describe('getConfiguration', () => {
                 '*': true,
                 scminput: false,
             },
-            experimentalCommandLenses: false,
+            commandCodeLenses: false,
             editorTitleCommandIcon: true,
             experimentalChatPanel: false,
             experimentalChatPredictions: false,
@@ -76,7 +76,7 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.newSearch':
                         return true
-                    case 'cody.experimental.commandLenses':
+                    case 'cody.commandCodeLenses':
                         return true
                     case 'cody.editorTitleCommandIcon':
                         return true
@@ -147,7 +147,7 @@ describe('getConfiguration', () => {
             experimentalChatPanel: true,
             experimentalChatPredictions: true,
             experimentalSearchPanel: true,
-            experimentalCommandLenses: true,
+            commandCodeLenses: true,
             editorTitleCommandIcon: true,
             experimentalGuardrails: true,
             experimentalLocalSymbols: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -89,7 +89,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
         experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),
         experimentalLocalSymbols: config.get(CONFIG_KEY.experimentalLocalSymbols, false),
-        experimentalCommandLenses: config.get(CONFIG_KEY.experimentalCommandLenses, false),
+        commandCodeLenses: config.get(CONFIG_KEY.commandCodeLenses, false),
         editorTitleCommandIcon: config.get(CONFIG_KEY.editorTitleCommandIcon, true),
         autocompleteAdvancedProvider,
         autocompleteAdvancedServerEndpoint: config.get<string | null>(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -63,6 +63,9 @@ export async function start(context: vscode.ExtensionContext, platform: Platform
                 const config = await getFullConfig()
                 onConfigurationChange(config)
                 platform.onConfigurationChange?.(config)
+                if (config.chatPreInstruction) {
+                    PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
+                }
             }
         })
     )

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -94,6 +94,13 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.autocomplete
                 ),
                 createFeatureToggle(
+                    'Code Actions',
+                    undefined,
+                    'Enable Cody fix and explain options in the Quick Fix menu',
+                    'cody.codeActions.enabled',
+                    c => c.codeActions
+                ),
+                createFeatureToggle(
                     'Editor Title Icon',
                     undefined,
                     'Enable Cody to appear in editor title menu for quick access to Cody commands',
@@ -101,18 +108,11 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.editorTitleCommandIcon
                 ),
                 createFeatureToggle(
-                    'Inline Chat',
+                    'Code Lenses',
                     undefined,
-                    'Enable chatting and editing with Cody, directly in your code',
-                    'cody.inlineChat.enabled',
-                    c => c.inlineChat
-                ),
-                createFeatureToggle(
-                    'Code Actions',
-                    undefined,
-                    'Enable Cody fix and explain options in the Quick Fix menu',
-                    'cody.codeActions.enabled',
-                    c => c.codeActions
+                    'Enable Code Lenses in documents for quick access to Cody commands',
+                    'cody.commandCodeLenses',
+                    c => c.commandCodeLenses
                 ),
                 createFeatureToggle(
                     'Chat Suggestions',
@@ -135,13 +135,6 @@ export function createStatusBar(): CodyStatusBar {
                     'Enable new search panel',
                     'cody.experimental.newSearch',
                     c => c.experimentalSearchPanel
-                ),
-                createFeatureToggle(
-                    'Code Lenses',
-                    'Experimental',
-                    'Enable Code Lenses in documents for quick access to Cody commands',
-                    'cody.experimental.commandLenses',
-                    c => c.experimentalCommandLenses
                 ),
                 { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
                 {

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -132,7 +132,7 @@ function escapeToPath(text: string): string {
 export async function buildWorkSpaceSettings(workspaceDirectory: string): Promise<void> {
     const settings = {
         'cody.serverEndpoint': 'http://localhost:49300',
-        'cody.experimental.commandLenses': true,
+        'cody.commandCodeLenses': true,
         'cody.editorTitleCommandIcon': true,
     }
     // create a temporary directory with settings.json and add to the workspaceDirectory


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1521

This PR includes the following changes:
- [x] Move `Command Code Lenses` out of Experimental
- [x] Keep `Chat Suggestions` in Experimental
- [x] Move `Custom Commands` to Beta

Also update Chat Pre-Instructio on config change

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Check if the features above are showing up with the correct label