### PR TITLE
Provide anonymousUserId via agent clients

### DIFF
--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -4,12 +4,12 @@ import { Memento } from 'vscode'
 import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 export class LocalStorage {
+    public readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
     // Bump this on storage changes so we don't handle incorrectly formatted data
-    protected KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'
-    protected ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
-    protected LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
-    protected CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
-    protected KEY_LAST_USED_RECIPES = 'SOURCEGRAPH_CODY_LAST_USED_RECIPE_NAMES'
+    protected readonly KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'
+    protected readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
+    protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
+    protected readonly KEY_LAST_USED_RECIPES = 'SOURCEGRAPH_CODY_LAST_USED_RECIPE_NAMES'
 
     /**
      * Should be set on extension activation via `localStorage.setStorage(context.globalState)`

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -60,7 +60,7 @@ export async function createOrUpdateEventLogger(
             logEvent('CodyInstalled', undefined, {
                 hasV2Event: true, // Created in src/services/telemetry-v2.ts
             })
-        } else {
+        } else if (!config.isRunningInsideAgent) {
             logEvent('CodyVSCodeExtension:CodySavedLogin:executed', undefined, {
                 hasV2Event: true, // Created in src/services/telemetry-v2.ts
             })


### PR DESCRIPTION
For clients that generate, persist and include this via ClientInfo.extensionConfiguration, we dont want to generate CodyInstalled events at every agent startup. For now, this means that JetBrains (the only non-vscode IDE that matters :clueless:) will continue to emit CodyInstalled events itself until we come up with a solution for agent to do so based on IDE-provided info.

Based on [the existing agent-side code](https://sourcegraph.com/github.com/sourcegraph/cody@nsc/agent-anonymoususerid/-/blob/vscode/src/services/telemetry.ts?L93%3A4-116%3A2), 

## Test plan

Confirmed based on whether CodyInstalled event is fired or not when a client provides anonymousUserID
