### PR TITLE
add: include text in dotCom chat events

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -29,6 +29,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Commands: The Custom Commands Menu now closes on click outside of the menu. [pull/1854](https://github.com/sourcegraph/cody/pull/1854)
 - Autocomplete: Remove the frequency of unhelpful autocompletions. [pull/1862](https://github.com/sourcegraph/cody/pull/1862)
 - Chat: The default chat model `claude-2` has been replaced with the pinned version `claude-2.0`. [pull/1860](https://github.com/sourcegraph/cody/pull/1860)
+- Chat: Include text in dotCom chat events. [pull/1910](https://github.com/sourcegraph/cody/pull/1910)
 
 ## [0.16.1]
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -461,7 +461,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
             }
         }
 
-        const promptText = this.isDotComUser ? interaction.getHumanMessage().text : ''
+        const promptText = this.isDotComUser ? interaction.getHumanMessage().text : undefined
         const properties = { contextSummary, source, requestID, chatModel: this.chatModel, promptText }
         telemetryService.log(`CodyVSCodeExtension:recipe:${recipe.id}:executed`, properties, { hasV2Event: true })
         telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'executed', { metadata: { ...contextSummary } })


### PR DESCRIPTION
Spin off from https://github.com/sourcegraph/cody/pull/1856

Include chat prompt and response to `CodyVSCodeExtension:chatResponse` and `CodyVSCodeExtension:recipe` log events is users are connected to dotCom.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Check the Output channels to confirm the log events include prompt and LLM response IF you are connected to DotCom only.

### DEMO

You can see when the instance is switched to a non-DotCom instance, promptText and responseText are not included.

https://github.com/sourcegraph/cody/assets/68532117/516953f0-8f2f-4aa9-9421-cdbae7a3246c



