### PR TITLE
change: show editor icon in non-ready only

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -29,6 +29,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Commands: The Custom Commands Menu now closes on click outside of the menu. [pull/1854](https://github.com/sourcegraph/cody/pull/1854)
 - Autocomplete: Remove the frequency of unhelpful autocompletions. [pull/1862](https://github.com/sourcegraph/cody/pull/1862)
 - Chat: The default chat model `claude-2` has been replaced with the pinned version `claude-2.0`. [pull/1860](https://github.com/sourcegraph/cody/pull/1860)
+- Command: Editor title icon will only show up in non-readonly file editor views. [pull/1909](https://github.com/sourcegraph/cody/pull/1909)
 
 ## [0.16.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -829,7 +829,7 @@
       "editor/title": [
         {
           "command": "cody.action.commands.menu",
-          "when": "cody.activated && config.cody.editorTitleCommandIcon",
+          "when": "cody.activated && config.cody.editorTitleCommandIcon && resourceScheme == file && !editorReadonly",
           "group": "navigation",
           "visibility": "visible"
         },


### PR DESCRIPTION
REQUESTED AND CLOSE  https://github.com/sourcegraph/cody/issues/1821


Add a check for !editorReadonly in the 'when' condition for the editor title menu command to prevent the menu from showing when the editor is readonly or in non-file editors view.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Cody Icon should not show up in non-editable editor view:

![image](https://github.com/sourcegraph/cody/assets/68532117/957ab6c4-67fa-430f-9ba9-eed28bd00489)

![image](https://github.com/sourcegraph/cody/assets/68532117/5c7e9ee1-2d3c-4f5a-bf61-96485f711bfb)


Cody icon shows up in editor view for editable files:

![image](https://github.com/sourcegraph/cody/assets/68532117/81d7e865-10e4-4d5e-b815-d149dfc52fcd)
