### PR TITLE
add: transcript syncing

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -24,7 +24,7 @@ export enum FeatureFlag {
     CodyAutocompleteDisableNetworkCache = 'cody-autocomplete-disable-network-cache',
     CodyAutocompleteDisableRecyclingOfPreviousRequests = 'cody-autocomplete-disable-recycling-of-previous-requests',
 
-    CodyChatTranscript = 'cody-chat-transcript-sync',
+    CodyChatTranscript1Week = 'cody-chat-transcript-sync-since-1-week',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -23,6 +23,8 @@ export enum FeatureFlag {
     CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
     CodyAutocompleteDisableNetworkCache = 'cody-autocomplete-disable-network-cache',
     CodyAutocompleteDisableRecyclingOfPreviousRequests = 'cody-autocomplete-disable-recycling-of-previous-requests',
+
+    CodyChatTranscript = 'cody-chat-transcript-sync',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -30,7 +30,7 @@ import { logDebug, logError } from '../log'
 import { FixupTask } from '../non-stop/FixupTask'
 import { AuthProvider, isNetworkError } from '../services/AuthProvider'
 import { localStorage } from '../services/LocalStorageProvider'
-import { telemetryService } from '../services/telemetry'
+import { syncTranscript, telemetryService } from '../services/telemetry'
 import { telemetryRecorder } from '../services/telemetry-v2'
 import { TestSupport } from '../test-support'
 
@@ -748,6 +748,11 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (localHistory) {
             MessageProvider.chatHistory = localHistory?.chat
             MessageProvider.inputHistory = localHistory.input
+        }
+
+        const endpoint = this.authProvider.getAuthStatus().endpoint
+        if (endpoint) {
+            void syncTranscript(endpoint)
         }
     }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -7,6 +7,7 @@ import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/confi
 import { FixupIntent } from '@sourcegraph/cody-shared/src/editor'
 import { featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
+import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
 import { ChatManager } from './chat/chat-view/ChatManager'
@@ -33,7 +34,7 @@ import { localStorage } from './services/LocalStorageProvider'
 import * as OnboardingExperiment from './services/OnboardingExperiment'
 import { getAccessToken, secretStorage, VSCodeSecretStorage } from './services/SecretStorageProvider'
 import { createStatusBar } from './services/StatusBar'
-import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
+import { createOrUpdateEventLogger, syncTranscript, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { workspaceActionsOnConfigChange } from './services/utils/workspace-action'
 import { TestSupport } from './test-support'
@@ -202,6 +203,9 @@ const register = async (
             workspaceActionsOnConfigChange(editor.getWorkspaceRootUri(), authStatus.endpoint)
         } else {
             symfRunner?.setSourcegraphAuth(null, null)
+        }
+        if (authStatus.endpoint && isDotCom(authStatus.endpoint)) {
+            void syncTranscript(authStatus.endpoint)
         }
     })
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -697,6 +697,7 @@ export class FixupController
                 telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', {
                     ...countCode(text),
                     source: task.source,
+                    response: text,
                 })
                 break
         }

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -120,15 +120,6 @@ export class LocalStorage {
         return { anonymousUserID: id, created }
     }
 
-    public async lastSyncTimestamp(): Promise<number> {
-        const storedSyncedTime = this.storage.get<number>(this.LAST_TRANSCRIPT_SYNC_TIMESTAMP, 0)
-        const newSyncedTime = Date.now()
-        const lastSyncedTime = storedSyncedTime
-        // Update sync time to now
-        await this.storage.update(this.LAST_TRANSCRIPT_SYNC_TIMESTAMP, newSyncedTime)
-        return lastSyncedTime
-    }
-
     public async setLastUsedCommands(recipes: string[]): Promise<void> {
         if (recipes.length === 0) {
             return
@@ -158,6 +149,28 @@ export class LocalStorage {
 
     public async delete(key: string): Promise<void> {
         await this.storage.update(key, undefined)
+    }
+
+    /**
+     * Gets the last transcript sync timestamp from storage, or the provided
+     * lastSyncedTranscriptTimestamp if it is more recent. Also updates the stored
+     * last sync timestamp if a more recent one was provided.
+     *
+     * @param lastSyncedTranscriptTimestamp - An optional more recent transcript
+     * sync timestamp to use and store instead of the stored one.
+     * @returns The most recent transcript sync timestamp, either the stored one
+     * or the one provided.
+     */
+    public async lastSyncedTimestamp(lastSyncedTranscriptTimestamp?: number): Promise<number> {
+        const storedSyncedTime = this.storage.get<number>(this.LAST_TRANSCRIPT_SYNC_TIMESTAMP, 0)
+
+        if (lastSyncedTranscriptTimestamp && lastSyncedTranscriptTimestamp > storedSyncedTime) {
+            // Update last sync time to lastTranscriptTimestamp so that we know when not to sync next time
+            await this.storage.update(this.LAST_TRANSCRIPT_SYNC_TIMESTAMP, lastSyncedTranscriptTimestamp)
+            return lastSyncedTranscriptTimestamp
+        }
+
+        return storedSyncedTime
     }
 }
 

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -10,6 +10,7 @@ export class LocalStorage {
     protected LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
     protected CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected KEY_LAST_USED_RECIPES = 'SOURCEGRAPH_CODY_LAST_USED_RECIPE_NAMES'
+    protected LAST_TRANSCRIPT_SYNC_TIMESTAMP = 'SOURCEGRAPH_CODY_DOTCOM_LAST_SYNC_TIMESTAMP'
 
     /**
      * Should be set on extension activation via `localStorage.setStorage(context.globalState)`
@@ -117,6 +118,15 @@ export class LocalStorage {
             }
         }
         return { anonymousUserID: id, created }
+    }
+
+    public async lastSyncTimestamp(): Promise<number> {
+        const storedSyncedTime = this.storage.get<number>(this.LAST_TRANSCRIPT_SYNC_TIMESTAMP, 0)
+        const newSyncedTime = Date.now()
+        const lastSyncedTime = storedSyncedTime
+        // Update sync time to now
+        await this.storage.update(this.LAST_TRANSCRIPT_SYNC_TIMESTAMP, newSyncedTime)
+        return lastSyncedTime
     }
 
     public async setLastUsedCommands(recipes: string[]): Promise<void> {


### PR DESCRIPTION
feat: add transcript syncing with Sourcegraph Cloud

Added chat transcript syncing with dotCom behind a feature flag.

- This adds the ability to sync th chat transcript with Sourcegraph Cloud if the Cody endpoint is on DomCom. 
- Added a new feature flag 'cody-chat-transcript-sync' controls this behavior.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Waiting for @akalia25 's team to confirm where we should log the transcript