### PR TITLE
Edit: Faster `doc` workflow with more target context

### DIFF
--- a/lib/shared/src/chat/prompts/cody.json
+++ b/lib/shared/src/chat/prompts/cody.json
@@ -5,7 +5,6 @@
       "prompt": "Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not output any other code or comments besides the documentation. Output only the comment and do not enclose it in markdown.",
       "context": {
         "currentFile": true,
-        "currentDir": true,
         "selection": true
       },
       "mode": "insert"

--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -100,6 +100,11 @@ export class Fixup implements Recipe {
              * No additional context is required. We already have the errors directly via the instruction, and we know their selected code.
              */
             case 'fix':
+            /**
+             * Very narrow set of possible instructions.
+             * Fetching context is unlikely to be very helpful or optimal.
+             */
+            case 'doc': {
                 const contextMessages = []
                 if (truncatedPrecedingText.trim().length > 0) {
                     contextMessages.push(
@@ -118,6 +123,7 @@ export class Fixup implements Recipe {
                     )
                 }
                 return contextMessages
+            }
             /**
              * Broad set of possible instructions.
              * Fetch context from the users' selection, use any errors/warnings in said selection, and use context from current file.
@@ -143,41 +149,6 @@ export class Fixup implements Recipe {
                         )
                     ),
                 ]
-            /**
-             * Very narrow set of possible instructions.
-             * Fetching context is unlikely to be very helpful or optimal.
-             * Instead, we can fetch editor specific context as we likely have a much more constrained range.
-             */
-            case 'doc':
-                const docContext = []
-                const symbolContext = await context.editor.getLSPReferencesForPosition(task.selectionRange.start)
-
-                if (symbolContext.length > 0) {
-                    docContext.push(
-                        ...symbolContext.flatMap(({ text, fileName }) => {
-                            return getContextMessageWithResponse(populateCodeContextTemplate(text, fileName), {
-                                fileName,
-                            })
-                        })
-                    )
-                }
-                if (truncatedPrecedingText.trim().length > 0) {
-                    docContext.push(
-                        ...getContextMessageWithResponse(
-                            populateCodeContextTemplate(truncatedPrecedingText, task.fileName),
-                            task
-                        )
-                    )
-                }
-                if (truncatedFollowingText.trim().length > 0) {
-                    docContext.push(
-                        ...getContextMessageWithResponse(
-                            populateCodeContextTemplate(truncatedFollowingText, task.fileName),
-                            task
-                        )
-                    )
-                }
-                return docContext
         }
         /* eslint-enable no-case-declarations */
     }

--- a/lib/shared/src/chat/recipes/fixup.ts
+++ b/lib/shared/src/chat/recipes/fixup.ts
@@ -1,5 +1,5 @@
 import { ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
-import { VsCodeFixupTaskRecipeData } from '../../editor'
+import { FixupIntent, VsCodeFixupTaskRecipeData } from '../../editor'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
 import { populateCodeContextTemplate, populateCurrentEditorDiagnosticsTemplate } from '../../prompt/templates'
 import { truncateText, truncateTextStart } from '../../prompt/truncation'
@@ -8,12 +8,6 @@ import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection } from './helpers'
 import { Recipe, RecipeContext, RecipeID } from './recipe'
-
-/**
- * The intent classification.
- * Inferred from the prefix provided to the fixup command, e.g. `/edit` or `/fix`
- */
-export type FixupIntent = 'add' | 'edit' | 'fix'
 
 export const PROMPT_TOPICS = {
     OUTPUT: 'CODE5711',
@@ -57,6 +51,7 @@ export class Fixup implements Recipe {
             case 'add':
                 return Fixup.addPrompt.replace('{instruction}', task.instruction).replace('{fileName}', task.fileName)
             case 'edit':
+            case 'doc':
                 return Fixup.editPrompt
                     .replace('{instruction}', promptInstruction)
                     .replace('{selectedText}', task.selectedText)
@@ -148,6 +143,41 @@ export class Fixup implements Recipe {
                         )
                     ),
                 ]
+            /**
+             * Very narrow set of possible instructions.
+             * Fetching context is unlikely to be very helpful or optimal.
+             * Instead, we can fetch editor specific context as we likely have a much more constrained range.
+             */
+            case 'doc':
+                const docContext = []
+                const symbolContext = await context.editor.getLSPReferencesForPosition(task.selectionRange.start)
+
+                if (symbolContext.length > 0) {
+                    docContext.push(
+                        ...symbolContext.flatMap(({ text, fileName }) => {
+                            return getContextMessageWithResponse(populateCodeContextTemplate(text, fileName), {
+                                fileName,
+                            })
+                        })
+                    )
+                }
+                if (truncatedPrecedingText.trim().length > 0) {
+                    docContext.push(
+                        ...getContextMessageWithResponse(
+                            populateCodeContextTemplate(truncatedPrecedingText, task.fileName),
+                            task
+                        )
+                    )
+                }
+                if (truncatedFollowingText.trim().length > 0) {
+                    docContext.push(
+                        ...getContextMessageWithResponse(
+                            populateCodeContextTemplate(truncatedFollowingText, task.fileName),
+                            task
+                        )
+                    )
+                }
+                return docContext
         }
         /* eslint-enable no-case-declarations */
     }

--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -11,14 +11,15 @@ export interface ActiveTextEditor {
     selectionRange?: ActiveTextEditorSelectionRange
 }
 
