### PR TITLE
Autocomplete: fix parse completions edit positions

### DIFF
--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -6,6 +6,7 @@ import { DocumentContext } from '../get-current-doc-context'
 import { InlineCompletionItem } from '../types'
 
 import { getMatchingSuffixLength, InlineCompletionItemWithAnalytics } from './process-inline-completions'
+import { getLastLine, lines } from './utils'
 
 export interface CompletionContext {
     completion: InlineCompletionItem
@@ -36,7 +37,7 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
         completion,
         document,
         docContext,
-        docContext: { prefix, position, multilineTrigger },
+        docContext: { position, multilineTrigger },
     } = context
     const parseTreeCache = getCachedParseTreeForDocument(document)
 
@@ -46,15 +47,20 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     }
 
     const { parser, tree } = parseTreeCache
+
+    const completionEndPosition = position.translate(
+        lines(completion.insertText).length,
+        getLastLine(completion.insertText).length
+    )
+
     const treeWithCompletion = pasteCompletion({
         completion,
         document,
         docContext,
         tree,
         parser,
+        completionEndPosition,
     })
-
-    const completionEndPosition = position.translate(0, completion.insertText.length)
 
     const points: ParsedCompletion['points'] = {
         start: {
@@ -68,7 +74,9 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     }
 
     if (multilineTrigger) {
-        const triggerPosition = document.positionAt(prefix.lastIndexOf(multilineTrigger))
+        const triggerPosition = document.positionAt(
+            document.getText(new Range(new Position(0, 0), position)).lastIndexOf(multilineTrigger)
+        )
 
         points.trigger = {
             row: triggerPosition.line,
@@ -95,25 +103,26 @@ interface PasteCompletionParams {
     docContext: DocumentContext
     tree: Tree
     parser: Parser
+    completionEndPosition: Position
 }
 
 function pasteCompletion(params: PasteCompletionParams): Tree {
     const {
-        completion: { range, insertText },
+        completion: { insertText },
         document,
-        docContext,
         tree,
         parser,
         docContext: { position, currentLineSuffix },
+        completionEndPosition,
     } = params
 
     const matchingSuffixLength = getMatchingSuffixLength(insertText, currentLineSuffix)
 
     // Adjust suffix and prefix based on completion insert range.
-    const prefix = range ? document.getText(new Range(new Position(0, 0), range.start as Position)) : docContext.prefix
-    const suffix = range
-        ? document.getText(new Range(range.end as Position, document.positionAt(document.getText().length)))
-        : docContext.suffix
+    const prefix = document.getText(new Range(new Position(0, 0), position))
+    const suffix = document.getText(new Range(position, document.positionAt(document.getText().length)))
+
+    const offset = document.offsetAt(position)
 
     // Remove the characters that are being replaced by the completion to avoid having
     // them in the parse tree. It breaks the multiline truncation logic which looks for
@@ -121,14 +130,13 @@ function pasteCompletion(params: PasteCompletionParams): Tree {
     const textWithCompletion = prefix + insertText + suffix.slice(matchingSuffixLength)
 
     const treeCopy = tree.copy()
-    const completionEndPosition = position.translate(undefined, insertText.length)
 
     treeCopy.edit({
-        startIndex: prefix.length,
-        oldEndIndex: prefix.length,
-        newEndIndex: prefix.length + insertText.length,
+        startIndex: offset,
+        oldEndIndex: offset,
+        newEndIndex: offset + insertText.length,
         startPosition: asPoint(position),
-        oldEndPosition: asPoint(range?.end || position),
+        oldEndPosition: asPoint(position),
         newEndPosition: asPoint(completionEndPosition),
     })
 


### PR DESCRIPTION
## Context

- `completion.range` is not set before `parseCompletion()` calls anymore, so this PR drops it from the `parseCompletion()` implementation.
- Fixes the logic for generating positions at the end of a long document where the prefix does not start at the beginning of a file.
- It's me extracting parts of the work on #1619 to several small PRs.


## Test plan

- Existing unit tests. 
- I plan to add unit tests to cover this issue in #1890 after finishing with #1619.