### PR TITLE
Fix flaky completion test and clean up console

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Input history is now preserved between chat sessions. [pull/1826](https://github.com/sourcegraph/cody/pull/1826)
 - Chat: Fixed chat command selection behavior in chat input box. [pull/1828](https://github.com/sourcegraph/cody/pull/1828)
 - Chat: Add delays before sending webview ready events to prevent premature sending. This fixes issue where chat panel fails to load when multiple chat panels are opened simultaneously. [pull/1836](https://github.com/sourcegraph/cody/pull/1836)
+- Autocomplete: Fixes a bug that caused autocomplete to be triggered at the end of a block or function invocation. [pull/1864](https://github.com/sourcegraph/cody/pull/1864)
 
 ### Changed
 

--- a/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
@@ -169,10 +169,10 @@ describe('[getInlineCompletions] triggers', () => {
     })
 
     describe('closing symbols', () => {
-        it.each(['{}█', '[]█', '()█'])('does not trigger for %s', async prompt =>
+        it.each(['{}█', '[]█', '()█', ';█'])('does not trigger for %s', async prompt =>
             expect(await getInlineCompletions(params(prompt, [completion`bar`]))).toEqual<V>(null)
         )
-        it.each(['{}\n█', '[]\n█', '()\n█'])('does trigger for %s', async prompt =>
+        it.each(['{}\n█', '[]\n█', '()\n█', ';\n█'])('does trigger for %s', async prompt =>
             expect(await getInlineCompletions(params(prompt, [completion`bar`]))).toEqual<V>({
                 items: [{ insertText: 'bar' }],
                 source: InlineCompletionsResultSource.Network,

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -184,7 +184,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     }
 
     // Do not trigger when the last character is a closing symbol
-    if (triggerKind !== TriggerKind.Manual && /[)\]}]$/.test(currentLinePrefix.trim())) {
+    if (triggerKind !== TriggerKind.Manual && /[);\]}]$/.test(currentLinePrefix.trim())) {
         return null
     }
 

--- a/vscode/test/e2e/inline-completion.test.ts
+++ b/vscode/test/e2e/inline-completion.test.ts
@@ -102,14 +102,13 @@ test('inline completion onboarding notice on first completion accept', async ({ 
     // Trigger/accept another completion, but don't expect the notification.
     await triggerInlineCompletionAfter(page, firstAcceptedCompletion)
     await acceptInlineCompletion(page)
-    await expect(otherAcceptedCompletion).toBeVisible()
-    await expect(decoration).not.toBeVisible()
-
     // After accepting a completion, a new completion request will be made. Since this can interfere
     // with the expected event order (especially since suggestion events are logged after the
     // completion is hidden), we type a semicolon which will prevent an automatic completion from
     // showing up
     await page.keyboard.press(';')
+    await expect(otherAcceptedCompletion).toBeVisible()
+    await expect(decoration).not.toBeVisible()
 
     await assertEvents(loggedEvents, expectedEvents)
 })

--- a/vscode/test/e2e/inline-completion.test.ts
+++ b/vscode/test/e2e/inline-completion.test.ts
@@ -63,7 +63,6 @@ test('inline completion onboarding notice on first completion accept', async ({ 
         'CodyVSCodeExtension:completion:suggested', // Suggestion that appears immediately after accepting
         'CodyVSCodeExtension:completion:suggested', // Second suggestion after typing "a" to test hiding
         'CodyVSCodeExtension:completion:accepted', // Second accept
-        'CodyVSCodeExtension:completion:suggested', // Suggestion that appears immediately after accepting
     ]
 
     const indexFile = page.getByRole('treeitem', { name: 'index.html' }).locator('a')
@@ -105,6 +104,13 @@ test('inline completion onboarding notice on first completion accept', async ({ 
     await acceptInlineCompletion(page)
     await expect(otherAcceptedCompletion).toBeVisible()
     await expect(decoration).not.toBeVisible()
+
+    // After accepting a completion, a new completion request will be made. Since this can interfere
+    // with the expected event order (especially since suggestion events are logged after the
+    // completion is hidden), we type a semicolon which will prevent an automatic completion from
+    // showing up
+    await page.keyboard.press(';')
+
     await assertEvents(loggedEvents, expectedEvents)
 })
 

--- a/vscode/test/e2e/install-deps.ts
+++ b/vscode/test/e2e/install-deps.ts
@@ -1,11 +1,21 @@
 import { spawn } from 'child_process'
 
-import { downloadAndUnzipVSCode } from '@vscode/test-electron'
+import { ConsoleReporter, downloadAndUnzipVSCode, ProgressReport, ProgressReportStage } from '@vscode/test-electron'
 
 export const vscodeVersion = '1.81.1'
 
+// A custom version of the VS Code download reporter that silences matching installation
+// notifications as these otherwise are emitted on every test run
+class CustomConsoleReporter extends ConsoleReporter {
+    public report(report: ProgressReport): void {
+        if (report.stage !== ProgressReportStage.FoundMatchingInstall) {
+            return super.report(report)
+        }
+    }
+}
+
 export function installVsCode(): Promise<string> {
-    return downloadAndUnzipVSCode(vscodeVersion)
+    return downloadAndUnzipVSCode(vscodeVersion, undefined, new CustomConsoleReporter(process.stdout.isTTY))
 }
 
 export function installChromium(): Promise<void> {

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -123,9 +123,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
         }
     })
 
-    const server = app.listen(SERVER_PORT, () => {
-        console.log(`Mock server listening on port ${SERVER_PORT}`)
-    })
+    const server = app.listen(SERVER_PORT)
 
     const result = await around()
 
@@ -135,6 +133,10 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
 }
 
 export async function logTestingData(type: 'legacy' | 'new', data: string): Promise<void> {
+    if (process.env.CI === undefined) {
+        return
+    }
+
     const message = {
         type,
         event: data,


### PR DESCRIPTION
- Fix flaky inline completion test by making sure we do not trigger a follow up completion after the last action that may or may not be logged
- Clean up VS Code install noise when the file was already downloaded. Not helpful.
- Don't spam the console with logging noise when not on CI
- Prevent completions from showing up after a `;` (similar to `)` `]` `}`)

<img width="1201" alt="Screenshot 2023-11-22 at 13 44 24" src="https://github.com/sourcegraph/cody/assets/458591/29e48e0e-acb7-4315-85f2-75dd84fbdccb">

bliss!

## Test plan

- Run inline completion test a bunch of times and make sure it doesn't fail anymore
- No more noise in the console
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
