### PR TITLE
Autocomplete: dynamically switch to multliline completions

### DIFF
--- a/agent/src/bfg/BfgContextFetcher.test.ts
+++ b/agent/src/bfg/BfgContextFetcher.test.ts
@@ -97,7 +97,13 @@ describe('BfgRetriever', async () => {
         const offset = content.indexOf(CURSOR)
         assert(offset >= 0, content)
         const position = document.positionAt(offset)
-        const docContext = getCurrentDocContext({ document, position, maxPrefixLength: 10_000, maxSuffixLength: 1_000 })
+        const docContext = getCurrentDocContext({
+            document,
+            position,
+            maxPrefixLength: 10_000,
+            maxSuffixLength: 1_000,
+            dynamicMultlilineCompletions: false,
+        })
         const maxChars = 1_000
         const maxMs = 100
 

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -42,6 +42,7 @@ export interface Configuration {
     autocompleteAdvancedAccessToken: string | null
     autocompleteCompleteSuggestWidgetSelection?: boolean
     autocompleteExperimentalSyntacticPostProcessing?: boolean
+    autocompleteExperimentalDynamicMultilineCompletions?: boolean
     autocompleteExperimentalGraphContext: 'lsp-light' | 'bfg' | 'bfg-mixed' | null
     isRunningInsideAgent?: boolean
     agentIDE?: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -20,6 +20,7 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoderExtendedTokenWindow = 'cody-autocomplete-starcoder-extended-token-window',
     CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
     CodyAutocompleteDisableRecyclingOfPreviousRequests = 'cody-autocomplete-disable-recycling-of-previous-requests',
+    CodyAutocompleteDynamicMultilineCompletions = 'cody-autocomplete-dynamic-multline-completions',
 
     CodyChatMockTest = 'cody-chat-mock-test',
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1121,6 +1121,11 @@
           "default": true,
           "markdownDescription": "Rank autocomplete results with tree-sitter."
         },
+        "cody.autocomplete.experimental.dynamicMultilineCompletions": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Dynamically switch from singleline to multiline completion based on the first completion line."
+        },
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,

--- a/vscode/src/completions/can-use-partial-completion.ts
+++ b/vscode/src/completions/can-use-partial-completion.ts
@@ -1,4 +1,4 @@
-import { Position, TextDocument } from 'vscode'
+import { TextDocument } from 'vscode'
 
 import { DocumentContext } from './get-current-doc-context'
 import { parseAndTruncateCompletion } from './text-processing/parse-and-truncate-completion'
@@ -6,9 +6,7 @@ import { InlineCompletionItemWithAnalytics } from './text-processing/process-inl
 
 export interface CanUsePartialCompletionParams {
     document: TextDocument
-    position: Position
     docContext: DocumentContext
-    multiline: boolean
 }
 
 /**
@@ -26,6 +24,7 @@ export function canUsePartialCompletion(
     partialResponse: string,
     params: CanUsePartialCompletionParams
 ): InlineCompletionItemWithAnalytics | null {
+    const { docContext } = params
     const lastNewlineIndex = partialResponse.lastIndexOf('\n')
 
     // If there is no `\n` in the completion, we have not received a single full line yet
@@ -35,7 +34,7 @@ export function canUsePartialCompletion(
 
     const item = parseAndTruncateCompletion(partialResponse, params)
 
-    if (params.multiline) {
+    if (docContext.multilineTrigger) {
         return (item.lineTruncatedCount || 0) > 0 ? item : null
     }
 

--- a/vscode/src/completions/can-use-partial-completion.ts
+++ b/vscode/src/completions/can-use-partial-completion.ts
@@ -33,8 +33,7 @@ export function canUsePartialCompletion(
         return null
     }
 
-    // The last line might not be complete yet, so we discard it
-    const item = parseAndTruncateCompletion(partialResponse.slice(0, lastNewlineIndex), params)
+    const item = parseAndTruncateCompletion(partialResponse, params)
 
     if (params.multiline) {
         return (item.lineTruncatedCount || 0) > 0 ? item : null

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -35,6 +35,7 @@ const docContext = getCurrentDocContext({
     position,
     maxPrefixLength: 100,
     maxSuffixLength: 100,
+    dynamicMultlilineCompletions: false,
 })
 
 const defaultOptions = {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -57,6 +57,7 @@ export async function createInlineCompletionItemProvider({
         bfgMixedContextFlag,
         localMixedContextFlag,
         disableRecyclingOfPreviousRequests,
+        dynamicMultlilineCompletionsFlag,
     ] = await Promise.all([
         createProviderConfig(config, client, authProvider.getAuthStatus().configOverwrites),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteContextLspLight),
@@ -64,6 +65,7 @@ export async function createInlineCompletionItemProvider({
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteContextBfgMixed),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteContextLocalMixed),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDisableRecyclingOfPreviousRequests),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDynamicMultilineCompletions),
     ])
     if (providerConfig) {
         const contextStrategy: ContextStrategy =
@@ -83,6 +85,9 @@ export async function createInlineCompletionItemProvider({
                 ? 'local-mixed'
                 : 'jaccard-similarity'
 
+        const dynamicMultlilineCompletions =
+            config.autocompleteExperimentalDynamicMultilineCompletions || dynamicMultlilineCompletionsFlag
+
         const completionsProvider = new InlineCompletionItemProvider({
             providerConfig,
             featureFlagProvider,
@@ -94,6 +99,7 @@ export async function createInlineCompletionItemProvider({
             isRunningInsideAgent: config.isRunningInsideAgent,
             contextStrategy,
             createBfgRetriever,
+            dynamicMultlilineCompletions,
         })
 
         const documentFilters = await getInlineCompletionItemProviderFilters(config.autocompleteLanguages)

--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -69,7 +69,12 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
         }
     }
 
-    if (
+    const nonEmptyLineEndsWithBlockStart =
+        currentLinePrefix.length > 0 &&
+        isBlockStartActive &&
+        indentation(currentLinePrefix) >= indentation(nextNonEmptyLine)
+
+    const isEmptyLineAfterBlockStart =
         currentLinePrefix.trim() === '' &&
         currentLineSuffix.trim() === '' &&
         // Only trigger multiline suggestions for the beginning of blocks
@@ -79,7 +84,8 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
         // Only trigger multiline suggestions when the next non-empty line is indented less
         // than the block start line (the newly created block is empty).
         indentation(prevNonEmptyLine) >= indentation(nextNonEmptyLine)
-    ) {
+
+    if ((dynamicMultlilineCompletions && nonEmptyLineEndsWithBlockStart) || isEmptyLineAfterBlockStart) {
         return {
             multilineTrigger: blockStart,
             multilineTriggerPosition: getPrefixLastNonEmptyCharPosition(prefix, position),

--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -92,6 +92,10 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
     }
 }
 
+/**
+ * Precalculate the multiline trigger position based on `prefix` and `cursorPosition` to be
+ * able to change it during streaming to the end of the first line of the completion.
+ */
 function getPrefixLastNonEmptyCharPosition(prefix: string, cursorPosition: Position): Position {
     const trimmedPrefix = prefix.trimEnd()
     const diffLength = prefix.length - trimmedPrefix.length

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -17,6 +17,7 @@ function testGetCurrentDocContext(code: string, context?: vscode.InlineCompletio
         maxPrefixLength: 100,
         maxSuffixLength: 100,
         context,
+        dynamicMultlilineCompletions: false,
     })
 }
 
@@ -32,6 +33,10 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: 'function myFunction() {',
             nextNonEmptyLine: '',
             multilineTrigger: '{',
+            multilineTriggerPosition: {
+                character: 23,
+                line: 0,
+            },
             injectedPrefix: null,
             position: { character: 2, line: 1 },
         })
