### PR TITLE
Fix types for autocomplete agent notifications

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -339,7 +339,7 @@ export class Agent extends MessageHandler {
             }
         })
 
-        this.registerNotification('autocomplete/completionAccepted', async completionID => {
+        this.registerNotification('autocomplete/completionAccepted', async ({ completionID }) => {
             const client = await this.client
             if (!client) {
                 throw new Error('Cody client not initialized')
@@ -348,7 +348,7 @@ export class Agent extends MessageHandler {
             provider.handleDidAcceptCompletionItem(completionID)
         })
 
-        this.registerNotification('autocomplete/completionSuggested', async completionID => {
+        this.registerNotification('autocomplete/completionSuggested', async ({ completionID }) => {
             const client = await this.client
             if (!client) {
                 throw new Error('Cody client not initialized')

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -105,10 +105,10 @@ export type Notifications = {
     'autocomplete/clearLastCandidate': [null]
     // The completion was presented to the user, and will be logged for telemetry
     // purposes.
-    'autocomplete/completionSuggested': [CompletionItemID]
+    'autocomplete/completionSuggested': [CompletionItemParams]
     // The completion was accepted by the user, and will be logged for telemetry
     // purposes.
-    'autocomplete/completionAccepted': [CompletionItemID]
+    'autocomplete/completionAccepted': [CompletionItemParams]
     // Resets the chat transcript and clears any in-progress interactions.
     // This notification should be sent when the user starts a new conversation.
     // The chat transcript grows indefinitely if this notification is never sent.
@@ -127,6 +127,10 @@ export type Notifications = {
 
 export interface CancelParams {
     id: string | number
+}
+
+export interface CompletionItemParams {
+    completionID: CompletionItemID
 }
 
 export interface AutocompleteParams {


### PR DESCRIPTION
Sending primitives as params via JSONRPC is not supported, they end up being wrapped in an array. Therefore we need to create an object type for the params

## Test plan

Viewed output of agent trace logs
