### PR TITLE
Telemetry v1 prefix for non-vscode clientse

### DIFF
--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -19,7 +19,7 @@ import { logDebug } from '../log'
 import { repositoryRemoteUrl } from '../repository/repositoryHelpers'
 import { AuthProvider } from '../services/AuthProvider'
 import { secretStorage } from '../services/SecretStorageProvider'
-import { telemetryService } from '../services/telemetry'
+import { logPrefix, telemetryService } from '../services/telemetry'
 import { telemetryRecorder } from '../services/telemetry-v2'
 
 import { SidebarChatWebview } from './chat-view/SidebarChatProvider'
@@ -175,7 +175,11 @@ export class ContextProvider implements vscode.Disposable {
         // this.sendEvent(ContextEvent.Auth, isAppEvent, eventValue)
         switch (ContextEvent.Auth) {
             case 'auth':
-                telemetryService.log(`CodyVSCodeExtension:Auth${isAppEvent.replace(/^\./, ':')}:${eventValue}`)
+                telemetryService.log(
+                    `${logPrefix(newConfig.agentIDE)}:Auth${isAppEvent.replace(/^\./, ':')}:${eventValue}`,
+                    undefined,
+                    { agent: true }
+                )
                 telemetryRecorder.recordEvent(`cody.auth${isAppEvent}`, eventValue)
                 break
         }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -6,7 +6,7 @@ import { isNetworkError } from '@sourcegraph/cody-shared/src/sourcegraph-api/err
 
 import { getConfiguration } from '../configuration'
 import { captureException, shouldErrorBeReported } from '../services/sentry/sentry'
-import { telemetryService } from '../services/telemetry'
+import { getExtensionDetails, logPrefix, telemetryService } from '../services/telemetry'
 import { CompletionIntent } from '../tree-sitter/query-sdk'
 
 import { ContextSummary } from './context/context-mixer'
@@ -188,9 +188,8 @@ export function logCompletionEvent(
         | 'synthesizedFromParallelRequest'
 ): void
 export function logCompletionEvent(name: string, params: {} = {}): void {
-    // TODO: Clean up this name mismatch when we move to TelemetryV2
-    const prefix = isRunningInsideAgent() ? 'CodyAgent' : 'CodyVSCodeExtension'
-    telemetryService.log(`${prefix}:completion:${name}`, params, { agent: true })
+    const extDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
+    telemetryService.log(`${logPrefix(extDetails.ide)}:completion:${name}`, params, { agent: true })
 }
 
 export interface CompletionBookkeepingEvent {

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -138,3 +138,15 @@ export const telemetryService: TelemetryService = {
         logEvent(eventName, properties, opts)
     },
 }
+
+// TODO: Clean up this name mismatch when we move to TelemetryV2
+export function logPrefix(ide: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs' | undefined): string {
+    return ide
+        ? {
+              VSCode: 'CodyVSCodeExtension',
+              JetBrains: 'CodyJetBrainsPlugin',
+              Emacs: 'CodyEmacsPlugin',
+              Neovim: 'CodyNeovimPlugin',
+          }[ide]
+        : 'CodyAgent'
+}


### PR DESCRIPTION
This can be adopted in other places that will adopt the `{ agent: true }` (currently just `Auth:connected` and the `completion:${name}` ones)

## Test plan

:eyes:

```
2023-11-24 17:34:42,525 [  14285]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ logEvent: CodyJetBrainsPlugin:Auth:connected JetBrains {"opts":{"agent":true}}
...
2023-11-24 17:34:55,861 [  27621]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ logEvent: CodyJetBrainsPlugin:completion:suggested JetBrains {"properties":{"multiline":false,"triggerKind":"Automatic","providerIdentifier":"anthropic","providerModel":"claude-instant-1.2","languageId":"kotlin","artificialDelay":0,"multilineMode":null,"id":"77723921-4d0a-4bf3-a10e-88de5d635101","contextSummary":{"strategy":"jaccard-similarity","duration":0.14302000030875206,"totalChars":0,"retrieverStats":{}},"source":"CacheAfterRequestStart","items":[{"lineCount":1,"charCount":8,"stopReason":"stop_sequence"}],"otherCompletionProviderEnabled":false,"otherCompletionProviders":[],"latency":432.5469189994037,"displayDuration":718.3536360003054,"read":true,"accepted":true,"completionsStartedSinceLastSuggestion":7},"opts":{"agent":true}}
2023-11-24 17:34:55,861 [  27621]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ logEvent: CodyJetBrainsPlugin:completion:accepted JetBrains {"properties":{"multiline":false,"triggerKind":"Automatic","providerIdentifier":"anthropic","providerModel":"claude-instant-1.2","languageId":"kotlin","artificialDelay":0,"multilineMode":null,"id":"77723921-4d0a-4bf3-a10e-88de5d635101","contextSummary":{"strategy":"jaccard-similarity","duration":0.14302000030875206,"totalChars":0,"retrieverStats":{}},"source":"CacheAfterRequestStart","items":[{"lineCount":1,"charCount":8,"stopReason":"stop_sequence"}],"otherCompletionProviderEnabled":false,"otherCompletionProviders":[],"acceptedItem":{"lineCount":1,"charCount":8,"stopReason":"stop_sequence"}},"opts":{"agent":true}}

```
:eyes:
