### PR TITLE
Agent: use `uri: vscode.Uri` instead of `filePath: string`

### DIFF
--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -8,386 +8,6 @@
     },
     "entries": [
       {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 289,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluatedFeatureFlags\":[]}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a75bf503-49af-4184-8925-88d37391a864"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "2AewrpmJ2irf1LiAUyCRaV1vxcQ8xWMmuvy_hcOAgd8-1701000051-0-Aers81/1qHnp3WPugfpOsysLw7V0wSJqz5h7Cd7CyVNZVU/NrKdJm+CCSfVa+IaXpL2FoCJhDE+mo6vcv5gWmJQ="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a75bf503-49af-4184-8925-88d37391a864; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=2AewrpmJ2irf1LiAUyCRaV1vxcQ8xWMmuvy_hcOAgd8-1701000051-0-Aers81/1qHnp3WPugfpOsysLw7V0wSJqz5h7Cd7CyVNZVU/NrKdJm+CCSfVa+IaXpL2FoCJhDE+mo6vcv5gWmJQ=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "63a250ec1a74b9ab8ab5c266822dc497"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2c4a1071393aad37"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/63a250ec1a74b9ab8ab5c266822dc497"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f92f8c9b6a3c-MAN"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:45.388Z",
-        "time": 187,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 187
-        }
-      },
-      {
-        "_id": "457ee78ea180e105401d1713fa553a05",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 171,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "171"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 296,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "3f243ce6-b665-48db-adab-410c2289270a"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "eGe7Tn8vTnXwFYUquD3EM4.0X0XDwHIAHSLdgm5WmEc-1701000051-0-AYAKyew4Z8nZUi0SbMo++lZ5zKRDLOl1g9ZVL5iryM2S040BOGCiZeTcT4Hg3wDP5WmI42htADfvwR5iNbUyCEI="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3f243ce6-b665-48db-adab-410c2289270a; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=eGe7Tn8vTnXwFYUquD3EM4.0X0XDwHIAHSLdgm5WmEc-1701000051-0-AYAKyew4Z8nZUi0SbMo++lZ5zKRDLOl1g9ZVL5iryM2S040BOGCiZeTcT4Hg3wDP5WmI42htADfvwR5iNbUyCEI=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ab9c696ff739fd4aa635ba0cf05a3b34"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e1e9b146825e42bd"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ab9c696ff739fd4aa635ba0cf05a3b34"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f92f9f2d06c9-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:45.390Z",
-        "time": 220,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 220
-        }
-      },
-      {
         "_id": "1234fcdcc45995910ae0218be6622d91",
         "_order": 0,
         "cache": {},
@@ -457,30 +77,30 @@
             "encoding": "base64",
             "mimeType": "application/json",
             "size": 136,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamRoamRvFGBkbGuoaGukbG8aZ6RrqpZibmlomJFpYmZiZKtbW1AAAAAP//AwDnZxG1SQAAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamRqaG5vFGBkbGuoaGukYW8aZ6RrqpqYlJZsYpFqaGKYlKtbW1AAAAAP//AwBEZCXqSQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-11-26T12:00:51.000Z",
+              "expires": "2024-11-28T15:19:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "3e5bbd84-8682-4c7d-9604-c12ace069938"
+              "value": "50faf11a-5cf3-4234-b0b7-020a88c2acc4"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
+              "expires": "2023-11-28T15:49:15.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "MgbZLbeAztyFYTczTHoVxj51dz1hOlSdXF6fbRjrzWE-1701000051-0-AcG5LlvUul+NX+6c0AGHyFPEtWOI3w4srp4X/6L75Wyze+eggzGZtoKYCyYCoQbL/KXmewN+zSQgc1tiDcjY/KM="
+              "value": "m0nOGQ8iG_tlso6RW56gBXz0spAXippcCwmD_2kFx9s-1701184755-0-AT86jMVJu8Hab786XIUQUIurCeNscPIKvrEyl28hRiCiKgBGOY9dvTnu4wLoELJ4wlqen6Qt9NKhowOdr8wRRMc="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
+              "value": "Tue, 28 Nov 2023 15:19:15 GMT"
             },
             {
               "name": "content-type",
@@ -493,6 +113,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "557"
             },
             {
               "name": "access-control-allow-credentials",
@@ -509,12 +141,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3e5bbd84-8682-4c7d-9604-c12ace069938; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
+              "value": "sourcegraphDeviceId=50faf11a-5cf3-4234-b0b7-020a88c2acc4; Expires=Thu, 28 Nov 2024 15:19:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=MgbZLbeAztyFYTczTHoVxj51dz1hOlSdXF6fbRjrzWE-1701000051-0-AcG5LlvUul+NX+6c0AGHyFPEtWOI3w4srp4X/6L75Wyze+eggzGZtoKYCyYCoQbL/KXmewN+zSQgc1tiDcjY/KM=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=m0nOGQ8iG_tlso6RW56gBXz0spAXippcCwmD_2kFx9s-1701184755-0-AT86jMVJu8Hab786XIUQUIurCeNscPIKvrEyl28hRiCiKgBGOY9dvTnu4wLoELJ4wlqen6Qt9NKhowOdr8wRRMc=; path=/; expires=Tue, 28-Nov-23 15:49:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -530,15 +162,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e3e08284fdf94a6b877813de5281b4d4"
+              "value": "949c83caa7bb409d56e5d011e50d4083"
             },
             {
               "name": "x-trace-span",
-              "value": "861cd602c68f9b22"
+              "value": "51e1a1f37cbaa720"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e3e08284fdf94a6b877813de5281b4d4"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/949c83caa7bb409d56e5d011e50d4083"
             },
             {
               "name": "x-xss-protection",
@@ -562,21 +194,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "82c1f9312874888f-LHR"
+              "value": "82d39692db387129-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-11-26T12:00:45.650Z",
-        "time": 197,
+        "startedDateTime": "2023-11-28T15:19:15.540Z",
+        "time": 235,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -584,207 +216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 197
-        }
-      },
-      {
-        "_id": "26f7093bcc1d125e7768f46a33e590e8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 318,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "318"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 337,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 208,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 208,
-            "text": "[\"H4sIAAAAAAAAA4yOwQqDMBBE/2XPitFbc/Vqbv2BJYkamu6KWcEi+feil5YcSk8Dw5vHHOBQEPQBKYg/07J7DYPpmcYwbStKYLr6GcWw8xE0IMm88hJsYyNuztcdVB/A4H7nh6cEuu2UUhWMmKT/tQ+UBEnqFgr4y3W7VJafS/Tnqb9kBV7ocs75DQAA//8DAEB8TJgCAQAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e1f8215f-5abd-464f-9724-3923537a35d2"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "l5vrSYOBHYOavt3rlnZBRLSAuma3u76SskhHrdRoPcg-1701000051-0-AZUtm9Mp/LXJXKNVVThm7Kk2bu5e9+S/PgBVf91q33FFpF1k8QMc7pZM8hHH1kwoPOAgG7Xs5oZMFDgf5lVFhik="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e1f8215f-5abd-464f-9724-3923537a35d2; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=l5vrSYOBHYOavt3rlnZBRLSAuma3u76SskhHrdRoPcg-1701000051-0-AZUtm9Mp/LXJXKNVVThm7Kk2bu5e9+S/PgBVf91q33FFpF1k8QMc7pZM8hHH1kwoPOAgG7Xs5oZMFDgf5lVFhik=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "15e02997a8dbf26dac7785e3942dd78a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e93460ac7e6c262c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/15e02997a8dbf26dac7785e3942dd78a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f9314b4152a6-LHR"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:45.652Z",
-        "time": 198,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 198
+          "wait": 235
         }
       },
       {
@@ -852,35 +284,35 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
         },
         "response": {
-          "bodySize": 128,
+          "bodySize": 138,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 128,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+            "size": 138,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP8=\",\"/w==\",\"AwAfFAXARQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-11-26T12:00:51.000Z",
+              "expires": "2024-11-28T15:19:16.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "57c9ff01-cbe2-4c36-8a3a-7d34f0d31432"
+              "value": "0200e2db-4051-4218-99a6-94dbdd330656"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
+              "expires": "2023-11-28T15:49:16.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Xmu6fIKU.yis5aGZnMb3d6ZGo6R38aaKKWHi7YzcY8s-1701000051-0-AUqtDkmb5bLDdoJbABZsWVB1dn8eB7frHHA6rjaTRKSgjblDIGPIhPqw1E9reuNpDQ5hlrYU3FSfkej9C5u9iqM="
+              "value": "8.rLRACCpvcnEGl6GqT3rYF.8Hr9ME3me7MHMhLOFQk-1701184756-0-AeAtRhg10+V7Nx5A1hAFv1shTid5wWyaHnFNFwrNTFs9MXe2g0Mcm5vcsrNZRNaG/nkuMCWxC9QDup5LbULvCB4="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
+              "value": "Tue, 28 Nov 2023 15:19:16 GMT"
             },
             {
               "name": "content-type",
@@ -893,6 +325,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "556"
             },
             {
               "name": "access-control-allow-credentials",
@@ -909,12 +353,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=57c9ff01-cbe2-4c36-8a3a-7d34f0d31432; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
+              "value": "sourcegraphDeviceId=0200e2db-4051-4218-99a6-94dbdd330656; Expires=Thu, 28 Nov 2024 15:19:16 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=Xmu6fIKU.yis5aGZnMb3d6ZGo6R38aaKKWHi7YzcY8s-1701000051-0-AUqtDkmb5bLDdoJbABZsWVB1dn8eB7frHHA6rjaTRKSgjblDIGPIhPqw1E9reuNpDQ5hlrYU3FSfkej9C5u9iqM=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=8.rLRACCpvcnEGl6GqT3rYF.8Hr9ME3me7MHMhLOFQk-1701184756-0-AeAtRhg10+V7Nx5A1hAFv1shTid5wWyaHnFNFwrNTFs9MXe2g0Mcm5vcsrNZRNaG/nkuMCWxC9QDup5LbULvCB4=; path=/; expires=Tue, 28-Nov-23 15:49:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -930,15 +374,15 @@
             },
             {
               "name": "x-trace",
-              "value": "cc7725b62924c91d77ee36589c1f97d3"
+              "value": "f7c911ed61140db121ee5143722d7bdf"
             },
             {
               "name": "x-trace-span",
-              "value": "65759b9ac85346da"
+              "value": "841307c3ba575b88"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cc7725b62924c91d77ee36589c1f97d3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f7c911ed61140db121ee5143722d7bdf"
             },
             {
               "name": "x-xss-protection",
@@ -962,21 +406,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "82c1f9313ad3074b-MAN"
+              "value": "82d3969769561c16-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-11-26T12:00:45.653Z",
-        "time": 219,
+        "startedDateTime": "2023-11-28T15:19:16.279Z",
+        "time": 222,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -984,7 +428,219 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 219
+          "wait": 222
+        }
+      },
+      {
+        "_id": "26f7093bcc1d125e7768f46a33e590e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 318,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "318"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 337,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:16.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "e945955d-12bb-43ab-91eb-ea11c033cbbb"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:16.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "QM54qTdKIm0Rm1yE6xdo.VRoyp2.wDw_NV8gyWprdDU-1701184756-0-AYnKPr29AUIU1WIJpRziXy+mGx07QfL13mMZPSwlEs/uVts/8av6Mg1oIq1nS6TZ3tWqXlhICUfW2WBTYia/Gug="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:16 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "556"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=e945955d-12bb-43ab-91eb-ea11c033cbbb; Expires=Thu, 28 Nov 2024 15:19:16 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=QM54qTdKIm0Rm1yE6xdo.VRoyp2.wDw_NV8gyWprdDU-1701184756-0-AYnKPr29AUIU1WIJpRziXy+mGx07QfL13mMZPSwlEs/uVts/8av6Mg1oIq1nS6TZ3tWqXlhICUfW2WBTYia/Gug=; path=/; expires=Tue, 28-Nov-23 15:49:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "ef1130d56acc8147938affa05afe092b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c8b9eb891cdff697"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ef1130d56acc8147938affa05afe092b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396976fac568f-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:16.276Z",
+        "time": 576,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 576
         }
       },
       {
@@ -1052,35 +708,35 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
         },
         "response": {
-          "bodySize": 164,
+          "bodySize": 156,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 164,
-            "text": "[\"H4sIAAAAAAAAAxTHQQ6DIBAF0Lv8tScgcSfL2m4kbqfMGGlQkgGTCuHuTd/uNTAVgmnwl6qcZcmi/waGgVvn6D/p+6i2Pic7YsBO2YmGLQjbg0KEKXrJAJ/4fmmyJ72jMMxGMUvv/QcAAP//AwCkVx2QYQAAAA==\"]"
+            "size": 156,
+            "text": "[\"H4sIAAAAAAAAAxTHsQ5AMBAG4Hf5Z6ulM2tjIYynd6JSmlzbAem7i2/7XjBlgnnhiqpceUyifz3DYJptcEd8bLe0aLBTmkT95oX7k3yAyVqkgYt8Dxr7i9YgDLNRSFJr/QAAAP//AwDEJLhpXQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-11-26T12:00:51.000Z",
+              "expires": "2024-11-28T15:19:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7821426f-0c0a-4e17-98d4-88e19746310d"
+              "value": "d5eb4d98-bcec-4342-b5ec-a83baa4bba64"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
+              "expires": "2023-11-28T15:49:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3v6hA7vmOR8LTZhAJMwpK_DDbnnZbnAoYPQslIEAtDk-1701000051-0-Abpt1lwpjZS2zX5BwbZJRaUKc1oc0xx/vhJFakhUjcb2OBvWihTjk58V9ByPtG2wh7Iz2R/25S48soSz3kEDbzU="
+              "value": "35lSd_I44nN8qjUM4M1kxyQUEDCdZ2eiKkQNfJT7F0M-1701184757-0-AVTxtOGO9gLFC0UYgKYXN99+He4BqS5MssjTIWvdb0l1cErW9DGD7UKNJMEp3iwrxIy1jSJzYDHYWKa5DaWL6xo="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
             },
             {
               "name": "content-type",
@@ -1093,6 +749,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "556"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1109,12 +777,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7821426f-0c0a-4e17-98d4-88e19746310d; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
+              "value": "sourcegraphDeviceId=d5eb4d98-bcec-4342-b5ec-a83baa4bba64; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3v6hA7vmOR8LTZhAJMwpK_DDbnnZbnAoYPQslIEAtDk-1701000051-0-Abpt1lwpjZS2zX5BwbZJRaUKc1oc0xx/vhJFakhUjcb2OBvWihTjk58V9ByPtG2wh7Iz2R/25S48soSz3kEDbzU=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=35lSd_I44nN8qjUM4M1kxyQUEDCdZ2eiKkQNfJT7F0M-1701184757-0-AVTxtOGO9gLFC0UYgKYXN99+He4BqS5MssjTIWvdb0l1cErW9DGD7UKNJMEp3iwrxIy1jSJzYDHYWKa5DaWL6xo=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1130,15 +798,15 @@
             },
             {
               "name": "x-trace",
-              "value": "00bfb909b0fe5dc75983e870fbdd8af9"
+              "value": "e3b462602c413afbc882bfddef4a1804"
             },
             {
               "name": "x-trace-span",
-              "value": "81f15c70697d40f0"
+              "value": "7b91ec0da8dc6881"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/00bfb909b0fe5dc75983e870fbdd8af9"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e3b462602c413afbc882bfddef4a1804"
             },
             {
               "name": "x-xss-protection",
@@ -1162,21 +830,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "82c1f932ad9a54cf-MAN"
+              "value": "82d3969b09e4b500-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-11-26T12:00:45.895Z",
-        "time": 191,
+        "startedDateTime": "2023-11-28T15:19:16.859Z",
+        "time": 214,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1184,7 +852,840 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 191
+          "wait": 214
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 318,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 711,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 711,
+            "text": "[\"H4sIAAAAAAAA/5SUUW7jOAyG7+Ln8gI5QC+x2AeKYiwisuSSVBxv0bsv5A46bTOOO28GLP76+esjX4eIjsPpdeAr5obO8ZnRm/JzxtGG0w==\",\"P69DwYmH00A1roDNK9VpzuwMGcvYcOwfzoXW4WnoIjycXBu/PX2UjjrT7s9Nd+EAHMWrgjLJzLZ73hiVEtSlsFqS+aHwQ0vwX+WLPzb2pWGqxfnmEM4jTHLj+Lv2jNk+F2OcpAAWzKsLGXDBkD8XfLts1hobOVgLRiqzSy0GxnoVYkCi2orvX/crlMihjYenFMtFyrjrxTnzxK4r8G2uepAQ32ZWmbg45qNH2wIsDgGN48YPRHam3u2+7ffswFwZJykjjOIQcv+5dx8GuIptPHltCot4glKdQ62XQ7YKL3Dhdan64IW35imhw1TpAs52EFRnHPN+Rve8RT5jyw7mqFQjK6Q1qESw2pR4VJzTI4PFFc1h0xMsDrYWxxskGVOWMfkXCr7X/xlJZexGfkzmz7s6epWDU/cXuSI97PClCV02H/6Oyblql0hcXKgvQ2jGaj8fc0JKDFHs27Tf1RGxmXSsz5K7Vd6HOeQaYO6L1hZxSoDKaGCpqlPzfZw/sDOJHFCPEpYyN++6CyQxr7q/Pz+k+wT8DdLv0fQtv1Luw1zPMCtfpbYO10tj87vA/317+z8AAP//07rSRqoGAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2da53b89-16d0-41cd-bc7a-96e855069c58"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "zToeqyrK2hm4mHokvgw4l.sVKBa1_eCxA.pVqIrrgTM-1701184757-0-AbkueFB2jAmE+/cFzY6uCIa+cS6wY+3D20VbmKsDIweqW/hbA0ciT9FjX3Au8ThDQd0ktkTfz+wCMdxyVXTjD0g="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "556"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2da53b89-16d0-41cd-bc7a-96e855069c58; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=zToeqyrK2hm4mHokvgw4l.sVKBa1_eCxA.pVqIrrgTM-1701184757-0-AbkueFB2jAmE+/cFzY6uCIa+cS6wY+3D20VbmKsDIweqW/hbA0ciT9FjX3Au8ThDQd0ktkTfz+wCMdxyVXTjD0g=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "2944aed4bb1067b656bcfb1392b9308e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "ebaf4752538ce26c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2944aed4bb1067b656bcfb1392b9308e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969c79b1568b-OSL"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.095Z",
+        "time": 228,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 228
+        }
+      },
+      {
+        "_id": "457ee78ea180e105401d1713fa553a05",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 171,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "171"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "dbc6326f-077a-4717-bf10-aab494e93b0b"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "QMeOLt.ESeiQSbLi02enNsZU37XnohdbgNuw8I06SqQ-1701184757-0-Abad3GqMlJVMbXdGDePPoWeo0TEoaSJig7VNGQF3wr1jgD2wxcF2Fe8r9na7ctVkbnF7uhed3Lso9ZTk8z0d3/s="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "556"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=dbc6326f-077a-4717-bf10-aab494e93b0b; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=QMeOLt.ESeiQSbLi02enNsZU37XnohdbgNuw8I06SqQ-1701184757-0-Abad3GqMlJVMbXdGDePPoWeo0TEoaSJig7VNGQF3wr1jgD2wxcF2Fe8r9na7ctVkbnF7uhed3Lso9ZTk8z0d3/s=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "55aa82de218d2d77c5ed44bec73f26d6"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "f29db636bb088d7a"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/55aa82de218d2d77c5ed44bec73f26d6"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969c887b56a2-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.102Z",
+        "time": 226,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 226
+        }
+      },
+      {
+        "_id": "68618dc68610496fb5623c6778ea6c25",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 177,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "177"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2b4baba2-7826-4fc8-9ec9-e52908e261cf"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "NoWCFgouc9jF6f7Gb.ibtvrLHOIEI6XLn6dvjL5TZX8-1701184757-0-AQBi1dRq72wLzAj1HAtXc+BvbywcVy8bYiRMSsSbJS2K7f+q2cSwiC5/kzkucyoWGUYGwxABx50BkrzRnzaIrmM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "556"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2b4baba2-7826-4fc8-9ec9-e52908e261cf; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=NoWCFgouc9jF6f7Gb.ibtvrLHOIEI6XLn6dvjL5TZX8-1701184757-0-AQBi1dRq72wLzAj1HAtXc+BvbywcVy8bYiRMSsSbJS2K7f+q2cSwiC5/kzkucyoWGUYGwxABx50BkrzRnzaIrmM=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "095a105da0d2f8752cdb0ba4e87f4d03"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3f95426ee3b968ee"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/095a105da0d2f8752cdb0ba4e87f4d03"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969c7df71bfa-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.098Z",
+        "time": 242,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 242
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ac6dbd6c-a672-42f6-a021-5919aa23bb78"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "P688e_FDX17XV4qz6LkEuhGEpMd5ENY.xWyc2je7X.Y-1701184757-0-AQNnozBHzY6IjZs+IZxMZRVN3nb06tmcXgD3GnXVBbZBEXmAk81uF7aYPIgyoHZ8kPnK0N6HksdPXBCzJrAsZ6s="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "555"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ac6dbd6c-a672-42f6-a021-5919aa23bb78; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=P688e_FDX17XV4qz6LkEuhGEpMd5ENY.xWyc2je7X.Y-1701184757-0-AQNnozBHzY6IjZs+IZxMZRVN3nb06tmcXgD3GnXVBbZBEXmAk81uF7aYPIgyoHZ8kPnK0N6HksdPXBCzJrAsZ6s=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "149101c9302f6042755675edb00bd4fe"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "bbf6286d0b229c01"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/149101c9302f6042755675edb00bd4fe"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969e39690b69-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.363Z",
+        "time": 238,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 238
         }
       },
       {
@@ -1195,6 +1696,11 @@
           "bodySize": 208,
           "cookies": [],
           "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
             {
               "_fromType": "array",
               "name": "content-type",
@@ -1230,7 +1736,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 258,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1247,34 +1753,34 @@
           "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 37,
+          "bodySize": 38,
           "content": {
             "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
           },
           "cookies": [
             {
-              "expires": "2024-11-26T12:00:51.000Z",
+              "expires": "2024-11-28T15:19:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "996d5014-2747-4bdf-8fcd-a7e761458298"
+              "value": "0d80e77b-2d94-4569-b29f-a5af94e2467b"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
+              "expires": "2023-11-28T15:49:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Js1O1SUhLza8nY4s3gvYY7_GCtNpUREqr4mxLW7R16k-1701000051-0-AYCxiA7s07qBRgfU6N7JJoKXG5kCiB6NbccxsGlRKsppNhAPMc2FLM2zhJNsJuQXBBMEuBg6wy3e0i+DbTKdR14="
+              "value": "kMkRdm_P2DslF0L9sf9cSN9eabXEOO9RMnm0Ze.dn_4-1701184757-0-AWMCmzkL91rEnjOxjU5yMG0GbkMMClCqB2vLaGmdEK8cPKFYGgvC6Ig6xBOix+2J+/Ex6/YNDR7CR/ifaEgWl+I="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
             },
             {
               "name": "content-type",
@@ -1282,11 +1788,23 @@
             },
             {
               "name": "content-length",
-              "value": "37"
+              "value": "38"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "555"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1303,12 +1821,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=996d5014-2747-4bdf-8fcd-a7e761458298; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
+              "value": "sourcegraphDeviceId=0d80e77b-2d94-4569-b29f-a5af94e2467b; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=Js1O1SUhLza8nY4s3gvYY7_GCtNpUREqr4mxLW7R16k-1701000051-0-AYCxiA7s07qBRgfU6N7JJoKXG5kCiB6NbccxsGlRKsppNhAPMc2FLM2zhJNsJuQXBBMEuBg6wy3e0i+DbTKdR14=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=kMkRdm_P2DslF0L9sf9cSN9eabXEOO9RMnm0Ze.dn_4-1701184757-0-AWMCmzkL91rEnjOxjU5yMG0GbkMMClCqB2vLaGmdEK8cPKFYGgvC6Ig6xBOix+2J+/Ex6/YNDR7CR/ifaEgWl+I=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1324,15 +1842,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e6f3acd4759cb9ef2e8f8fb6799c7a35"
+              "value": "55d753a599a737adcce53cc5e91eea65"
             },
             {
               "name": "x-trace-span",
-              "value": "88eb6b93881a757a"
+              "value": "83aaf9db7157b974"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e6f3acd4759cb9ef2e8f8fb6799c7a35"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/55d753a599a737adcce53cc5e91eea65"
             },
             {
               "name": "x-xss-protection",
@@ -1356,17 +1874,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "82c1f9341a4c71ce-LHR"
+              "value": "82d3969e3a810b65-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-11-26T12:00:46.125Z",
-        "time": 170,
+        "startedDateTime": "2023-11-28T15:19:17.369Z",
+        "time": 233,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1374,7 +1892,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 170
+          "wait": 233
         }
       },
       {
@@ -1385,6 +1903,11 @@
           "bodySize": 181,
           "cookies": [],
           "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
             {
               "_fromType": "array",
               "name": "content-type",
@@ -1420,7 +1943,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 258,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1445,26 +1968,2465 @@
           },
           "cookies": [
             {
-              "expires": "2024-11-26T12:00:51.000Z",
+              "expires": "2024-11-28T15:19:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6df5ccd8-f9ae-4b32-ae8b-0cda5b3df5d2"
+              "value": "d71bc8c5-a798-4fed-a70c-e21c33142779"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
+              "expires": "2023-11-28T15:49:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "VKdVKVGLBI.HjfZvS6ywzjAOYnZpFqiETWiFt8nA1vs-1701000051-0-AcyZPlGcOVzqqz0TTRQJwpESh0tdVsgNQpLuEqrnrmrExGX1MNz+LVDSY1hY0dGOA4IxrKybCRAJv7HZudFPNmQ="
+              "value": "P96xWPFXCfht4eKR3sZ69RorW2rI4p7CcpoAtVUExek-1701184757-0-ATir8/wQ1i8AjJ2ptKaej3MplNyBRFTkqUl6Hf+RLRr6mS4N7zdi5LnTmtHnC40VMgnVtXCTaHQe/kz5fguSO7E="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "555"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=d71bc8c5-a798-4fed-a70c-e21c33142779; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=P96xWPFXCfht4eKR3sZ69RorW2rI4p7CcpoAtVUExek-1701184757-0-ATir8/wQ1i8AjJ2ptKaej3MplNyBRFTkqUl6Hf+RLRr6mS4N7zdi5LnTmtHnC40VMgnVtXCTaHQe/kz5fguSO7E=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e8742fdb20376197146ab02e5b4b2f0d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "7df9f4216060f18d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e8742fdb20376197146ab02e5b4b2f0d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969e38630afa-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.360Z",
+        "time": 290,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 290
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "df95e4bd-04ea-4635-b204-41eccfdfd4e3"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "sM0OhYpGjDdJdAN70ryW8ojmrizQSPLhKseAT9Y44lI-1701184757-0-AdAn8QRypM8+XaYe6CQ/Yedpzft9YpvqtdWvLihdbw4icYTWeUOJv/sANF8vUg647a/8z22x8yXHe3DBLrUMDXM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "555"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=df95e4bd-04ea-4635-b204-41eccfdfd4e3; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=sM0OhYpGjDdJdAN70ryW8ojmrizQSPLhKseAT9Y44lI-1701184757-0-AdAn8QRypM8+XaYe6CQ/Yedpzft9YpvqtdWvLihdbw4icYTWeUOJv/sANF8vUg647a/8z22x8yXHe3DBLrUMDXM=; path=/; expires=Tue, 28-Nov-23 15:49:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "244b0e55cfa8adbb75e2263b5a52ded0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a5674c1e383f5078"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/244b0e55cfa8adbb75e2263b5a52ded0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969e3e2b5687-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.366Z",
+        "time": 414,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 414
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "4bdd62af-e2ec-4da0-a053-160729541fe4"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:18.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "KyhYIycysD.kw0SHH.bZwTBeUBtZECV60.k_do9sroY-1701184758-0-AQUcGoXJFc2Mwd4Sw3Bs8CtssgPKhJtux0kqTY63BDKtccwapQQSir/JoWodZUiEdkpsvhY5BC1IazbGzwbrpq8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:18 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "555"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4bdd62af-e2ec-4da0-a053-160729541fe4; Expires=Thu, 28 Nov 2024 15:19:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=KyhYIycysD.kw0SHH.bZwTBeUBtZECV60.k_do9sroY-1701184758-0-AQUcGoXJFc2Mwd4Sw3Bs8CtssgPKhJtux0kqTY63BDKtccwapQQSir/JoWodZUiEdkpsvhY5BC1IazbGzwbrpq8=; path=/; expires=Tue, 28-Nov-23 15:49:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c45de7e060735108ff4fa2dad0371715"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a74df70796556279"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c45de7e060735108ff4fa2dad0371715"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3969e3d050b31-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:17.354Z",
+        "time": 606,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 606
+        }
+      },
+      {
+        "_id": "4cb0e95333a7b013a23cbf416464bd74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:19.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "db44b545-cece-492a-aa62-1eece7ab0486"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:19.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "iJPOCOHCwEiC2_3HzeFn8h7gn9CjRmxSpMGqz1EkbAk-1701184759-0-Afme+p/EGyvlhIQlJwYjDJJepp+VPOvUCGnRnq5KVyfEoCCoURpk8bj3bH67AfqUik0cvGzhbCP2rqrv418DOVM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:19 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "554"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=db44b545-cece-492a-aa62-1eece7ab0486; Expires=Thu, 28 Nov 2024 15:19:19 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=iJPOCOHCwEiC2_3HzeFn8h7gn9CjRmxSpMGqz1EkbAk-1701184759-0-Afme+p/EGyvlhIQlJwYjDJJepp+VPOvUCGnRnq5KVyfEoCCoURpk8bj3bH67AfqUik0cvGzhbCP2rqrv418DOVM=; path=/; expires=Tue, 28-Nov-23 15:49:19 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3af59f089c36b660a9fcae80cbf6574a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a491b77a34af9618"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3af59f089c36b660a9fcae80cbf6574a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396a9da4c5685-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:19.230Z",
+        "time": 214,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 214
+        }
+      },
+      {
+        "_id": "3bfde46a074296956deef9dbd207df0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:19.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "a4ba3314-a69a-4113-8170-fa9d7c78ce62"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:19.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "xN4f8XFa2sSpX2uhx_T3TbJnqTV.CIXnryAuaDSGdyk-1701184759-0-AV+jh6IcsF/1aGAOS5+GojiD4emhf60afyBf7Pig1OKnKUQ6Wog3yfP0iRR3fSPrijxYqvHRuIb8i5gg1sAf6Xc="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:19 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "554"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=a4ba3314-a69a-4113-8170-fa9d7c78ce62; Expires=Thu, 28 Nov 2024 15:19:19 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=xN4f8XFa2sSpX2uhx_T3TbJnqTV.CIXnryAuaDSGdyk-1701184759-0-AV+jh6IcsF/1aGAOS5+GojiD4emhf60afyBf7Pig1OKnKUQ6Wog3yfP0iRR3fSPrijxYqvHRuIb8i5gg1sAf6Xc=; path=/; expires=Tue, 28-Nov-23 15:49:19 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "2ca5f4159a119f087283d811f6b3c477"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "79352dcac5668e88"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2ca5f4159a119f087283d811f6b3c477"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396a9dbcc5694-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:19.232Z",
+        "time": 217,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 217
+        }
+      },
+      {
+        "_id": "ac7fc975d31f02e814346a770195c756",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 192,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "192"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:19.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "9d44c147-8e8f-4e8a-bba3-bff53969af45"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:19.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "KAdFB1xYEyd7nsBDRtEWUVLhSuW9KGVRc26AX4pHcrI-1701184759-0-AbMAYQ9YHksgEEmP8OxVtCAuDFTolWseOaBXf7MOHOV/jeKERLjtR0QA96XHfAuD1Yf1olbn4FxRYU8iOdlk1F8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:19 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "554"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=9d44c147-8e8f-4e8a-bba3-bff53969af45; Expires=Thu, 28 Nov 2024 15:19:19 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=KAdFB1xYEyd7nsBDRtEWUVLhSuW9KGVRc26AX4pHcrI-1701184759-0-AbMAYQ9YHksgEEmP8OxVtCAuDFTolWseOaBXf7MOHOV/jeKERLjtR0QA96XHfAuD1Yf1olbn4FxRYU8iOdlk1F8=; path=/; expires=Tue, 28-Nov-23 15:49:19 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "770d71366a9c20e8ac2d17b06fbef1ce"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "dddf4c4cc8173a98"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/770d71366a9c20e8ac2d17b06fbef1ce"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396a9dffc56c7-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:19.234Z",
+        "time": 219,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 219
+        }
+      },
+      {
+        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 190,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "190"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:19.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "24f594a6-9c20-4b00-91f5-c764bbd24b23"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:19.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "kpO1.0a_sVPylmJvTFxPs_WfmECWiy2mQH_t9H.JCYo-1701184759-0-AaGXgIh3j03D+scGHqXHKGWdo5467k0+Ha6qL2bO5zwvm06zXQh2n/XOqkRTm/uZf1YTnMKGPK0EloAzcHWwwNM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:19 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "554"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=24f594a6-9c20-4b00-91f5-c764bbd24b23; Expires=Thu, 28 Nov 2024 15:19:19 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=kpO1.0a_sVPylmJvTFxPs_WfmECWiy2mQH_t9H.JCYo-1701184759-0-AaGXgIh3j03D+scGHqXHKGWdo5467k0+Ha6qL2bO5zwvm06zXQh2n/XOqkRTm/uZf1YTnMKGPK0EloAzcHWwwNM=; path=/; expires=Tue, 28-Nov-23 15:49:19 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "433d7bcead539783ada060d3b7173af8"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "814e0f3d34472dae"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/433d7bcead539783ada060d3b7173af8"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396a9da4a5685-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:19.228Z",
+        "time": 242,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 242
+        }
+      },
+      {
+        "_id": "7449140909c921a511332d4c1de94c1f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 182,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "a8e1653a-c1c1-47e5-99ac-a41cf38aa43d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "nyC5032xmG1tieDDfPH8uffKc9iTqZZHgNWW2Bsw7e4-1701184760-0-AZrxXmnJEPSLsfkICdAGWjV5riuVIHI8OfddDtHJEeEZ3kRyGQIvoOiA+GwTYGwFuYuxeG+hDCJV21tCbXtkJac="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "552"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=a8e1653a-c1c1-47e5-99ac-a41cf38aa43d; Expires=Thu, 28 Nov 2024 15:19:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=nyC5032xmG1tieDDfPH8uffKc9iTqZZHgNWW2Bsw7e4-1701184760-0-AZrxXmnJEPSLsfkICdAGWjV5riuVIHI8OfddDtHJEeEZ3kRyGQIvoOiA+GwTYGwFuYuxeG+hDCJV21tCbXtkJac=; path=/; expires=Tue, 28-Nov-23 15:49:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d6288c4211dd805947f8b1f28c322ee0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e216f6e56d543a1d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d6288c4211dd805947f8b1f28c322ee0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396b11e091bfe-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:20.402Z",
+        "time": 207,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 207
+        }
+      },
+      {
+        "_id": "03c26228549f19324c6c7aa44f045c3a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 309,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "309"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 319,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topP\":0.95,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/code"
+        },
+        "response": {
+          "bodySize": 172,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 172,
+            "text": "event: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "811a719d-9eba-4eb2-b5be-11f6faff4fa6"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Y0mB.xtBTdjLJdKbW_yNmu.xYz9vGRKkTBTnkIjj8D0-1701184761-0-AXQERdOZH+Hl0IOFL24228bscb7nPDDupToekEOMXSLGiMVxjJRPOz6XATBalFz0T6mPZS+bS0eXs+kArdzp7LI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "552"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=811a719d-9eba-4eb2-b5be-11f6faff4fa6; Expires=Thu, 28 Nov 2024 15:19:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Y0mB.xtBTdjLJdKbW_yNmu.xYz9vGRKkTBTnkIjj8D0-1701184761-0-AXQERdOZH+Hl0IOFL24228bscb7nPDDupToekEOMXSLGiMVxjJRPOz6XATBalFz0T6mPZS+bS0eXs+kArdzp7LI=; path=/; expires=Tue, 28-Nov-23 15:49:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "820adf6b49ce763b464169b68fa98988"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "105152e466592f37"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/820adf6b49ce763b464169b68fa98988"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396b2996c0b49-OSL"
+            }
+          ],
+          "headersSize": 1239,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:20.626Z",
+        "time": 511,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 511
+        }
+      },
+      {
+        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 333,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "333"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "49258259-8f23-4368-88b4-a6b4333a9a9e"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": ".KZtTikuLow7HNNLzJ5U7OgHkU.qkLc1nCISU3keST0-1701184763-0-AbFcmsrBYAPC7AsWNzZWY8NjmssDmSu2kl0+Yknn9zj77IIHmWWghjX4LoRQiobfGeIHvSmICza7CC0FYI2q4No="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "551"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=49258259-8f23-4368-88b4-a6b4333a9a9e; Expires=Thu, 28 Nov 2024 15:19:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=.KZtTikuLow7HNNLzJ5U7OgHkU.qkLc1nCISU3keST0-1701184763-0-AbFcmsrBYAPC7AsWNzZWY8NjmssDmSu2kl0+Yknn9zj77IIHmWWghjX4LoRQiobfGeIHvSmICza7CC0FYI2q4No=; path=/; expires=Tue, 28-Nov-23 15:49:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8dcb78a102fd08659f58950bfc121262"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "6c737fd6d6c404b1"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8dcb78a102fd08659f58950bfc121262"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396b95ac41c16-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:21.714Z",
+        "time": 1545,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1545
+        }
+      },
+      {
+        "_id": "34fa3baab68c77b4e329fd24907b91f7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1300,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 217,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/stream"
+        },
+        "response": {
+          "bodySize": 43445,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 43445,
+            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum` function you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum` function you need\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum` function you need implemented\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum` function you need implemented.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the desired behavior, input, output, and programming language, I may be able to suggest a possible implementation. However, without additional context I do not want to make assumptions or provide misleading examples. Please let me know if you can provide any more details about the specific `sum` function you need implemented.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:19:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3c7f2ace-2760-432b-bda9-a4187140dac5"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:49:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "pIPqEJTRsJHNzYI8LMn.op5iLHm8_b9d.Hfv6lLTVuI-1701184763-0-AVdCwdCa0vMhkIqbvmrHY4S76iSdpnYeey7gH57/FkdVw3dXanO2PmbfhhnLRKV+ax+aOzntTgroGbcWz7cxTf4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:19:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "551"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3c7f2ace-2760-432b-bda9-a4187140dac5; Expires=Thu, 28 Nov 2024 15:19:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=pIPqEJTRsJHNzYI8LMn.op5iLHm8_b9d.Hfv6lLTVuI-1701184763-0-AVdCwdCa0vMhkIqbvmrHY4S76iSdpnYeey7gH57/FkdVw3dXanO2PmbfhhnLRKV+ax+aOzntTgroGbcWz7cxTf4=; path=/; expires=Tue, 28-Nov-23 15:49:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "7c15c9ca04b0a96b6db5c5c69e04784c"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "188ba0da6b5a8168"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7c15c9ca04b0a96b6db5c5c69e04784c"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d396b7e98856a8-OSL"
+            }
+          ],
+          "headersSize": 1239,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:19:21.491Z",
+        "time": 5085,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 5085
+        }
+      },
+      {
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 164,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "164"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 257,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "SiteIdentification",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:16:51.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "8699e9a7-dede-4a7e-b9df-33f4f6510d9d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:46:51.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "mRsZdr1fNFUgjOBMpyhOrK2OcbBLREvjiXodk4RCPqw-1701184611-0-Ac3BVk1JXCpiBtgaxRVo9Pe70SSnH9LrI0CFRHFxmFKC1lOxmp2xRrMve3vbZuPPp7thP5qfGnQxzOFX3ltsWo8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:16:51 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=8699e9a7-dede-4a7e-b9df-33f4f6510d9d; Expires=Thu, 28 Nov 2024 15:16:51 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=mRsZdr1fNFUgjOBMpyhOrK2OcbBLREvjiXodk4RCPqw-1701184611-0-Ac3BVk1JXCpiBtgaxRVo9Pe70SSnH9LrI0CFRHFxmFKC1lOxmp2xRrMve3vbZuPPp7thP5qfGnQxzOFX3ltsWo8=; path=/; expires=Tue, 28-Nov-23 15:46:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c1d6f7a6c81b2202811852e8904594c2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "2c2302e833f11824"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c1d6f7a6c81b2202811852e8904594c2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "82d3930a7ff9b500-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-11-28T15:16:50.850Z",
+        "time": 227,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 227
+        }
+      },
+      {
+        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 160,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "160"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 258,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-11-28T15:16:51.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "c21f90de-e2d2-4582-8c38-419910ab1420"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-11-28T15:46:51.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "94D54SleD3jSkmhYF2WynA72kCwvTcXMVouPefSJTgw-1701184611-0-AeoZDJ/sHorg+NQOoJIVnS0T/7Jy/rf/bcs8kwS+1byYnv58YqdlGrrHhiIt0NufBiJJTsiVM9/GmEqKFnZsvx0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Tue, 28 Nov 2023 15:16:51 GMT"
             },
             {
               "name": "content-type",
@@ -1493,12 +4455,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6df5ccd8-f9ae-4b32-ae8b-0cda5b3df5d2; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
+              "value": "sourcegraphDeviceId=c21f90de-e2d2-4582-8c38-419910ab1420; Expires=Thu, 28 Nov 2024 15:16:51 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=VKdVKVGLBI.HjfZvS6ywzjAOYnZpFqiETWiFt8nA1vs-1701000051-0-AcyZPlGcOVzqqz0TTRQJwpESh0tdVsgNQpLuEqrnrmrExGX1MNz+LVDSY1hY0dGOA4IxrKybCRAJv7HZudFPNmQ=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=94D54SleD3jSkmhYF2WynA72kCwvTcXMVouPefSJTgw-1701184611-0-AeoZDJ/sHorg+NQOoJIVnS0T/7Jy/rf/bcs8kwS+1byYnv58YqdlGrrHhiIt0NufBiJJTsiVM9/GmEqKFnZsvx0=; path=/; expires=Tue, 28-Nov-23 15:46:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1514,15 +4476,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d45dc55f50d86d930296587e3108314f"
+              "value": "79b30663957aad6d18661860d5dfa399"
             },
             {
               "name": "x-trace-span",
-              "value": "d55173e535bedde5"
+              "value": "72f95cd70edabdc3"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d45dc55f50d86d930296587e3108314f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/79b30663957aad6d18661860d5dfa399"
             },
             {
               "name": "x-xss-protection",
@@ -1546,7 +4508,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "82c1f9340f35074e-MAN"
+              "value": "82d3930c0935b50c-OSL"
             }
           ],
           "headersSize": 1129,
