### PR TITLE
Allow awaiting extension activation instead of being unawaitably async

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -28,12 +28,12 @@ import * as vscode_shim from './vscode-shim'
 
 const secretStorage = new Map<string, string>()
 
-export function initializeVscodeExtension(
+export async function initializeVscodeExtension(
     workspaceRoot: vscode.Uri,
     extensionConfiguration?: ExtensionConfiguration
-): void {
+): Promise<void> {
     const paths = envPaths('Cody')
-    activate({
+    await activate({
         asAbsolutePath(relativePath) {
             return path.resolve(workspaceRoot.fsPath, relativePath)
         },
@@ -182,7 +182,7 @@ export class Agent extends MessageHandler {
             this.workspace.workspaceRootUri = clientInfo.workspaceRootUri
                 ? vscode.Uri.parse(clientInfo.workspaceRootUri)
                 : vscode.Uri.from({ scheme: 'file', path: clientInfo.workspaceRootPath })
-            initializeVscodeExtension(this.workspace.workspaceRootUri, clientInfo.extensionConfiguration)
+            await initializeVscodeExtension(this.workspace.workspaceRootUri, clientInfo.extensionConfiguration)
 
             // Register client info
             this.clientInfo = clientInfo

--- a/agent/src/bfg/BfgContextFetcher.test.ts
+++ b/agent/src/bfg/BfgContextFetcher.test.ts
@@ -39,7 +39,7 @@ describe('BfgRetriever', async () => {
     beforeAll(async () => {
         process.env.CODY_TESTING = 'true'
         await initTreeSitterParser()
-        initializeVscodeExtension(vscode.Uri.file(process.cwd()))
+        await initializeVscodeExtension(vscode.Uri.file(process.cwd()))
 
         if (shouldCreateGitDir) {
             await exec('git init', { cwd: dir })

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -36,24 +36,26 @@ export interface PlatformContext {
     onConfigurationChange?: (configuration: Configuration) => void
 }
 
-export function activate(context: vscode.ExtensionContext, platformContext: PlatformContext): ExtensionApi {
+export async function activate(
+    context: vscode.ExtensionContext,
+    platformContext: PlatformContext
+): Promise<ExtensionApi> {
     const api = new ExtensionApi()
 
-    start(context, platformContext)
-        .then(disposable => {
-            if (!context.globalState.get('extension.hasActivatedPreviously')) {
-                void context.globalState.update('extension.hasActivatedPreviously', 'true')
-            }
-            context.subscriptions.push(disposable)
+    try {
+        const disposable = await start(context, platformContext)
+        if (!context.globalState.get('extension.hasActivatedPreviously')) {
+            void context.globalState.update('extension.hasActivatedPreviously', 'true')
+        }
+        context.subscriptions.push(disposable)
 
-            if (context.extensionMode === vscode.ExtensionMode.Development) {
-                onActivationDevelopmentHelpers()
-            }
-        })
-        .catch(error => {
-            captureException(error)
-            console.error(error)
-        })
+        if (context.extensionMode === vscode.ExtensionMode.Development) {
+            onActivationDevelopmentHelpers()
+        }
+    } catch (error) {
+        captureException(error)
+        console.error(error)
+    }
 
     return api
 }

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -23,7 +23,7 @@ import { NodeSentryService } from './services/sentry/sentry.node'
  * Activation entrypoint for the VS Code extension when running VS Code as a desktop app
  * (Node.js/Electron).
  */
-export function activate(context: vscode.ExtensionContext): ExtensionApi {
+export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
     initializeNetworkAgent()
 
     return activateCommon(context, {

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -46,7 +46,7 @@ export const VSCODE_WEB_RECIPES: Recipe[] = [
  * Activation entrypoint for the VS Code extension when running in VS Code Web (https://vscode.dev,
  * https://github.dev, etc.).
  */
-export function activate(context: vscode.ExtensionContext): ExtensionApi {
+export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
     return activateCommon(context, {
         createCompletionsClient: (...args) => new SourcegraphBrowserCompletionsClient(...args),
         createSentryService: (...args) => new WebSentryService(...args),


### PR DESCRIPTION
Discovered while debugging why commands executed in agent on initialization weren't being fired, there can be a race condition whereby the extension hasnt activated yet by the time we attempt to execute the commands due to activation of the extension being unawaitably async.

## Test plan

Confirmed by observing that [looking up commands to execute](https://sourcegraph.com/github.com/sourcegraph/cody@nsc/promise-extension-activation/-/blob/agent/src/vscode-shim.ts?L412) no longer fails