@@ -48,6 +53,10 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: 'if (true) {',
             nextNonEmptyLine: '}',
             multilineTrigger: '{',
+            multilineTriggerPosition: {
+                character: 11,
+                line: 1,
+            },
             injectedPrefix: null,
             position: { character: 2, line: 2 },
         })
@@ -64,6 +73,10 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: '',
             nextNonEmptyLine: '];',
             multilineTrigger: '[',
+            multilineTriggerPosition: {
+                character: 13,
+                line: 0,
+            },
             injectedPrefix: null,
             position: { character: 13, line: 0 },
         })
@@ -80,6 +93,10 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: 'console.log(1337);',
             nextNonEmptyLine: '];',
             multilineTrigger: '[',
+            multilineTriggerPosition: {
+                character: 13,
+                line: 1,
+            },
             injectedPrefix: null,
             position: { character: 13, line: 1 },
         })
@@ -107,6 +124,7 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: '',
             nextNonEmptyLine: '',
             multilineTrigger: null,
+            multilineTriggerPosition: null,
             injectedPrefix: 'ssert',
             position: { character: 9, line: 0 },
         })
@@ -135,6 +153,7 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: '// some line before',
             nextNonEmptyLine: '',
             multilineTrigger: null,
+            multilineTriggerPosition: null,
             injectedPrefix: 'log',
             position: { character: 8, line: 1 },
         })
@@ -162,6 +181,7 @@ describe('getCurrentDocContext', () => {
             prevNonEmptyLine: '',
             nextNonEmptyLine: '',
             multilineTrigger: null,
+            multilineTriggerPosition: null,
             injectedPrefix: null,
             position: { character: 7, line: 0 },
         })
@@ -191,6 +211,7 @@ describe('getCurrentDocContext', () => {
             position,
             maxPrefixLength: 140,
             maxSuffixLength: 60,
+            dynamicMultlilineCompletions: false,
         })
         const contextRange = getContextRange(document, docContext)
 

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -228,4 +228,19 @@ describe('getCurrentDocContext', () => {
           }
         `)
     })
+
+    it('detect the multiline trigger for python with `dynamicMultlilineCompletions` enabled', () => {
+        const { document, position } = documentAndPosition('def greatest_common_divisor(a, b):█', 'python')
+
+        const { multilineTrigger, multilineTriggerPosition } = getCurrentDocContext({
+            document,
+            position,
+            maxPrefixLength: 100,
+            maxSuffixLength: 100,
+            dynamicMultlilineCompletions: true,
+        })
+
+        expect(multilineTrigger).toBe(':')
+        expect(multilineTriggerPosition).toEqual({ line: 0, character: 34 })
+    })
 })

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -11,12 +11,16 @@ export interface DocumentContext extends DocumentDependentContext, LinesContext 
 export interface DocumentDependentContext {
     prefix: string
     suffix: string
-
     /**
      * This is set when the document context is looking at the selected item in the
      * suggestion widget and injects the item into the prefix.
      */
     injectedPrefix: string | null
+    /**
+     * @deprecated
+     * will be removed after migrating `completionPostProcessLogger` to OpenTelemtry exporter.
+     */
+    completionPostProcessId?: string
 }
 
 interface GetCurrentDocContextParams {
@@ -27,6 +31,7 @@ interface GetCurrentDocContextParams {
     /* A number representing the maximum length of the suffix to get from the document. */
     maxSuffixLength: number
     context?: vscode.InlineCompletionContext
+    dynamicMultlilineCompletions?: boolean
 }
 
 /**
@@ -108,6 +113,7 @@ interface GetDerivedDocContextParams {
     languageId: string
     position: vscode.Position
     documentDependentContext: DocumentDependentContext
+    dynamicMultlilineCompletions?: boolean
 }
 
 /**
@@ -115,7 +121,7 @@ interface GetDerivedDocContextParams {
  * Used if the document context needs to be calculated for the updated text but there's no `document` instance for that.
  */
 export function getDerivedDocContext(params: GetDerivedDocContextParams): DocumentContext {
-    const { position, documentDependentContext, languageId } = params
+    const { position, documentDependentContext, languageId, dynamicMultlilineCompletions } = params
     const linesContext = getLinesContext(documentDependentContext)
 
     return {
@@ -125,6 +131,7 @@ export function getDerivedDocContext(params: GetDerivedDocContextParams): Docume
         multilineTrigger: detectMultiline({
             docContext: { ...linesContext, ...documentDependentContext },
             languageId,
+            dynamicMultlilineCompletions,
         }),
     }
 }

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -6,6 +6,7 @@ import { getFirstLine, getLastLine, getNextNonEmptyLine, getPrevNonEmptyLine, li
 export interface DocumentContext extends DocumentDependentContext, LinesContext {
     position: vscode.Position
     multilineTrigger: string | null
+    multilineTriggerPosition: vscode.Position | null
 }
 
 export interface DocumentDependentContext {
@@ -31,14 +32,14 @@ interface GetCurrentDocContextParams {
     /* A number representing the maximum length of the suffix to get from the document. */
     maxSuffixLength: number
     context?: vscode.InlineCompletionContext
-    dynamicMultlilineCompletions?: boolean
+    dynamicMultlilineCompletions: boolean
 }
 
 /**
  * Get the current document context based on the cursor position in the current document.
  */
 export function getCurrentDocContext(params: GetCurrentDocContextParams): DocumentContext {
-    const { document, position, maxPrefixLength, maxSuffixLength, context } = params
+    const { document, position, maxPrefixLength, maxSuffixLength, context, dynamicMultlilineCompletions } = params
     const offset = document.offsetAt(position)
 
     // TODO(philipp-spiess): This requires us to read the whole document. Can we limit our ranges
@@ -101,6 +102,7 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
     return getDerivedDocContext({
         position,
         languageId: document.languageId,
+        dynamicMultlilineCompletions,
         documentDependentContext: {
             prefix,
             suffix,
@@ -113,7 +115,7 @@ interface GetDerivedDocContextParams {
     languageId: string
     position: vscode.Position
     documentDependentContext: DocumentDependentContext
-    dynamicMultlilineCompletions?: boolean
+    dynamicMultlilineCompletions: boolean
 }
 
 /**
@@ -128,10 +130,11 @@ export function getDerivedDocContext(params: GetDerivedDocContextParams): Docume
         ...documentDependentContext,
         ...linesContext,
         position,
-        multilineTrigger: detectMultiline({
+        ...detectMultiline({
             docContext: { ...linesContext, ...documentDependentContext },
             languageId,
             dynamicMultlilineCompletions,
+            position,
         }),
     }
 }

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -80,6 +80,7 @@ export function params(
         position,
         maxPrefixLength: 1000,
         maxSuffixLength: 1000,
+        dynamicMultlilineCompletions: false,
         context: takeSuggestWidgetSelectionIntoAccount
             ? {
                   triggerKind: 0,

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -26,6 +26,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             position,
             maxPrefixLength: 100,
             maxSuffixLength: 100,
+            dynamicMultlilineCompletions: false,
             context: lastTriggerSelectedCompletionInfo
                 ? {
                       triggerKind: vscode.InlineCompletionTriggerKind.Automatic,

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -45,6 +45,7 @@ export interface InlineCompletionsParams {
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
+    dynamicMultlilineCompletions?: boolean
 
     // Callbacks to accept completions
     handleDidAcceptCompletionItem?: (
@@ -174,6 +175,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         handleDidPartiallyAcceptCompletionItem,
         artificialDelay,
         completionIntent,
+        dynamicMultlilineCompletions,
     } = params
 
     tracer?.({ params: { document, position, triggerKind, selectedCompletionInfo } })
@@ -269,6 +271,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         triggerKind,
         providerConfig,
         docContext,
+        dynamicMultlilineCompletions,
     })
     tracer?.({
         completers: completionProviders.map(({ options }) => ({
@@ -312,17 +315,21 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 }
 
 interface GetCompletionProvidersParams
-    extends Pick<InlineCompletionsParams, 'document' | 'position' | 'triggerKind' | 'providerConfig'> {
+    extends Pick<
+        InlineCompletionsParams,
+        'document' | 'position' | 'triggerKind' | 'providerConfig' | 'dynamicMultlilineCompletions'
+    > {
     docContext: DocumentContext
 }
 
 function getCompletionProviders(params: GetCompletionProvidersParams): Provider[] {
-    const { document, position, triggerKind, providerConfig, docContext } = params
+    const { document, position, triggerKind, providerConfig, docContext, dynamicMultlilineCompletions } = params
 
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
         docContext,
         document,
         position,
+        dynamicMultlilineCompletions,
     }
 
     if (docContext.multilineTrigger) {

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -136,6 +136,7 @@ describe('InlineCompletionItemProvider', () => {
               "currentLineSuffix": "",
               "injectedPrefix": null,
               "multilineTrigger": null,
+              "multilineTriggerPosition": null,
               "nextNonEmptyLine": "console.log(1)",
               "position": Position {
                 "character": 12,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -121,6 +121,7 @@ export interface CodyCompletionItemProviderConfig {
     // Feature flags
     completeSuggestWidgetSelection?: boolean
     disableRecyclingOfPreviousRequests?: boolean
+    dynamicMultlilineCompletions?: boolean
 }
 
 interface CompletionRequest {
@@ -158,6 +159,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     constructor({
         completeSuggestWidgetSelection = true,
         disableRecyclingOfPreviousRequests = false,
+        dynamicMultlilineCompletions = false,
         tracer = null,
         createBfgRetriever,
         ...config
@@ -166,6 +168,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             ...config,
             completeSuggestWidgetSelection,
             disableRecyclingOfPreviousRequests,
+            dynamicMultlilineCompletions,
             tracer,
             isRunningInsideAgent: config.isRunningInsideAgent ?? false,
         }
@@ -241,9 +244,6 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             // before we need it.
             const userLatencyPromise = this.config.featureFlagProvider.evaluateFeatureFlag(
                 FeatureFlag.CodyAutocompleteUserLatency
-            )
-            const dynamicMultlilineCompletions = this.config.featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteDynamicMultilineCompletions
             )
             const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
 
@@ -340,7 +340,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     completeSuggestWidgetSelection: takeSuggestWidgetSelectionIntoAccount,
                     artificialDelay,
                     completionIntent,
-                    dynamicMultlilineCompletions: await dynamicMultlilineCompletions,
+                    dynamicMultlilineCompletions: this.config.dynamicMultlilineCompletions,
                 })
 
                 // Avoid any further work if the completion is invalidated already.

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -233,7 +233,10 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
 
         // We start feature flag requests early so that we have a high chance of getting a response
         // before we need it.
-        const userLatencyPromise = featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteUserLatency)
+        const [userLatencyPromise, dynamicMultlilineCompletions] = [
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteUserLatency),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDynamicMultilineCompletions),
+        ]
 
         const tracer = this.config.tracer ? createTracerForInvocation(this.config.tracer) : undefined
 
@@ -288,6 +291,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             maxSuffixLength: this.config.providerConfig.contextSizeHints.suffixChars,
             // We ignore the current context selection if completeSuggestWidgetSelection is not enabled
             context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,
+            dynamicMultlilineCompletions: await dynamicMultlilineCompletions,
         })
 
         const completionIntent = getCompletionIntent({
@@ -327,6 +331,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 handleDidAcceptCompletionItem: this.handleDidAcceptCompletionItem.bind(this),
                 handleDidPartiallyAcceptCompletionItem: this.unstable_handleDidPartiallyAcceptCompletionItem.bind(this),
                 completeSuggestWidgetSelection: takeSuggestWidgetSelectionIntoAccount,
+                dynamicMultlilineCompletions: await dynamicMultlilineCompletions,
                 artificialDelay,
                 completionIntent,
             })

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -298,6 +298,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 maxSuffixLength: this.config.providerConfig.contextSizeHints.suffixChars,
                 // We ignore the current context selection if completeSuggestWidgetSelection is not enabled
                 context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,
+                dynamicMultlilineCompletions: this.config.dynamicMultlilineCompletions,
             })
 
             const completionIntent = getCompletionIntent({

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -34,6 +34,7 @@ const defaultRequestParams: RequestParams = {
         position,
         maxPrefixLength: 100,
         maxSuffixLength: 100,
+        dynamicMultlilineCompletions: false,
     }),
     selectedCompletionInfo: undefined,
 }

--- a/vscode/src/completions/post-process-logger.ts
+++ b/vscode/src/completions/post-process-logger.ts
@@ -1,0 +1,59 @@
+/* eslint-disable no-constant-condition, @typescript-eslint/no-empty-function */
+interface Log {
+    completionPostProcessId?: string
+    stage: string
+    text?: string
+    obj?: Record<string, unknown>
+    isCollapsedGroup?: boolean
+}
+
+class GroupedLogger {
+    private logs: Map<string, Log[]> = new Map()
+
+    public info(logObj: Log): void {
+        const id = logObj.completionPostProcessId
+
+        if (!id) {
+            return
+        }
+
+        if (!this.logs.has(id)) {
+            this.logs.set(id, [])
+        }
+
+        this.logs.get(id)?.push(logObj)
+    }
+
+    public flush(): void {
+        for (const [id, msgs] of this.logs) {
+            if (msgs.length < 2) {
+                break
+            }
+
+            const [{ stage, isCollapsedGroup }] = msgs
+            const groupStart = isCollapsedGroup ? console.groupCollapsed : console.group
+            groupStart(`Grouped Logs for ID ${id}-${stage}`)
+
+            for (const { stage, text = '', obj } of msgs) {
+                logStage(stage, text, obj)
+            }
+            console.groupEnd()
+        }
+
+        this.logs.clear()
+    }
+}
+
+/**
+ * @deprecated
+ * Will be replaced with an OpenTelemetry console exporter and manual spans.
+ */
+export const completionPostProcessLogger = true ? { info() {}, flush() {} } : new GroupedLogger()
+
+function logStage(stage: string, text: string, obj?: Record<string, unknown>): void {
+    console.log(
+        `%c${stage}%c: ${obj ? JSON.stringify(obj) : ''}\n${text}`,
+        'color: green; font-weight:bold',
+        'color: black; font-weight: normal;'
+    )
+}

--- a/vscode/src/completions/post-process-logger.ts
+++ b/vscode/src/completions/post-process-logger.ts
@@ -26,6 +26,8 @@ class GroupedLogger {
 
     public flush(): void {
         for (const [id, msgs] of this.logs) {
+            // Many requests are aborted right after the start stage, and seeing logs for them is not helpful.
+            // This check declutters the conosle output.
             if (msgs.length < 2) {
                 break
             }

--- a/vscode/src/completions/post-process-logger.ts
+++ b/vscode/src/completions/post-process-logger.ts
@@ -7,6 +7,10 @@ interface Log {
     isCollapsedGroup?: boolean
 }
 
+/**
+ * Used to log the stages of the completion post-processing during streaming.
+ * Logs for each response chunk are grouped together by `console.group` and `completionPostProcessId`.
+ */
 class GroupedLogger {
     private logs: Map<string, Log[]> = new Map()
 

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -3,9 +3,7 @@ import * as vscode from 'vscode'
 
 import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
-import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-import { canUsePartialCompletion } from '../can-use-partial-completion'
 import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import {
     CLOSING_CODE_TAG,
@@ -17,11 +15,11 @@ import {
     PrefixComponents,
     trimLeadingWhitespaceUntilNewline,
 } from '../text-processing'
-import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'
 import { InlineCompletionItemWithAnalytics } from '../text-processing/process-inline-completions'
 import { ContextSnippet } from '../types'
-import { forkSignal, messagesToText } from '../utils'
+import { messagesToText } from '../utils'
 
+import { fetchAndProcessCompletions, fetchAndProcessDynamicMultilineCompletions } from './fetch-and-process-completions'
 import {
     CompletionProviderTracer,
     Provider,
@@ -39,6 +37,14 @@ export interface AnthropicOptions {
 }
 
 const MAX_RESPONSE_TOKENS = 256
+const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<
+    CodeCompletionsParams,
+    'maxTokensToSample' | 'stopSequences' | 'timeoutMs'
+> = {
+    maxTokensToSample: MAX_RESPONSE_TOKENS,
+    stopSequences: MULTI_LINE_STOP_SEQUENCES,
+    timeoutMs: 15000,
+}
 
 export class AnthropicProvider extends Provider {
     private promptChars: number
@@ -138,11 +144,12 @@ export class AnthropicProvider extends Provider {
         if (prompt.length > this.promptChars) {
             throw new Error(`prompt length (${prompt.length}) exceeded maximum character length (${this.promptChars})`)
         }
+        const { dynamicMultlilineCompletions, multiline } = this.options
 
         const requestParams: CodeCompletionsParams = {
             temperature: 0.5,
             messages: prompt,
-            ...(this.options.multiline
+            ...(multiline
                 ? {
                       maxTokensToSample: MAX_RESPONSE_TOKENS,
                       stopSequences: MULTI_LINE_STOP_SEQUENCES,
@@ -155,11 +162,26 @@ export class AnthropicProvider extends Provider {
                   }),
         }
 
+        let fetchAndProcessCompletionsImpl = fetchAndProcessCompletions
+        if (dynamicMultlilineCompletions) {
+            // If the feature flag is enabled use params adjusted for the experiment.
+            Object.assign(requestParams, DYNAMIC_MULTLILINE_COMPLETIONS_ARGS)
+
+            // Use an alternative fetch completions implementation.
+            fetchAndProcessCompletionsImpl = fetchAndProcessDynamicMultilineCompletions
+        }
+
         tracer?.params(requestParams)
 
         const completions = await Promise.all(
             Array.from({ length: this.options.n }).map(() => {
-                return this.fetchAndProcessCompletions(this.client, requestParams, abortSignal)
+                return fetchAndProcessCompletionsImpl({
+                    client: this.client,
+                    requestParams,
+                    abortSignal,
+                    providerSpecificPostProcess: this.postProcess,
+                    providerOptions: this.options,
+                })
             })
         )
 
@@ -167,42 +189,7 @@ export class AnthropicProvider extends Provider {
         return completions
     }
 
-    private async fetchAndProcessCompletions(
-        client: Pick<CodeCompletionsClient, 'complete'>,
-        params: CodeCompletionsParams,
-        abortSignal: AbortSignal
-    ): Promise<InlineCompletionItemWithAnalytics> {
-        // The Async executor is required to return the completion early if a partial result from SSE can be used.
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
-        return new Promise(async (resolve, reject) => {
-            try {
-                const abortController = forkSignal(abortSignal)
-
-                const result = await client.complete(
-                    params,
-                    (incompleteResponse: CompletionResponse) => {
-                        const processedCompletion = this.postProcess(incompleteResponse.completion)
-                        const completion = canUsePartialCompletion(processedCompletion, this.options)
-
-                        if (completion) {
-                            resolve({ ...completion, stopReason: 'streaming-truncation' })
-                            abortController.abort()
-                        }
-                    },
-                    abortController.signal
-                )
-
-                const processedCompletion = this.postProcess(result.completion)
-                const completion = parseAndTruncateCompletion(processedCompletion, this.options)
-
-                resolve({ ...completion, stopReason: result.stopReason })
-            } catch (error) {
-                reject(error)
-            }
-        })
-    }
-
-    private postProcess(rawResponse: string): string {
+    private postProcess = (rawResponse: string): string => {
         let completion = extractFromCodeBlock(rawResponse)
 
         const trimmedPrefixContainNewline = this.options.docContext.prefix

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -43,7 +43,7 @@ const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<
 > = {
     maxTokensToSample: MAX_RESPONSE_TOKENS,
     stopSequences: MULTI_LINE_STOP_SEQUENCES,
-    timeoutMs: 15000,
+    timeoutMs: 15_000,
 }
 
 export class AnthropicProvider extends Provider {

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -1,0 +1,250 @@
+import * as uuid from 'uuid'
+
+import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+
+import { canUsePartialCompletion } from '../can-use-partial-completion'
+import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
+import { getDerivedDocContext } from '../get-current-doc-context'
+import { completionPostProcessLogger } from '../post-process-logger'
+import { getFirstLine, lines } from '../text-processing'
+import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'
+import {
+    getMatchingSuffixLength,
+    InlineCompletionItemWithAnalytics,
+} from '../text-processing/process-inline-completions'
+import { forkSignal } from '../utils'
+
+import { ProviderOptions } from './provider'
+
+interface FetchAndProcessCompletionsParams {
+    client: Pick<CodeCompletionsClient, 'complete'>
+    requestParams: CodeCompletionsParams
+    abortSignal: AbortSignal
+    providerSpecificPostProcess: (insertText: string) => string
+    providerOptions: Readonly<ProviderOptions>
+}
+
+export async function fetchAndProcessDynamicMultilineCompletions(
+    params: FetchAndProcessCompletionsParams
+): Promise<InlineCompletionItemWithAnalytics> {
+    const { client, requestParams, abortSignal, providerOptions, providerSpecificPostProcess } = params
+    const {
+        multiline,
+        position,
+        document,
+        docContext,
+        docContext: { prefix, suffix, currentLineSuffix },
+    } = providerOptions
+
+    // The Async executor is required to return the completion early if a partial result from SSE can be used.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+        try {
+            const abortController = forkSignal(abortSignal)
+
+            function stopStreamingAndUsePartialResponse(completionItem: InlineCompletionItemWithAnalytics): void {
+                resolve({ ...completionItem, stopReason: 'streaming-truncation' })
+                abortController.abort()
+            }
+
+            const completionPostProcessId = uuid.v4()
+            let responseChunkNumber = 0
+
+            const result = await client.complete(
+                requestParams,
+                (incompleteResponse: CompletionResponse) => {
+                    completionPostProcessLogger.flush()
+                    responseChunkNumber += 1
+                    completionPostProcessLogger.info({
+                        completionPostProcessId,
+                        stage: `start ${responseChunkNumber}`,
+                    })
+
+                    const processedCompletion = providerSpecificPostProcess(incompleteResponse.completion)
+
+                    completionPostProcessLogger.info({
+                        completionPostProcessId,
+                        stage: 'incomplete response',
+                        text: processedCompletion,
+                        obj: {
+                            multiline,
+                        },
+                    })
+
+                    /**
+                     * This completion was triggered with the multiline trigger at the end of current line.
+                     * Process it as the usual multline completion: continue streaming until it's truncated.
+                     */
+                    if (multiline) {
+                        completionPostProcessLogger.info({ completionPostProcessId, stage: 'multiline', text: '' })
+                        const completion = canUsePartialCompletion(processedCompletion, {
+                            ...providerOptions,
+                            docContext: {
+                                completionPostProcessId,
+                                ...docContext,
+                            },
+                        })
+
+                        if (completion) {
+                            stopStreamingAndUsePartialResponse(completion)
+                        }
+                    } else {
+                        /**
+                         * This completion was started without the multline trigger at the end of current line.
+                         * Check if the the first completion line ends with the multline trigger. If that's the case
+                         * continue streaming and pretend like this completion was multiline in the first place:
+                         *
+                         * 1. Set `multiline` to true
+                         * 2. Move set the cursor position to the position of the multiline trigger.
+                         */
+                        const firstLine = getFirstLine(processedCompletion)
+                        const matchingSuffixLength = getMatchingSuffixLength(firstLine, currentLineSuffix)
+                        const updatedPosition = position.translate(0, firstLine.length - 1)
+
+                        completionPostProcessLogger.info({
+                            completionPostProcessId,
+                            stage: 'getDerivedDocContext',
+                            text: processedCompletion,
+                        })
+
+                        const updatedDocContext = getDerivedDocContext({
+                            languageId: document.languageId,
+                            position: updatedPosition,
+                            documentDependentContext: {
+                                prefix: prefix + firstLine,
+                                // Remove the characters that are being replaced by the completion to avoid having
+                                // to reduce the chances of breaking the parse tree with redundant symbols.
+                                suffix: suffix.slice(matchingSuffixLength),
+                                injectedPrefix: null,
+                                completionPostProcessId,
+                            },
+                        })
+
+                        const isMultilineBasedOnFirstLine = Boolean(updatedDocContext.multilineTrigger)
+
+                        if (isMultilineBasedOnFirstLine) {
+                            completionPostProcessLogger.info({
+                                completionPostProcessId,
+                                stage: 'isMultilineBasedOnFirstLine',
+                                text: processedCompletion,
+                            })
+
+                            const completion = canUsePartialCompletion(processedCompletion, {
+                                ...providerOptions,
+                                multiline: true,
+                                docContext: {
+                                    ...docContext,
+                                    completionPostProcessId,
+                                    position: updatedDocContext.position,
+                                    multilineTrigger: updatedDocContext.multilineTrigger,
+                                },
+                            })
+
+                            if (completion) {
+                                completionPostProcessLogger.info({
+                                    completionPostProcessId,
+                                    stage: 'isMultilineBasedOnFirstLine resolve',
+                                    text: completion.insertText,
+                                })
+
+                                stopStreamingAndUsePartialResponse({
+                                    ...completion,
+                                    insertText: completion.insertText,
+                                })
+                            }
+                        } else {
+                            /**
+                             * This completion was started without the multline trigger at the end of current line
+                             * and the first generated line does not end with a multiline trigger.
+                             *
+                             * Process this completion as a singleline completion: cut-off after the first new line char.
+                             */
+                            const completion = canUsePartialCompletion(processedCompletion, providerOptions)
+
+                            if (completion) {
+                                const firstLine = getFirstLine(completion.insertText)
+
+                                completionPostProcessLogger.info({
+                                    completionPostProcessId,
+                                    stage: 'singleline resolve',
+                                    text: firstLine,
+                                })
+
+                                stopStreamingAndUsePartialResponse({
+                                    ...completion,
+                                    insertText: firstLine,
+                                })
+                            }
+                        }
+                    }
+                },
+                abortController.signal
+            )
+
+            if (abortController.signal.aborted) {
+                return
+            }
+
+            /**
+             * We were not able to use a partial streaming response as a completion and receive the full
+             * compeltion text generated by the LLM.
+             */
+            const processedCompletion = providerSpecificPostProcess(result.completion)
+            completionPostProcessLogger.info({
+                completionPostProcessId,
+                stage: 'full response',
+                text: processedCompletion,
+            })
+
+            const completion = parseAndTruncateCompletion(processedCompletion, {
+                ...providerOptions,
+                multiline: lines(processedCompletion).length > 0,
+            })
+
+            completionPostProcessLogger.info({
+                completionPostProcessId,
+                stage: 'full response resolve',
+                text: completion.insertText,
+            })
+
+            resolve({ ...completion, stopReason: result.stopReason })
+        } catch (error) {
+            reject(error)
+        }
+    })
+}
+
+export async function fetchAndProcessCompletions(
+    params: FetchAndProcessCompletionsParams
+): Promise<InlineCompletionItemWithAnalytics> {
+    const { client, requestParams, abortSignal, providerOptions, providerSpecificPostProcess } = params
+
+    // The Async executor is required to return the completion early if a partial result from SSE can be used.
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+        try {
+            const abortController = forkSignal(abortSignal)
+
+            const result = await client.complete(
+                requestParams,
+                (incompleteResponse: CompletionResponse) => {
+                    const processedCompletion = providerSpecificPostProcess(incompleteResponse.completion)
+                    const completion = canUsePartialCompletion(processedCompletion, providerOptions)
+
+                    if (completion) {
+                        resolve({ ...completion, stopReason: 'streaming-truncation' })
+                        abortController.abort()
+                    }
+                },
+                abortController.signal
+            )
+
+            const processedCompletion = providerSpecificPostProcess(result.completion)
+            const completion = parseAndTruncateCompletion(processedCompletion, providerOptions)
+
+            resolve({ ...completion, stopReason: result.stopReason })
+        } catch (error) {
+            reject(error)
+        }
+    })
+}

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -25,6 +25,10 @@ interface FetchAndProcessCompletionsParams {
     providerOptions: Readonly<ProviderOptions>
 }
 
+/**
+ * Uses the first line of the completion to figure out if it start the new multiline syntax node.
+ * If it does, continues streaming until the completion is truncated or we reach the token sample limit.
+ */
 export async function fetchAndProcessDynamicMultilineCompletions(
     params: FetchAndProcessCompletionsParams
 ): Promise<InlineCompletionItemWithAnalytics> {

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -265,9 +265,10 @@ function getUpdatedDocContext(params: GetUpdatedDocumentContextParams): Document
     const updatedDocContext = getDerivedDocContext({
         languageId: document.languageId,
         position: updatedPosition,
+        dynamicMultlilineCompletions: true,
         documentDependentContext: {
             prefix: prefix + firstLine,
-            // Remove the characters that are being replaced by the completion to avoid having
+            // Remove the characters that are being replaced by the completion
             // to reduce the chances of breaking the parse tree with redundant symbols.
             suffix: suffix.slice(matchingSuffixLength),
             injectedPrefix: null,
@@ -287,8 +288,8 @@ function getUpdatedDocContext(params: GetUpdatedDocumentContextParams): Document
         return {
             ...docContext,
             completionPostProcessId,
-            position: updatedDocContext.position,
             multilineTrigger: updatedDocContext.multilineTrigger,
+            multilineTriggerPosition: updatedDocContext.multilineTriggerPosition,
         }
     }
 

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -247,6 +247,11 @@ interface GetUpdatedDocumentContextParams extends FetchAndProcessCompletionsPara
     initialCompletion: string
 }
 
+/**
+ * 1. Generates the updated document context pretending like the first line of the completion is already in the document.
+ * 2. If the updated document context has the multiline trigger, returns the updated document context.
+ * 3. Otherwise, returns the initial document context.
+ */
 function getUpdatedDocContext(params: GetUpdatedDocumentContextParams): DocumentContext {
     const { completionPostProcessId, initialCompletion, providerOptions } = params
     const {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -82,9 +82,13 @@ function getMaxContextTokens(model: FireworksModel): number {
 
 const MAX_RESPONSE_TOKENS = 256
 
-const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<CodeCompletionsParams, 'maxTokensToSample' | 'stopSequences'> = {
+const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<
+    CodeCompletionsParams,
+    'maxTokensToSample' | 'stopSequences' | 'timeoutMs'
+> = {
     maxTokensToSample: MAX_RESPONSE_TOKENS,
     stopSequences: undefined,
+    timeoutMs: 15_000,
 }
 
 export class FireworksProvider extends Provider {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -2,17 +2,15 @@ import * as vscode from 'vscode'
 
 import { AutocompleteTimeouts } from '@sourcegraph/cody-shared/src/configuration'
 import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
-import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
 import { getLanguageConfig } from '../../tree-sitter/language'
-import { canUsePartialCompletion } from '../can-use-partial-completion'
 import { CodeCompletionsClient, CodeCompletionsParams } from '../client'
+import { completionPostProcessLogger } from '../post-process-logger'
 import { CLOSING_CODE_TAG, getHeadAndTail, OPENING_CODE_TAG } from '../text-processing'
-import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'
 import { InlineCompletionItemWithAnalytics } from '../text-processing/process-inline-completions'
 import { ContextSnippet } from '../types'
-import { forkSignal } from '../utils'
 
+import { fetchAndProcessCompletions, fetchAndProcessDynamicMultilineCompletions } from './fetch-and-process-completions'
 import {
     CompletionProviderTracer,
     Provider,
@@ -84,6 +82,11 @@ function getMaxContextTokens(model: FireworksModel): number {
 
 const MAX_RESPONSE_TOKENS = 256
 
+const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<CodeCompletionsParams, 'maxTokensToSample' | 'stopSequences'> = {
+    maxTokensToSample: MAX_RESPONSE_TOKENS,
+    stopSequences: undefined,
+}
+
 export class FireworksProvider extends Provider {
     private model: FireworksModel
     private promptChars: number
@@ -152,7 +155,7 @@ export class FireworksProvider extends Provider {
         snippets: ContextSnippet[],
         tracer?: CompletionProviderTracer
     ): Promise<InlineCompletionItemWithAnalytics[]> {
-        const { multiline } = this.options
+        const { multiline, dynamicMultlilineCompletions } = this.options
         const prompt = this.createPrompt(snippets)
 
         const model =
@@ -171,7 +174,7 @@ export class FireworksProvider extends Provider {
             return []
         }
 
-        const args: CodeCompletionsParams = {
+        const requestParams: CodeCompletionsParams = {
             messages: [{ speaker: 'human', text: prompt }],
             // To speed up sample generation in single-line case, we request a lower token limit
             // since we can't terminate on the first `\n`.
@@ -184,14 +187,30 @@ export class FireworksProvider extends Provider {
             timeoutMs,
         }
 
-        tracer?.params(args)
+        let fetchAndProcessCompletionsImpl = fetchAndProcessCompletions
+        if (dynamicMultlilineCompletions) {
+            // If the feature flag is enabled use params adjusted for the experiment.
+            Object.assign(requestParams, DYNAMIC_MULTLILINE_COMPLETIONS_ARGS)
+
+            // Use an alternative fetch completions implementation.
+            fetchAndProcessCompletionsImpl = fetchAndProcessDynamicMultilineCompletions
+        }
+
+        tracer?.params(requestParams)
 
         const completions = await Promise.all(
             Array.from({ length: this.options.n }).map(() => {
-                return this.fetchAndProcessCompletions(this.client, args, abortSignal)
+                return fetchAndProcessCompletionsImpl({
+                    client: this.client,
+                    requestParams,
+                    abortSignal,
+                    providerSpecificPostProcess: this.postProcess,
+                    providerOptions: this.options,
+                })
             })
         )
 
+        completionPostProcessLogger.flush()
         tracer?.result({ completions })
 
         return completions
@@ -225,42 +244,7 @@ ${intro}${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}
         return `${intro}${prefix}`
     }
 
-    private async fetchAndProcessCompletions(
-        client: Pick<CodeCompletionsClient, 'complete'>,
-        params: CodeCompletionsParams,
-        abortSignal: AbortSignal
-    ): Promise<InlineCompletionItemWithAnalytics> {
-        // The Async executor is required to return the completion early if a partial result from SSE can be used.
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises, no-async-promise-executor
-        return new Promise(async (resolve, reject) => {
-            try {
-                const abortController = forkSignal(abortSignal)
-
-                const result = await client.complete(
-                    params,
-                    (incompleteResponse: CompletionResponse) => {
-                        const processedCompletion = this.postProcess(incompleteResponse.completion)
-                        const completion = canUsePartialCompletion(processedCompletion, this.options)
-
-                        if (completion) {
-                            resolve({ ...completion, stopReason: 'streaming-truncation' })
-                            abortController.abort()
-                        }
-                    },
-                    abortController.signal
-                )
-
-                const processedCompletion = this.postProcess(result.completion)
-                const completion = parseAndTruncateCompletion(processedCompletion, this.options)
-
-                resolve({ ...completion, stopReason: result.stopReason })
-            } catch (error) {
-                reject(error)
-            }
-        })
-    }
-
-    private postProcess(content: string): string {
+    private postProcess = (content: string): string => {
         if (isStarCoderFamily(this.model)) {
             return content.replace(EOT_STARCODER, '')
         }

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -62,6 +62,9 @@ export interface ProviderOptions {
     multiline: boolean
     // Number of parallel LLM requests per completion.
     n: number
+
+    // feature flags
+    dynamicMultlilineCompletions?: boolean
 }
 
 export abstract class Provider {

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -41,7 +41,7 @@ const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<
 > = {
     maxTokensToSample: MAX_RESPONSE_TOKENS,
     stopSequences: MULTI_LINE_STOP_SEQUENCES,
-    timeoutMs: 15000,
+    timeoutMs: 15_000,
 }
 
 export class UnstableOpenAIProvider extends Provider {

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -49,6 +49,7 @@ function docState(prefix: string, suffix: string = ';'): RequestParams {
             position,
             maxPrefixLength: 100,
             maxSuffixLength: 100,
+            dynamicMultlilineCompletions: false,
         }),
         selectedCompletionInfo: undefined,
     }

--- a/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
+++ b/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
@@ -1,4 +1,4 @@
-import { Position, TextDocument } from 'vscode'
+import { TextDocument } from 'vscode'
 
 import { DocumentContext } from '../get-current-doc-context'
 import { completionPostProcessLogger } from '../post-process-logger'
@@ -10,9 +10,7 @@ import { truncateParsedCompletion } from './truncate-parsed-completion'
 
 export interface ParseAndTruncateParams {
     document: TextDocument
-    position: Position
     docContext: DocumentContext
-    multiline: boolean
 }
 
 export function parseAndTruncateCompletion(
@@ -21,11 +19,11 @@ export function parseAndTruncateCompletion(
 ): InlineCompletionItemWithAnalytics {
     const {
         document,
-        multiline,
         docContext,
-        docContext: { completionPostProcessId, prefix },
+        docContext: { multilineTrigger, completionPostProcessId, prefix },
     } = params
 
+    const multiline = Boolean(multilineTrigger)
     const insertTextBeforeTruncation = (multiline ? normalizeStartLine(completion, prefix) : completion).trimEnd()
 
     const parsed = parseCompletion({

--- a/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
+++ b/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
@@ -1,11 +1,12 @@
 import { Position, TextDocument } from 'vscode'
 
 import { DocumentContext } from '../get-current-doc-context'
+import { completionPostProcessLogger } from '../post-process-logger'
 
 import { parseCompletion, ParsedCompletion } from './parse-completion'
 import { InlineCompletionItemWithAnalytics } from './process-inline-completions'
 import { normalizeStartLine, truncateMultilineCompletion } from './truncate-multiline-completion'
-import { truncateParsedCompletionByNextSibling } from './truncate-parsed-completion'
+import { truncateParsedCompletion } from './truncate-parsed-completion'
 
 export interface ParseAndTruncateParams {
     document: TextDocument
@@ -22,16 +23,18 @@ export function parseAndTruncateCompletion(
         document,
         multiline,
         docContext,
-        docContext: { prefix },
+        docContext: { completionPostProcessId, prefix },
     } = params
 
-    const insertTextBeforeTruncation = multiline ? normalizeStartLine(completion, prefix) : completion
+    const insertTextBeforeTruncation = (multiline ? normalizeStartLine(completion, prefix) : completion).trimEnd()
 
     const parsed = parseCompletion({
         completion: { insertText: insertTextBeforeTruncation },
         document,
         docContext,
     })
+
+    completionPostProcessLogger.info({ completionPostProcessId, stage: 'parsed', text: parsed.insertText })
 
     if (parsed.insertText === '') {
         return parsed
@@ -48,6 +51,12 @@ export function parseAndTruncateCompletion(
         const truncatedLineCount = truncationResult.insertText.split('\n').length
 
         parsed.lineTruncatedCount = initialLineCount - truncatedLineCount
+        completionPostProcessLogger.info({
+            completionPostProcessId,
+            stage: 'lineTruncatedCount',
+            text: String(parsed.lineTruncatedCount),
+        })
+
         parsed.insertText = truncationResult.insertText
         parsed.truncatedWith = truncationResult.truncatedWith
     }
@@ -72,7 +81,7 @@ export function truncateMultilineBlock(params: TruncateMultilineBlockParams): Tr
     if (parsed.tree) {
         return {
             truncatedWith: 'tree-sitter',
-            insertText: truncateParsedCompletionByNextSibling({
+            insertText: truncateParsedCompletion({
                 completion: parsed,
                 docContext,
                 document,

--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -74,8 +74,11 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     }
 
     if (multilineTrigger) {
+        const existingTextBeforeTheCursor = document.getText(new Range(new Position(0, 0), position))
+
+        // Append the completion `insertText` because the multiline trigger can be at the end of the first completion line.
         const triggerPosition = document.positionAt(
-            document.getText(new Range(new Position(0, 0), position)).lastIndexOf(multilineTrigger)
+            (existingTextBeforeTheCursor + completion.insertText).lastIndexOf(multilineTrigger)
         )
 
         points.trigger = {

--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -37,7 +37,7 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
         completion,
         document,
         docContext,
-        docContext: { position, multilineTrigger },
+        docContext: { position, multilineTriggerPosition },
     } = context
     const parseTreeCache = getCachedParseTreeForDocument(document)
 
@@ -73,18 +73,8 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
         },
     }
 
-    if (multilineTrigger) {
-        const existingTextBeforeTheCursor = document.getText(new Range(new Position(0, 0), position))
-
-        // Append the completion `insertText` because the multiline trigger can be at the end of the first completion line.
-        const triggerPosition = document.positionAt(
-            (existingTextBeforeTheCursor + completion.insertText).lastIndexOf(multilineTrigger)
-        )
-
-        points.trigger = {
-            row: triggerPosition.line,
-            column: triggerPosition.character,
-        }
+    if (multilineTriggerPosition) {
+        points.trigger = asPoint(multilineTriggerPosition)
     }
 
     // Search for ERROR nodes in the completion range.

--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -6,6 +6,7 @@ import { DocumentContext } from '../get-current-doc-context'
 import { InlineCompletionItem } from '../types'
 
 import { getMatchingSuffixLength, InlineCompletionItemWithAnalytics } from './process-inline-completions'
+import { getLastLine, lines } from './utils'
 
 export interface CompletionContext {
     completion: InlineCompletionItem
@@ -36,7 +37,7 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
         completion,
         document,
         docContext,
-        docContext: { prefix, position, multilineTrigger },
+        docContext: { position, multilineTrigger },
     } = context
     const parseTreeCache = getCachedParseTreeForDocument(document)
 
@@ -46,15 +47,20 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     }
 
     const { parser, tree } = parseTreeCache
+
+    const completionEndPosition = position.translate(
+        lines(completion.insertText).length,
+        getLastLine(completion.insertText).length
+    )
+
     const treeWithCompletion = pasteCompletion({
         completion,
         document,
         docContext,
         tree,
         parser,
+        completionEndPosition,
     })
-
-    const completionEndPosition = position.translate(0, completion.insertText.length)
 
     const points: ParsedCompletion['points'] = {
         start: {
@@ -68,7 +74,9 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
     }
 
     if (multilineTrigger) {
-        const triggerPosition = document.positionAt(prefix.lastIndexOf(multilineTrigger))
+        const triggerPosition = document.positionAt(
+            document.getText(new Range(new Position(0, 0), position)).lastIndexOf(multilineTrigger)
+        )
 
         points.trigger = {
             row: triggerPosition.line,
@@ -95,25 +103,26 @@ interface PasteCompletionParams {
     docContext: DocumentContext
     tree: Tree
     parser: Parser
+    completionEndPosition: Position
 }
 
 function pasteCompletion(params: PasteCompletionParams): Tree {
     const {
-        completion: { range, insertText },
+        completion: { insertText },
         document,
-        docContext,
         tree,
         parser,
         docContext: { position, currentLineSuffix },
+        completionEndPosition,
     } = params
 
     const matchingSuffixLength = getMatchingSuffixLength(insertText, currentLineSuffix)
 
     // Adjust suffix and prefix based on completion insert range.
-    const prefix = range ? document.getText(new Range(new Position(0, 0), range.start as Position)) : docContext.prefix
-    const suffix = range
-        ? document.getText(new Range(range.end as Position, document.positionAt(document.getText().length)))
-        : docContext.suffix
+    const prefix = document.getText(new Range(new Position(0, 0), position))
+    const suffix = document.getText(new Range(position, document.positionAt(document.getText().length)))
+
+    const offset = document.offsetAt(position)
 
     // Remove the characters that are being replaced by the completion to avoid having
     // them in the parse tree. It breaks the multiline truncation logic which looks for
@@ -121,14 +130,13 @@ function pasteCompletion(params: PasteCompletionParams): Tree {
     const textWithCompletion = prefix + insertText + suffix.slice(matchingSuffixLength)
 
     const treeCopy = tree.copy()
-    const completionEndPosition = position.translate(undefined, insertText.length)
 
     treeCopy.edit({
-        startIndex: prefix.length,
-        oldEndIndex: prefix.length,
-        newEndIndex: prefix.length + insertText.length,
+        startIndex: offset,
+        oldEndIndex: offset,
+        newEndIndex: offset + insertText.length,
         startPosition: asPoint(position),
-        oldEndPosition: asPoint(range?.end || position),
+        oldEndPosition: asPoint(position),
         newEndPosition: asPoint(completionEndPosition),
     })
 

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -7,6 +7,7 @@ import { getNodeAtCursorAndParents } from '../../tree-sitter/ast-getters'
 import { asPoint, getCachedParseTreeForDocument } from '../../tree-sitter/parse-tree-cache'
 import { DocumentContext } from '../get-current-doc-context'
 import { ItemPostProcessingInfo } from '../logger'
+import { completionPostProcessLogger } from '../post-process-logger'
 import { InlineCompletionItem } from '../types'
 
 import { dropParserFields, ParsedCompletion } from './parse-completion'
@@ -30,6 +31,12 @@ export function processInlineCompletions(
     items: ParsedCompletion[],
     params: ProcessInlineCompletionsParams
 ): InlineCompletionItemWithAnalytics[] {
+    completionPostProcessLogger.info({
+        completionPostProcessId: 'constant',
+        stage: 'enter',
+        text: items[0]?.insertText,
+        isCollapsedGroup: true,
+    })
     // Shared post-processing logic
     const completionItems = items.map(item => processCompletion(item, params))
 
@@ -41,6 +48,11 @@ export function processInlineCompletions(
 
     // Rank results
     const rankedResults = rankCompletions(uniqueResults)
+    completionPostProcessLogger.info({
+        completionPostProcessId: 'constant',
+        stage: 'exit',
+        text: rankedResults[0]?.insertText,
+    })
 
     return rankedResults.map(dropParserFields)
 }

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -37,11 +37,8 @@ export function processInlineCompletions(
         text: items[0]?.insertText,
         isCollapsedGroup: true,
     })
-    // Shared post-processing logic
-    const completionItems = items.map(item => processCompletion(item, params))
-
     // Remove low quality results
-    const visibleResults = removeLowQualityCompletions(completionItems)
+    const visibleResults = removeLowQualityCompletions(items)
 
     // Remove duplicate results
     const uniqueResults = dedupeWith(visibleResults, 'insertText')
@@ -53,6 +50,7 @@ export function processInlineCompletions(
         stage: 'exit',
         text: rankedResults[0]?.insertText,
     })
+    completionPostProcessLogger.flush()
 
     return rankedResults.map(dropParserFields)
 }
@@ -63,7 +61,7 @@ interface ProcessItemParams {
     docContext: DocumentContext
 }
 
-function processCompletion(completion: ParsedCompletion, params: ProcessItemParams): ParsedCompletion {
+export function processCompletion(completion: ParsedCompletion, params: ProcessItemParams): ParsedCompletion {
     const { document, position, docContext } = params
     const { prefix, suffix, currentLineSuffix, multilineTrigger } = docContext
     let { insertText } = completion

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.ts
@@ -103,21 +103,11 @@ export function truncateParsedCompletion(context: CompletionContext): string {
 }
 
 function findLastAncestorOnTheSameRow(root: SyntaxNode, position: Point): SyntaxNode | null {
-    console.log('root', root.type, root.text)
-    console.log('-----------')
     const initial = root.namedDescendantForPosition(position)
     let current = initial
-    console.log('initial', initial.type, initial.text)
-    console.log('-------------')
 
     while (current?.parent?.startPosition.row === initial?.startPosition.row && current.parent.id !== root.id) {
         current = current.parent
-        if (current.type === 'module') {
-            console.log(current.id)
-            console.log(root.id)
-        }
-        console.log('current', current.type, current.text)
-        console.log('-------------')
     }
 
     return current

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.ts
@@ -34,10 +34,11 @@ function insertMissingBracketIfNeeded(params: InsertMissingBracketParams): strin
 
     const openingBracket = Object.keys(BRACKET_PAIR).find(openingBracket =>
         textToCheck.trimEnd().endsWith(openingBracket)
-    ) as OpeningBracket
+    ) as OpeningBracket | undefined
 
-    if (openingBracket && !nextNonEmptyLine.startsWith(BRACKET_PAIR[openingBracket])) {
-        return textToComplete + BRACKET_PAIR[openingBracket]
+    const closingBracket = openingBracket && BRACKET_PAIR[openingBracket]
+    if (closingBracket && !nextNonEmptyLine.startsWith(closingBracket) && !textToComplete.endsWith(closingBracket)) {
+        return textToComplete + closingBracket
     }
 
     return textToComplete

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -252,7 +252,10 @@ export const BRACKET_PAIR = {
     '(': ')',
     '[': ']',
     '{': '}',
+    '<': '>',
 } as const
+export type OpeningBracket = keyof typeof BRACKET_PAIR
+export type ClosingBracket = (typeof BRACKET_PAIR)[OpeningBracket]
 
 export function getEditorTabSize(): number {
     return vscode.window.activeTextEditor ? (vscode.window.activeTextEditor.options.tabSize as number) : 2

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -45,6 +45,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteExperimentalSyntacticPostProcessing: true,
+            autocompleteExperimentalDynamicMultilineCompletions: false,
             autocompleteExperimentalGraphContext: null,
             autocompleteTimeouts: {},
         })
@@ -121,6 +122,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.experimental.syntacticPostProcessing':
                         return true
+                    case 'cody.autocomplete.experimental.dynamicMultilineCompletions':
+                        return false
                     case 'cody.autocomplete.experimental.graphContext':
                         return 'lsp-light'
                     case 'cody.advanced.agent.running':
@@ -170,6 +173,7 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteExperimentalSyntacticPostProcessing: true,
+            autocompleteExperimentalDynamicMultilineCompletions: false,
             autocompleteExperimentalGraphContext: 'lsp-light',
             autocompleteTimeouts: {},
         })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -106,6 +106,10 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
             true
         ),
         autocompleteExperimentalGraphContext,
+        autocompleteExperimentalDynamicMultilineCompletions: config.get(
+            CONFIG_KEY.autocompleteExperimentalDynamicMultilineCompletions,
+            false
+        ),
 
         // NOTE: Inline Chat will be deprecated soon - Do not enable inline-chat when experimental.chatPanel is enabled
         inlineChat:


### PR DESCRIPTION
## Context

- **TLDR**: we now use the completion's first line to determine if it starts the new multiline syntax node. If it does, we continue streaming until the completion is truncated or we reach the token sample limit.
- Closes https://github.com/sourcegraph/cody/issues/1619
- Adds a **feature flag** `cody-autocomplete-dynamic-multline-completions` to run an experiment on the updated logic.
- Adds an **experimental setting**, `cody.autocomplete.experimental.dynamicMultilineCompletions` to test the feature locally.
- Adds `completionPostProcessLogger` used for local debugging. It's disabled by default, and I will replace it with OpenTelemetry spans in a follow-up PR. I put a little effort into improving this logger because it's a throw-away code, but I need it here because debugging streaming-truncation bugs is much faster with it.
- Revamps the multiline truncation logic:
    - We no longer look for the next new sibling after the completion. This approach is unreliable because the parse tree often breaks because of incomplete code in the completion insert text.
    - Instead, we take the descendant at the current cursor position (or multiline trigger position), look for the farthest ancestor that starts at the same line, and then wait for a moment when completion generates more line than this syntax node has. This means we do not care about broken parse-tree after the node under the cursor:

```ts
// Start completion
function test() {
  █
}

// ---------------------------

// Continue streaming
function test() {
  █if (true) {
    console.log('hello world'
}

// ---------------------------

// Stop, because characters were added outside of `function test` syntax node boundaries
function test() {
  █if (true) {
    console.log('hello world'
}

function 
```
- ~~Need to merge https://github.com/sourcegraph/cody/pull/1891 first to reduce the diff in this PR.~~

## Screenshots

![Group 2](https://github.com/sourcegraph/cody/assets/3846380/79cb9e77-7230-4199-9509-45e2218305bf)
![Group 3](https://github.com/sourcegraph/cody/assets/3846380/f59f9bc0-689c-4b79-bfa9-a5151b77e926)
![Group 4](https://github.com/sourcegraph/cody/assets/3846380/b3c5185c-38a5-4cbd-b9e1-0b449acf91fd)
![Group 1](https://github.com/sourcegraph/cody/assets/3846380/11fe193f-0ccc-427b-bb0b-6fcfe0c30d4d)


## Follow-ups

- https://github.com/sourcegraph/cody/issues/1923
- https://github.com/sourcegraph/cody/issues/1924
- https://github.com/sourcegraph/cody/issues/1920
- https://github.com/sourcegraph/cody/issues/1921

## Merged preparation PRs

- https://github.com/sourcegraph/cody/pull/1709
- https://github.com/sourcegraph/cody/pull/1784
- https://github.com/sourcegraph/cody/pull/1888
- https://github.com/sourcegraph/cody/pull/1891
- https://github.com/sourcegraph/cody/pull/1893

## Test plan

- Tested manually:
    - Ensure that code completions are generated without changes on this branch.
    - Ensure that code completions are dynamically switched to multiline based on the first line when `cody.autocomplete.experimental.dynamicMultilineCompletions` is set to true.
- Existing tests pass.
- The functionality is disabled by default. I'm going to add more unit tests for the new logic in a separate PR (see planned follow-ups section).
