### PR TITLE
Autocomplete: use a smaller percentage to detect the same string

### DIFF
--- a/vscode/src/completions/text-processing/string-comparator.test.ts
+++ b/vscode/src/completions/text-processing/string-comparator.test.ts
@@ -6,7 +6,7 @@ describe('isAlmostTheSameString', () => {
     it.each([
         [true, '', ''],
         [true, 'return []', ' return []'],
-        [true, 'const abortController = new AbortController()', 'const networkAbortController = new AbortController()'],
+        [true, 'const abortController = new AbortController()', 'const networkController = new AbortController()'],
         [
             true,
             'const currentFilePath = path.normalize(document.fileName)',
@@ -18,6 +18,11 @@ describe('isAlmostTheSameString', () => {
             "console.error('Error log', getDBConnection(context))",
         ],
         [false, '    chatId: z.string(),', '    prompt: z.string(),'],
+        [
+            false,
+            '    public get(key: RequestParams): InlineCompletionItemWithAnalytics[] | undefined {',
+            '    public set(key: RequestParams, entry: InlineCompletionItemWithAnalytics[]): void {',
+        ],
     ])('should return %s for strings %j and %j', (expected, stringA, stringB) => {
         expect(isAlmostTheSameString(stringA, stringB)).toBe(expected)
     })

--- a/vscode/src/completions/text-processing/string-comparator.ts
+++ b/vscode/src/completions/text-processing/string-comparator.ts
@@ -11,7 +11,7 @@ import levenshtein from 'js-levenshtein'
  *
  * For more details see https://en.wikipedia.org/wiki/Levenshtein_distance
  */
-export const isAlmostTheSameString = (stringA: string, stringB: string, percentage: number = 0.2): boolean => {
+export const isAlmostTheSameString = (stringA: string, stringB: string, percentage: number = 0.15): boolean => {
     const maxLength = Math.max(stringA.length, stringB.length)
     const editOperations = levenshtein(stringA, stringB)
 


### PR DESCRIPTION
## Context

- While working on dynamic multiline completion, I extensively tested autocomplete manually and noticed that helpful completions were hidden in multiple cases. It happened because `isAlmostTheSameString` decided that the generated completion matches the string after it. This PR lowers the percentage defined in `isAlmostTheSameString` to fix the issue.
- The main reason for this functionality was the lack of fill-in-the-middle support by the existing models, so LLMs generated completion, duplicating the current code. That's not the case anymore, and we may not need this logic or can lower the percentage further.
- To repro, open `src/completions/request-manager.ts`, go to line 210, delete the implementation of the `get` method keeping `public ge`, and generate the completion at the end of this string. It will be hidden.
- It's me extracting parts of the work on #1619 to several small PRs.

## Test plan

- Updated unit tests.
