### PR TITLE
example: cody pro page

### DIFF
--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -345,19 +345,14 @@ export class ChatPanelProvider extends MessageProvider {
      * NOTE: Panel doesn't support view other than 'chat' currently
      */
     public async setWebviewView(view: View): Promise<void> {
-        await this.webview?.postMessage({
-            type: 'view',
-            messages: view,
-        })
-
-        if (view !== 'chat') {
-            return
-        }
-
         if (!this.webviewPanel) {
             await this.createWebviewPanel(vscode.ViewColumn.Beside, this.sessionID)
         }
         this.webviewPanel?.reveal()
+        await this.webview?.postMessage({
+            type: 'view',
+            messages: view,
+        })
     }
 
     private startUpChatID?: string = undefined

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -9,6 +9,8 @@ import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/e
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
+import { View } from '../webviews/NavBar'
+
 import { ChatManager } from './chat/chat-view/ChatManager'
 import { ContextProvider, hackGetCodebaseContext } from './chat/ContextProvider'
 import { FixupManager } from './chat/FixupViewProvider'
@@ -384,6 +386,9 @@ const register = async (
             await chatManager.clearAndRestartSession()
             telemetryService.log('CodyVSCodeExtension:chatTitleButton:clicked', { name: 'clear' }, { hasV2Event: true })
             telemetryRecorder.recordEvent('cody.interactive.clear', 'clicked', { privateMetadata: { name: 'clear' } })
+        }),
+        vscode.commands.registerCommand('cody.chat.set.view', async (view: View) => {
+            await chatManager.setWebviewView(view)
         }),
         // TODO remove cody.interactive.clear when we remove the old chat
         vscode.commands.registerCommand('cody.interactive.clear', async () => {

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -62,6 +62,12 @@ export function createCodyChatTreeItems(userHistory: UserLocalHistory): CodySide
 
 const supportItems: CodySidebarTreeItem[] = [
     {
+        title: 'Cody Pro',
+        description: 'Lean more about Cody Pro',
+        icon: 'cody-logo',
+        command: { command: 'cody.chat.set.view', args: ['codyPro'] },
+    },
+    {
         title: 'Upgrade',
         description: 'Upgrade to Pro',
         icon: 'zap',

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -12,6 +12,7 @@ import { ChatModelSelection } from '@sourcegraph/cody-ui/src/Chat'
 import { AuthMethod, AuthStatus, LocalEnv } from '../src/chat/protocol'
 
 import { Chat } from './Chat'
+import { CodyPro } from './CodyPro'
 import { LoadingPage } from './LoadingPage'
 import { View } from './NavBar'
 import { Notices } from './Notices'
@@ -68,7 +69,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         setIsAppInstalled(message.config.isAppInstalled)
                         setEndpoint(message.authStatus.endpoint)
                         setAuthStatus(message.authStatus)
-                        setView(message.authStatus.isLoggedIn ? 'chat' : 'login')
+                        setView(message.authStatus.isLoggedIn ? view || 'chat' : 'login')
                         break
                     case 'login':
                         break
@@ -206,6 +207,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         probablyNewInstall={!!userHistory && Object.entries(userHistory).length === 0}
                     />
                     {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
+                    {view === 'codyPro' && <CodyPro />}
                     {view === 'history' && (
                         <UserHistory
                             userHistory={userHistory}

--- a/vscode/webviews/CodyPro.tsx
+++ b/vscode/webviews/CodyPro.tsx
@@ -1,0 +1,7 @@
+export const CodyPro: React.FunctionComponent<React.PropsWithChildren> = () => {
+    return (
+        <div>
+            <h1>Cody Pro</h1>
+        </div>
+    )
+}

--- a/vscode/webviews/NavBar.tsx
+++ b/vscode/webviews/NavBar.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import styles from './NavBar.module.css'
 
-export type View = 'chat' | 'login' | 'history'
+export type View = 'chat' | 'login' | 'history' | 'codyPro'
 
 interface NavBarProps {
     setView: (selectedView: View) => void


### PR DESCRIPTION
Example of clicking on a new cody pro tree item to open the cody pro webview:
<img width="2010" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/8d5496c2-adb8-4fa6-af7e-ab94ce613a22">


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