-export interface ActiveTextEditorPosition {
-    line: number
-    character: number
-}
-
 export interface ActiveTextEditorSelectionRange {
-    start: ActiveTextEditorPosition
-    end: ActiveTextEditorPosition
+    start: {
+        line: number
+        character: number
+    }
+    end: {
+        line: number
+        character: number
+    }
 }
 
 export interface ActiveTextEditorSelection {
@@ -39,13 +40,6 @@ export interface ActiveTextEditorDiagnostic {
     range: ActiveTextEditorSelectionRange
     text: string
     message: string
-}
-
-export interface LSPReference {
-    uri: URI
-    fileName: string
-    range: ActiveTextEditorSelectionRange
-    text: string
 }
 
 export interface ActiveTextEditorVisibleContent {
@@ -140,10 +134,6 @@ export interface Editor<
      * Get diagnostics (errors, warnings, hints) for a range within the active text editor.
      */
     getActiveTextEditorDiagnosticsForRange(range: ActiveTextEditorSelectionRange): ActiveTextEditorDiagnostic[] | null
-    /**
-     * Get references for any symbol at the given position in the active text editor.
-     */
-    getLSPReferencesForPosition(position: ActiveTextEditorPosition): Promise<LSPReference[]>
 
     getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null
 
@@ -202,10 +192,6 @@ export class NoopEditor implements Editor {
 
     public getActiveTextEditorDiagnosticsForRange(): ActiveTextEditorDiagnostic[] | null {
         return null
-    }
-
-    public getLSPReferencesForPosition(): Promise<LSPReference[]> {
-        return Promise.resolve([])
     }
 
     public getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null {

--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -11,15 +11,14 @@ export interface ActiveTextEditor {
     selectionRange?: ActiveTextEditorSelectionRange
 }
 
+export interface ActiveTextEditorPosition {
+    line: number
+    character: number
+}
+
 export interface ActiveTextEditorSelectionRange {
-    start: {
-        line: number
-        character: number
-    }
-    end: {
-        line: number
-        character: number
-    }
+    start: ActiveTextEditorPosition
+    end: ActiveTextEditorPosition
 }
 
 export interface ActiveTextEditorSelection {
@@ -40,6 +39,13 @@ export interface ActiveTextEditorDiagnostic {
     range: ActiveTextEditorSelectionRange
     text: string
     message: string
+}
+
+export interface LSPReference {
+    uri: URI
+    fileName: string
+    range: ActiveTextEditorSelectionRange
+    text: string
 }
 
 export interface ActiveTextEditorVisibleContent {
@@ -68,7 +74,7 @@ export interface VsCodeInlineController {
  * The intent classification for the fixup.
  * Manually determined depending on how the fixup is triggered.
  */
-export type FixupIntent = 'add' | 'edit' | 'fix'
+export type FixupIntent = 'add' | 'edit' | 'fix' | 'doc'
 
 export interface VsCodeFixupTaskRecipeData {
     instruction: string
@@ -134,6 +140,10 @@ export interface Editor<
      * Get diagnostics (errors, warnings, hints) for a range within the active text editor.
      */
     getActiveTextEditorDiagnosticsForRange(range: ActiveTextEditorSelectionRange): ActiveTextEditorDiagnostic[] | null
+    /**
+     * Get references for any symbol at the given position in the active text editor.
+     */
+    getLSPReferencesForPosition(position: ActiveTextEditorPosition): Promise<LSPReference[]>
 
     getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null
 
@@ -192,6 +202,10 @@ export class NoopEditor implements Editor {
 
     public getActiveTextEditorDiagnosticsForRange(): ActiveTextEditorDiagnostic[] | null {
         return null
+    }
+
+    public getLSPReferencesForPosition(): Promise<LSPReference[]> {
+        return Promise.resolve([])
     }
 
     public getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: New chat preview models `claude-2.1` is now avaliable for sourcegraph.com users. [pull/1860](https://github.com/sourcegraph/cody/pull/1860)
 - Edit: Added context-aware code actions for "Generate", "Edit" and "Document" commands. [pull/1724](https://github.com/sourcegraph/cody/pull/1724)
 - Chat: @'ing files now uses a case insensitive fuzzy search. [pull/1889](https://github.com/sourcegraph/cody/pull/1889)
+- Edit: Added a faster, more optimized response for the "document" command. [pull/1900](https://github.com/sourcegraph/cody/pull/1900)
 
 ### Fixed
 

--- a/vscode/src/code-actions/document.ts
+++ b/vscode/src/code-actions/document.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { FixupIntent } from '@sourcegraph/cody-shared/src/editor'
+
 import { execQueryWrapper } from '../tree-sitter/query-sdk'
 
 export class DocumentCodeAction implements vscode.CodeActionProvider {
@@ -33,7 +35,16 @@ export class DocumentCodeAction implements vscode.CodeActionProvider {
         const source = 'code-action:document'
         action.command = {
             command: 'cody.command.edit-code',
-            arguments: [{ instruction: this.instruction, range, intent: 'edit', document, insertMode: true }, source],
+            arguments: [
+                {
+                    instruction: this.instruction,
+                    range,
+                    intent: 'doc' satisfies FixupIntent,
+                    document,
+                    insertMode: true,
+                },
+                source,
+            ],
             title: displayText,
         }
         return action

--- a/vscode/src/code-actions/edit.ts
+++ b/vscode/src/code-actions/edit.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { FixupIntent } from '@sourcegraph/cody-shared/src/editor'
+
 export class EditCodeAction implements vscode.CodeActionProvider {
     public static readonly providedCodeActionKinds = [vscode.CodeActionKind.RefactorRewrite]
 
@@ -36,7 +38,7 @@ export class EditCodeAction implements vscode.CodeActionProvider {
             arguments: [
                 {
                     range: selection ? new vscode.Range(selection.start, selection.end) : undefined,
-                    intent: 'edit',
+                    intent: 'edit' satisfies FixupIntent,
                     document,
                 },
                 source,

--- a/vscode/src/code-actions/fixup.ts
+++ b/vscode/src/code-actions/fixup.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { FixupIntent } from '@sourcegraph/cody-shared/src/chat/recipes/fixup'
+import { FixupIntent } from '@sourcegraph/cody-shared/src/editor'
 
 import { getSmartSelection } from '../editor/utils'
 

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { CodyPrompt } from '@sourcegraph/cody-shared'
+import { FixupIntent } from '@sourcegraph/cody-shared/src/editor'
 
 import { getActiveEditor } from '../editor/active-editor'
 import { getSmartSelection } from '../editor/utils'
@@ -139,6 +140,7 @@ export class CommandRunner implements vscode.Disposable {
         }
 
         const range = this.kind === 'doc' ? getDocCommandRange(this.editor, selection, doc.languageId) : selection
+        const intent: FixupIntent = this.kind === 'doc' ? 'doc' : 'edit'
         const instruction = insertMode ? addSelectionToPrompt(this.command.prompt, code) : this.command.prompt
         const source = this.kind
         await vscode.commands.executeCommand(
@@ -147,6 +149,7 @@ export class CommandRunner implements vscode.Disposable {
                 range,
                 instruction,
                 document: doc,
+                intent,
                 auto: true,
                 insertMode,
             },

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -4,13 +4,11 @@ import type {
     ActiveTextEditor,
     ActiveTextEditorDiagnostic,
     ActiveTextEditorDiagnosticType,
-    ActiveTextEditorPosition,
     ActiveTextEditorSelection,
     ActiveTextEditorSelectionRange,
     ActiveTextEditorViewControllers,
     ActiveTextEditorVisibleContent,
     Editor,
-    LSPReference,
 } from '@sourcegraph/cody-shared/src/editor'
 import { SURROUNDING_LINES } from '@sourcegraph/cody-shared/src/prompt/constants'
 
@@ -217,8 +215,8 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
 
         let range: vscode.Range | undefined
         if (selectionRange) {
-            const startLine = selectionRange.start.line
-            let endLine = selectionRange.end.line
+            const startLine = selectionRange?.start?.line
+            let endLine = selectionRange?.end?.line
             if (startLine === endLine) {
                 endLine++
             }
@@ -266,33 +264,6 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
                 text: activeEditor.document.getText(range),
                 message,
             }))
-    }
-
-    public async getLSPReferencesForPosition({ line, character }: ActiveTextEditorPosition): Promise<LSPReference[]> {
-        const activeEditor = this.getActiveTextEditorInstance()
-        if (!activeEditor) {
-            return []
-        }
-        const position = new vscode.Position(line, character)
-        const references = await vscode.commands.executeCommand<vscode.Location[]>(
-            'vscode.executeReferenceProvider',
-            activeEditor.document.uri,
-            position
-        )
-
-        const result: LSPReference[] = []
-        for (const { uri, range } of references) {
-            const text = await this.getTextEditorContentForFile(uri, range)
-            if (text) {
-                result.push({
-                    uri,
-                    fileName: vscode.workspace.asRelativePath(activeEditor.document.uri.fsPath),
-                    range,
-                    text,
-                })
-            }
-        }
-        return result
     }
 
     private createActiveTextEditorSelection(

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -4,11 +4,13 @@ import type {
     ActiveTextEditor,
     ActiveTextEditorDiagnostic,
     ActiveTextEditorDiagnosticType,
+    ActiveTextEditorPosition,
     ActiveTextEditorSelection,
     ActiveTextEditorSelectionRange,
     ActiveTextEditorViewControllers,
     ActiveTextEditorVisibleContent,
     Editor,
+    LSPReference,
 } from '@sourcegraph/cody-shared/src/editor'
 import { SURROUNDING_LINES } from '@sourcegraph/cody-shared/src/prompt/constants'
 
@@ -215,8 +217,8 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
 
         let range: vscode.Range | undefined
         if (selectionRange) {
-            const startLine = selectionRange?.start?.line
-            let endLine = selectionRange?.end?.line
+            const startLine = selectionRange.start.line
+            let endLine = selectionRange.end.line
             if (startLine === endLine) {
                 endLine++
             }
@@ -264,6 +266,33 @@ export class VSCodeEditor implements Editor<InlineController, FixupController, C
                 text: activeEditor.document.getText(range),
                 message,
             }))
+    }
+
+    public async getLSPReferencesForPosition({ line, character }: ActiveTextEditorPosition): Promise<LSPReference[]> {
+        const activeEditor = this.getActiveTextEditorInstance()
+        if (!activeEditor) {
+            return []
+        }
+        const position = new vscode.Position(line, character)
+        const references = await vscode.commands.executeCommand<vscode.Location[]>(
+            'vscode.executeReferenceProvider',
+            activeEditor.document.uri,
+            position
+        )
+
+        const result: LSPReference[] = []
+        for (const { uri, range } of references) {
+            const text = await this.getTextEditorContentForFile(uri, range)
+            if (text) {
+                result.push({
+                    uri,
+                    fileName: vscode.workspace.asRelativePath(activeEditor.document.uri.fsPath),
+                    range,
+                    text,
+                })
+            }
+        }
+        return result
     }
 
     private createActiveTextEditorSelection(

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode'
 
-import { FixupIntent } from '@sourcegraph/cody-shared/src/chat/recipes/fixup'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { VsCodeFixupController, VsCodeFixupTaskRecipeData } from '@sourcegraph/cody-shared/src/editor'
+import { FixupIntent, VsCodeFixupController, VsCodeFixupTaskRecipeData } from '@sourcegraph/cody-shared/src/editor'
 import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -623,8 +623,8 @@ export class FixupController
             return undefined
         }
 
-        // Expand the selection range for edits and fixes
-        const getSmartSelection = task.intent === 'edit' || task.intent === 'fix'
+        // Support expanding the selection range for intents where it is useful
+        const getSmartSelection = task.intent !== 'add'
         if (getSmartSelection && task.selectionRange) {
             const newRange = await this.getFixupTaskSmartSelection(task, task.selectionRange)
             task.selectionRange = newRange


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/1464

## Description

This PR:
- Streamlines the `doc` intent flow for fixup tasks. Previously we would treat these as "edit", which means we would try to fetch lots of context from the selected code. That is very rarely helpful, for documenting we really just want to take the surrounding code and the current selection.

I also investigating going the other way, and fetching relevant reference code for a documentable symbol. This confirmed to me that it's not necessarily helpful. It can lead to the LLM documenting code based on how it is used elsewhere rather than how it should be used. That might help for "explaining" code but not for documenting. (Related PR: https://github.com/sourcegraph/cody/pull/1904)


## Test plan

1. Run doc command via right click menu
2. Run doc command via sidebar
3. Run doc command via code action

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
