### PR TITLE
fix: format chat panel titles

### DIFF
--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -27,6 +27,7 @@ import {
     WebviewMessage,
 } from '../protocol'
 
+import { getChatPanelTitle } from './chat-helpers'
 import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {
@@ -206,7 +207,7 @@ export class ChatPanelProvider extends MessageProvider {
         // Update / reset webview panel title
         const text = this.transcript.getLastInteraction()?.getHumanMessage()?.displayText || 'New Chat'
         if (this.webviewPanel) {
-            this.webviewPanel.title = text.length > 10 ? `${text?.slice(0, 20)}...` : text
+            this.webviewPanel.title = getChatPanelTitle(text)
         }
     }
 
@@ -398,9 +399,7 @@ export class ChatPanelProvider extends MessageProvider {
         this.startUpChatID = chatID
 
         const viewType = CodyChatPanelViewType
-        // truncate firstQuestion to first 10 chars
-        const text = lastQuestion && lastQuestion?.length > 10 ? `${lastQuestion?.slice(0, 20)}...` : lastQuestion
-        const panelTitle = text || 'New Chat'
+        const panelTitle = getChatPanelTitle(lastQuestion)
         const viewColumn = activePanelViewColumn || vscode.ViewColumn.Beside
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
         const panel = vscode.window.createWebviewPanel(

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -37,7 +37,7 @@ import { openExternalLinks, openFilePath, openLocalFileWithRange } from '../../s
 import { ConfigurationSubsetForWebview, getChatModelsForWebview, LocalEnv, WebviewMessage } from '../protocol'
 import { countGeneratedCode } from '../utils'
 
-import { embeddingsUrlScheme, relativeFileUrl, stripContextWrapper } from './chat-helpers'
+import { embeddingsUrlScheme, getChatPanelTitle, relativeFileUrl, stripContextWrapper } from './chat-helpers'
 import { ChatHistoryManager } from './ChatHistoryManager'
 import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
 import { ChatViewProviderWebview } from './ChatPanelProvider'
@@ -130,9 +130,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         }
 
         const viewType = CodyChatPanelViewType
-        // truncate firstQuestion to first 10 chars
-        const text = lastQuestion && lastQuestion?.length > 10 ? `${lastQuestion?.slice(0, 20)}...` : lastQuestion
-        const panelTitle = text || 'New Chat'
+        const panelTitle = getChatPanelTitle(lastQuestion)
         const viewColumn = activePanelViewColumn || vscode.ViewColumn.Beside
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
         const panel = vscode.window.createWebviewPanel(

--- a/vscode/src/chat/chat-view/chat-helpers.test.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.test.ts
@@ -8,7 +8,12 @@ import {
 
 import * as vscode from '../../testutils/mocks'
 
-import { contextItemsToContextFiles, contextMessageToContextItem, stripContextWrapper } from './chat-helpers'
+import {
+    contextItemsToContextFiles,
+    contextMessageToContextItem,
+    getChatPanelTitle,
+    stripContextWrapper,
+} from './chat-helpers'
 import { ContextItem } from './SimpleChatModel'
 
 describe('unwrap context snippets', () => {
@@ -78,3 +83,41 @@ function prettyJSON(obj: any): string {
     }
     return JSON.stringify(obj, Object.keys(obj).sort())
 }
+
+describe('getChatPanelTitle', () => {
+    test('returns default title when no lastDisplayText', () => {
+        const result = getChatPanelTitle()
+        expect(result).toEqual('New Chat')
+    })
+
+    test('truncates long titles', () => {
+        const longTitle = 'This is a very long title that should get truncated'
+        const result = getChatPanelTitle(longTitle)
+        expect(result).toEqual('This is a very long title...')
+    })
+
+    test('keeps command key', () => {
+        const title = '/explain this is the title'
+        const result = getChatPanelTitle(title)
+        expect(result).toEqual('/explain')
+    })
+
+    test('removes markdown links', () => {
+        const title = 'Summarize this file [_@a.ts_](a.ts)'
+        const result = getChatPanelTitle(title)
+        expect(result).toEqual('Summarize this file @a.ts')
+    })
+
+    test('removes multiple markdown links', () => {
+        const title = '[_@a.py_](a.py) [_@b.py_](b.py) explain'
+        const result = getChatPanelTitle(title)
+        expect(result).toEqual('@a.py @b.py explain')
+    })
+
+    test('truncates long title with multiple markdown links', () => {
+        const title =
+            'Explain the relationship between [_@foo/bar.py_](command:vscode.open?foo/bar.py) and [_@foo/bar_test.py_](command:vscode.open?foo/bar_test.py)'
+        const result = getChatPanelTitle(title)
+        expect(result).toEqual('Explain the relationship...')
+    })
+})

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -109,3 +109,16 @@ function activeEditorSelectionRangeToRange(range?: ActiveTextEditorSelectionRang
     }
     return new vscode.Range(range.start.line, range.start.character, range.end.line, range.end.character)
 }
+
+export function getChatPanelTitle(lastDisplayText?: string): string {
+    if (!lastDisplayText) {
+        return 'New Chat'
+    }
+    // Regex to remove the markdown formatted links with this format: '[_@FILENAME_]()'
+    const MARKDOWN_LINK_REGEX = /\[_(.+?)_]\((.+?)\)/g
+    lastDisplayText = lastDisplayText.replaceAll(MARKDOWN_LINK_REGEX, '$1')?.trim()
+    // truncate firstQuestion to first 25 chars
+    const title = lastDisplayText.length > 25 ? `${lastDisplayText?.slice(0, 25)?.trim()}...` : lastDisplayText
+    // Display command key only
+    return title.startsWith('/') ? title.split(' ')[0] : title
+}

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -1,6 +1,7 @@
 import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
+import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { ACCOUNT_UPGRADE_URL, ACCOUNT_USAGE_URL, CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
 
 import { envInit } from './LocalAppDetector'
@@ -42,13 +43,7 @@ export function createCodyChatTreeItems(userHistory: UserLocalHistory): CodySide
     chatHistoryEntries.forEach(([id, entry]) => {
         const lastHumanMessage = entry?.interactions?.findLast(interaction => interaction?.humanMessage)
         if (lastHumanMessage?.humanMessage.displayText && lastHumanMessage?.humanMessage.text) {
-            let title = lastHumanMessage.humanMessage.displayText.split('\n')[0]
-
-            // Display command key only
-            if (title.startsWith('/')) {
-                title = title.split(' ')[0]
-            }
-
+            const title = getChatPanelTitle(lastHumanMessage.humanMessage.displayText.split('\n')[0])
             chatTreeItems.push({
                 id,
                 title,


### PR DESCRIPTION
fix: clean up chat panel titles

- Add a new helper function `getChatPanelTitle()` to generate truncated titles for chat panels. 
- Update usages in `ChatPanelProvider` and `SimpleChatPanelProvider` to use this new helper.
- Add test for the new helper function

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before

- The chat panel title in editor and tree views are different for the same chat session
- Display markdown links
- Some titles are truncated, and some are not

<img width="1274" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/20c8f006-a333-425c-81a7-4db9f5573adb">

### After

- The chat panel title in editor and tree views are the same for the same chat session
- Display links without markdown format 
- All titles are truncated correctly

<img width="1070" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/ea881259-2689-43a1-ba0d-d74d9ae17808">