### PR TITLE
fix: backspace and delete keys to remove character

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -387,6 +387,12 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 return
             }
 
+            // Allows backspace and delete keystrokes to remove characters
+            const deleteKeysList = new Set(['Backspace', 'Delete'])
+            if (deleteKeysList.has(event.key)) {
+                return
+            }
+
             // Handles keyboard shortcuts with Ctrl key.
             // Checks if the Ctrl key is pressed with a key not in the allow list
             // to avoid triggering default browser shortcuts and bubbling the event.

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: Add delays before sending webview ready events to prevent premature sending. This fixes issue where chat panel fails to load when multiple chat panels are opened simultaneously. [pull/1836](https://github.com/sourcegraph/cody/pull/1836)
 - Autocomplete: Fixes a bug that caused autocomplete to be triggered at the end of a block or function invocation. [pull/1864](https://github.com/sourcegraph/cody/pull/1864)
 - Edit: Incoming edits that are afixed to the selected code and now handled properly (e.g. docstrings). [pull/1724](https://github.com/sourcegraph/cody/pull/1724)
+- Chat: Allowed backspace and delete keys to remove characters in chat messages input box.
 
 ### Changed
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1869

Previously, we blocked any keys with Cltr and Alt that's not on the key allow list.

This PR allows any keystrokes that have 'Backspace' and 'Delete' to pass through to use default behavior. 

After this change:
- Pressing "Delete" removes the character behind the cursor as mentioned in the issue https://github.com/sourcegraph/cody/issues/1869
- Pressing "Alt+Delete" removes the word behind the cursor
- Pressing "Ctrl+Delete" on Mac does nothing as that's the default behavior. You can test the default behavior in a slack chat box:

https://github.com/sourcegraph/cody/assets/68532117/5dc0b57d-cafb-48bc-9d7a-97fd9b962c5f

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- in the chat box, move your cursor in the middle of a text string, then press "Delete" 
- Before: nothing happens
- After:

https://github.com/sourcegraph/cody/assets/68532117/c2258db0-f7d5-446f-b4cf-0dc0f298e469
