### PR TITLE
fix: display local context

### DIFF
--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -12,8 +12,6 @@ export interface FileLinkProps {
     range?: ActiveTextEditorSelectionRange
 }
 
-const enhancedContextSources = new Set(['embeddings', 'keyword', 'symf', 'filename'])
-
 export const EnhancedContext: React.FunctionComponent<{
     contextFiles: ContextFile[]
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
@@ -25,10 +23,11 @@ export const EnhancedContext: React.FunctionComponent<{
 
     const uniqueFiles = new Set<string>()
     const filteredFiles = contextFiles.filter(file => {
-        if (uniqueFiles.has(file.fileName) || !file.source) {
+        if (uniqueFiles.has(file.fileName)) {
             return false
         }
-        if (!enhancedContextSources.has(file.source)) {
+        // Skip files added by user. e.g. @-files
+        if (file.source === 'user') {
             return false
         }
         uniqueFiles.add(file.fileName)

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -21,7 +21,11 @@ export const EnhancedContext: React.FunctionComponent<{
         return
     }
 
+    const enhancedContextSources = new Set(['embeddings', 'keyword', 'symf', 'filename'])
     const uniqueFiles = new Set<string>()
+
+    let hasEnhancedContext = false
+
     const filteredFiles = contextFiles.filter(file => {
         if (uniqueFiles.has(file.fileName)) {
             return false
@@ -29,6 +33,9 @@ export const EnhancedContext: React.FunctionComponent<{
         // Skip files added by user. e.g. @-files
         if (file.source === 'user') {
             return false
+        }
+        if (file.source && enhancedContextSources.has(file.source)) {
+            hasEnhancedContext = true
         }
         uniqueFiles.add(file.fileName)
         return true
@@ -38,6 +45,7 @@ export const EnhancedContext: React.FunctionComponent<{
         return
     }
 
+    const emoji = hasEnhancedContext ? '✨ ' : ''
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
     const lineCount = filteredFiles.reduce(
@@ -47,12 +55,12 @@ export const EnhancedContext: React.FunctionComponent<{
     const fileCount = filteredFiles.length
     const lines = `${lineCount} line` + (lineCount > 1 ? 's' : '')
     const files = `${fileCount} file` + (fileCount > 1 ? 's' : '')
-    const title = lineCount ? `✨ ${lines} from ${files}` : `✨ snippets from ${files}`
+    const title = lineCount ? `${lines} from ${files}` : `from ${files}`
 
     return (
         <TranscriptAction
             title={{
-                verb: title,
+                verb: emoji + title,
                 object: '',
                 tooltip: 'Related code automatically included as context',
             }}


### PR DESCRIPTION
As discussed with @toolmantim on slack ([thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1700631673836569?thread_ts=1700622656.385639&cid=C05AGQYD528)), the context display widget should also include local context except the ones added by the user manually via @ 

>  I was considering anything that wasn't explicitly @-included as "enhanced context"

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try running the `/test` command, which use local context only.

#### BEFORE

Used local context is not showing up in the enhance context widget

<img width="777" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/c81eda23-85e8-4dc1-a649-aabf69857dc6">


#### AFTER

Used local context is included in the context widget

<img width="843" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/06d41ebb-b06d-4c36-a276-d5345eafbe68">
 