### PR TITLE
Emit Auth:connected event to correct endpoint for agent

### DIFF
--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -4,9 +4,9 @@ import { Memento } from 'vscode'
 import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 export class LocalStorage {
-    public readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
     // Bump this on storage changes so we don't handle incorrectly formatted data
     protected readonly KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'
+    protected readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
     protected readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
     protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected readonly KEY_LAST_USED_RECIPES = 'SOURCEGRAPH_CODY_LAST_USED_RECIPE_NAMES'


### PR DESCRIPTION
More initialization order woes. Included comments this time for ye who follow in later times.

## Test plan

Observed the EventLogger global was being initialized with `https://sourcegraph.com`, while agent trace logs showed `serverEndpoint` was `https://sourcegraph.test:3443`. After the changes, I observed CodyJetBrainsPlugin:Auth:connected events in my local instance's event_logs table
