### PR TITLE
Edit: Show notification when no valid document

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -250,6 +250,7 @@ const register = async (
         telemetryRecorder.recordEvent('cody.command.edit', 'executed', { privateMetadata: { source } })
         const document = args.document || getActiveEditor()?.document
         if (!document) {
+            void vscode.window.showErrorMessage('Please open a file before running a command.')
             return
         }
 


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/1815

## Description

Matches behaviour of other commands.

We can still support creating a document behind the scenes, but this fixes the immediate problem.

<img width="1157" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/d3a1d7d9-b6c4-44ff-90d2-863fbdaca92c">


## Test plan

1. Open document
2. Try edit command from sidebar
3. Close document
4. Try edit command from sidebar

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
