### PR TITLE
change: replace vscode links with command

### DIFF
--- a/lib/shared/src/chat/prompts/display-text.test.ts
+++ b/lib/shared/src/chat/prompts/display-text.test.ts
@@ -8,7 +8,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
         const result = replaceFileNameWithMarkdownLink(text, '@test.js', '/path/to/test.js')
 
-        expect(result).toEqual('Hello [_@test.js_](vscode://file/path/to/test.js)')
+        expect(result).toEqual('Hello [_@test.js_](command:cody.chat.open.file?"/path/to/test.js")')
     })
 
     it('respects spaces in file name', () => {
@@ -16,7 +16,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
         const result = replaceFileNameWithMarkdownLink(text, '@my file.js', '/path/to/my file.js')
 
-        expect(result).toEqual('Loaded [_@my file.js_](vscode://file/path/to/my file.js)')
+        expect(result).toEqual('Loaded [_@my file.js_](command:cody.chat.open.file?"/path/to/my file.js")')
     })
 
     it('returns original text if no match', () => {
@@ -32,7 +32,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
         const result = replaceFileNameWithMarkdownLink(text, '@test.js', '/path/with/@#special$chars.js')
 
-        expect(result).toEqual('Loaded [_@test.js_](vscode://file/path/with/@#special$chars.js)')
+        expect(result).toEqual('Loaded [_@test.js_](command:cody.chat.open.file?"/path/with/@#special$chars.js")')
     })
 
     it('handles line numbers', () => {
@@ -40,7 +40,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
         const result = replaceFileNameWithMarkdownLink(text, '@test.js', '/path/test.js', 10)
 
-        expect(result).toEqual('Error in [_@test.js_](vscode://file/path/test.js:10)')
+        expect(result).toEqual('Error in [_@test.js_](command:cody.chat.open.file?"/path/test.js:range:10")')
     })
 
     it('handles edge case where start line at 0 - exclude start line in markdown link', () => {
@@ -48,7 +48,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
         const result = replaceFileNameWithMarkdownLink(text, '@test.js', '/path/test.js', 0)
 
-        expect(result).toEqual('Error in [_@test.js_](vscode://file/path/test.js)')
+        expect(result).toEqual('Error in [_@test.js_](command:cody.chat.open.file?"/path/test.js")')
     })
 
     it('handles names that showed up more than once', () => {
@@ -57,7 +57,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
         const result = replaceFileNameWithMarkdownLink(text, '@foo.js', '/path/foo.js', 10)
 
         expect(result).toEqual(
-            'Compare and explain [_@foo.js_](vscode://file/path/foo.js:10) and @bar.js. What does [_@foo.js_](vscode://file/path/foo.js:10) do?'
+            'Compare and explain [_@foo.js_](command:cody.chat.open.file?"/path/foo.js:range:10") and @bar.js. What does [_@foo.js_](command:cody.chat.open.file?"/path/foo.js:range:10") do?'
         )
     })
 
@@ -67,7 +67,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
         const result = replaceFileNameWithMarkdownLink(text, '@foo.js', '/path/foo.js', 10)
 
         expect(result).toEqual(
-            'Compare and explain [_@foo.js_](vscode://file/path/foo.js:10) and @bar.js. What does @foo.js#FooBar() do?'
+            'Compare and explain [_@foo.js_](command:cody.chat.open.file?"/path/foo.js:range:10") and @bar.js. What does @foo.js#FooBar() do?'
         )
     })
 
@@ -83,7 +83,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
         )
 
         expect(result).toEqual(
-            '[_@vscode/src/logged-rerank.ts:7-23#getRerankWithLog()_](vscode://file/vscode/src/logged-rerank.ts:7) what does this do'
+            '[_@vscode/src/logged-rerank.ts:7-23#getRerankWithLog()_](command:cody.chat.open.file?"/vscode/src/logged-rerank.ts:range:7") what does this do'
         )
     })
 })

