### PR TITLE
DX: log errors with source maps

### DIFF
--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -45,6 +45,7 @@ export interface InlineCompletionsParams {
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
+    dynamicMultlilineCompletions?: boolean
 
     // Callbacks to accept completions
     handleDidAcceptCompletionItem?: (
@@ -136,6 +137,11 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
         const error = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
 
         params.tracer?.({ error: error.toString() })
+        if (process.env.NODE_ENV === 'development') {
+            // Log errors to the console in the development mode to see the stack traces with source maps
+            // in Chrome dev tools.
+            console.error(error)
+        }
         logError('getInlineCompletions:error', error.message, error.stack, { verbose: { error } })
         CompletionLogger.logError(error)
 


### PR DESCRIPTION
## Context

- Log autocomplete runtime errors to the console to see stack traces with source maps in Chrome Dev tools.

## Test plan

1. Start the dev instance of the extension.
2. Connect it to standalone Chrome Dev tools.
3. Throw a runtime error.
4. See a proper stack trace.
