### PR TITLE
evaluate-autocomplete: fix git-log strategy and add more CSV columns

### DIFF
--- a/agent/src/cli/evaluate-autocomplete/AutocompleteDocument.ts
+++ b/agent/src/cli/evaluate-autocomplete/AutocompleteDocument.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import { ObjectHeaderItem } from 'csv-writer/src/lib/record'
 import * as vscode from 'vscode'
 
+import { CompletionEvent } from '../../../../vscode/src/completions/logger'
 import { AgentTextDocument } from '../../AgentTextDocument'
 
 export class AutocompleteDocument {
@@ -13,21 +14,25 @@ export class AutocompleteDocument {
     constructor(
         public readonly params: Pick<
             AutocompleteItem,
-            'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath'
+            'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath' | 'revision'
         >,
-        public readonly text: string
+        public readonly text: string,
+        public readonly snapshotDirectory?: string
     ) {
         this.lines = text.split('\n')
         this.textDocument = new AgentTextDocument({ filePath: params.filepath, content: text })
     }
 
     public pushItem(
-        item: Omit<AutocompleteItem, 'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath'>
+        item: Omit<AutocompleteItem, 'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath' | 'revision'>
     ): void {
         item.rangeStartLine = item.range.start.line
         item.rangeStartCharacter = item.range.start.character
         item.rangeEndLine = item.range.end.line
         item.rangeEndCharacter = item.range.end.character
+        if (item.event) {
+            item.eventJSON = JSON.stringify(item.event)
+        }
         this.items.push({
             ...item,
             ...this.params,
@@ -132,6 +137,7 @@ export interface AutocompleteItem {
     fixture: string
     strategy: string
     filepath: string
+    revision: string
     range: vscode.Range
     rangeStartLine?: number
     rangeStartCharacter?: number
@@ -145,6 +151,8 @@ export interface AutocompleteItem {
     resultParses?: boolean
     resultTypechecks?: boolean
     resultText?: string
+    event?: CompletionEvent
+    eventJSON?: string
 }
 
 export const autocompleteItemHeaders: ObjectHeaderItem[] = [
@@ -153,6 +161,7 @@ export const autocompleteItemHeaders: ObjectHeaderItem[] = [
     { id: 'fixture', title: 'FIXTURE' },
     { id: 'strategy', title: 'STRATEGY' },
     { id: 'filepath', title: 'FILEPATH' },
+    { id: 'revision', title: 'REVISION' },
     { id: 'rangeStartLine', title: 'RANGE_START_LINE' },
     { id: 'rangeStartCharacter', title: 'RANGE_START_CHARACTER' },
     { id: 'rangeEndLine', title: 'RANGE_END_LINE' },
@@ -165,6 +174,7 @@ export const autocompleteItemHeaders: ObjectHeaderItem[] = [
     { id: 'resultTypechecks', title: 'RESULT_TYPECHECKS' },
     { id: 'resultText', title: 'RESULT_TEXT' },
     { id: 'resultNonInsertPatch', title: 'RESULT_NON_INSERT_PATCH' },
+    { id: 'eventJSON', title: 'EVENT' },
 ]
 
 function commentSyntaxForLanguage(languageid: string): string {

--- a/agent/src/cli/evaluate-autocomplete/SnapshotWriter.ts
+++ b/agent/src/cli/evaluate-autocomplete/SnapshotWriter.ts
@@ -1,0 +1,32 @@
+import * as fspromises from 'fs/promises'
+
+import { createObjectCsvWriter } from 'csv-writer'
+import { CsvWriter } from 'csv-writer/src/lib/csv-writer'
+import { rimraf } from 'rimraf'
+
+import { AutocompleteDocument, autocompleteItemHeaders } from './AutocompleteDocument'
+import { EvaluateAutocompleteOptions } from './evaluate-autocomplete'
+
+export class SnapshotWriter {
+    public csvWriter: CsvWriter<any> | undefined
+    constructor(public readonly options: Pick<EvaluateAutocompleteOptions, 'snapshotDirectory' | 'csvPath'>) {}
+    public async writeHeader(): Promise<void> {
+        if (this.options.snapshotDirectory) {
+            await rimraf(this.options.snapshotDirectory)
+            await fspromises.mkdir(this.options.snapshotDirectory, { recursive: true })
+            if (this.options.csvPath) {
+                this.csvWriter = createObjectCsvWriter({
+                    header: autocompleteItemHeaders,
+                    path: this.options.csvPath,
+                })
+            }
+        }
+    }
+    public async writeDocument(document: AutocompleteDocument): Promise<void> {
+        if (!this.options.snapshotDirectory || document.items.length === 0) {
+            return
+        }
+        await document.writeSnapshot(this.options.snapshotDirectory)
+        await this.csvWriter?.writeRecords(document.items)
+    }
+}

--- a/agent/src/cli/evaluate-autocomplete/triggerAutocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/triggerAutocomplete.ts
@@ -67,13 +67,18 @@ export async function triggerAutocomplete(parameters: AutocompleteParameters): P
             patches.push(text)
         }
         if (hasNonInsertPatch) {
-            document.pushItem({ resultText: item.insertText, range, resultNonInsertPatch: true })
+            document.pushItem({
+                resultText: item.insertText,
+                range,
+                resultNonInsertPatch: true,
+                event: result.completionEvent,
+            })
         } else if (patches.length > 0) {
             const text = patches.join('')
             if (text === removedContent) {
-                document.pushItem({ range, resultExact: true })
+                document.pushItem({ range, resultExact: true, event: result.completionEvent })
             } else {
-                document.pushItem({ range, resultText: text })
+                document.pushItem({ range, resultText: text, event: result.completionEvent })
             }
         }
     }

--- a/vscode/src/completions/artificial-delay.ts
+++ b/vscode/src/completions/artificial-delay.ts
@@ -92,5 +92,4 @@ export function resetArtificialDelay(timestamp = 0): void {
         suggested: 0,
         uri: '',
     }
-    logDebug('CodyCompletionProvider:resetArtificialDelay', 'Latency Reset')
 }


### PR DESCRIPTION
Previously, the `git-log` strategy did not run correctly due to a regression in the last change. This PR fixes that regression and adds two new columns to the generated CSV file:

- `EVENT`: for detailed information about each autocomplete response like latency. This is the JSON object we include in telemetry events.
- `REVISION`: to be able to know at which git commit the request was sent. This is mostly helpful to know if two requests for the same file/line location happened on the same file content.


## Test plan

Manually tested.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