--- a/lib/shared/src/chat/prompts/display-text.ts
+++ b/lib/shared/src/chat/prompts/display-text.ts
@@ -56,9 +56,9 @@ export function replaceFileNameWithMarkdownLink(
     startLine = 0
 ): string {
     // Create markdown link to the file
-    const range = startLine ? `:${startLine}` : ''
-    const fileLink = `vscode://file${fsPath}${range}`
-    const markdownText = `[_${fileName.trim()}_](${fileLink})`
+    const range = startLine ? `:range:${startLine}` : ''
+    const fileLink = `${fsPath}${range}`
+    const markdownText = `[_${fileName.trim()}_](command:cody.chat.open.file?"${fileLink}")`
 
     // Use regex to makes sure the file name is surrounded by spaces and not a substring of another file name
     const textToBeReplaced = new RegExp(`\\s*${fileName.replaceAll(/[$()*+./?[\\\]^{|}-]/g, '\\$&')}(?!\\S)`, 'g')

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -33,6 +33,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: The default chat model `claude-2` has been replaced with the pinned version `claude-2.0`. [pull/1860](https://github.com/sourcegraph/cody/pull/1860)
 - Command: Editor title icon will only show up in non-readonly file editor views. [pull/1909](https://github.com/sourcegraph/cody/pull/1909)
 - Chat: Include text in dotCom chat events. [pull/1910](https://github.com/sourcegraph/cody/pull/1910)
+- Chat: Replaced vscode links with custom "cody.chat.open.file" protocol when displaying file names in chat. [pull/1919](https://github.com/sourcegraph/cody/pull/1919)
 
 ## [0.16.1]
 

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -49,7 +49,8 @@ export class ChatManager implements vscode.Disposable {
             vscode.commands.registerCommand('cody.chat.history.clear', async () => this.clearHistory()),
             vscode.commands.registerCommand('cody.chat.history.delete', async item => this.clearHistory(item)),
             vscode.commands.registerCommand('cody.chat.panel.new', async () => this.createNewWebviewPanel()),
-            vscode.commands.registerCommand('cody.chat.panel.restore', (id, chat) => this.restorePanel(id, chat))
+            vscode.commands.registerCommand('cody.chat.panel.restore', (id, chat) => this.restorePanel(id, chat)),
+            vscode.commands.registerCommand('cody.chat.open.file', async fsPath => this.openFileFromChat(fsPath))
         )
 
         // Register config change listener
@@ -226,6 +227,16 @@ export class ChatManager implements vscode.Disposable {
         this.getChatProvider()
             .then(provider => provider.triggerNotice(notice))
             .catch(error => console.error(error))
+    }
+
+    private async openFileFromChat(fsPath: string): Promise<void> {
+        const rangeIndex = fsPath.indexOf(':range:')
+        const range = rangeIndex ? fsPath.slice(Math.max(0, rangeIndex + 7)) : undefined
+        const filteredFsPath = range ? fsPath.slice(0, rangeIndex) : fsPath
+        const uri = vscode.Uri.file(filteredFsPath)
+        const doc = await vscode.workspace.openTextDocument(uri)
+        const viewColumn = vscode.ViewColumn.Beside - 2 > 1 ? vscode.ViewColumn.Beside - 2 : vscode.ViewColumn.Beside
+        await vscode.window.showTextDocument(doc, viewColumn)
     }
 
     private disposeChatPanelsManager(): void {

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -231,12 +231,16 @@ export class ChatManager implements vscode.Disposable {
 
     private async openFileFromChat(fsPath: string): Promise<void> {
         const rangeIndex = fsPath.indexOf(':range:')
-        const range = rangeIndex ? fsPath.slice(Math.max(0, rangeIndex + 7)) : undefined
+        const range = rangeIndex ? fsPath.slice(Math.max(0, rangeIndex + 7)) : 0
         const filteredFsPath = range ? fsPath.slice(0, rangeIndex) : fsPath
         const uri = vscode.Uri.file(filteredFsPath)
+        // If the active editor is undefined, that means the chat panel is the active editor
+        // so we will open the file in the first visible editor instead
+        const editor = vscode.window.activeTextEditor || vscode.window.visibleTextEditors[0]
+        // If there is no editor or visible editor found, then we will open the file next to chat panel
+        const viewColumn = editor ? editor.viewColumn : vscode.ViewColumn.Beside
         const doc = await vscode.workspace.openTextDocument(uri)
-        const viewColumn = vscode.ViewColumn.Beside - 2 > 1 ? vscode.ViewColumn.Beside - 2 : vscode.ViewColumn.Beside
-        await vscode.window.showTextDocument(doc, viewColumn)
+        await vscode.window.showTextDocument(doc, { viewColumn })
     }
 
     private disposeChatPanelsManager(): void {


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/cody/issues/1819

This PR replace the vscode links with custom protocol for the file links in chat view.

- Replace the vscode file links with a custom "cody.chat.open.file" command protocol when displaying file names in chat. This allows handling file opening in a more customizable way without the error message described in the issue.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Run the /explain command, and then click on the link after the @ sign:


https://github.com/sourcegraph/cody/assets/68532117/fdf7cad2-5eb3-48c5-926a-88fb56b751b3


