### PR TITLE
feat: restore chat webview on reload

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: New chat preview models `claude-2.1` is now avaliable for sourcegraph.com users. [pull/1860](https://github.com/sourcegraph/cody/pull/1860)
 - Edit: Added context-aware code actions for "Generate", "Edit" and "Document" commands. [pull/1724](https://github.com/sourcegraph/cody/pull/1724)
 - Chat: @'ing files now uses a case insensitive fuzzy search. [pull/1889](https://github.com/sourcegraph/cody/pull/1889)
+- Chat: Restore last opened chat panel on reload. [pull/1918](https://github.com/sourcegraph/cody/pull/1918)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -96,7 +96,8 @@
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onWebviewPanel:cody.chatPanel"
   ],
   "contributes": {
     "walkthroughs": [

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -15,6 +15,7 @@ import { AuthStatus } from '../protocol'
 import { ChatPanelsManager, IChatPanelProvider } from './ChatPanelsManager'
 import { SidebarChatOptions, SidebarChatProvider } from './SidebarChatProvider'
 
+export const CodyChatPanelViewType = 'cody.chatPanel'
 /**
  * Manages chat view providers and panels.
  */
@@ -56,7 +57,7 @@ export class ChatManager implements vscode.Disposable {
         this.onConfigurationChange = options.contextProvider.configurationChangeEvent.event(async () => {
             const isChatPanelEnabled = options.contextProvider.config.experimentalChatPanel
             // When chat.chatPanel is set to true, the sidebar chat view will never be shown
-            await vscode.commands.executeCommand('setContext', 'cody.chatPanel', isChatPanelEnabled)
+            await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, isChatPanelEnabled)
             if (isChatPanelEnabled) {
                 this.createChatPanelsManger()
             } else {
@@ -213,6 +214,14 @@ export class ChatManager implements vscode.Disposable {
             return undefined
         }
         return this.chatPanelsManager.createWebviewPanel(chatID, chatQuestion)
+    }
+
+    public async revive(panel: vscode.WebviewPanel, chatID: string): Promise<void> {
+        this.createChatPanelsManger()
+        if (this.chatPanelsManager) {
+            await this.chatPanelsManager.revive(panel, chatID)
+            telemetryService.log('CodyVSCodeExtension:chatPanelsManger:revive', undefined, { hasV2Event: true })
+        }
     }
 
     private lastDisplayedNotice = ''

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -200,6 +200,7 @@ export class ChatPanelProvider extends MessageProvider {
             type: 'transcript',
             messages: transcript,
             isMessageInProgress,
+            chatID: this.sessionID,
         })
 
         // Update / reset webview panel title

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -27,7 +27,7 @@ import {
     WebviewMessage,
 } from '../protocol'
 
-import { addWebviewViewHTML } from './ChatManager'
+import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {
     postMessage(message: ExtensionMessage): Thenable<boolean>
@@ -383,9 +383,11 @@ export class ChatPanelProvider extends MessageProvider {
         // Create the webview panel only if the user is logged in.
         // Allows users to login via the sidebar webview.
         if (!this.authProvider.getAuthStatus()?.isLoggedIn || !this.contextProvider.config.experimentalChatPanel) {
-            await vscode.commands.executeCommand('setContext', 'cody.chatPanel', false)
+            await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, false)
             return
         }
+
+        telemetryService.log('CodyVSCodeExtension:createWebviewPanel:clicked', undefined, { hasV2Event: true })
 
         // Checks if the webview panel already exists and is visible.
         // If so, returns early to avoid creating a duplicate.
@@ -395,13 +397,12 @@ export class ChatPanelProvider extends MessageProvider {
 
         this.startUpChatID = chatID
 
-        const viewType = 'cody.chatPanel'
+        const viewType = CodyChatPanelViewType
         // truncate firstQuestion to first 10 chars
         const text = lastQuestion && lastQuestion?.length > 10 ? `${lastQuestion?.slice(0, 20)}...` : lastQuestion
         const panelTitle = text || 'New Chat'
-        const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
         const viewColumn = activePanelViewColumn || vscode.ViewColumn.Beside
-
+        const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
         const panel = vscode.window.createWebviewPanel(
             viewType,
             panelTitle,
@@ -415,7 +416,33 @@ export class ChatPanelProvider extends MessageProvider {
             }
         )
 
+        return this.registerWebviewPanel(panel)
+    }
+
+    /**
+     * Revives the chat panel when the extension is reactivated.
+     * Registers the existing webviewPanel and sets the chatID.
+     */
+    public async revive(webviewPanel: vscode.WebviewPanel, chatID: string): Promise<vscode.WebviewPanel | undefined> {
+        telemetryService.log('CodyVSCodeExtension:ChatPanelProvider:revive', undefined, { hasV2Event: true })
+        this.startUpChatID = chatID
+        return this.registerWebviewPanel(webviewPanel)
+    }
+
+    /**
+     * Registers the given webview panel by setting up its options, icon, and handlers.
+     * Also stores the panel reference and disposes it when closed.
+     */
+    private async registerWebviewPanel(panel: vscode.WebviewPanel): Promise<vscode.WebviewPanel> {
+        const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
         panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'resources', 'cody.png')
+
+        panel.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [webviewPath],
+            enableCommandUris: true,
+        }
+
         await addWebviewViewHTML(this.extensionUri, panel)
 
         // Register webview
@@ -433,8 +460,7 @@ export class ChatPanelProvider extends MessageProvider {
         this.disposables.push(panel.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message)))
 
         // Used for keeping sidebar chat view closed when webview panel is enabled
-        await vscode.commands.executeCommand('setContext', 'cody.chatPanel', true)
-        telemetryService.log('CodyVSCodeExtension:createWebviewPanel:clicked', undefined, { hasV2Event: true })
+        await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, true)
 
         return panel
     }

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -15,6 +15,7 @@ import { createCodyChatTreeItems } from '../../services/treeViewItems'
 import { TreeViewProvider } from '../../services/TreeViewProvider'
 import { AuthStatus } from '../protocol'
 
+import { CodyChatPanelViewType } from './ChatManager'
 import { ChatPanelProvider, ChatPanelProviderOptions, ChatViewProviderWebview } from './ChatPanelProvider'
 import { SidebarChatOptions } from './SidebarChatProvider'
 import { SimpleChatPanelProvider } from './SimpleChatPanelProvider'
@@ -83,7 +84,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         this.onConfigurationChange = options.contextProvider.configurationChangeEvent.event(async () => {
             // When chat.chatPanel is set to true, the sidebar chat view will never be shown
             const isChatPanelEnabled = options.contextProvider.config.experimentalChatPanel
-            await vscode.commands.executeCommand('setContext', 'cody.chatPanel', isChatPanelEnabled)
+            await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, isChatPanelEnabled)
             // when config is disabled, remove all current panels
             if (!isChatPanelEnabled) {
                 this.disposePanels()
@@ -111,7 +112,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             this.disposePanels()
         }
 
-        await vscode.commands.executeCommand('setContext', 'cody.chatPanel', authStatus.isLoggedIn)
+        await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, authStatus.isLoggedIn)
     }
 
     public async getChatPanel(): Promise<IChatPanelProvider> {
@@ -176,6 +177,47 @@ export class ChatPanelsManager implements vscode.Disposable {
         const provider = new ChatPanelProvider(this.options)
         const webviewPanel = await provider.createWebviewPanel(activePanelViewColumn, chatID, chatQuestion)
         const sessionID = chatID || provider.sessionID
+        this.activePanelProvider = provider
+        this.panelProvidersMap.set(sessionID, provider)
+
+        webviewPanel?.onDidChangeViewState(e => {
+            if (e.webviewPanel.visible && e.webviewPanel.active) {
+                this.activePanelProvider = provider
+                this.options.contextProvider.webview = provider.webview
+                void this.selectTreeItem(provider.sessionID)
+            }
+        })
+
+        webviewPanel?.onDidDispose(() => {
+            this.disposeProvider(sessionID)
+        })
+
+        this.selectTreeItem(sessionID)
+        return provider
+    }
+
+    public async revive(
+        panel: vscode.WebviewPanel,
+        sessionID: string,
+        chatQuestion?: string
+    ): Promise<IChatPanelProvider> {
+        logDebug('ChatPanelsManager:revive', sessionID, chatQuestion)
+
+        const provider = this.useSimpleChatPanelProvider
+            ? new SimpleChatPanelProvider({
+                  ...this.options,
+                  config: this.options.contextProvider.config,
+                  chatClient: this.chatClient,
+                  embeddingsClient: this.embeddingsSearch,
+              })
+            : new ChatPanelProvider(this.options)
+
+        const webviewPanel = await provider.revive(panel, sessionID)
+
+        if (this.useSimpleChatPanelProvider) {
+            await provider.restoreSession(sessionID)
+        }
+
         this.activePanelProvider = provider
         this.panelProvidersMap.set(sessionID, provider)
 

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -256,6 +256,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
             type: 'transcript',
             messages: transcript,
             isMessageInProgress,
+            chatID: this.sessionID,
         })
     }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -527,6 +527,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             type: 'transcript',
             messages,
             isMessageInProgress: !!messageInProgress,
