### PR TITLE
Remove Claude Instant Cyan

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -8,7 +8,6 @@ export enum FeatureFlag {
     TestFlagDoNotUse = 'test-flag-do-not-use',
 
     CodyAutocompleteTracing = 'cody-autocomplete-tracing',
-    CodyAutocompleteAnthropicCyan = 'cody-autocomplete-anthropic-cyan',
     CodyAutocompleteStarCoder7B = 'cody-autocomplete-default-starcoder-7b',
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -240,7 +240,7 @@ export function getChatModelsForWebview(endpoint?: string | null): ChatModelSele
 const defaultChatModels = [
     { title: 'Claude 2.0', model: 'anthropic/claude-2.0', provider: 'Anthropic', default: true },
     { title: 'Claude 2.1 Preview', model: 'anthropic/claude-2.1', provider: 'Anthropic', default: false },
-    { title: 'Claude Instant', model: 'anthropic/claude-instant-1.2-cyan', provider: 'Anthropic', default: false },
+    { title: 'Claude Instant', model: 'anthropic/claude-instant-1.2', provider: 'Anthropic', default: false },
     { title: 'ChatGPT 3.5 Turbo', model: 'openai/gpt-3.5-turbo', provider: 'OpenAI', default: false },
     { title: 'ChatGPT 4 Turbo Preview', model: 'openai/gpt-4-1106-preview', provider: 'OpenAI', default: false },
 ]

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -66,10 +66,7 @@ export function params(
                 : Promise.resolve(responses?.[requestCounter++] || { completion: '', stopReason: 'unknown' })
         },
     }
-    const providerConfig = createProviderConfig({
-        client,
-        model: null,
-    })
+    const providerConfig = createProviderConfig({ client })
 
     const { document, position } = documentAndPosition(code, languageId, URI_FIXTURE.toString())
 

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -55,7 +55,6 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
             providerConfig: createProviderConfig({
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
                 client: null as any,
-                model: null,
             }),
             triggerNotice: null,
             contextStrategy: 'none',

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -125,13 +125,12 @@ describe('createProviderConfig', () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({
                     autocompleteAdvancedProvider: 'anthropic',
-                    autocompleteAdvancedModel: 'claude-instant-1.2-cyan',
                 }),
                 dummyCodeCompletionsClient,
                 {}
             )
             expect(provider?.identifier).toBe('anthropic')
-            expect(provider?.model).toBe('claude-instant-1.2-cyan')
+            expect(provider?.model).toBe('claude-instant-1.2')
         })
 
         it('provider specified in VSCode settings takes precedence over the one defined in the site config', async () => {


### PR DESCRIPTION
Cyan is now the default Claude Instant mechanism so no need to have that specialised in the client code anymore. We can always bring it back if they deploy another experiment onto that codename.

## Test plan

👀 



<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
