### PR TITLE
evaluate-autocomplete: add support to run test commands

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -30,6 +30,7 @@
     "env-paths": "^3.0.0",
     "fast-myers-diff": "^3.1.0",
     "minimatch": "^9.0.3",
+    "pretty-ms": "^8.0.0",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -449,6 +449,7 @@ export class Agent extends MessageHandler {
                 // functionality), we return true to always triggger the callback.
                 true,
         })
+
         const client = await createClient({
             initialTranscript: this.oldClient?.transcript,
             editor: new AgentEditor(this),

--- a/agent/src/cli/evaluate-autocomplete/EvaluationDocument.ts
+++ b/agent/src/cli/evaluate-autocomplete/EvaluationDocument.ts
@@ -7,13 +7,13 @@ import * as vscode from 'vscode'
 import { CompletionBookkeepingEvent } from '../../../../vscode/src/completions/logger'
 import { AgentTextDocument } from '../../AgentTextDocument'
 
-export class AutocompleteDocument {
-    public items: AutocompleteItem[] = []
+export class EvaluationDocument {
+    public items: EvaluationItem[] = []
     public readonly lines: string[]
     public readonly textDocument: AgentTextDocument
     constructor(
         public readonly params: Pick<
-            AutocompleteItem,
+            EvaluationItem,
             'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath' | 'revision'
         >,
         public readonly text: string,
@@ -24,7 +24,7 @@ export class AutocompleteDocument {
     }
 
     public pushItem(
-        item: Omit<AutocompleteItem, 'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath' | 'revision'>
+        item: Omit<EvaluationItem, 'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath' | 'revision'>
     ): void {
         item.rangeStartLine = item.range.start.line
         item.rangeStartCharacter = item.range.start.character
@@ -73,21 +73,23 @@ export class AutocompleteDocument {
                     throw new Error(this.format(item.range, 'negative length occurrence!'))
                 }
                 out.push('^'.repeat(length))
-                out.push(' ')
-                out.push('AUTOCOMPLETE')
-                out.push(' ')
+                out.push(' AUTOCOMPLETE')
                 if (item.resultEmpty) {
-                    out.push('EMPTY_RESULT')
-                } else if (item.resultTimeout) {
-                    out.push('TIMEOUT')
-                } else if (item.resultExact) {
-                    out.push('EXACT_MATCH')
-                } else if (item.resultTypechecks) {
-                    out.push('TYPECHECKS')
-                } else if (item.resultParses) {
-                    out.push('PARSES')
-                } else if (item.resultText) {
-                    out.push('RESULT ')
+                    out.push(' EMPTY_RESULT')
+                }
+                if (item.resultTimeout) {
+                    out.push(' TIMEOUT')
+                }
+                if (item.resultExact) {
+                    out.push(' EXACT_MATCH')
+                }
+                if (item.resultTypechecks === true) {
+                    out.push(' TYPECHECK_OK')
+                } else if (item.resultTypechecks === false) {
+                    out.push(' TYPECHECK_ERROR')
+                }
+                if (item.resultText) {
+                    out.push(' RESULT ')
                     out.push(item.resultText)
                 }
                 out.push('\n')
@@ -130,7 +132,7 @@ export class AutocompleteDocument {
  * An AutocompleteItem represents one row in the final CSV file that
  * evaluate-autocomplete emits.
  */
-export interface AutocompleteItem {
+export interface EvaluationItem {
     languageid: string
     workspace: string
     fixture: string
@@ -147,7 +149,6 @@ export interface AutocompleteItem {
     resultError?: string
     resultEmpty?: boolean
     resultExact?: boolean
-    resultParses?: boolean
     resultTypechecks?: boolean
     resultText?: string
     event?: CompletionBookkeepingEvent
@@ -169,7 +170,6 @@ export const autocompleteItemHeaders: ObjectHeaderItem[] = [
     { id: 'resultError', title: 'RESULT_ERROR' },
     { id: 'resultEmpty', title: 'RESULT_EMPTY' },
     { id: 'resultExact', title: 'RESULT_EXACT' },
-    { id: 'resultParses', title: 'RESULT_PARSES' },
     { id: 'resultTypechecks', title: 'RESULT_TYPECHECKS' },
     { id: 'resultText', title: 'RESULT_TEXT' },
     { id: 'resultNonInsertPatch', title: 'RESULT_NON_INSERT_PATCH' },
@@ -194,7 +194,7 @@ function commentSyntaxForLanguage(languageid: string): string {
     }
 }
 
-function compareItemByRange(a: AutocompleteItem, b: AutocompleteItem): number {
+function compareItemByRange(a: EvaluationItem, b: EvaluationItem): number {
     const byStart = a.range.start.compareTo(b.range.start)
     if (byStart !== 0) {
         return byStart

--- a/agent/src/cli/evaluate-autocomplete/SnapshotWriter.ts
+++ b/agent/src/cli/evaluate-autocomplete/SnapshotWriter.ts
@@ -4,8 +4,8 @@ import { createObjectCsvWriter } from 'csv-writer'
 import { CsvWriter } from 'csv-writer/src/lib/csv-writer'
 import { rimraf } from 'rimraf'
 
-import { AutocompleteDocument, autocompleteItemHeaders } from './AutocompleteDocument'
 import { EvaluateAutocompleteOptions } from './evaluate-autocomplete'
+import { autocompleteItemHeaders, EvaluationDocument } from './EvaluationDocument'
 
 export class SnapshotWriter {
     public csvWriter: CsvWriter<any> | undefined
@@ -22,7 +22,7 @@ export class SnapshotWriter {
             }
         }
     }
-    public async writeDocument(document: AutocompleteDocument): Promise<void> {
+    public async writeDocument(document: EvaluationDocument): Promise<void> {
         if (!this.options.snapshotDirectory || document.items.length === 0) {
             return
         }

--- a/agent/src/cli/evaluate-autocomplete/Timer.ts
+++ b/agent/src/cli/evaluate-autocomplete/Timer.ts
@@ -1,0 +1,14 @@
+import prettyMs from 'pretty-ms'
+
+export class Timer {
+    public readonly start: number
+    constructor() {
+        this.start = Date.now()
+    }
+    public elapsed(): number {
+        return Date.now() - this.start
+    }
+    public toString(): string {
+        return prettyMs(this.elapsed())
+    }
+}

--- a/agent/src/cli/evaluate-autocomplete/strategy-bfg.ts
+++ b/agent/src/cli/evaluate-autocomplete/strategy-bfg.ts
@@ -9,10 +9,11 @@ import { createParser } from '../../../../vscode/src/tree-sitter/parser'
 import { MessageHandler } from '../../jsonrpc-alias'
 import { getLanguageForFileName } from '../../language'
 
-import { AutocompleteDocument } from './AutocompleteDocument'
 import { EvaluateAutocompleteOptions, matchesGlobPatterns } from './evaluate-autocomplete'
+import { EvaluationDocument } from './EvaluationDocument'
 import { Queries } from './Queries'
 import { SnapshotWriter } from './SnapshotWriter'
+import { testCleanup, testInstall } from './testTypecheck'
 import { triggerAutocomplete } from './triggerAutocomplete'
 
 /**
@@ -21,110 +22,124 @@ import { triggerAutocomplete } from './triggerAutocomplete'
  * code. Eventually, we could make the logic configurable via command-line
  * flags so that we can reuse this command for different kinds of evaluations.
  */
-export async function evaluateBfgStrategy(
-    client: MessageHandler,
-    options: EvaluateAutocompleteOptions,
-    workspace: string
-): Promise<void> {
+export async function evaluateBfgStrategy(client: MessageHandler, options: EvaluateAutocompleteOptions): Promise<void> {
+    const { workspace } = options
     const queries = new Queries(options.queriesDirectory)
     const grammarDirectory = path.normalize(options.treeSitterGrammars)
     const files = execSync('git ls-files', { cwd: workspace }).toString().split('\n')
     files.sort()
     let remainingTests = options.testCount
     const snapshots = new SnapshotWriter(options)
-    await snapshots.writeHeader()
+    await testInstall(options)
+    try {
+        await snapshots.writeHeader()
 
-    const revision = execSync('git rev-parse HEAD', { cwd: workspace }).toString().trim()
+        const revision = execSync('git rev-parse HEAD', { cwd: workspace }).toString().trim()
 
-    for (const file of files) {
-        if (!matchesGlobPatterns(options.includeFilepath ?? [], options.excludeFilepath ?? [], file)) {
-            continue
-        }
-        const filePath = path.join(workspace, file)
-        const stat = await fspromises.stat(filePath)
-        if (!stat.isFile()) {
-            continue
-        }
-        const content = (await fspromises.readFile(filePath)).toString()
-        const languageid = getLanguageForFileName(file)
-        const language = getParseLanguage(languageid)
-        if (!language) {
-            continue
-        }
-        client.notify('textDocument/didOpen', { filePath, content })
-        const parser = await createParser({ language, grammarDirectory })
-        const tree = parser.parse(content)
-        const query = await queries.loadQuery(parser, language, 'context')
-        if (!query) {
-            continue
-        }
-
-        const document = new AutocompleteDocument(
-            {
-                languageid,
-                filepath: file,
-                strategy: options.fixture.strategy,
-                fixture: options.fixture.name,
-                workspace: path.basename(options.workspace),
-                revision,
-            },
-            content
-        )
-        for (const match of query.matches(tree.rootNode)) {
-            if (remainingTests <= 0) {
-                break
+        for (const file of files) {
+            if (!matchesGlobPatterns(options.includeFilepath ?? [], options.excludeFilepath ?? [], file)) {
+                continue
             }
-            for (const capture of match.captures) {
+            const filePath = path.join(workspace, file)
+            const stat = await fspromises.stat(filePath)
+            if (!stat.isFile()) {
+                continue
+            }
+            const content = (await fspromises.readFile(filePath)).toString()
+            const languageid = getLanguageForFileName(file)
+            const language = getParseLanguage(languageid)
+            if (!language) {
+                continue
+            }
+            if (!matchesGlobPatterns(options.includeLanguage ?? [], options.excludeLanguage ?? [], languageid)) {
+                continue
+            }
+            client.notify('textDocument/didOpen', { filePath, content })
+            const parser = await createParser({ language, grammarDirectory })
+            const tree = parser.parse(content)
+            const query = await queries.loadQuery(parser, language, 'context')
+            if (!query) {
+                continue
+            }
+            const documentTestCountStart = remainingTests
+
+            const document = new EvaluationDocument(
+                {
+                    languageid,
+                    filepath: file,
+                    strategy: options.fixture.strategy,
+                    fixture: options.fixture.name,
+                    workspace: path.basename(options.workspace),
+                    revision,
+                },
+                content
+            )
+            for (const match of query.matches(tree.rootNode)) {
+                if (documentTestCountStart - remainingTests > options.maxFileTestCount) {
+                    console.log(`--max-file-test-count=${options.maxFileTestCount} limit hit for file '${file}'`)
+                    break
+                }
                 if (remainingTests <= 0) {
                     break
                 }
-                if (capture.name === 'range') {
-                    // Modify the content by replacing the argument list to the call expression
-                    // with an empty argument list. This evaluation is interesting because it
-                    // allows us to test how good Cody is at inferring the original argument
-                    // list.
+                for (const capture of match.captures) {
+                    if (remainingTests <= 0) {
+                        break
+                    }
+                    if (capture.name === 'range') {
+                        // Modify the content by replacing the argument list to the call expression
+                        // with an empty argument list. This evaluation is interesting because it
+                        // allows us to test how good Cody is at inferring the original argument
+                        // list.
 
-                    const isArgumentList =
-                        content.slice(capture.node.startIndex, capture.node.startIndex + 1) === '(' &&
-                        content.slice(capture.node.endIndex - 1, capture.node.endIndex) === ')'
-                    const range = isArgumentList
-                        ? new vscode.Range(
-                              new vscode.Position(
-                                  capture.node.startPosition.row,
-                                  capture.node.startPosition.column + 1
-                              ),
-                              new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column - 1)
-                          )
-                        : new vscode.Range(
-                              new vscode.Position(capture.node.startPosition.row, capture.node.startPosition.column),
-                              new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column)
-                          )
+                        const isArgumentList =
+                            content.slice(capture.node.startIndex, capture.node.startIndex + 1) === '(' &&
+                            content.slice(capture.node.endIndex - 1, capture.node.endIndex) === ')'
+                        const range = isArgumentList
+                            ? new vscode.Range(
+                                  new vscode.Position(
+                                      capture.node.startPosition.row,
+                                      capture.node.startPosition.column + 1
+                                  ),
+                                  new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column - 1)
+                              )
+                            : new vscode.Range(
+                                  new vscode.Position(
+                                      capture.node.startPosition.row,
+                                      capture.node.startPosition.column
+                                  ),
+                                  new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column)
+                              )
 
-                    const modifiedContent = [
-                        document.textDocument.getText(new vscode.Range(new vscode.Position(0, 0), range.start)),
-                        document.textDocument.getText(
-                            new vscode.Range(range.end, new vscode.Position(document.textDocument.lineCount, 0))
-                        ),
-                    ].join('')
-                    const removedContent = document.textDocument.getText(range)
-                    const position = new vscode.Position(
-                        capture.node.startPosition.row,
-                        capture.node.startPosition.column + 1
-                    )
-                    await triggerAutocomplete({
-                        range,
-                        client,
-                        document,
-                        emptyMatchContent: isArgumentList ? '()' : '',
-                        modifiedContent,
-                        removedContent,
-                        position,
-                    })
-                    remainingTests--
+                        const modifiedContent = [
+                            document.textDocument.getText(new vscode.Range(new vscode.Position(0, 0), range.start)),
+                            document.textDocument.getText(
+                                new vscode.Range(range.end, new vscode.Position(document.textDocument.lineCount, 0))
+                            ),
+                        ].join('')
+                        const removedContent = document.textDocument.getText(range)
+                        const position = new vscode.Position(
+                            capture.node.startPosition.row,
+                            capture.node.startPosition.column + 1
+                        )
+                        await triggerAutocomplete({
+                            range,
+                            client,
+                            document,
+                            options,
+                            emptyMatchContent: isArgumentList ? '()' : '',
+                            modifiedContent,
+                            removedContent,
+                            position,
+                        })
+                        remainingTests--
+                    }
                 }
             }
-        }
 
-        await snapshots.writeDocument(document)
+            await snapshots.writeDocument(document)
+        }
+    } finally {
+        await testCleanup(options)
     }
 }

--- a/agent/src/cli/evaluate-autocomplete/testTypecheck.ts
+++ b/agent/src/cli/evaluate-autocomplete/testTypecheck.ts
@@ -1,0 +1,96 @@
+import { exec } from 'child_process'
+import * as fspromises from 'fs/promises'
+import * as os from 'os'
+import path from 'path'
+
+import * as vscode from 'vscode'
+
+import { AgentTextDocument } from '../../AgentTextDocument'
+import { AutocompleteItem } from '../../protocol-alias'
+
+import { EvaluateAutocompleteOptions } from './evaluate-autocomplete'
+import { Timer } from './Timer'
+import { AutocompleteParameters } from './triggerAutocomplete'
+
+async function runCommand(command: string | undefined, cwd: string): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+        if (!command) {
+            resolve(true)
+            return
+        }
+        console.log(`> ${command}`)
+        const cmd = exec(command, { cwd })
+        cmd.stdout?.pipe(process.stderr)
+        cmd.stderr?.pipe(process.stderr)
+        cmd.on('error', () => resolve(false))
+        cmd.on('exit', code => resolve(code === 0))
+    })
+}
+
+// Same as runCommand but rejects the promise instead of returning false
+async function runVoidCommand(command: string | undefined, cwd: string): Promise<void> {
+    return runCommand(command, cwd).then(ok => (ok ? Promise.resolve() : Promise.reject(`Command failed: ${command}`)))
+}
+
+export async function testCleanup(options: EvaluateAutocompleteOptions): Promise<void> {
+    if (options.worktree) {
+        await runVoidCommand(`git worktree remove ${options.worktree}`, options.workspace)
+    }
+}
+
+export async function testInstall(options: EvaluateAutocompleteOptions): Promise<void> {
+    if (!options.runTestCommand) {
+        return
+    }
+    if (options.worktree) {
+        throw new Error(`options.worktree=${options.worktree} is already defined, expected it to be undefined`)
+    }
+    options.worktree = await fspromises.mkdtemp(path.join(os.tmpdir(), 'evaluate-autocomplete-'))
+    await runVoidCommand('git diff --exit-code', options.workspace)
+
+    // Create a git worktree so that we can run parallel evaluations. Without
+    // worktrees, we risk having separate fixtures making modifications to the
+    // same worktree causing the results to be inaccurate.
+    await runVoidCommand(`git worktree add ${options.worktree}`, options.workspace)
+    await runVoidCommand(options.installCommand, options.worktree)
+    await runVoidCommand(options.testCommand, options.worktree)
+}
+
+export async function testTypecheck(
+    parameters: AutocompleteParameters,
+    item: AutocompleteItem
+): Promise<boolean | undefined> {
+    const { options, document } = parameters
+    const { worktree } = options
+    if (!worktree) {
+        return undefined
+    }
+    const absolutePath = path.join(worktree, document.params.filepath)
+    const { testCommand, runTestCommand } = options
+    if (!testCommand || !runTestCommand) {
+        return undefined
+    }
+    const start = new vscode.Position(item.range.start.line, item.range.start.character)
+    const end = new vscode.Position(item.range.end.line, item.range.end.character)
+    const modifiedDocument = new AgentTextDocument({
+        filePath: document.params.filepath,
+        content: parameters.modifiedContent,
+    })
+    const newText = [
+        modifiedDocument.getText(new vscode.Range(new vscode.Position(0, 0), start)),
+        item.insertText,
+        modifiedDocument.getText(new vscode.Range(end, new vscode.Position(document.textDocument.lineCount, 0))),
+    ].join('')
+
+    try {
+        // Assert that the codebase has no diffs to ensure that we're evaluating a clean worktree
+        await runVoidCommand('git diff --exit-code', worktree)
+        await fspromises.writeFile(absolutePath, newText)
+        const timer = new Timer()
+        const result = await runCommand(testCommand, worktree)
+        console.error(`Completion '${item.insertText}': ${result ? 'typecheck_ok' : 'typecheck_error'} (${timer})`)
+        return result
+    } finally {
+        await fspromises.writeFile(absolutePath, document.text)
+    }
+}

--- a/agent/src/cli/evaluate-autocomplete/testTypecheck.ts
+++ b/agent/src/cli/evaluate-autocomplete/testTypecheck.ts
@@ -29,7 +29,10 @@ async function runCommand(command: string | undefined, cwd: string): Promise<boo
 
 // Same as runCommand but rejects the promise instead of returning false
 async function runVoidCommand(command: string | undefined, cwd: string): Promise<void> {
-    return runCommand(command, cwd).then(ok => (ok ? Promise.resolve() : Promise.reject(`Command failed: ${command}`)))
+    const ok = await runCommand(command, cwd)
+    if (!ok) {
+        throw new Error(`Command failed: ${command}`)
+    }
 }
 
 export async function testCleanup(options: EvaluateAutocompleteOptions): Promise<void> {

--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 
 import { Agent } from '../agent'
 
@@ -6,6 +6,12 @@ export const jsonrpcCommand = new Command('jsonrpc')
     .description(
         'Interact with the Agent using JSON-RPC via stdout/stdin. ' +
             'This is the subcommand that is used by Cody clients like the JetBrains and Neovim plugins.'
+    )
+    .addOption(
+        new Option(
+            '--testing-directory <path>',
+            'Path to the directory where network traffic is recorded or replayed from. This option should only be used in testing environments.'
+        ).env('TESTING_DIRECTORY')
     )
     .action(() => {
         process.stderr.write('Starting Cody Agent...\n')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       minimatch:
         specifier: ^9.0.3
         version: 9.0.3
+      pretty-ms:
+        specifier: ^8.0.0
+        version: 8.0.0
       vscode-uri:
         specifier: ^3.0.7
         version: 3.0.7
@@ -13014,6 +13017,11 @@ packages:
       lines-and-columns: 1.1.6
     dev: true
 
+  /parse-ms@3.0.0:
+    resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /parse-semver@1.1.1:
     resolution: {integrity: sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==}
     dependencies:
@@ -13347,6 +13355,13 @@ packages:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
     dev: true
+
+  /pretty-ms@8.0.0:
+    resolution: {integrity: sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      parse-ms: 3.0.0
+    dev: false
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}


### PR DESCRIPTION
Previously, evaluate-autocomplete only supported testing whether an autocomplete result was an exact match with the original code or if it was an empty result. This PR adds an additional test to check whether the code typechecks.


## Test plan

Ran it manually.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
