### PR TITLE
Roll cody-engine to v5.2.9998.

### DIFF
--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -12,7 +12,8 @@ import { getOSArch } from '../../os'
 import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
-const defaultBfgVersion = '5.2.6637'
+// Do not include 'v' in this string.
+const defaultBfgVersion = '5.2.9998'
 
 export async function downloadBfg(context: vscode.ExtensionContext): Promise<string | null> {
     const config = vscode.workspace.getConfiguration()


### PR DESCRIPTION
This rolls Cody engine, including an improved tsx matcher. This does *not* include local embeddings because of a release build issue with that.

## Test plan

CI tests.