### PR TITLE
Add rate limit notification/upgrade buttons in chat

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -27,6 +27,7 @@
     "@microsoft/fetch-event-source": "^2.0.1",
     "@opentelemetry/api": "^1.7.0",
     "@sourcegraph/telemetry": "^0.13.0",
+    "date-fns": "^2.30.0",
     "dompurify": "^3.0.4",
     "highlight.js": "^10.7.3",
     "isomorphic-fetch": "^3.0.0",

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -170,13 +170,13 @@ export async function createClient({
                         sendTranscript(options?.data)
                         resolve()
                     },
-                    onError(error) {
+                    onError(error: Error) {
                         // Display error message as assistant response
                         transcript.addErrorAsAssistantResponse(error)
                         isMessageInProgress = false
                         sendTranscript(options?.data)
                         console.error(`Completion request failed: ${error}`)
-                        reject(new Error(error))
+                        reject(error)
                     },
                 })
                 options?.signal?.addEventListener('abort', () => {

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -2,6 +2,7 @@ import { ContextFile, ContextMessage, OldContextMessage, PreciseContext } from '
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH } from '../../prompt/constants'
 import { PromptMixin } from '../../prompt/prompt-mixin'
 import { Message } from '../../sourcegraph-api'
+import { RateLimitError } from '../../sourcegraph-api/errors'
 
 import { Interaction, InteractionJSON } from './interaction'
 import { ChatMessage } from './messages'
@@ -143,22 +144,84 @@ export class Transcript {
     }
 
     /**
-     * Adds a error div to the assistant response. If the assistant has collected
+     * Adds an error div to the assistant response. If the assistant has collected
      * some response before, we will add the error message after it.
-     * @param errorText The error TEXT to be displayed. Do not wrap it in HTML tags.
+     * @param error The error to be displayed.
      */
-    public addErrorAsAssistantResponse(errorText: string): void {
+    public addErrorAsAssistantResponse(error: Error): void {
+        if (error instanceof RateLimitError) {
+            this.addRateLimitErrorAsAssistantResponse(error)
+            return
+        }
+
         const lastInteraction = this.getLastInteraction()
         if (!lastInteraction) {
             return
         }
         // If assistant has responsed before, we will add the error message after it
         const lastAssistantMessage = lastInteraction.getAssistantMessage().displayText || ''
+
+        const errorHtml = `<div class="cody-chat-error"><span>Request failed: </span>${error.message}</div>`
+
         lastInteraction.setAssistantMessage({
             speaker: 'assistant',
             text: 'Failed to generate a response due to server error.',
-            displayText:
-                lastAssistantMessage + `<div class="cody-chat-error"><span>Request failed: </span>${errorText}</div>`,
+            displayText: lastAssistantMessage + errorHtml,
+        })
+    }
+
+    /**
+     * Adds an error div to the assistant response with information about the
+     * RateLimitError that was triggered.
+     */
+    public addRateLimitErrorAsAssistantResponse(error: RateLimitError): void {
+        const lastInteraction = this.getLastInteraction()
+        if (!lastInteraction) {
+            return
+        }
+
+        const canUpgrade = false // TODO(dantup): Get from auth + GA feature flag
+        const className = canUpgrade ? 'rate-limit-error upgradable' : 'rate-limit-error'
+        const title = canUpgrade ? 'Upgrade to Cody Pro' : 'Unable to Send Message'
+        let description = error.buildMessage('chat messages')
+        if (canUpgrade) {
+            description += ' Upgrade to Cody Pro to get unlimited chats.'
+        }
+        // TODO(dantup): Is HTML here the right place?
+        const errorHtml = `
+                <div class="${className}">
+                    <h1>${title}</h1>
+                    <span>${description}</span>
+                </div>
+            `.trim()
+
+        lastInteraction.setAssistantMessage({
+            speaker: 'assistant',
+            text: 'Failed to generate a response due to rate limit error.',
+            displayText: errorHtml,
+            buttons: [
+                {
+                    label: 'Upgrade',
+                    action: '',
+                    onClick: (action: string) => {
+                        // TODO(dantup): How do we open a URL from here?
+                        // can we use something like vscode.env.openExternal or
+                        // vscode.commands.executeCommand()?
+                        // console.log(`TODO: Open ${ACCOUNT_UPGRADE_URL}`);
+                    },
+                    appearance: 'primary',
+                },
+                {
+                    label: 'Learn More',
+                    action: '',
+                    onClick: (action: string) => {
+                        // TODO: Where does Learn More go?
+                    },
+                    appearance: 'secondary',
+                },
+            ],
+            footerText: error.buildResetMessage(),
+            isRateLimitError: true,
         })
     }
 

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -156,7 +156,13 @@ export class Transcript {
         lastInteraction.setAssistantMessage({
             ...lastInteraction.getAssistantMessage(),
             text: 'Failed to generate a response due to server error.',
-            error,
+            // Serializing normal errors will lose name/message so
+            // just read them off manually and attach the rest of the fields.
+            error: {
+                ...error,
+                message: error.message,
+                name: error.name,
+            },
         })
     }
 

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -26,14 +26,14 @@ export interface ChatMessage extends Message {
     error?: string | ChatError
 }
 
+export interface InteractionMessage extends ChatMessage {
+    prefix?: string
+}
+
 export interface ChatError {
     kind?: string
     name: string
     message: string
-}
-
-export interface InteractionMessage extends ChatMessage {
-    prefix?: string
 }
 
 export interface ChatMetadata {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -9,22 +9,30 @@ export interface ChatButton {
     label: string
     action: string
     onClick: (action: string) => void
+    appearance?: 'primary' | 'secondary' | 'icon'
 }
 
 export interface ChatMessage extends Message {
+    className?: string
     displayText?: string
     contextFiles?: ContextFile[]
     preciseContext?: PreciseContext[]
     buttons?: ChatButton[]
+    footerText?: string
     data?: any
     metadata?: ChatMetadata
+    isRateLimitError?: boolean
 }
 
 export interface InteractionMessage extends Message {
+    className?: string
     displayText?: string
     prefix?: string
     error?: string
     metadata?: ChatMetadata
+    buttons?: ChatButton[]
+    footerText?: string
+    isRateLimitError?: boolean
 }
 
 export interface ChatMetadata {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -13,13 +13,10 @@ export interface ChatButton {
 }
 
 export interface ChatMessage extends Message {
-    kind?: string
-    className?: string
     displayText?: string
     contextFiles?: ContextFile[]
     preciseContext?: PreciseContext[]
     buttons?: ChatButton[]
-    footerText?: string
     data?: any
     metadata?: ChatMetadata
     // TODO(dantup): Is anyone using string?

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -23,7 +23,13 @@ export interface ChatMessage extends Message {
     data?: any
     metadata?: ChatMetadata
     // TODO(dantup): Is anyone using string?
-    error?: string | Error
+    error?: string | ChatError
+}
+
+export interface ChatError {
+    kind?: string
+    name: string
+    message: string
 }
 
 export interface InteractionMessage extends ChatMessage {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -13,6 +13,7 @@ export interface ChatButton {
 }
 
 export interface ChatMessage extends Message {
+    kind?: string
     className?: string
     displayText?: string
     contextFiles?: ContextFile[]
@@ -21,18 +22,12 @@ export interface ChatMessage extends Message {
     footerText?: string
     data?: any
     metadata?: ChatMetadata
-    isRateLimitError?: boolean
+    // TODO(dantup): Is anyone using string?
+    error?: string | Error
 }
 
-export interface InteractionMessage extends Message {
-    className?: string
-    displayText?: string
+export interface InteractionMessage extends ChatMessage {
     prefix?: string
-    error?: string
-    metadata?: ChatMetadata
-    buttons?: ChatButton[]
-    footerText?: string
-    isRateLimitError?: boolean
 }
 
 export interface ChatMetadata {

--- a/lib/shared/src/codebase-context/rerank.ts
+++ b/lib/shared/src/codebase-context/rerank.ts
@@ -41,8 +41,8 @@ export class LLMReranker implements Reranker {
                     onComplete: () => {
                         resolve(responseText)
                     },
-                    onError: (message: string, statusCode?: number) => {
-                        reject(new Error(`Status code ${statusCode}: ${message}`))
+                    onError: (error: Error, statusCode?: number) => {
+                        reject(statusCode ? new Error(`Status code ${statusCode}: ${error.message}`) : error)
                     },
                 },
                 {

--- a/lib/shared/src/codebase-context/rerank.ts
+++ b/lib/shared/src/codebase-context/rerank.ts
@@ -2,6 +2,7 @@ import x2js from 'x2js'
 
 import { ChatClient } from '../chat/chat'
 import { ContextResult } from '../local-context'
+import { SerializableError } from '../sourcegraph-api/errors'
 
 export interface Reranker {
     rerank(userQuery: string, results: ContextResult[]): Promise<ContextResult[]>
@@ -41,8 +42,10 @@ export class LLMReranker implements Reranker {
                     onComplete: () => {
                         resolve(responseText)
                     },
-                    onError: (error: Error, statusCode?: number) => {
-                        reject(statusCode ? new Error(`Status code ${statusCode}: ${error.message}`) : error)
+                    onError: (error: SerializableError, statusCode?: number) => {
+                        reject(
+                            statusCode ? new SerializableError(`Status code ${statusCode}: ${error.message}`) : error
+                        )
                     },
                 },
                 {

--- a/lib/shared/src/codebase-context/rerank.ts
+++ b/lib/shared/src/codebase-context/rerank.ts
@@ -2,7 +2,6 @@ import x2js from 'x2js'
 
 import { ChatClient } from '../chat/chat'
 import { ContextResult } from '../local-context'
-import { SerializableError } from '../sourcegraph-api/errors'
 
 export interface Reranker {
     rerank(userQuery: string, results: ContextResult[]): Promise<ContextResult[]>
@@ -42,10 +41,8 @@ export class LLMReranker implements Reranker {
                     onComplete: () => {
                         resolve(responseText)
                     },
-                    onError: (error: SerializableError, statusCode?: number) => {
-                        reject(
-                            statusCode ? new SerializableError(`Status code ${statusCode}: ${error.message}`) : error
-                        )
+                    onError: (error: Error, statusCode?: number) => {
+                        reject(statusCode ? new Error(`Status code ${statusCode}: ${error.message}`) : error)
                     },
                 },
                 {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -2,6 +2,7 @@
 
 export { ChatContextStatus } from './chat/context'
 export { ChatButton, ChatMessage } from './chat/transcript/messages'
+export { SerializableError, RateLimitError } from './sourcegraph-api/errors'
 export { renderCodyMarkdown } from './chat/markdown'
 export { basename, pluralize, isDefined, dedupeWith } from './common'
 export { ContextFile, PreciseContext } from './codebase-context/messages'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,8 +1,8 @@
 // Add anything else here that needs to be used outside of this repository.
 
 export { ChatContextStatus } from './chat/context'
-export { ChatButton, ChatMessage } from './chat/transcript/messages'
-export { SerializableError, RateLimitError } from './sourcegraph-api/errors'
+export { ChatButton, ChatMessage, ChatError } from './chat/transcript/messages'
+export { RateLimitError } from './sourcegraph-api/errors'
 export { renderCodyMarkdown } from './chat/markdown'
 export { basename, pluralize, isDefined, dedupeWith } from './common'
 export { ContextFile, PreciseContext } from './codebase-context/messages'

--- a/lib/shared/src/intent-detector/client.ts
+++ b/lib/shared/src/intent-detector/client.ts
@@ -113,8 +113,8 @@ export class SourcegraphIntentDetectorClient implements IntentDetector {
                     onComplete: () => {
                         resolve(responseText)
                     },
-                    onError: (message: string, statusCode?: number) => {
-                        console.error(`Error detecting intent: Status code ${statusCode}: ${message}`)
+                    onError: (error: Error, statusCode?: number) => {
+                        console.error(`Error detecting intent: Status code ${statusCode}: ${error.message}`)
                         resolve(fallback)
                     },
                 }

--- a/lib/shared/src/intent-detector/client.ts
+++ b/lib/shared/src/intent-detector/client.ts
@@ -1,6 +1,7 @@
 import { ANSWER_TOKENS } from '../prompt/constants'
 import { Message } from '../sourcegraph-api'
 import { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
+import { SerializableError } from '../sourcegraph-api/errors'
 import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 
 import { IntentClassificationOption, IntentDetector } from '.'
@@ -113,7 +114,7 @@ export class SourcegraphIntentDetectorClient implements IntentDetector {
                     onComplete: () => {
                         resolve(responseText)
                     },
-                    onError: (error: Error, statusCode?: number) => {
+                    onError: (error: SerializableError, statusCode?: number) => {
                         console.error(`Error detecting intent: Status code ${statusCode}: ${error.message}`)
                         resolve(fallback)
                     },

--- a/lib/shared/src/intent-detector/client.ts
+++ b/lib/shared/src/intent-detector/client.ts
@@ -1,7 +1,6 @@
 import { ANSWER_TOKENS } from '../prompt/constants'
 import { Message } from '../sourcegraph-api'
 import { SourcegraphCompletionsClient } from '../sourcegraph-api/completions/client'
-import { SerializableError } from '../sourcegraph-api/errors'
 import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 
 import { IntentClassificationOption, IntentDetector } from '.'
@@ -114,7 +113,7 @@ export class SourcegraphIntentDetectorClient implements IntentDetector {
                     onComplete: () => {
                         resolve(responseText)
                     },
-                    onError: (error: SerializableError, statusCode?: number) => {
+                    onError: (error: Error, statusCode?: number) => {
                         console.error(`Error detecting intent: Status code ${statusCode}: ${error.message}`)
                         resolve(fallback)
                     },

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -34,12 +34,12 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
                         // We show the generic error message in this case
                         console.error(error)
                     }
-                    cb.onError(
+                    const error = new Error(
                         errorMessage === null || errorMessage.length === 0
                             ? `Request failed with status code ${response.status}`
-                            : errorMessage,
-                        response.status
+                            : errorMessage
                     )
+                    cb.onError(error, response.status)
                     abort.abort()
                     return
                 }

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -44,7 +44,7 @@ export abstract class SourcegraphCompletionsClient {
                     break
                 case 'error':
                     this.errorEncountered = true
-                    cb.onError(event.error)
+                    cb.onError(new Error(event.error))
                     break
                 case 'done':
                     if (!this.errorEncountered) {
@@ -77,8 +77,8 @@ export function bufferStream(
             onComplete() {
                 resolve(buffer)
             },
-            onError(message: string, code?: number) {
-                reject(new Error(code ? `${message} (code ${code})` : message))
+            onError(error: Error, code?: number) {
+                reject(code ? new Error(`${error} (code ${code})`) : error)
             },
         }
         client.stream(params, callbacks)

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -45,10 +45,15 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     log?.onError(e.message)
 
                     if (res.statusCode === 429) {
+                        // Check for explicit false, because if the header is not set, there
+                        // is no upgrade available.
+                        const upgradeIsAvailable = res.headers['x-is-cody-pro-user'] === 'false'
                         const retryAfter = res.headers['retry-after']
                         const limit = res.headers['x-ratelimit-limit'] ? res.headers['x-ratelimit-limit'][0] : undefined
                         const error = new RateLimitError(
+                            'chat messages',
                             e.message,
+                            upgradeIsAvailable,
                             limit ? parseInt(limit, 10) : undefined,
                             retryAfter ? new Date(retryAfter) : undefined
                         )

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -2,6 +2,7 @@ import http from 'http'
 import https from 'https'
 
 import { isError } from '../../utils'
+import { RateLimitError } from '../errors'
 import { customUserAgent } from '../graphql/client'
 import { toPartialUtf8String } from '../utils'
 
@@ -35,6 +36,28 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 if (res.statusCode === undefined) {
                     throw new Error('no status code present')
                 }
+
+                // Calls the error callback handler for an error.
+                //
+                // If the request failed with a rate limit error, wraps the
+                // error in RateLimitError.
+                function handleError(e: Error): void {
+                    log?.onError(e.message)
+
+                    if (res.statusCode === 429) {
+                        const retryAfter = res.headers['retry-after']
+                        const limit = res.headers['x-ratelimit-limit'] ? res.headers['x-ratelimit-limit'][0] : undefined
+                        const error = new RateLimitError(
+                            e.message,
+                            limit ? parseInt(limit, 10) : undefined,
+                            retryAfter ? new Date(retryAfter) : undefined
+                        )
+                        cb.onError(error, res.statusCode)
+                    } else {
+                        cb.onError(e, res.statusCode)
+                    }
+                }
+
                 // For failed requests, we just want to read the entire body and
                 // ultimately return it to the error callback.
                 if (res.statusCode >= 400) {
@@ -53,18 +76,12 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         bufferBin = buf
                     })
 
-                    res.on('error', e => {
-                        log?.onError(e.message)
-                        cb.onError(e.message, res.statusCode)
-                    })
-                    res.on('end', () => {
-                        log?.onError(errorMessage)
-                        cb.onError(errorMessage, res.statusCode)
-                    })
+                    res.on('error', e => handleError(e))
+                    res.on('end', () => handleError(new Error(errorMessage)))
                     return
                 }
 
-                // Bytes which have not been decoded as UTF-8 text
+                // By tes which have not been decoded as UTF-8 text
                 let bufferBin = Buffer.of()
                 // Text which has not been decoded as a server-sent event (SSE)
                 let bufferText = ''
@@ -90,21 +107,19 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     bufferText = parseResult.remainingBuffer
                 })
 
-                res.on('error', e => {
-                    log?.onError(e.message)
-                    cb.onError(e.message)
-                })
+                res.on('error', e => handleError(e))
             }
         )
 
         request.on('error', e => {
-            let message = e.message
-            if (message.includes('ECONNREFUSED')) {
-                message =
+            let error = e
+            if (error.message.includes('ECONNREFUSED')) {
+                error = new Error(
                     'Could not connect to Cody. Please ensure that Cody app is running or that you are connected to the Sourcegraph server.'
+                )
             }
-            log?.onError(message)
-            cb.onError(message)
+            log?.onError(error.message)
+            cb.onError(error)
         })
 
         request.write(JSON.stringify(params))

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -46,5 +46,5 @@ export interface CompletionCallbacks {
      * assumed to be a "complete" event, and no other callbacks will be called
      * afterwards.
      */
-    onError: (message: string, statusCode?: number) => void
+    onError: (error: Error, statusCode?: number) => void
 }

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -1,5 +1,3 @@
-import { SerializableError } from '../errors'
-
 export interface DoneEvent {
     type: 'done'
 }
@@ -48,5 +46,5 @@ export interface CompletionCallbacks {
      * assumed to be a "complete" event, and no other callbacks will be called
      * afterwards.
      */
-    onError: (error: SerializableError, statusCode?: number) => void
+    onError: (error: Error, statusCode?: number) => void
 }

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -1,3 +1,5 @@
+import { SerializableError } from '../errors'
+
 export interface DoneEvent {
     type: 'done'
 }
@@ -46,5 +48,5 @@ export interface CompletionCallbacks {
      * assumed to be a "complete" event, and no other callbacks will be called
      * afterwards.
      */
-    onError: (error: Error, statusCode?: number) => void
+    onError: (error: SerializableError, statusCode?: number) => void
 }

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -1,3 +1,5 @@
+import { formatDistance } from 'date-fns'
+
 import { isError } from '../utils'
 
 export class RateLimitError extends Error {
@@ -7,6 +9,16 @@ export class RateLimitError extends Error {
         public retryAfter?: Date
     ) {
         super(message)
+    }
+
+    public buildMessage(feature: string): string {
+        const limit = this.limit
+        return `You've used all${limit ? ` ${limit}` : ''} ${feature} for today.`
+    }
+
+    public buildResetMessage(): string | undefined {
+        const retryAfter = this.retryAfter
+        return retryAfter ? `Usage will reset in ${formatDistance(retryAfter, new Date())}.` : undefined
     }
 }
 

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -3,25 +3,24 @@ import { formatDistance } from 'date-fns'
 import { isError } from '../utils'
 
 /**
- * Passing normal [Error]s to react causes messages to be lost so this class is a stand-in with
- * a real 'message' field so that errors extending from this class can carry their messages
- * to the UI.
+ * Passing normal Errors through postMessage loses the type/message so any errors to be passed
+ * around must include a message and kind explicitly.
  */
-export class SerializableError implements Error {
-    public readonly name: string = 'SerializableError'
-    constructor(public message: string) {}
+export interface SerializableError {
+    name?: string
+    message: string
 }
 
-export class RateLimitError extends SerializableError {
-    public static readonly name = 'RateLimitError'
-    public readonly name = RateLimitError.name
+export class RateLimitError implements SerializableError {
+    public static readonly errorName = 'RateLimitError'
+    public readonly name = RateLimitError.errorName
 
     public readonly userMessage: string
     public readonly retryMessage: string | undefined
 
     constructor(
         public readonly feature: string,
-        message: string,
+        public readonly message: string,
         /**
          * Whether an upgrade is available that would increase rate limits.
          */
@@ -29,7 +28,6 @@ export class RateLimitError extends SerializableError {
         public readonly limit?: number,
         public readonly retryAfter?: Date
     ) {
-        super(message)
         this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for today.`
         this.retryMessage = retryAfter ? `Usage will reset in ${formatDistance(retryAfter, new Date())}.` : undefined
     }

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -2,16 +2,7 @@ import { formatDistance } from 'date-fns'
 
 import { isError } from '../utils'
 
-/**
- * Passing normal Errors through postMessage loses the type/message so any errors to be passed
- * around must include a message and kind explicitly.
- */
-export interface SerializableError {
-    name?: string
-    message: string
-}
-
-export class RateLimitError implements SerializableError {
+export class RateLimitError extends Error {
     public static readonly errorName = 'RateLimitError'
     public readonly name = RateLimitError.errorName
 
@@ -28,6 +19,7 @@ export class RateLimitError implements SerializableError {
         public readonly limit?: number,
         public readonly retryAfter?: Date
     ) {
+        super(message)
         this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for today.`
         this.retryMessage = retryAfter ? `Usage will reset in ${formatDistance(retryAfter, new Date())}.` : undefined
     }

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -71,12 +71,15 @@ interface ChatProps extends ChatClassNames {
     ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
     onCurrentChatModelChange?: (model: ChatModelProvider) => void
     userInfo?: UserAccountInfo
+    postMessage?: ApiPostMessage
 }
 
 export interface UserAccountInfo {
     isDotComUser: boolean
     isCodyProUser: boolean
 }
+
+export type ApiPostMessage = (message: any) => void
 
 interface ChatClassNames extends TranscriptItemClassNames {
     inputRowClassName?: string
@@ -222,6 +225,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     EnhancedContextSettings,
     onCurrentChatModelChange,
     userInfo,
+    postMessage,
 }) => {
     const [inputRows, setInputRows] = useState(1)
     const [displayCommands, setDisplayCommands] = useState<[string, CodyPrompt & { instruction?: string }][] | null>(
@@ -554,6 +558,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     onCurrentChatModelChange={onCurrentChatModelChange}
                     ChatModelDropdownMenu={ChatModelDropdownMenu}
                     userInfo={userInfo}
+                    postMessage={postMessage}
                 />
             )}
 

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -88,6 +88,7 @@ export interface ChatButtonProps {
     label: string
     action: string
     onClick: (action: string) => void
+    appearance?: 'primary' | 'secondary' | 'icon'
 }
 
 export interface ChatUITextAreaProps {

--- a/lib/ui/src/chat/ErrorItem.module.css
+++ b/lib/ui/src/chat/ErrorItem.module.css
@@ -1,0 +1,15 @@
+h1 {
+    text-transform: uppercase;
+    font-size: 1.2em;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    padding: 0 0 var(--spacing) 0;
+    gap: 10px;
+}
+
+.retry-message {
+    font-size: 0.8em;
+}

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ChatError, RateLimitError } from '@sourcegraph/cody-shared'
 
-import { ApiPostMessage, ChatButtonProps } from '../Chat'
+import { ApiPostMessage, ChatButtonProps, UserAccountInfo } from '../Chat'
 
 import styles from './ErrorItem.module.css'
 
@@ -12,8 +12,9 @@ import styles from './ErrorItem.module.css'
 export const ErrorItem: React.FunctionComponent<{
     error: string | ChatError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+    userInfo?: UserAccountInfo
     postMessage?: ApiPostMessage
-}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent, postMessage }) {
+}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent, userInfo, postMessage }) {
     return typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage ? (
         <RateLimitErrorItem
             error={error as RateLimitError}
@@ -34,15 +35,19 @@ export const ErrorItem: React.FunctionComponent<{
 export const RateLimitErrorItem: React.FunctionComponent<{
     error: RateLimitError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+    userInfo?: UserAccountInfo
     postMessage: ApiPostMessage
-}> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent, postMessage }) {
+}> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent, userInfo, postMessage }) {
+    // Only show Upgrades if both the error said an upgrade was available and we know the user
+    // has not since upgraded.
+    const canUpgrade = error.upgradeIsAvailable && userInfo?.isCodyProUser !== true
     return (
         <div className={styles.errorItem}>
-            <h1>{error.upgradeIsAvailable ? 'Upgrade to Cody Pro' : 'Unable to Send Message'}</h1>
+            <h1>{canUpgrade ? 'Upgrade to Cody Pro' : 'Unable to Send Message'}</h1>
             <p>{error.userMessage}</p>
             {ChatButtonComponent && (
                 <div className={styles.actions}>
-                    {error.upgradeIsAvailable && (
+                    {canUpgrade && (
                         <ChatButtonComponent
                             label="Upgrade"
                             action=""

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { RateLimitError, SerializableError } from '@sourcegraph/cody-shared'
+import { ChatError, RateLimitError } from '@sourcegraph/cody-shared'
 
 import { ChatButtonProps } from '../Chat'
 
@@ -10,7 +10,7 @@ import styles from './ErrorItem.module.css'
  * An error message shown in the chat.
  */
 export const ErrorItem: React.FunctionComponent<{
-    error: string | SerializableError
+    error: string | ChatError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
 }> = React.memo(function ErrorItemContent({ error, ChatButtonComponent }) {
     return typeof error !== 'string' && error.name === RateLimitError.errorName ? (

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -13,7 +13,7 @@ export const ErrorItem: React.FunctionComponent<{
     error: string | SerializableError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
 }> = React.memo(function ErrorItemContent({ error, ChatButtonComponent }) {
-    return typeof error !== 'string' && error.name === 'RateLimitError' ? (
+    return typeof error !== 'string' && error.name === RateLimitError.errorName ? (
         <RateLimitErrorItem error={error as RateLimitError} ChatButtonComponent={ChatButtonComponent} />
     ) : (
         <div className="cody-chat-error">

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { ChatError, RateLimitError } from '@sourcegraph/cody-shared'
 
-import { ChatButtonProps } from '../Chat'
+import { ApiPostMessage, ChatButtonProps } from '../Chat'
 
 import styles from './ErrorItem.module.css'
 
@@ -12,9 +12,14 @@ import styles from './ErrorItem.module.css'
 export const ErrorItem: React.FunctionComponent<{
     error: string | ChatError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
-}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent }) {
-    return typeof error !== 'string' && error.name === RateLimitError.errorName ? (
-        <RateLimitErrorItem error={error as RateLimitError} ChatButtonComponent={ChatButtonComponent} />
+    postMessage?: ApiPostMessage
+}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent, postMessage }) {
+    return typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage ? (
+        <RateLimitErrorItem
+            error={error as RateLimitError}
+            ChatButtonComponent={ChatButtonComponent}
+            postMessage={postMessage}
+        />
     ) : (
         <div className="cody-chat-error">
             <span>Request failed: </span>
@@ -29,7 +34,8 @@ export const ErrorItem: React.FunctionComponent<{
 export const RateLimitErrorItem: React.FunctionComponent<{
     error: RateLimitError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
-}> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent }) {
+    postMessage: ApiPostMessage
+}> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent, postMessage }) {
     return (
         <div className={styles.errorItem}>
             <h1>{error.upgradeIsAvailable ? 'Upgrade to Cody Pro' : 'Unable to Send Message'}</h1>
@@ -40,20 +46,14 @@ export const RateLimitErrorItem: React.FunctionComponent<{
                         <ChatButtonComponent
                             label="Upgrade"
                             action=""
-                            onClick={() => {
-                                // TODO(dantup): We don't have access to vsCodeApi to call postMessage here?
-                                // vsCodeApi.postMessage({ command: 'show-page', page: 'upgrade')
-                            }}
+                            onClick={() => postMessage({ command: 'show-page', page: 'upgrade' })}
                             appearance="primary"
                         />
                     )}
                     <ChatButtonComponent
                         label="Learn More"
                         action=""
-                        onClick={() => {
-                            // TODO(dantup): We don't have access to vsCodeApi to call postMessage here?
-                            // vsCodeApi.postMessage({ command: 'show-page', page: 'rate-limits')
-                        }}
+                        onClick={() => postMessage({ command: 'show-page', page: 'rate-limits' })}
                         appearance="secondary"
                     />
                 </div>

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+import { RateLimitError, SerializableError } from '@sourcegraph/cody-shared'
+
+import { ChatButtonProps } from '../Chat'
+
+import styles from './ErrorItem.module.css'
+
+/**
+ * An error message shown in the chat.
+ */
+export const ErrorItem: React.FunctionComponent<{
+    error: string | SerializableError
+    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent }) {
+    return typeof error !== 'string' && error.name === 'RateLimitError' ? (
+        <RateLimitErrorItem error={error as RateLimitError} ChatButtonComponent={ChatButtonComponent} />
+    ) : (
+        <div className="cody-chat-error">
+            <span>Request failed: </span>
+            {typeof error === 'string' ? error : error.message}
+        </div>
+    )
+})
+
+/**
+ * An error message shown in the chat.
+ */
+export const RateLimitErrorItem: React.FunctionComponent<{
+    error: RateLimitError
+    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+}> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent }) {
+    return (
+        <div className={styles.errorItem}>
+            <h1>{error.upgradeIsAvailable ? 'Upgrade to Cody Pro' : 'Unable to Send Message'}</h1>
+            <p>{error.userMessage}</p>
+            {ChatButtonComponent && (
+                <div className={styles.actions}>
+                    {error.upgradeIsAvailable && (
+                        <ChatButtonComponent
+                            label="Upgrade"
+                            action=""
+                            onClick={() => {
+                                // TODO(dantup): We don't have access to vsCodeApi to call postMessage here?
+                                // vsCodeApi.postMessage({ command: 'show-page', page: 'upgrade')
+                            }}
+                            appearance="primary"
+                        />
+                    )}
+                    <ChatButtonComponent
+                        label="Learn More"
+                        action=""
+                        onClick={() => {
+                            // TODO(dantup): We don't have access to vsCodeApi to call postMessage here?
+                            // vsCodeApi.postMessage({ command: 'show-page', page: 'rate-limits')
+                        }}
+                        appearance="secondary"
+                    />
+                </div>
+            )}
+            <p className={styles.retryMessage}>{error.retryMessage}</p>
+        </div>
+    )
+})

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -143,7 +143,7 @@ export const Transcript: React.FunctionComponent<
     const messageToTranscriptItem =
         (offset: number) =>
         (message: ChatMessage, index: number): JSX.Element | null => {
-            if (!message?.displayText) {
+            if (!message?.displayText && !message.error) {
                 return null
             }
             const offsetIndex = index + offset === earlierMessages.length
@@ -167,12 +167,12 @@ export const Transcript: React.FunctionComponent<
                     textAreaComponent={textAreaComponent}
                     EditButtonContainer={EditButtonContainer}
                     editButtonOnSubmit={editButtonOnSubmit}
-                    showEditButton={offsetIndex && !messageInProgress?.speaker && !message.displayText.startsWith('/')}
+                    showEditButton={offsetIndex && !messageInProgress?.speaker && !message.displayText?.startsWith('/')}
                     FeedbackButtonsContainer={FeedbackButtonsContainer}
                     feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     insertButtonOnSubmit={insertButtonOnSubmit}
-                    showFeedbackButtons={index !== 0 && !isTranscriptError}
+                    showFeedbackButtons={index !== 0 && !isTranscriptError && !message.error}
                     submitButtonComponent={submitButtonComponent}
                     chatInputClassName={chatInputClassName}
                     ChatButtonComponent={ChatButtonComponent}

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -179,6 +179,7 @@ export const Transcript: React.FunctionComponent<
                     submitButtonComponent={submitButtonComponent}
                     chatInputClassName={chatInputClassName}
                     ChatButtonComponent={ChatButtonComponent}
+                    userInfo={userInfo}
                     postMessage={postMessage}
                 />
             )

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { ChatMessage, ChatModelProvider } from '@sourcegraph/cody-shared'
 
 import {
+    ApiPostMessage,
     ChatButtonProps,
     ChatModelDropdownMenuProps,
     ChatUISubmitButtonProps,
@@ -44,6 +45,7 @@ export const Transcript: React.FunctionComponent<
         ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
         onCurrentChatModelChange?: (model: ChatModelProvider) => void
         userInfo?: UserAccountInfo
+        postMessage?: ApiPostMessage
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
@@ -74,6 +76,7 @@ export const Transcript: React.FunctionComponent<
     ChatModelDropdownMenu,
     onCurrentChatModelChange,
     userInfo,
+    postMessage,
 }) {
     // Scroll the last human message to the top whenever a new human message is received as input.
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
@@ -176,6 +179,7 @@ export const Transcript: React.FunctionComponent<
                     submitButtonComponent={submitButtonComponent}
                     chatInputClassName={chatInputClassName}
                     ChatButtonComponent={ChatButtonComponent}
+                    postMessage={postMessage}
                 />
             )
         }
@@ -214,6 +218,7 @@ export const Transcript: React.FunctionComponent<
                         submitButtonComponent={submitButtonComponent}
                         chatInputClassName={chatInputClassName}
                         ChatButtonComponent={ChatButtonComponent}
+                        postMessage={postMessage}
                     />
                 )}
                 {messageInProgress && messageInProgress.speaker === 'assistant' && (

--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -188,12 +188,3 @@
     flex-direction: column;
     padding: 0;
 }
-
-.rate-limit-error .actions {
-    flex-direction: row;
-    gap: 10px;
-}
-
-.footer-text {
-    font-size: 0.8em;
-}

--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -188,3 +188,12 @@
     flex-direction: column;
     padding: 0;
 }
+
+.rate-limit-error .actions {
+    flex-direction: row;
+    gap: 10px;
+}
+
+.footer-text {
+    font-size: 0.8em;
+}

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -129,7 +129,8 @@ export const TranscriptItem: React.FunctionComponent<
             className={classNames(
                 styles.row,
                 transcriptItemClassName,
-                message.speaker === 'human' ? humanTranscriptItemClassName : styles.assistantRow
+                message.speaker === 'human' ? humanTranscriptItemClassName : styles.assistantRow,
+                message.isRateLimitError ? styles.rateLimitError : undefined
             )}
         >
             {showEditButton && EditButtonContainer && editButtonOnSubmit && TextArea && message.speaker === 'human' && (
@@ -175,6 +176,7 @@ export const TranscriptItem: React.FunctionComponent<
             {message.buttons?.length && ChatButtonComponent && (
                 <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>
             )}
+            {message.footerText && <div className={styles.footerText}>{message.footerText}</div>}
             {message.speaker === 'human' && (
                 <div className={styles.contextFilesContainer}>
                     {message.contextFiles && message.contextFiles.length > 0 ? (

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -12,6 +12,7 @@ import {
     CodeBlockActionsProps,
     EditButtonProps,
     FeedbackButtonsProps,
+    UserAccountInfo,
 } from '../Chat'
 
 import { BlinkingCursor, LoadingContext } from './BlinkingCursor'
@@ -60,6 +61,7 @@ export const TranscriptItem: React.FunctionComponent<
         abortMessageInProgressComponent?: React.FunctionComponent<{ onAbortMessageInProgress: () => void }>
         onAbortMessageInProgress?: () => void
         ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+        userInfo?: UserAccountInfo
         postMessage?: ApiPostMessage
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
@@ -87,6 +89,7 @@ export const TranscriptItem: React.FunctionComponent<
     submitButtonComponent: SubmitButton,
     chatInputClassName,
     ChatButtonComponent,
+    userInfo,
     postMessage,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
@@ -158,7 +161,12 @@ export const TranscriptItem: React.FunctionComponent<
                 </div>
             )}
             {message.error && (
-                <ErrorItem error={message.error} ChatButtonComponent={ChatButtonComponent} postMessage={postMessage} />
+                <ErrorItem
+                    error={message.error}
+                    ChatButtonComponent={ChatButtonComponent}
+                    userInfo={userInfo}
+                    postMessage={postMessage}
+                />
             )}
             <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
                 {message.displayText ? (

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -160,33 +160,34 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </div>
             )}
-            {message.error && (
+            {message.error ? (
                 <ErrorItem
                     error={message.error}
                     ChatButtonComponent={ChatButtonComponent}
                     userInfo={userInfo}
                     postMessage={postMessage}
                 />
-            )}
-            <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
-                {message.displayText ? (
-                    EditTextArea ? (
-                        !inProgress && !message.displayText.startsWith('/') && EditTextArea
+            ) : (
+                <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
+                    {message.displayText && !message.error ? (
+                        EditTextArea ? (
+                            !inProgress && !message.displayText.startsWith('/') && EditTextArea
+                        ) : (
+                            <CodeBlocks
+                                displayText={message.displayText}
+                                copyButtonClassName={codeBlocksCopyButtonClassName}
+                                copyButtonOnSubmit={copyButtonOnSubmit}
+                                insertButtonClassName={codeBlocksInsertButtonClassName}
+                                insertButtonOnSubmit={insertButtonOnSubmit}
+                                metadata={message.metadata}
+                                inProgress={inProgress}
+                            />
+                        )
                     ) : (
-                        <CodeBlocks
-                            displayText={message.displayText}
-                            copyButtonClassName={codeBlocksCopyButtonClassName}
-                            copyButtonOnSubmit={copyButtonOnSubmit}
-                            insertButtonClassName={codeBlocksInsertButtonClassName}
-                            insertButtonOnSubmit={insertButtonOnSubmit}
-                            metadata={message.metadata}
-                            inProgress={inProgress}
-                        />
-                    )
-                ) : (
-                    inProgress && <BlinkingCursor />
-                )}
-            </div>
+                        inProgress && <BlinkingCursor />
+                    )}
+                </div>
+            )}
             {message.buttons?.length && ChatButtonComponent && (
                 <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>
             )}

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { ChatMessage } from '@sourcegraph/cody-shared'
 
 import {
+    ApiPostMessage,
     ChatButtonProps,
     ChatUISubmitButtonProps,
     ChatUITextAreaProps,
@@ -59,6 +60,7 @@ export const TranscriptItem: React.FunctionComponent<
         abortMessageInProgressComponent?: React.FunctionComponent<{ onAbortMessageInProgress: () => void }>
         onAbortMessageInProgress?: () => void
         ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+        postMessage?: ApiPostMessage
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
     message,
@@ -85,6 +87,7 @@ export const TranscriptItem: React.FunctionComponent<
     submitButtonComponent: SubmitButton,
     chatInputClassName,
     ChatButtonComponent,
+    postMessage,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
     const EditTextArea =
@@ -154,7 +157,9 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </div>
             )}
-            {message.error && <ErrorItem error={message.error} ChatButtonComponent={ChatButtonComponent} />}
+            {message.error && (
+                <ErrorItem error={message.error} ChatButtonComponent={ChatButtonComponent} postMessage={postMessage} />
+            )}
             <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
                 {message.displayText ? (
                     EditTextArea ? (

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -17,6 +17,7 @@ import { BlinkingCursor, LoadingContext } from './BlinkingCursor'
 import { CodeBlocks } from './CodeBlocks'
 import { FileLinkProps } from './components/ContextFiles'
 import { EnhancedContext } from './components/EnhancedContext'
+import { ErrorItem } from './ErrorItem'
 import { PreciseContexts, SymbolLinkProps } from './PreciseContext'
 
 import styles from './TranscriptItem.module.css'
@@ -129,8 +130,7 @@ export const TranscriptItem: React.FunctionComponent<
             className={classNames(
                 styles.row,
                 transcriptItemClassName,
-                message.speaker === 'human' ? humanTranscriptItemClassName : styles.assistantRow,
-                message.isRateLimitError ? styles.rateLimitError : undefined
+                message.speaker === 'human' ? humanTranscriptItemClassName : styles.assistantRow
             )}
         >
             {showEditButton && EditButtonContainer && editButtonOnSubmit && TextArea && message.speaker === 'human' && (
@@ -154,6 +154,7 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </div>
             )}
+            {message.error && <ErrorItem error={message.error} ChatButtonComponent={ChatButtonComponent} />}
             <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
                 {message.displayText ? (
                     EditTextArea ? (
@@ -176,7 +177,6 @@ export const TranscriptItem: React.FunctionComponent<
             {message.buttons?.length && ChatButtonComponent && (
                 <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>
             )}
-            {message.footerText && <div className={styles.footerText}>{message.footerText}</div>}
             {message.speaker === 'human' && (
                 <div className={styles.contextFilesContainer}>
                     {message.contextFiles && message.contextFiles.length > 0 ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@sourcegraph/telemetry':
         specifier: ^0.13.0
         version: 0.13.0
+      date-fns:
+        specifier: ^2.30.0
+        version: 2.30.0
       dompurify:
         specifier: ^3.0.4
         version: 3.0.4
@@ -403,9 +406,6 @@ importers:
       classnames:
         specifier: ^2.3.2
         version: 2.3.2
-      date-fns:
-        specifier: ^2.30.0
-        version: 2.30.0
       detect-indent:
         specifier: ^7.0.1
         version: 7.0.1

--- a/slack/src/services/openai-completions-client.ts
+++ b/slack/src/services/openai-completions-client.ts
@@ -87,7 +87,7 @@ export class OpenAICompletionsClient implements Pick<SourcegraphCompletionsClien
 
                 stream.on('error', e => {
                     console.error('OpenAI stream failed', e)
-                    cb.onError(e.message)
+                    cb.onError(e)
                 })
                 stream.on('end', () => cb.onComplete())
             })

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1197,7 +1197,6 @@
     "async-mutex": "^0.4.0",
     "axios": "^1.3.6",
     "classnames": "^2.3.2",
-    "date-fns": "^2.30.0",
     "detect-indent": "^7.0.1",
     "glob": "^7.2.3",
     "isomorphic-fetch": "^3.0.0",

--- a/vscode/src/chat/FixupViewProvider.ts
+++ b/vscode/src/chat/FixupViewProvider.ts
@@ -70,7 +70,7 @@ export class FixupProvider extends MessageProvider {
 
         // Error state: The transcript finished but we didn't receive any text
         if (!lastMessage.displayText && !isMessageInProgress) {
-            this.handleError('Cody did not respond with any text')
+            this.handleError(new Error('Cody did not respond with any text'))
         }
 
         if (!lastMessage.displayText) {
@@ -139,8 +139,8 @@ export class FixupProvider extends MessageProvider {
      * Display an erred codelens to the user on failed fixup apply.
      * Will allow the user to view the error in more detail if needed.
      */
-    protected handleError(errorMsg: string): void {
-        this.editor.controllers.fixups?.error(this.task.id, errorMsg)
+    protected handleError(error: Error): void {
+        this.editor.controllers.fixups?.error(this.task.id, error.toString())
     }
 
     protected handleCodyCommands(): void {

--- a/vscode/src/chat/InlineChatViewProvider.ts
+++ b/vscode/src/chat/InlineChatViewProvider.ts
@@ -101,8 +101,8 @@ export class InlineChatViewProvider extends MessageProvider {
      * Unlike the sidebar, this message is displayed as an assistant response.
      * TODO(umpox): Should we render these differently for inline chat? We are limited in UI options.
      */
-    protected handleError(errorMsg: string): void {
-        void this.editor.controllers.inline?.error(errorMsg)
+    protected handleError(error: Error): void {
+        void this.editor.controllers.inline?.error(error.toString())
     }
 
     protected handleHistory(): void {

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -68,7 +68,7 @@ abstract class MessageHandler {
     protected abstract handleHistory(history: UserLocalHistory): void
     protected abstract handleSuggestions(suggestions: string[]): void
     protected abstract handleCodyCommands(prompts: [string, CodyPrompt][]): void
-    protected abstract handleError(errorMsg: string, type: MessageErrorType): void
+    protected abstract handleError(error: Error, type: MessageErrorType): void
 }
 
 export interface MessageProviderOptions {
@@ -284,7 +284,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 },
                 onError: (err, statusCode) => {
                     // TODO notify the multiplexer of the error
-                    logError('ChatViewProvider:onError', err)
+                    logError('ChatViewProvider:onError', err.message)
 
                     if (isAbortError(err)) {
                         this.isMessageInProgress = false
@@ -301,12 +301,13 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                                 this.contextProvider.config.customHeaders
                             )
                             .catch(error => console.error(error))
-                        logError('ChatViewProvider:onError:unauthUser', err, { verbose: { statusCode } })
+                        logError('ChatViewProvider:onError:unauthUser', err.message, { verbose: { statusCode } })
                     }
 
                     if (isNetworkError(err)) {
-                        err = 'Cody could not respond due to network error.'
+                        err = new Error('Cody could not respond due to network error.')
                     }
+
                     // Display error message as assistant response
                     this.handleError(err, 'transcript')
                     // We ignore embeddings errors in this instance because we're already showing an
@@ -358,7 +359,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         addEnhancedContext = true
     ): Promise<void> {
         if (this.isMessageInProgress) {
-            this.handleError('Cannot execute multiple actions. Please wait for the current action to finish.', 'system')
+            this.handleError(
+                new Error('Cannot execute multiple actions. Please wait for the current action to finish.'),
+                'system'
+            )
             return
         }
 
@@ -406,7 +410,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 userInputContextFiles,
             })
         } catch (error) {
-            this.handleError('Fail to submit question', 'system')
+            this.handleError(new Error('Fail to submit question'), 'system')
             console.error(error)
             return
         }
@@ -812,7 +816,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         const searchErrors = this.contextProvider.context.getEmbeddingSearchErrors()
         // Display error message as assistant response for users with indexed codebase but getting search errors
         if (this.contextProvider.context.checkEmbeddingsConnection() && searchErrors) {
-            this.handleError(searchErrors, 'transcript')
+            this.handleError(new Error(searchErrors), 'transcript')
             logError('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
         }
     }
@@ -865,6 +869,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     }
 }
 
-function isAbortError(error: string): boolean {
-    return error === 'aborted' || error === 'socket hang up'
+function isAbortError(error: Error): boolean {
+    return error.message === 'aborted' || error.message === 'socket hang up'
 }

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -313,7 +313,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                     // We ignore embeddings errors in this instance because we're already showing an
                     // error message and don't want to overwhelm the user.
                     void this.onCompletionEnd(true)
-                    console.error(`Completion request failed: ${err}`)
+                    console.error(`Completion request failed: ${err.message}`)
                 },
             },
             { model: this.chatModel, stopSequences: recipe.stopSequences }
@@ -421,7 +421,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
 
         const errorMsg = interaction?.getAssistantMessage()?.error
         if (errorMsg !== undefined) {
-            await this.addCustomInteraction({ assistantResponse: errorMsg }, interaction)
+            await this.addCustomInteraction({ assistantResponse: errorMsg.toString() }, interaction)
             return
         }
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -419,9 +419,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             return
         }
 
-        const errorMsg = interaction?.getAssistantMessage()?.error
-        if (errorMsg !== undefined) {
-            await this.addCustomInteraction({ assistantResponse: errorMsg.toString() }, interaction)
+        const error = interaction?.getAssistantMessage()?.error
+        if (error) {
+            const errorMsg = typeof error === 'string' ? error : error.message
+            await this.addCustomInteraction({ assistantResponse: errorMsg }, interaction)
             return
         }
 

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -126,7 +126,7 @@ export class ChatPanelProvider extends MessageProvider {
                 this.contextProvider.localEmbeddingsIndexRepository()
                 break
             case 'show-page':
-                await vscode.commands.executeCommand('cody.showPage', message.page)
+                await vscode.commands.executeCommand('cody.show-page', message.page)
                 break
             default:
                 this.handleError(new Error('Invalid request type from Webview Panel'), 'system')

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -125,6 +125,9 @@ export class ChatPanelProvider extends MessageProvider {
             case 'embeddings/index':
                 this.contextProvider.localEmbeddingsIndexRepository()
                 break
+            case 'show-page':
+                await vscode.commands.executeCommand('cody.showPage', message.page)
+                break
             default:
                 this.handleError(new Error('Invalid request type from Webview Panel'), 'system')
         }

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -126,7 +126,7 @@ export class ChatPanelProvider extends MessageProvider {
                 this.contextProvider.localEmbeddingsIndexRepository()
                 break
             default:
-                this.handleError('Invalid request type from Webview Panel', 'system')
+                this.handleError(new Error('Invalid request type from Webview Panel'), 'system')
         }
     }
 
@@ -251,14 +251,14 @@ export class ChatPanelProvider extends MessageProvider {
     /**
      * Display error message in webview, either as part of the transcript or as a banner alongside the chat.
      */
-    public handleError(errorMsg: string, type: MessageErrorType): void {
+    public handleError(error: Error, type: MessageErrorType): void {
         if (type === 'transcript') {
-            this.transcript.addErrorAsAssistantResponse(errorMsg)
+            this.transcript.addErrorAsAssistantResponse(error)
             void this.webview?.postMessage({ type: 'transcript-errors', isTranscriptError: true })
             return
         }
 
-        void this.webview?.postMessage({ type: 'errors', errors: errorMsg })
+        void this.webview?.postMessage({ type: 'errors', errors: error.message })
     }
 
     protected handleCodyCommands(prompts: [string, CodyPrompt][]): void {

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -194,8 +194,11 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
                     break
                 }
                 break
+            case 'show-page':
+                await vscode.commands.executeCommand('cody.showPage', message.page)
+                break
             default:
-                this.handleError('Invalid request type from Webview', 'system')
+                this.handleError(new Error('Invalid request type from Webview'), 'system')
         }
     }
 
@@ -288,14 +291,14 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
     /**
      * Display error message in webview, either as part of the transcript or as a banner alongside the chat.
      */
-    public handleError(errorMsg: string, type: MessageErrorType): void {
+    public handleError(error: Error, type: MessageErrorType): void {
         if (type === 'transcript') {
-            this.transcript.addErrorAsAssistantResponse(errorMsg)
+            this.transcript.addErrorAsAssistantResponse(error)
             void this.webview?.postMessage({ type: 'transcript-errors', isTranscriptError: true })
             return
         }
 
-        void this.webview?.postMessage({ type: 'errors', errors: errorMsg })
+        void this.webview?.postMessage({ type: 'errors', errors: error.toString() })
     }
 
     protected handleCodyCommands(prompts: [string, CodyPrompt][]): void {

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -195,7 +195,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
                 }
                 break
             case 'show-page':
-                await vscode.commands.executeCommand('cody.showPage', message.page)
+                await vscode.commands.executeCommand('show-page', message.page)
                 break
             default:
                 this.handleError(new Error('Invalid request type from Webview'), 'system')

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -322,7 +322,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 void this.localEmbeddings?.index()
                 break
             case 'show-page':
-                await vscode.commands.executeCommand('cody.showPage', message.page)
+                await vscode.commands.executeCommand('cody.show-page', message.page)
                 break
             default:
                 this.postError(new Error('Invalid request type from Webview Panel'))

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -321,8 +321,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             case 'embeddings/index':
                 void this.localEmbeddings?.index()
                 break
+            case 'show-page':
+                await vscode.commands.executeCommand('cody.showPage', message.page)
+                break
             default:
-                this.postError('Invalid request type from Webview Panel')
+                this.postError(new Error('Invalid request type from Webview Panel'))
         }
     }
 
@@ -459,7 +462,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             if (warnings.length > 0) {
                 const warningMsg =
                     'Warning: ' + warnings.map(w => (w.trim().endsWith('.') ? w.trim() : w.trim() + '.')).join(' ')
-                this.postError(warningMsg)
+                this.postError(new Error(warningMsg))
             }
 
             void this.postViewTranscript()
@@ -527,7 +530,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 { model: this.chatModel.modelID }
             )
         } catch (error) {
-            this.postError(`${error}`)
+            this.postError(new Error(`${error}`))
         }
     }
 
@@ -607,8 +610,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
     /**
      * Display error message in webview, either as part of the transcript or as a banner alongside the chat.
      */
-    private postError(errorMsg: string): void {
-        void this.webview?.postMessage({ type: 'errors', errors: errorMsg })
+    private postError(error: Error): void {
+        void this.webview?.postMessage({ type: 'errors', errors: error.toString() })
     }
 
     private async guardrailsAnnotateAttributions(text: string): Promise<string> {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -37,6 +37,10 @@ export type WebviewMessage =
     | { command: 'restoreHistory'; chatID: string }
     | { command: 'deleteHistory'; chatID: string }
     | { command: 'links'; value: string }
+    | {
+          command: 'show-page'
+          page: string
+      }
     | { command: 'chatModel'; model: string }
     | {
           command: 'openFile'
@@ -131,6 +135,9 @@ export const APP_REPOSITORIES_URL = new URL('sourcegraph://users/admin/app-setti
 // Account
 export const ACCOUNT_UPGRADE_URL = new URL('https://sourcegraph.com/cody/subscription')
 export const ACCOUNT_USAGE_URL = new URL('https://sourcegraph.com/cody/manage')
+export const ACCOUNT_LIMITS_INFO_URL = new URL(
+    'https://docs.sourcegraph.com/cody/troubleshooting#autocomplete-rate-limits'
+)
 
 /**
  * The status of a users authentication, whether they're authenticated and have a
@@ -197,21 +204,21 @@ export const networkErrorAuthStatus = {
 
 /** The local environment of the editor. */
 export interface LocalEnv {
-    // The operating system kind
+    // The  operating system kind
     os: string
     arch: string
     homeDir?: string | undefined
 
-    // The URL scheme the editor is registered to in the operating system
+    // The  URL scheme the editor is registered to in the operating system
     uriScheme: string
-    // The application name of the editor
+    // The  application name of the editor
     appName: string
     extensionVersion: string
 
-    /** Whether the extension is running in VS Code Web (as opposed to VS Code Desktop). */
+    /** Whe ther the extension is running in VS Code Web (as opposed to VS Code Desktop). */
     uiKindIsWeb: boolean
 
-    // App Local State
+    // App  Local State
     hasAppJson: boolean
     isAppInstalled: boolean
     isAppRunning: boolean
@@ -224,7 +231,7 @@ export function isLoggedIn(authStatus: AuthStatus): boolean {
     return authStatus.authenticated && (authStatus.requiresVerifiedEmail ? authStatus.hasVerifiedEmail : true)
 }
 
-// The OS and Arch support for Cody app
+// The  OS and Arch support for Cody app
 export function isOsSupportedByApp(os?: string, arch?: string): boolean {
     if (!os || !arch) {
         return false
@@ -232,7 +239,7 @@ export function isOsSupportedByApp(os?: string, arch?: string): boolean {
     return os === 'darwin' || os === 'linux'
 }
 
-// Map the Arch to the app's supported Arch
+// Map  the Arch to the app's supported Arch
 export function archConvertor(arch: string): string {
     switch (arch) {
         case 'arm64':

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -101,10 +101,15 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
 
         // When rate-limiting occurs, the response is an error message
         if (response.status === 429) {
+            // Check for explicit false, because if the header is not set, there
+            // is no upgrade available.
+            const upgradeIsAvailable = response.headers.get('x-is-cody-pro-user') === 'false'
             const retryAfter = response.headers.get('retry-after')
             const limit = response.headers.get('x-ratelimit-limit')
             throw new RateLimitError(
+                'autocompletions',
                 await response.text(),
+                upgradeIsAvailable,
                 limit ? parseInt(limit, 10) : undefined,
                 retryAfter ? new Date(retryAfter) : undefined
             )

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -94,8 +94,6 @@ export async function createInlineCompletionItemProvider({
 
         const completionsProvider = new InlineCompletionItemProvider({
             providerConfig,
-            featureFlagProvider,
-            authProvider,
             statusBar,
             completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
             disableRecyclingOfPreviousRequests,

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -505,7 +505,7 @@ describe('InlineCompletionItemProvider', () => {
             const { document, position } = documentAndPosition('█')
             const fn = vi
                 .fn(getInlineCompletions)
-                .mockRejectedValue(new RateLimitError('test feature', 'rate limited oh no', false, 1234))
+                .mockRejectedValue(new RateLimitError('autocompletions', 'rate limited oh no', false, 1234))
             const addError = vi.fn()
             const provider = new MockableInlineCompletionItemProvider(fn, { statusBar: { addError } as any })
 
@@ -515,7 +515,7 @@ describe('InlineCompletionItemProvider', () => {
             expect(addError).toHaveBeenCalledWith(
                 expect.objectContaining({
                     title: 'Cody Autocomplete Disabled Due to Rate Limit',
-                    description: "You've used all 1234 daily autocompletions.",
+                    description: "You've used all 1234 autocompletions for today.",
                 })
             )
 
@@ -525,17 +525,13 @@ describe('InlineCompletionItemProvider', () => {
             expect(addError).toHaveBeenCalledTimes(1)
         })
 
-        it.each([
-            { canUpgrade: true, expectUpgrade: true },
-            { canUpgrade: true, expectUpgrade: false },
-            { canUpgrade: false, expectUpgrade: false },
-        ])(
-            'reports correct message (canUpgrade:$canUpgrade) -> expected upgrade? $expectUpgrade',
-            async ({ canUpgrade, expectUpgrade }) => {
+        it.each([{ canUpgrade: true }, { canUpgrade: false }])(
+            'reports correct message when canUpgrade=$canUpgrade',
+            async ({ canUpgrade }) => {
                 const { document, position } = documentAndPosition('█')
                 const fn = vi
                     .fn(getInlineCompletions)
-                    .mockRejectedValue(new RateLimitError('test feature', 'rate limited oh no', canUpgrade, 1234))
+                    .mockRejectedValue(new RateLimitError('autocompletions', 'rate limited oh no', canUpgrade, 1234))
                 const addError = vi.fn()
                 const provider = new MockableInlineCompletionItemProvider(fn, { statusBar: { addError } as any })
 
@@ -544,10 +540,10 @@ describe('InlineCompletionItemProvider', () => {
                 )
                 expect(addError).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        title: expectUpgrade
+                        title: canUpgrade
                             ? 'Upgrade to Continue Using Cody Autocomplete'
                             : 'Cody Autocomplete Disabled Due to Rate Limit',
-                        description: "You've used all 1234 daily autocompletions.",
+                        description: "You've used all 1234 autocompletions for today.",
                     })
                 )
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -2,13 +2,11 @@ import { LRUCache } from 'lru-cache'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
-import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { startAsyncSpan } from '@sourcegraph/cody-shared/src/tracing'
 
-import { ACCOUNT_UPGRADE_URL } from '../chat/protocol'
 import { logDebug } from '../log'
-import { AuthProvider } from '../services/AuthProvider'
 import { localStorage } from '../services/LocalStorageProvider'
 import { CodyStatusBar } from '../services/StatusBar'
 
@@ -107,8 +105,6 @@ const suggestedCompletionItemIDs = new LRUCache<CompletionItemID, AutocompleteIt
 
 export interface CodyCompletionItemProviderConfig {
     providerConfig: ProviderConfig
-    authProvider: AuthProvider
-    featureFlagProvider: FeatureFlagProvider
     statusBar: CodyStatusBar
     tracer?: ProvideInlineCompletionItemsTracer | null
     triggerNotice: ((notice: { key: string }) => void) | null
@@ -241,9 +237,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
 
             // We start feature flag requests early so that we have a high chance of getting a response
             // before we need it.
-            const userLatencyPromise = this.config.featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteUserLatency
-            )
+            const userLatencyPromise = featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteUserLatency)
             const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
 
             let stopLoading: () => void | undefined
@@ -439,7 +433,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
 
                 return completionResult
             } catch (error) {
-                void this.onError(error as Error)
+                this.onError(error as Error)
                 throw error
             }
         })
@@ -575,29 +569,27 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
      * error messages so every unexpected error is deduplicated by its message and rate limit errors
      * are only shown once during the rate limit period.
      */
-    private async onError(error: Error | RateLimitError): Promise<void> {
+    private onError(error: Error): void {
         if (error instanceof RateLimitError) {
             if (this.resetRateLimitErrorsAfter && this.resetRateLimitErrorsAfter > Date.now()) {
                 return
             }
             this.resetRateLimitErrorsAfter = error.retryAfter?.getTime() ?? Date.now() + 24 * 60 * 60 * 1000
-            const canUpgrade =
-                this.config.authProvider.getAuthStatus().userCanUpgrade &&
-                (await this.config.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyPro))
+            const canUpgrade = error.upgradeIsAvailable
             let errorTitle: string
-            let errorUrl: string
+            let pageName: string
             if (canUpgrade) {
                 errorTitle = 'Upgrade to Continue Using Cody Autocomplete'
-                errorUrl = ACCOUNT_UPGRADE_URL.toString()
+                pageName = 'upgrade'
             } else {
                 errorTitle = 'Cody Autocomplete Disabled Due to Rate Limit'
-                errorUrl = 'https://docs.sourcegraph.com/cody/troubleshooting#autocomplete-rate-limits'
+                pageName = 'rate-limits'
             }
             this.config.statusBar.addError({
                 title: errorTitle,
-                description: (error.buildMessage('autocompletions') + ' ' + (error.buildResetMessage() ?? '')).trim(),
+                description: (error.userMessage + ' ' + (error.retryMessage ?? '')).trim(),
                 onSelect: () => {
-                    void vscode.env.openExternal(vscode.Uri.parse(errorUrl))
+                    void vscode.commands.executeCommand('cody.show-page', pageName)
                 },
             })
             return

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -1,4 +1,3 @@
-import { formatDistance } from 'date-fns'
 import { LRUCache } from 'lru-cache'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
@@ -596,9 +595,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             }
             this.config.statusBar.addError({
                 title: errorTitle,
-                description:
-                    `You've used all${error.limit ? ` ${error.limit}` : ''} daily autocompletions.` +
-                    (error.retryAfter ? ` Usage will reset in ${formatDistance(error.retryAfter, new Date())}.` : ''),
+                description: (error.buildMessage('autocompletions') + ' ' + (error.buildResetMessage() ?? '')).trim(),
                 onSelect: () => {
                     void vscode.env.openExternal(vscode.Uri.parse(errorUrl))
                 },

--- a/vscode/src/local-context/filename-context-fetcher.ts
+++ b/vscode/src/local-context/filename-context-fetcher.ts
@@ -8,7 +8,6 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { ContextFileSource, ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult } from '@sourcegraph/cody-shared/src/local-context'
-import { SerializableError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { logDebug } from '../log'
 
@@ -113,7 +112,7 @@ export class FilenameContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (error: SerializableError, statusCode?: number) => reject(error),
+                    onError: (error: Error, statusCode?: number) => reject(error),
                 },
                 {
                     temperature: 0,

--- a/vscode/src/local-context/filename-context-fetcher.ts
+++ b/vscode/src/local-context/filename-context-fetcher.ts
@@ -8,6 +8,7 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { ContextFileSource, ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult } from '@sourcegraph/cody-shared/src/local-context'
+import { SerializableError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { logDebug } from '../log'
 
@@ -112,7 +113,7 @@ export class FilenameContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (error: Error, statusCode?: number) => reject(error),
+                    onError: (error: SerializableError, statusCode?: number) => reject(error),
                 },
                 {
                     temperature: 0,

--- a/vscode/src/local-context/filename-context-fetcher.ts
+++ b/vscode/src/local-context/filename-context-fetcher.ts
@@ -112,9 +112,7 @@ export class FilenameContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (message: string, statusCode?: number) => {
-                        reject(new Error(message))
-                    },
+                    onError: (error: Error, statusCode?: number) => reject(error),
                 },
                 {
                     temperature: 0,

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -155,9 +155,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (message: string) => {
-                        reject(new Error(message))
-                    },
+                    onError: (error: Error) => reject(error),
                 },
                 {
                     temperature: 0,

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -10,7 +10,6 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { ContextFileSource, ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult, KeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
-import { SerializableError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { logDebug } from '../log'
 import { telemetryService } from '../services/telemetry'
@@ -156,7 +155,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (error: SerializableError) => reject(error),
+                    onError: (error: Error) => reject(error),
                 },
                 {
                     temperature: 0,

--- a/vscode/src/local-context/local-keyword-context-fetcher.ts
+++ b/vscode/src/local-context/local-keyword-context-fetcher.ts
@@ -10,6 +10,7 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { ContextFileSource, ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { ContextResult, KeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
+import { SerializableError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 import { logDebug } from '../log'
 import { telemetryService } from '../services/telemetry'
@@ -155,7 +156,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                     onComplete: () => {
                         resolve(responseText.split(/\s+/).filter(e => e.length > 0))
                     },
-                    onError: (error: Error) => reject(error),
+                    onError: (error: SerializableError) => reject(error),
                 },
                 {
                     temperature: 0,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -14,7 +14,13 @@ import { ContextProvider, hackGetCodebaseContext } from './chat/ContextProvider'
 import { FixupManager } from './chat/FixupViewProvider'
 import { InlineChatViewManager } from './chat/InlineChatViewProvider'
 import { MessageProviderOptions } from './chat/MessageProvider'
-import { AuthStatus, CODY_FEEDBACK_URL } from './chat/protocol'
+import {
+    ACCOUNT_LIMITS_INFO_URL,
+    ACCOUNT_UPGRADE_URL,
+    ACCOUNT_USAGE_URL,
+    AuthStatus,
+    CODY_FEEDBACK_URL,
+} from './chat/protocol'
 import { CodeActionProvider } from './code-actions/CodeActionProvider'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { getConfiguration, getFullConfig } from './configuration'
@@ -452,6 +458,26 @@ const register = async (
         vscode.commands.registerCommand('cody.command.context-search', () =>
             executeRecipeInChatView('context-search', true)
         ),
+
+        // Account links
+        vscode.commands.registerCommand('cody.show-page', (page: string) => {
+            let url: URL
+            switch (page) {
+                case 'upgrade':
+                    url = ACCOUNT_UPGRADE_URL
+                    break
+                case 'usage':
+                    url = ACCOUNT_USAGE_URL
+                    break
+                case 'rate-limits':
+                    url = ACCOUNT_LIMITS_INFO_URL
+                    break
+                default:
+                    console.warn(`Unable to show unknown page: "${page}"`)
+                    return
+            }
+            void vscode.env.openExternal(vscode.Uri.parse(url.toString()))
+        }),
 
         // Register URI Handler (vscode://sourcegraph.cody-ai)
         vscode.window.registerUriHandler({

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -196,7 +196,7 @@ export class AuthProvider {
 
             // check first if it's a network error
             if (isError(currentUserID)) {
-                if (isNetworkError(currentUserID.message)) {
+                if (isNetworkError(currentUserID)) {
                     return { ...networkErrorAuthStatus, endpoint }
                 }
             }
@@ -223,7 +223,7 @@ export class AuthProvider {
 
         // check first if it's a network error
         if (isError(userInfo)) {
-            if (isNetworkError(userInfo.message)) {
+            if (isNetworkError(userInfo)) {
                 return { ...networkErrorAuthStatus, endpoint }
             }
             return { ...unauthenticatedStatus, endpoint }
@@ -393,12 +393,13 @@ export class AuthProvider {
     }
 }
 
-export function isNetworkError(error: string): boolean {
+export function isNetworkError(error: Error): boolean {
+    const message = error.message
     return (
-        error.includes('ENOTFOUND') ||
-        error.includes('ECONNREFUSED') ||
-        error.includes('ECONNRESET') ||
-        error.includes('EHOSTUNREACH')
+        message.includes('ENOTFOUND') ||
+        message.includes('ECONNREFUSED') ||
+        message.includes('ECONNRESET') ||
+        message.includes('EHOSTUNREACH')
     )
 }
 

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -2,7 +2,7 @@ import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/m
 import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
-import { ACCOUNT_UPGRADE_URL, ACCOUNT_USAGE_URL, CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
+import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
 
 import { envInit } from './LocalAppDetector'
 
@@ -60,14 +60,14 @@ const supportItems: CodySidebarTreeItem[] = [
         title: 'Upgrade',
         description: 'Upgrade to Pro',
         icon: 'zap',
-        command: { command: 'vscode.open', args: [ACCOUNT_UPGRADE_URL.href] },
+        command: { command: 'cody.account.upgrade' },
         requireUpgradeAvailable: true,
         requireFeature: FeatureFlag.CodyPro,
     },
     {
         title: 'Usage',
         icon: 'pulse',
-        command: { command: 'vscode.open', args: [ACCOUNT_USAGE_URL.href] },
+        command: { command: 'cody.account.usage' },
         requireFeature: FeatureFlag.CodyPro,
     },
     {

--- a/vscode/test/e2e/chat.test.ts
+++ b/vscode/test/e2e/chat.test.ts
@@ -1,0 +1,71 @@
+import { expect, Frame, FrameLocator, Page } from '@playwright/test'
+
+import * as mockServer from '../fixtures/mock-server'
+
+import { sidebarSignin } from './common'
+import { test } from './helpers'
+
+test('shows appropriate rate limit message for free users', async ({ page, sidebar }) => {
+    const chatFrame = await prepareChat(page, sidebar)
+
+    await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/free`, {
+        method: 'POST',
+    })
+
+    await page.keyboard.type('Hello')
+    await page.keyboard.press('Enter')
+
+    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).toBeVisible()
+    await expect(chatFrame.getByText('Unable to Send Message')).not.toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+})
+
+test('shows appropriate rate limit message for pro users', async ({ page, sidebar }) => {
+    const chatFrame = await prepareChat(page, sidebar)
+
+    await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/pro`, {
+        method: 'POST',
+    })
+
+    await page.keyboard.type('Hello')
+    await page.keyboard.press('Enter')
+
+    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).not.toBeVisible()
+    await expect(chatFrame.getByText('Unable to Send Message')).toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).not.toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+})
+
+/**
+ * Sets up a chat window ready for testing.
+ */
+async function prepareChat(page: Page, sidebar: Frame): Promise<FrameLocator> {
+    // Sign into Cody
+    await sidebarSignin(page, sidebar)
+
+    // Enable new chat UI
+    await page.getByRole('button', { name: 'cody-logo-heavy, Cody Settings' }).click()
+    await page
+        .getByRole('option', { name: 'New Chat UI, Experimental, Enable new chat panel UI' })
+        .locator('span')
+        .filter({ hasText: 'Experimental' })
+        .first()
+        .click()
+
+    // Bring the cody sidebar to the foreground if it's not already there
+    if (!(await page.isVisible('[aria-label="Chat History"]'))) {
+        await page.click('[aria-label="Cody"]')
+    }
+
+    // Open the new chat panel
+    await page.getByRole('button', { name: 'New Chat', exact: true }).click()
+
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
+    const chatFrameLocator = page.frameLocator('iframe.webview').frameLocator('iframe')
+
+    await chatFrameLocator.getByRole('textbox', { name: 'Chat message' }).click({ timeout: 5000 })
+
+    return chatFrameLocator
+}

--- a/vscode/test/e2e/chat.test.ts
+++ b/vscode/test/e2e/chat.test.ts
@@ -61,11 +61,9 @@ async function prepareChat(page: Page, sidebar: Frame): Promise<FrameLocator> {
     // Open the new chat panel
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
 
-    await new Promise(resolve => setTimeout(resolve, 3000))
-
     const chatFrameLocator = page.frameLocator('iframe.webview').frameLocator('iframe')
 
-    await chatFrameLocator.getByRole('textbox', { name: 'Chat message' }).click({ timeout: 5000 })
+    await chatFrameLocator.getByRole('textbox', { name: 'Chat message' }).click()
 
     return chatFrameLocator
 }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -254,6 +254,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             ChatModelDropdownMenu={ChatModelDropdownMenu}
             userInfo={userInfo}
             EnhancedContextSettings={enableNewChatUI ? EnhancedContextSettings : undefined}
+            postMessage={msg => vscodeAPI.postMessage(msg)}
         />
     )
 }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -258,8 +258,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     )
 }
 
-const ChatButton: React.FunctionComponent<ChatButtonProps> = ({ label, action, onClick }) => (
-    <VSCodeButton type="button" onClick={() => onClick(action)} className={styles.chatButton}>
+const ChatButton: React.FunctionComponent<ChatButtonProps> = ({ label, action, onClick, appearance }) => (
+    <VSCodeButton type="button" onClick={() => onClick(action)} className={styles.chatButton} appearance={appearance}>
         {label}
     </VSCodeButton>
 )

--- a/vscode/webviews/index.css
+++ b/vscode/webviews/index.css
@@ -48,3 +48,9 @@ a:hover {
 .cody-chat-error > span {
     font-weight: bold;
 }
+
+.cody-chat-rate-limit-error {
+    color: var(--vscode-input-foreground);
+    background-color: var(--vscode-inputValidation-errorBackground);
+    padding: 0.5rem;
+}

--- a/vscode/webviews/index.css
+++ b/vscode/webviews/index.css
@@ -48,9 +48,3 @@ a:hover {
 .cody-chat-error > span {
     font-weight: bold;
 }
-
-.cody-chat-rate-limit-error {
-    color: var(--vscode-input-foreground);
-    background-color: var(--vscode-inputValidation-errorBackground);
-    padding: 0.5rem;
-}


### PR DESCRIPTION
I've updated the error handling so that `RateLimitError` (instead of just a string) is propagated up to the chat. With a fake rate limit (using the same status code + headers as the existing completion rate limit), it looks like this:

![image](https://github.com/sourcegraph/cody/assets/1078012/eb5f1ae7-cb32-44e1-8abb-3440cfe9b789)

## Test Plan

- There are some e2e tests that call fake methods on the mock server to set rate limit status and verify the appropriate messages show up
- This will require manual testing against a real service to verify the code/tests match what the live servers are doing. In particular:
  - non-dotCom should never show upgrade messages
  - dotCom should show upgrade messages if not already Pro
  - dotCom should not show upgrade messages if already Pro