+            chatID: this.sessionID,
         })
     }
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -90,7 +90,7 @@ export type ExtensionMessage =
     | { type: 'config'; config: ConfigurationSubsetForWebview & LocalEnv; authStatus: AuthStatus }
     | { type: 'login'; authStatus: AuthStatus }
     | { type: 'history'; messages: UserLocalHistory | null }
-    | { type: 'transcript'; messages: ChatMessage[]; isMessageInProgress: boolean }
+    | { type: 'transcript'; messages: ChatMessage[]; isMessageInProgress: boolean; chatID: string }
     | { type: 'contextStatus'; contextStatus: ChatContextStatus }
     | { type: 'view'; messages: View }
     | { type: 'errors'; errors: string }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -603,6 +603,19 @@ const register = async (
     // Clean up old onboarding experiment state
     void OnboardingExperiment.cleanUpCachedSelection()
 
+    if (vscode.window.registerWebviewPanelSerializer) {
+        console.log('Registering webview serializer')
+        // Make sure we register a serializer in activation event
+        vscode.window.registerWebviewPanelSerializer('cody.chatPanel', {
+            async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, chatID: string) {
+                if (chatID && webviewPanel.title) {
+                    await chatManager.createWebviewPanel(chatID, webviewPanel.title)
+                    webviewPanel.dispose()
+                }
+            },
+        })
+    }
+
     return {
         disposable: vscode.Disposable.from(...disposables),
         onConfigurationChange: newConfig => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -603,9 +603,8 @@ const register = async (
     // Clean up old onboarding experiment state
     void OnboardingExperiment.cleanUpCachedSelection()
 
+    // Register a serializer for reviving the chat panel on reload
     if (vscode.window.registerWebviewPanelSerializer) {
-        console.log('Registering webview serializer')
-        // Make sure we register a serializer in activation event
         vscode.window.registerWebviewPanelSerializer('cody.chatPanel', {
             async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, chatID: string) {
                 if (chatID && webviewPanel.title) {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -9,7 +9,7 @@ import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/e
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
-import { ChatManager } from './chat/chat-view/ChatManager'
+import { ChatManager, CodyChatPanelViewType } from './chat/chat-view/ChatManager'
 import { ContextProvider, hackGetCodebaseContext } from './chat/ContextProvider'
 import { FixupManager } from './chat/FixupViewProvider'
 import { InlineChatViewManager } from './chat/InlineChatViewProvider'
@@ -22,6 +22,7 @@ import { getActiveEditor } from './editor/active-editor'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { PlatformContext } from './extension.common'
 import { configureExternalServices } from './external-services'
+import { logDebug } from './log'
 import { FixupController } from './non-stop/FixupController'
 import { showSetupNotification } from './notifications/setup-notification'
 import { SearchViewProvider } from './search/SearchViewProvider'
@@ -605,11 +606,11 @@ const register = async (
 
     // Register a serializer for reviving the chat panel on reload
     if (vscode.window.registerWebviewPanelSerializer) {
-        vscode.window.registerWebviewPanelSerializer('cody.chatPanel', {
+        vscode.window.registerWebviewPanelSerializer(CodyChatPanelViewType, {
             async deserializeWebviewPanel(webviewPanel: vscode.WebviewPanel, chatID: string) {
                 if (chatID && webviewPanel.title) {
-                    await chatManager.createWebviewPanel(chatID, webviewPanel.title)
-                    webviewPanel.dispose()
+                    logDebug('main:deserializeWebviewPanel', 'reviving last unclosed chat panel')
+                    await chatManager.revive(webviewPanel, chatID)
                 }
             },
         })

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -5,6 +5,7 @@ import { DOTCOM_URL, isLocalApp, LOCAL_APP_URL } from '@sourcegraph/cody-shared/
 import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 import { isError } from '@sourcegraph/cody-shared/src/utils'
 
+import { CodyChatPanelViewType } from '../chat/chat-view/ChatManager'
 import { SidebarChatWebview } from '../chat/chat-view/SidebarChatProvider'
 import {
     AuthStatus,
@@ -161,7 +162,7 @@ export class AuthProvider {
         await localStorage.deleteEndpoint()
         await this.auth(endpoint, null)
         this.authStatus.endpoint = ''
-        await vscode.commands.executeCommand('setContext', 'cody.chatPanel', false)
+        await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, false)
         await vscode.commands.executeCommand('setContext', 'cody.activated', false)
     }
 

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -61,6 +61,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             setTranscript(message.messages)
                             setMessageInProgress(null)
                         }
+                        vscodeAPI.setState(message.chatID)
                         break
                     }
                     case 'config':


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1814

This PR added support for reviving the last opened chat panel (if any) on reload. 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- Build Cody from this branch
- Open a chat and ask Cody a question
- Reload your editor
- You should see the last opened chat opened in your editor before the reload
- Works with SimpleContext


### Update 1

Last panel that was not closed gets disposed before it gets recreated.

https://github.com/sourcegraph/cody/assets/68532117/9a1136df-9162-4eb3-8661-64aaab7a98c7

### Update 2

Loom: https://www.loom.com/share/1b7acfa69fff4b708bde8c9f3282bdb3?sid=f89aecb4-4caf-4525-bc56-63b34e5c9369

Last panel that was not closed gets revived properly.

https://github.com/sourcegraph/cody/assets/68532117/5aabc6f3-facd-406b-ba7a-0c4c2e89c1ff