@@ -1555,8 +4517,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-11-26T12:00:46.120Z",
-        "time": 179,
+        "startedDateTime": "2023-11-28T15:16:51.092Z",
+        "time": 219,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1564,7 +4526,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 179
+          "wait": 219
         }
       },
       {
@@ -1755,1161 +4717,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 183
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 258,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "56e58e75-ed4e-4774-9cb6-f955aa1fb13d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "K60xmU352egJkuxu7gHZVkkhSc7J3C1DpNjEzLYMXbk-1701000051-0-AaAWB9IpY4Qd/3fGwhFf4N4N38t3Z1ZRAD4ovI8AMXsEA8Zf8WrZzpP1DOy9zcuTeEI8GSzABauBKbCTr4WUND4="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=56e58e75-ed4e-4774-9cb6-f955aa1fb13d; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=K60xmU352egJkuxu7gHZVkkhSc7J3C1DpNjEzLYMXbk-1701000051-0-AaAWB9IpY4Qd/3fGwhFf4N4N38t3Z1ZRAD4ovI8AMXsEA8Zf8WrZzpP1DOy9zcuTeEI8GSzABauBKbCTr4WUND4=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6c5dcc8ef850596afa66069d4c98d5ab"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c6d92832b3d25fbd"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6c5dcc8ef850596afa66069d4c98d5ab"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93429d4240e-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:46.119Z",
-        "time": 189,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 189
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 258,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c55d7b22-2224-4a19-9029-2284041e9f0d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "nCKRAbZAU2Ev5Ti93OgZknWcxwiUKkxLtWJTRYEZw6U-1701000051-0-AfvSDTN91cv4rDgPhyX6+V7qNKbjBwGQghyHk5wbDO7M3B+WNiQzUUI8n4EdEYJRRCnLM5tnKdLR4UN6ztFEa9M="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c55d7b22-2224-4a19-9029-2284041e9f0d; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=nCKRAbZAU2Ev5Ti93OgZknWcxwiUKkxLtWJTRYEZw6U-1701000051-0-AfvSDTN91cv4rDgPhyX6+V7qNKbjBwGQghyHk5wbDO7M3B+WNiQzUUI8n4EdEYJRRCnLM5tnKdLR4UN6ztFEa9M=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "3e97f9ae543139013fd7fbb075198559"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "6a9e88d4104f43e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3e97f9ae543139013fd7fbb075198559"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f9342e6476a7-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:46.121Z",
-        "time": 192,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 192
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 258,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d7319bb5-8db3-491a-b850-532cd632d36a"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "aqLcqzbmUYhEvdgveZXVXGeM4N1EmdVt7SfP7QFx0eY-1701000051-0-Ac5mNeoGbdN25luczdvfS7mVmyn10lcZorXEToymzTTtC5h1tfgrcXK9O5nsuMY86O/uYd7avKsOMPLcNgY2VFU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d7319bb5-8db3-491a-b850-532cd632d36a; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=aqLcqzbmUYhEvdgveZXVXGeM4N1EmdVt7SfP7QFx0eY-1701000051-0-Ac5mNeoGbdN25luczdvfS7mVmyn10lcZorXEToymzTTtC5h1tfgrcXK9O5nsuMY86O/uYd7avKsOMPLcNgY2VFU=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "392da0a8c92dc45d86b0d69955495972"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "478e7e7a827407b2"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/392da0a8c92dc45d86b0d69955495972"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f9341c533607-MAN"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:46.122Z",
-        "time": 193,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 193
-        }
-      },
-      {
-        "_id": "ac7fc975d31f02e814346a770195c756",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 192,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "192"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:52.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7cfd7289-59ae-48d9-9325-bef7e36e5cfa"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "cCpdAikgfmIZ49dtVm4CLSE1EZAnZAmDQDqJgg3wz2M-1701000053-0-AdPQWWtkT61n1Ax5waSro5qAHtRt2TmcBcADYIFKAXtWPUTULDzssQofa2ffRAKkMKEkMkCyqR/stxeuv112sqg="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7cfd7289-59ae-48d9-9325-bef7e36e5cfa; Expires=Tue, 26 Nov 2024 12:00:52 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=cCpdAikgfmIZ49dtVm4CLSE1EZAnZAmDQDqJgg3wz2M-1701000053-0-AdPQWWtkT61n1Ax5waSro5qAHtRt2TmcBcADYIFKAXtWPUTULDzssQofa2ffRAKkMKEkMkCyqR/stxeuv112sqg=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c8afcadbacbdbfb53f23b642e5606dd2"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "b7ca3c83449375af"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c8afcadbacbdbfb53f23b642e5606dd2"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93a6aa84886-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.140Z",
-        "time": 177,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 177
-        }
-      },
-      {
-        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 190,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "190"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:52.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "df3f2a25-84d7-43a3-8d82-cb7ba5acafae"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "7ors36xHrzJa0bIIA1kCcqhA_SAwyvFDOsxsSYiPmCQ-1701000053-0-AQR2u6Y6kk21haOcFr5QrjEaT2xfMduHbWxnhd2RHJ5WSJoPcloSeqieW57VKdRi/yUKSejXTtvDfzZ5bBmrSP8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=df3f2a25-84d7-43a3-8d82-cb7ba5acafae; Expires=Tue, 26 Nov 2024 12:00:52 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=7ors36xHrzJa0bIIA1kCcqhA_SAwyvFDOsxsSYiPmCQ-1701000053-0-AQR2u6Y6kk21haOcFr5QrjEaT2xfMduHbWxnhd2RHJ5WSJoPcloSeqieW57VKdRi/yUKSejXTtvDfzZ5bBmrSP8=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f0e857461a68db892c7de0994494c28f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "9148abfd70150796"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f0e857461a68db892c7de0994494c28f"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93a698a23ca-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.136Z",
-        "time": 186,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 186
-        }
-      },
-      {
-        "_id": "3bfde46a074296956deef9dbd207df0b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:52.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a4e82199-2137-4dfd-90ca-712aa4e95930"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "aBgEWoHYE0ZnVZOvBFEiiS3x3BcTFgHLocypnHrxjns-1701000053-0-Ac73ni+J3/CR6dv7Shd2yrV0WyEYhM1/CW8zS/3Rxr286zL3a2V0/XJfRMIPoAoVXixC+CNu01ZpSJ8eEDdqRmE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a4e82199-2137-4dfd-90ca-712aa4e95930; Expires=Tue, 26 Nov 2024 12:00:52 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=aBgEWoHYE0ZnVZOvBFEiiS3x3BcTFgHLocypnHrxjns-1701000053-0-Ac73ni+J3/CR6dv7Shd2yrV0WyEYhM1/CW8zS/3Rxr286zL3a2V0/XJfRMIPoAoVXixC+CNu01ZpSJ8eEDdqRmE=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "dc21e0ac822388517c9b9843963e5d5f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "dd896c1eca5325fa"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dc21e0ac822388517c9b9843963e5d5f"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93a7db57708-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.139Z",
-        "time": 196,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 196
         }
       },
       {
@@ -3303,591 +5110,6 @@
         }
       },
       {
-        "_id": "4cb0e95333a7b013a23cbf416464bd74",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:52.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "38769e4d-6c22-4a2f-8e00-6afb160dc20f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9T89GOfIWnA35cb4TmjdrXD_Oph7pHkmPatl4KfD6.k-1701000053-0-AVAhckhwSaFRStioqspUaKT9psPeCyNd1fws9bHt7bZ3ePGPrf6idmxWODazxVRoqnpMZBUOyFNqgkPl/OFtmzg="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=38769e4d-6c22-4a2f-8e00-6afb160dc20f; Expires=Tue, 26 Nov 2024 12:00:52 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=9T89GOfIWnA35cb4TmjdrXD_Oph7pHkmPatl4KfD6.k-1701000053-0-AVAhckhwSaFRStioqspUaKT9psPeCyNd1fws9bHt7bZ3ePGPrf6idmxWODazxVRoqnpMZBUOyFNqgkPl/OFtmzg=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "aba38bd156c6283b89a583013daca808"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f1edffa5e89e4d8a"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/aba38bd156c6283b89a583013daca808"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93a7b6960e2-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.137Z",
-        "time": 209,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 209
-        }
-      },
-      {
-        "_id": "7449140909c921a511332d4c1de94c1f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 182,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "182"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:53.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ae5a877a-6325-4325-b54f-a3989221d282"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "JO0rjGFPW6O8AWI.OzKxWotR75.Qgl3V4S3sbSWHLSA-1701000053-0-ATjA6iJ2UxdUGOosABDjI0ArIRXMXES9fLkuNcyY1T8W4U5I00d8knX94gzi6118rVx1a/8eGMOdWg/+ng+NXco="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ae5a877a-6325-4325-b54f-a3989221d282; Expires=Tue, 26 Nov 2024 12:00:53 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=JO0rjGFPW6O8AWI.OzKxWotR75.Qgl3V4S3sbSWHLSA-1701000053-0-ATjA6iJ2UxdUGOosABDjI0ArIRXMXES9fLkuNcyY1T8W4U5I00d8knX94gzi6118rVx1a/8eGMOdWg/+ng+NXco=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "937a38351a22c133da29e378a774621e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "b6f25ea21f5ee898"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/937a38351a22c133da29e378a774621e"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93d5f6b3690-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.588Z",
-        "time": 212,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 212
-        }
-      },
-      {
-        "_id": "68618dc68610496fb5623c6778ea6c25",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 177,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "177"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:53.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d13c5e1b-4082-414b-9a72-2f738e912c31"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "6NO3MO4lJLwqP581r8pXMFR8AD570mPn.iF4Ze4j6II-1701000053-0-AWRvoehLj6e9muOly+AMhBMsZUAPnWP3OU4g/jobIUcp2UfFkKTQjxuKmy1uMwyhazx46VU0LMNdu99Kwo4ski8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d13c5e1b-4082-414b-9a72-2f738e912c31; Expires=Tue, 26 Nov 2024 12:00:53 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=6NO3MO4lJLwqP581r8pXMFR8AD570mPn.iF4Ze4j6II-1701000053-0-AWRvoehLj6e9muOly+AMhBMsZUAPnWP3OU4g/jobIUcp2UfFkKTQjxuKmy1uMwyhazx46VU0LMNdu99Kwo4ski8=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "1793f18597c5088ad7a6d4f06699d0d3"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "5e6ff5d0f8ee0717"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1793f18597c5088ad7a6d4f06699d0d3"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93edd2f24e4-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.840Z",
-        "time": 186,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 186
-        }
-      },
-      {
         "_id": "c9361d90a26c84c77ab2fc65f3686661",
         "_order": 0,
         "cache": {},
@@ -4075,373 +5297,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 504
-        }
-      },
-      {
-        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 333,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "333"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 327,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:54.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b4c7e9b9-3595-46ce-a0e5-8e098d705a54"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:54.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "mSkqx4FI22SS.n4JXKVYD1NlL392wmF4MQiWwetGgpw-1701000054-0-AbfTUOZv/VwCtZkKgfnTm7SFl3Uv+t2RA5oFf8M8T/Vj7deey7DqxKFtN9/K2auqeJLxNlTIdmVC11pnsV7QKcg="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:54 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b4c7e9b9-3595-46ce-a0e5-8e098d705a54; Expires=Tue, 26 Nov 2024 12:00:54 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=mSkqx4FI22SS.n4JXKVYD1NlL392wmF4MQiWwetGgpw-1701000054-0-AbfTUOZv/VwCtZkKgfnTm7SFl3Uv+t2RA5oFf8M8T/Vj7deey7DqxKFtN9/K2auqeJLxNlTIdmVC11pnsV7QKcg=; path=/; expires=Sun, 26-Nov-23 12:30:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f19b987d88269606ed2b65cc71b0b77b"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "84495574475fde24"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f19b987d88269606ed2b65cc71b0b77b"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f945b9a06a3c-MAN"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:48.946Z",
-        "time": 224,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 224
-        }
-      },
-      {
-        "_id": "34fa3baab68c77b4e329fd24907b91f7",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1300,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 217,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/stream"
-        },
-        "response": {
-          "bodySize": 71533,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 71533,
-            "text": "event: completion\ndata: {\"completion\":\" Unfortunately\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n-\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n-\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n-\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other details would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other details would be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other details would be helpful\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other details would be helpful!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Unfortunately, without any context about the programming language, project, or code you are working with, I do not have enough information to provide an implementation of a `sum` function. \\n\\nIf you are able to provide more context such as:\\n\\n- The programming language you are using (e.g. Python, JavaScript)\\n- The file you are editing and relevant code in that file\\n- What `sum` is intended to sum (array, list, dictionary values etc.)\\n\\nI would be happy to provide a context-specific implementation of a `sum` function. Please feel free to provide any additional details that may help. As a coding assistant, I aim to give precise, relevant recommendations based on the specifics of your project rather than assumptions. Let me know what other details would be helpful!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:54.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "226ed3c8-a219-4539-9e81-85c94f8daa62"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:55.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gNe.02SlDOWokph52HcHkH_YfDHs0mWuiXrG2rGztPs-1701000055-0-AcCbfgDYXhJpNNT2L/ws42Bf7qQm9iJZL3cimYTABoWkXp4Fid5bczIZXRFA2e2vP+Um0nUKrREPNmH7VCuzmcg="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:55 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=226ed3c8-a219-4539-9e81-85c94f8daa62; Expires=Tue, 26 Nov 2024 12:00:54 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=gNe.02SlDOWokph52HcHkH_YfDHs0mWuiXrG2rGztPs-1701000055-0-AcCbfgDYXhJpNNT2L/ws42Bf7qQm9iJZL3cimYTABoWkXp4Fid5bczIZXRFA2e2vP+Um0nUKrREPNmH7VCuzmcg=; path=/; expires=Sun, 26-Nov-23 12:30:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d6211d809c9eb29111d04ca519ebf289"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "b791324f0b6f14fd"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d6211d809c9eb29111d04ca519ebf289"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f9442f7e640f-LHR"
-            }
-          ],
-          "headersSize": 1127,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:48.656Z",
-        "time": 8613,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 8613
         }
       },
       {

--- a/agent/src/AgentTextDocument.test.ts
+++ b/agent/src/AgentTextDocument.test.ts
@@ -3,18 +3,21 @@ import assert from 'assert'
 import { describe, it } from 'vitest'
 import * as vscode from 'vscode'
 
+import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
+
 import { AgentTextDocument } from './AgentTextDocument'
 
 describe('AgentTextDocument', () => {
-    const basic = new AgentTextDocument({ filePath: 'foo', content: 'a\nb\n' })
-    const basicCrlf = new AgentTextDocument({ filePath: 'foo', content: 'a\r\nb\r\n' })
-    const emptyLine = new AgentTextDocument({ filePath: 'foo', content: 'a\n\n' })
-    const noEndOfFileNewline = new AgentTextDocument({ filePath: 'foo', content: 'a\nb' })
-    const emptyFirstLine = new AgentTextDocument({ filePath: 'foo', content: '\nb' })
-    const emptyFirstLineCrlf = new AgentTextDocument({ filePath: 'foo', content: '\r\nb' })
-    const noIndentation = new AgentTextDocument({ filePath: 'foo', content: 'sss\n' })
-    const indentation = new AgentTextDocument({ filePath: 'foo', content: '  a\n' })
-    const indentationTab = new AgentTextDocument({ filePath: 'foo', content: '\t\tab\n' })
+    const uri = vscode.Uri.file('foo')
+    const basic = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: 'a\nb\n' }))
+    const basicCrlf = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: 'a\r\nb\r\n' }))
+    const emptyLine = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: 'a\n\n' }))
+    const noEndOfFileNewline = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: 'a\nb' }))
+    const emptyFirstLine = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: '\nb' }))
+    const emptyFirstLineCrlf = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: '\r\nb' }))
+    const noIndentation = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: 'sss\n' }))
+    const indentation = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: '  a\n' }))
+    const indentationTab = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: '\t\tab\n' }))
 
     it('getText(Range)', () => {
         assert.equal(basic.getText(new vscode.Range(0, 0, 0, 1)), 'a')

--- a/agent/src/AgentTextDocument.ts
+++ b/agent/src/AgentTextDocument.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode'
 
+import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
+
 import { getLanguageForFileName } from './language'
 import { DocumentOffsets } from './offsets'
-import { TextDocument } from './protocol-alias'
 import * as vscode_shim from './vscode-shim'
 
 // TODO: implement with vscode-languageserver-textdocument The reason we don't
@@ -10,13 +11,13 @@ import * as vscode_shim from './vscode-shim'
 // the properties/functions that vscode.TextDocument has. For example, lineAt is
 // missing in vscode-languageserver-textdocument
 export class AgentTextDocument implements vscode.TextDocument {
-    constructor(public readonly textDocument: TextDocument) {
+    constructor(public readonly textDocument: TextDocumentWithUri) {
         this.content = textDocument.content ?? ''
-        this.uri = vscode.Uri.from({ scheme: 'file', path: textDocument.filePath })
-        this.fileName = textDocument.filePath
+        this.uri = textDocument.uri
+        this.fileName = textDocument.uri.fsPath
         this.isUntitled = false
         this.languageId = getLanguageForFileName(this.fileName)
-        this.offsets = new DocumentOffsets(textDocument)
+        this.offsets = new DocumentOffsets(textDocument.underlying)
         this.lineCount = this.offsets.lineCount()
     }
     private readonly content: string

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -16,6 +16,7 @@ import { NoOpTelemetryRecorderProvider } from '@sourcegraph/cody-shared/src/tele
 import { TelemetryEventParameters } from '@sourcegraph/telemetry'
 
 import { activate } from '../../vscode/src/extension.node'
+import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
 
 import { AgentTextDocument } from './AgentTextDocument'
 import { newTextEditor } from './AgentTextEditor'
@@ -30,6 +31,15 @@ const secretStorage = new Map<string, string>()
 
 export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Promise<void> {
     const paths = envPaths('Cody')
+    try {
+        const gitdirPath = path.join(workspaceRoot.fsPath, '.git')
+        const gitdir = await fspromises.stat(gitdirPath)
+        if (gitdir.isDirectory()) {
+            vscode_shim.addGitRepository(workspaceRoot, 'fake_vscode_shim_commit')
+        }
+    } catch {
+        /* ignore */
+    }
     await activate({
         asAbsolutePath(relativePath) {
             return path.resolve(workspaceRoot.fsPath, relativePath)
@@ -107,15 +117,6 @@ export async function newEmbeddedAgentClient(clientInfo: ClientInfo): Promise<Ag
     debugHandler.messageEncoder.pipe(agent.messageDecoder)
     agent.messageEncoder.pipe(debugHandler.messageDecoder)
     const client = agent.clientForThisInstance()
-    const workspaceRoot = vscode.Uri.parse(clientInfo.workspaceRootUri)
-    try {
-        const gitdir = await fspromises.stat(path.join(workspaceRoot.fsPath, '.git'))
-        if (gitdir.isDirectory()) {
-            vscode_shim.addGitRepository(workspaceRoot, 'fake_vscode_shim_commit')
-        }
-    } catch {
-        /* ignore */
-    }
     await client.request('initialize', clientInfo)
     client.notify('initialized', null)
     return agent
@@ -208,17 +209,21 @@ export class Agent extends MessageHandler {
         })
 
         this.registerNotification('textDocument/didFocus', document => {
-            this.workspace.setActiveTextEditor(newTextEditor(this.workspace.agentTextDocument(document)))
+            this.workspace.setActiveTextEditor(
+                newTextEditor(this.workspace.agentTextDocument(TextDocumentWithUri.fromDocument(document)))
+            )
         })
         this.registerNotification('textDocument/didOpen', document => {
-            this.workspace.addDocument(document)
-            const textDocument = this.workspace.agentTextDocument(document)
+            const documentWithUri = TextDocumentWithUri.fromDocument(document)
+            this.workspace.addDocument(documentWithUri)
+            const textDocument = this.workspace.agentTextDocument(documentWithUri)
             vscode_shim.onDidOpenTextDocument.fire(textDocument)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))
         })
         this.registerNotification('textDocument/didChange', document => {
-            const textDocument = this.workspace.agentTextDocument(document)
-            this.workspace.addDocument(document)
+            const documentWithUri = TextDocumentWithUri.fromDocument(document)
+            const textDocument = this.workspace.agentTextDocument(documentWithUri)
+            this.workspace.addDocument(documentWithUri)
             this.workspace.setActiveTextEditor(newTextEditor(textDocument))
             vscode_shim.onDidChangeTextDocument.fire({
                 document: textDocument,
@@ -227,8 +232,9 @@ export class Agent extends MessageHandler {
             })
         })
         this.registerNotification('textDocument/didClose', document => {
-            this.workspace.deleteDocument(document.filePath)
-            vscode_shim.onDidCloseTextDocument.fire(this.workspace.agentTextDocument(document))
+            const documentWithUri = TextDocumentWithUri.fromDocument(document)
+            this.workspace.deleteDocument(documentWithUri.uri)
+            vscode_shim.onDidCloseTextDocument.fire(this.workspace.agentTextDocument(documentWithUri))
         })
 
         this.registerNotification('extensionConfiguration/didChange', config => {
@@ -287,9 +293,9 @@ export class Agent extends MessageHandler {
                 console.log('Completion provider is not initialized')
                 return { items: [] }
             }
-            const document = this.workspace.getDocument(params.filePath)
+            const document = this.workspace.getDocument(vscode.Uri.parse(params.uri))
             if (!document) {
-                console.log('No document found for file path', params.filePath, [...this.workspace.allFilePaths()])
+                console.log('No document found for file path', params.uri, [...this.workspace.allUris()])
                 return { items: [] }
             }
 
@@ -297,7 +303,7 @@ export class Agent extends MessageHandler {
 
             try {
                 if (params.triggerKind === 'Invoke') {
-                    await provider.manuallyTriggerCompletion()
+                    await provider?.manuallyTriggerCompletion?.()
                 }
 
                 const result = await provider.provideInlineCompletionItems(

--- a/agent/src/cli/evaluate-autocomplete/EvaluationDocument.ts
+++ b/agent/src/cli/evaluate-autocomplete/EvaluationDocument.ts
@@ -5,6 +5,7 @@ import { ObjectHeaderItem } from 'csv-writer/src/lib/record'
 import * as vscode from 'vscode'
 
 import { CompletionBookkeepingEvent } from '../../../../vscode/src/completions/logger'
+import { TextDocumentWithUri } from '../../../../vscode/src/jsonrpc/TextDocumentWithUri'
 import { AgentTextDocument } from '../../AgentTextDocument'
 
 export class EvaluationDocument {
@@ -17,10 +18,11 @@ export class EvaluationDocument {
             'languageid' | 'workspace' | 'strategy' | 'fixture' | 'filepath' | 'revision'
         >,
         public readonly text: string,
+        public readonly uri: vscode.Uri,
         public readonly snapshotDirectory?: string
     ) {
         this.lines = text.split('\n')
-        this.textDocument = new AgentTextDocument({ filePath: params.filepath, content: text })
+        this.textDocument = new AgentTextDocument(TextDocumentWithUri.from(uri, { content: text }))
     }
 
     public pushItem(
@@ -90,7 +92,7 @@ export class EvaluationDocument {
                 }
                 if (item.resultText) {
                     out.push(' RESULT ')
-                    out.push(item.resultText)
+                    out.push(item.resultText.replaceAll('\n', '\\n'))
                 }
                 out.push('\n')
             }

--- a/agent/src/cli/evaluate-autocomplete/cli-parsers.ts
+++ b/agent/src/cli/evaluate-autocomplete/cli-parsers.ts
@@ -1,0 +1,17 @@
+import * as commander from 'commander'
+
+export function booleanOption(value: string): boolean {
+    return value === 'true'
+}
+
+export function intOption(value: string): number {
+    const parsedValue = Number.parseInt(value, 10)
+    if (isNaN(parsedValue)) {
+        throw new commander.InvalidArgumentError('Not a number.')
+    }
+    return parsedValue
+}
+
+export function arrayOption<T>(value: T, previous: T[]): T[] {
+    return previous.concat([value])
+}

--- a/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/evaluate-autocomplete.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 
 import { newAgentClient } from '../../agent'
 
+import { arrayOption, intOption } from './cli-parsers'
 import { evaluateBfgStrategy } from './strategy-bfg'
 import { evaluateGitLogStrategy } from './strategy-git-log'
 
@@ -100,18 +101,6 @@ async function loadEvaluationConfig(options: EvaluateAutocompleteOptions): Promi
     return result
 }
 
-function intOption(value: string): number {
-    const parsedValue = Number.parseInt(value, 10)
-    if (isNaN(parsedValue)) {
-        throw new commander.InvalidArgumentError('Not a number.')
-    }
-    return parsedValue
-}
-
-function collect<T>(value: T, previous: T[]): T[] {
-    return previous.concat([value])
-}
-
 export const evaluateAutocompleteCommand = new commander.Command('evaluate-autocomplete')
     .description('Evaluate Cody autocomplete by running the Agent in headless mode')
     .option('--workspace <path>', 'The workspace directory where to run the autocomplete evaluation', process.cwd())
@@ -142,49 +131,49 @@ export const evaluateAutocompleteCommand = new commander.Command('evaluate-autoc
     .option(
         '--include-workspace <glob>',
         'A glob pattern to determine what workspace paths to include in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--exclude-workspace <glob>',
         'A glob pattern to determine what workspace paths to exclude in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--include-language <glob>',
         'A glob pattern to determine what language paths to include in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--exclude-language <glob>',
         'A glob pattern to determine what language paths to exclude in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--include-fixture <glob>',
         'A glob pattern to determine what fixtures to include in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--exclude-fixture <glob>',
         'A glob pattern to determine what fixtures exclude in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--include-filepath <glob>',
         'A glob pattern to determine what files to include in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .option(
         '--exclude-filepath <glob>',
         'A glob pattern to determine what files exclude in the evaluation',
-        collect as any,
+        arrayOption as any,
         []
     )
     .addOption(new commander.Option('--bfg-binary <path>', 'Optional path to a BFG binary').env('BFG_BINARY'))
@@ -222,6 +211,7 @@ async function evaluateWorkspace(options: EvaluateAutocompleteOptions): Promise<
     }
 
     const workspaceRootUri = vscode.Uri.from({ scheme: 'file', path: options.workspace })
+
     const client = await newAgentClient({
         name: 'evaluate-autocomplete',
         version: '0.1.0',

--- a/agent/src/cli/evaluate-autocomplete/strategy-bfg.ts
+++ b/agent/src/cli/evaluate-autocomplete/strategy-bfg.ts
@@ -41,6 +41,7 @@ export async function evaluateBfgStrategy(client: MessageHandler, options: Evalu
                 continue
             }
             const filePath = path.join(workspace, file)
+            const uri = vscode.Uri.file(filePath)
             const stat = await fspromises.stat(filePath)
             if (!stat.isFile()) {
                 continue
@@ -54,7 +55,7 @@ export async function evaluateBfgStrategy(client: MessageHandler, options: Evalu
             if (!matchesGlobPatterns(options.includeLanguage ?? [], options.excludeLanguage ?? [], languageid)) {
                 continue
             }
-            client.notify('textDocument/didOpen', { filePath, content })
+            client.notify('textDocument/didOpen', { uri: uri.toString(), content })
             const parser = await createParser({ language, grammarDirectory })
             const tree = parser.parse(content)
             const query = await queries.loadQuery(parser, language, 'context')
@@ -72,7 +73,8 @@ export async function evaluateBfgStrategy(client: MessageHandler, options: Evalu
                     workspace: path.basename(options.workspace),
                     revision,
                 },
-                content
+                content,
+                uri
             )
             for (const match of query.matches(tree.rootNode)) {
                 if (documentTestCountStart - remainingTests > options.maxFileTestCount) {
@@ -86,54 +88,52 @@ export async function evaluateBfgStrategy(client: MessageHandler, options: Evalu
                     if (remainingTests <= 0) {
                         break
                     }
-                    if (capture.name === 'range') {
-                        // Modify the content by replacing the argument list to the call expression
-                        // with an empty argument list. This evaluation is interesting because it
-                        // allows us to test how good Cody is at inferring the original argument
-                        // list.
-
-                        const isArgumentList =
-                            content.slice(capture.node.startIndex, capture.node.startIndex + 1) === '(' &&
-                            content.slice(capture.node.endIndex - 1, capture.node.endIndex) === ')'
-                        const range = isArgumentList
-                            ? new vscode.Range(
-                                  new vscode.Position(
-                                      capture.node.startPosition.row,
-                                      capture.node.startPosition.column + 1
-                                  ),
-                                  new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column - 1)
-                              )
-                            : new vscode.Range(
-                                  new vscode.Position(
-                                      capture.node.startPosition.row,
-                                      capture.node.startPosition.column
-                                  ),
-                                  new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column)
-                              )
-
-                        const modifiedContent = [
-                            document.textDocument.getText(new vscode.Range(new vscode.Position(0, 0), range.start)),
-                            document.textDocument.getText(
-                                new vscode.Range(range.end, new vscode.Position(document.textDocument.lineCount, 0))
-                            ),
-                        ].join('')
-                        const removedContent = document.textDocument.getText(range)
-                        const position = new vscode.Position(
-                            capture.node.startPosition.row,
-                            capture.node.startPosition.column + 1
-                        )
-                        await triggerAutocomplete({
-                            range,
-                            client,
-                            document,
-                            options,
-                            emptyMatchContent: isArgumentList ? '()' : '',
-                            modifiedContent,
-                            removedContent,
-                            position,
-                        })
-                        remainingTests--
+                    if (capture.name !== 'range') {
+                        continue
                     }
+                    // Modify the content by replacing the argument list to the call expression
+                    // with an empty argument list. This evaluation is interesting because it
+                    // allows us to test how good Cody is at inferring the original argument
+                    // list.
+
+                    const isArgumentList =
+                        content.slice(capture.node.startIndex, capture.node.startIndex + 1) === '(' &&
+                        content.slice(capture.node.endIndex - 1, capture.node.endIndex) === ')'
+                    const range = isArgumentList
+                        ? new vscode.Range(
+                              new vscode.Position(
+                                  capture.node.startPosition.row,
+                                  capture.node.startPosition.column + 1
+                              ),
+                              new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column - 1)
+                          )
+                        : new vscode.Range(
+                              new vscode.Position(capture.node.startPosition.row, capture.node.startPosition.column),
+                              new vscode.Position(capture.node.endPosition.row, capture.node.endPosition.column)
+                          )
+
+                    const modifiedContent = [
+                        document.textDocument.getText(new vscode.Range(new vscode.Position(0, 0), range.start)),
+                        document.textDocument.getText(
+                            new vscode.Range(range.end, new vscode.Position(document.textDocument.lineCount, 0))
+                        ),
+                    ].join('')
+                    const removedContent = document.textDocument.getText(range)
+                    const position = new vscode.Position(
+                        capture.node.startPosition.row,
+                        capture.node.startPosition.column + 1
+                    )
+                    await triggerAutocomplete({
+                        range,
+                        client,
+                        document,
+                        options,
+                        emptyMatchContent: isArgumentList ? '()' : '',
+                        modifiedContent,
+                        removedContent,
+                        position,
+                    })
+                    remainingTests--
                 }
             }
 

--- a/agent/src/cli/evaluate-autocomplete/strategy-git-log.ts
+++ b/agent/src/cli/evaluate-autocomplete/strategy-git-log.ts
@@ -51,6 +51,7 @@ export async function evaluateGitLogStrategy(
                     }
 
                     const fullPath = path.join(workspace, filePath)
+                    const uri = vscode.Uri.file(fullPath)
                     const content = (await fspromises.readFile(fullPath)).toString()
                     const languageid = getLanguageForFileName(filePath)
                     const document = new EvaluationDocument(
@@ -62,7 +63,8 @@ export async function evaluateGitLogStrategy(
                             strategy: options.fixture.strategy,
                             workspace: path.basename(options.workspace),
                         },
-                        content
+                        content,
+                        uri
                     )
 
                     const isLastFile = index === parsedDiff.files.length - 1
@@ -70,7 +72,7 @@ export async function evaluateGitLogStrategy(
                     if (!isLastFile) {
                         // Open all files to simulate local editor context
                         // @TODO: Move the cursor into the changed sections
-                        client.notify('textDocument/didOpen', { filePath, content })
+                        client.notify('textDocument/didOpen', { uri: uri.toString(), content })
                     }
 
                     if (isLastFile) {

--- a/agent/src/cli/evaluate-autocomplete/testTypecheck.ts
+++ b/agent/src/cli/evaluate-autocomplete/testTypecheck.ts
@@ -5,6 +5,7 @@ import path from 'path'
 
 import * as vscode from 'vscode'
 
+import { TextDocumentWithUri } from '../../../../vscode/src/jsonrpc/TextDocumentWithUri'
 import { AgentTextDocument } from '../../AgentTextDocument'
 import { AutocompleteItem } from '../../protocol-alias'
 
@@ -76,10 +77,9 @@ export async function testTypecheck(
     }
     const start = new vscode.Position(item.range.start.line, item.range.start.character)
     const end = new vscode.Position(item.range.end.line, item.range.end.character)
-    const modifiedDocument = new AgentTextDocument({
-        filePath: document.params.filepath,
-        content: parameters.modifiedContent,
-    })
+    const modifiedDocument = new AgentTextDocument(
+        TextDocumentWithUri.from(document.uri, { content: parameters.modifiedContent })
+    )
     const newText = [
         modifiedDocument.getText(new vscode.Range(new vscode.Position(0, 0), start)),
         item.insertText,

--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -6,6 +6,8 @@ import { Command, Option } from 'commander'
 
 import { Agent } from '../agent'
 
+import { booleanOption } from './evaluate-autocomplete/cli-parsers'
+
 interface JsonrpcCommandOptions {
     expiresIn?: string | null | undefined
     recordingDirectory?: string
@@ -106,9 +108,10 @@ export const jsonrpcCommand = new Command('jsonrpc')
             .default('365d')
     )
     .addOption(
-        new Option('--recording-strict-replay <true|false>', 'If false, fails the test instead of recording').env(
-            'CODY_RECORD_IF_MISSING'
-        )
+        new Option('--record-if-missing <true|false>', 'If false, fails the test instead of recording')
+            .env('CODY_RECORD_IF_MISSING')
+            .argParser(booleanOption)
+            .default(false)
     )
     .action((options: JsonrpcCommandOptions) => {
         let polly: Polly | undefined

--- a/agent/src/editor.ts
+++ b/agent/src/editor.ts
@@ -10,9 +10,10 @@ import {
     Editor,
 } from '@sourcegraph/cody-shared/src/editor'
 
+import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
+
 import { Agent } from './agent'
 import { DocumentOffsets } from './offsets'
-import { TextDocument } from './protocol-alias'
 
 export class AgentEditor implements Editor {
     public controllers?: ActiveTextEditorViewControllers | undefined
@@ -33,7 +34,7 @@ export class AgentEditor implements Editor {
         return this.agent.workspace.workspaceRootUri ?? null
     }
 
-    private activeDocument(): TextDocument | undefined {
+    private activeDocument(): TextDocumentWithUri | undefined {
         if (this.agent.workspace.activeDocumentFilePath === null) {
             return undefined
         }
@@ -46,7 +47,9 @@ export class AgentEditor implements Editor {
             return null
         }
         return {
-            filePath: document.filePath,
+            filePath: document.uri.fsPath,
+            fileUri: document.uri,
+            selectionRange: document.selection,
             content: document.content || '',
         }
     }
@@ -56,7 +59,7 @@ export class AgentEditor implements Editor {
             return Promise.resolve(undefined)
         }
 
-        const doc = this.agent.workspace.getDocument(uri.fsPath)
+        const doc = this.agent.workspace.getDocumentFromUriString(uri.toString())
         return Promise.resolve(doc?.content)
     }
 
@@ -65,10 +68,12 @@ export class AgentEditor implements Editor {
         if (document?.content === undefined || document.selection === undefined) {
             return null
         }
-        const offsets = new DocumentOffsets(document)
+        const offsets = new DocumentOffsets(document.underlying)
         if (!document.selection) {
             return {
-                fileName: document.filePath ?? '',
+                fileName: document.uri.fsPath,
+                fileUri: document.uri,
+                selectionRange: document.selection,
                 precedingText: document.content ?? '',
                 selectedText: '',
                 followingText: '',
@@ -77,7 +82,9 @@ export class AgentEditor implements Editor {
         const from = offsets.offset(document.selection.start)
         const to = offsets.offset(document.selection.end)
         return {
-            fileName: document.filePath || '',
+            fileName: document.uri.fsPath,
+            fileUri: document.uri,
+            selectionRange: document.selection,
             precedingText: document.content.slice(0, from),
             selectedText: document.content.slice(from, to),
             followingText: document.content.slice(to, document.content.length),
@@ -88,7 +95,8 @@ export class AgentEditor implements Editor {
         const document = this.activeDocument()
         if (document !== undefined && document.selection === undefined) {
             return {
-                fileName: document.filePath || '',
+                fileName: document.uri.fsPath,
+                fileUri: document.uri,
                 precedingText: '',
                 selectedText: document.content || '',
                 followingText: '',
@@ -124,7 +132,8 @@ export class AgentEditor implements Editor {
         }
         return {
             content: document.content || '',
-            fileName: document.filePath,
+            fileName: document.uri.fsPath,
+            fileUri: document.uri,
         }
     }
 

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -3,6 +3,7 @@ import { execSync, spawn } from 'child_process'
 import path from 'path'
 
 import { afterAll, beforeAll, describe, it } from 'vitest'
+import { Uri } from 'vscode'
 
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 
@@ -141,14 +142,15 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
 
     it('returns non-empty autocomplete', async () => {
         const filePath = '/path/to/foo/file.ts'
+        const uri = Uri.file(filePath)
         const content = 'function sum(a: number, b: number) {\n    \n}'
         client.notify('textDocument/didOpen', {
-            filePath,
+            uri: uri.toString(),
             content,
             selection: { start: { line: 1, character: 0 }, end: { line: 1, character: 0 } },
         })
         const completions = await client.request('autocomplete/execute', {
-            filePath,
+            uri: uri.toString(),
             position: { line: 1, character: 3 },
             triggerKind: 'Invoke',
         })

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -101,6 +101,7 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
         stdio: 'pipe',
         cwd: agentDir,
         env: {
+            CODY_SHIM_TESTING: 'true',
             CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
             CODY_RECORDING_DIRECTORY: recordingDirectory,
             CODY_RECORDING_NAME: name,

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { execSync } from 'child_process'
+import path from 'path'
 
 import type * as vscode from 'vscode'
 
@@ -34,6 +35,11 @@ import {
 import type { Agent } from './agent'
 import { AgentTabGroups } from './AgentTabGroups'
 import type { ClientInfo, ExtensionConfiguration } from './protocol-alias'
+
+// Not using CODY_TESTING because it changes the URL endpoint we send requests
+// to and we want to send requests to sourcegraph.com because we record the HTTP
+// traffic.
+const isTesting = process.env.CODY_SHIM_TESTING === 'true'
 
 export {
     emptyEvent,
@@ -237,7 +243,24 @@ const _workspace: Partial<typeof vscode.workspace> = {
     onDidRenameFiles: onDidRenameFiles.event,
     onDidDeleteFiles: onDidDeleteFiles.event,
     registerTextDocumentContentProvider: () => emptyDisposable,
-    asRelativePath: (pathOrUri: string | vscode.Uri, includeWorkspaceFolder?: boolean): string => pathOrUri.toString(),
+    asRelativePath: (pathOrUri: string | vscode.Uri, includeWorkspaceFolder?: boolean): string => {
+        const uri: vscode.Uri | undefined =
+            typeof pathOrUri === 'string' ? Uri.file(pathOrUri) : pathOrUri instanceof Uri ? pathOrUri : undefined
+        if (uri === undefined) {
+            // Not sure what to do about non-string/non-uri arguments.
+            return `${pathOrUri}`
+        }
+
+        const relativePath = workspaceDocuments?.workspaceRootUri?.fsPath
+            ? path.relative(workspaceDocuments?.workspaceRootUri?.path ?? '', uri.path)
+            : uri.path
+        if (isTesting) {
+            // We insert relative paths in a lot of places like prompts that influence HTTP requests.
+            // When testing, we try to normalize the file paths across Windows/Linux/macOS.
+            return relativePath.replaceAll('\\', '/')
+        }
+        return relativePath
+    },
     createFileSystemWatcher: () => emptyFileWatcher,
     getConfiguration: (() => configuration) as any,
 }

--- a/cli/src/commands/complete/command.ts
+++ b/cli/src/commands/complete/command.ts
@@ -55,7 +55,7 @@ interface CompleteResponse {
 
 async function run(request: CompleteRequest): Promise<CompleteResponse> {
     const result = await codyAgentComplete({
-        filePath: request.uri.replace(/^file:\/\//, ''),
+        uri: request.uri,
         content: request.content,
         position: request.position,
     })
@@ -70,16 +70,12 @@ async function run(request: CompleteRequest): Promise<CompleteResponse> {
 }
 
 interface CodyAgentCompleteParams {
-    filePath: string
+    uri: string
     content: string
     position: AutocompleteParams['position']
 }
 
-async function codyAgentComplete({
-    filePath,
-    content,
-    position,
-}: CodyAgentCompleteParams): Promise<AutocompleteResult> {
+async function codyAgentComplete({ uri, content, position }: CodyAgentCompleteParams): Promise<AutocompleteResult> {
     const agent = new Agent()
     const client = agent.clientForThisInstance()
     await client.request('initialize', {
@@ -93,9 +89,9 @@ async function codyAgentComplete({
         },
     })
     client.notify('initialized', null)
-    client.notify('textDocument/didOpen', { filePath, content })
+    client.notify('textDocument/didOpen', { uri, content })
     return client.request('autocomplete/execute', {
-        filePath,
+        uri,
         position,
         triggerKind: 'Invoke',
     })

--- a/vscode/src/jsonrpc/TextDocumentWithUri.ts
+++ b/vscode/src/jsonrpc/TextDocumentWithUri.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode'
+
+import { Range, TextDocument } from './agent-protocol'
+
+/**
+ * Wrapper around `TextDocument` that also contains a parsed vscode.Uri.
+ *
+ * We can't use `vscode.Uri` in `TextDocument` because we use that type in the
+ * JSON-RPC protocol where URIs are string-encoded.
+ */
+export class TextDocumentWithUri {
+    public underlying: TextDocument
+    constructor(
+        public readonly uri: vscode.Uri,
+        underlying?: TextDocument
+    ) {
+        this.underlying = underlying ?? { uri: uri.toString() }
+    }
+
+    public static fromDocument(document: TextDocument): TextDocumentWithUri {
+        if (document?.uri === undefined && typeof document.filePath === 'string') {
+            // TODO: remove support for `document.filePath` once the migration to URIs is complete
+            const uri = vscode.Uri.file(document.filePath)
+            return new TextDocumentWithUri(uri, document)
+        }
+        return new TextDocumentWithUri(vscode.Uri.parse(document.uri), document)
+    }
+
+    public static from(uri: vscode.Uri, document: Partial<TextDocument>): TextDocumentWithUri {
+        return new TextDocumentWithUri(uri, { uri: uri.toString(), ...document })
+    }
+
+    public get content(): string | undefined {
+        return this.underlying.content
+    }
+
+    public get selection(): Range | undefined {
+        return this.underlying.selection
+    }
+}

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -294,7 +294,7 @@ export interface Range {
 export interface TextDocument {
     // Use TextDocumentWithUri.fromDocument(TextDocument) if you want to parse this `uri` property.
     uri: string
-    /* @deprecated use `uri` instead. This property only exists for backwards compatibility during the migration period. */
+    /** @deprecated use `uri` instead. This property only exists for backwards compatibility during the migration period. */
     filePath?: string
     content?: string
     selection?: Range

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -134,7 +134,7 @@ export interface CompletionItemParams {
 }
 
 export interface AutocompleteParams {
-    filePath: string
+    uri: string
     position: Position
     // Defaults to 'Automatic' for autocompletions which were not explicitly
     // triggered.
@@ -292,7 +292,10 @@ export interface Range {
 }
 
 export interface TextDocument {
-    filePath: string
+    // Use TextDocumentWithUri.fromDocument(TextDocument) if you want to parse this `uri` property.
+    uri: string
+    /* @deprecated use `uri` instead. This property only exists for backwards compatibility during the migration period. */
+    filePath?: string
     content?: string
     selection?: Range
 }


### PR DESCRIPTION
Previously, the agent used a property named `filePath` as the unique string identifier of documents. This was problematic for several reasons, including

- There's no idiomatic way to encode virtual files
- File paths have different formatting in Windows and Linux/macOS

This PR does a big refactoring around the agent internals so that we use URIs instead of `filePath`. URIs solve both problems above.

The motivation to prioritize this change was that bfg wasn't loading correctly in the evaluation because of a bug related to handling of relative file paths. This bug was trivial to prevent after moving to URIs.

The diff includes a few minor `evaluate-autocomplete`-related changes that I included since I wanted to validate that bfg evaluation works correctly after the refactoring.

## Test plan

Green CI.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
