### PR TITLE
fix: send-button resizes on click

### DIFF
--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -207,8 +207,8 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
 }
 
 .submit-button[disabled] {
-    opacity: 0.8;
-    cursor: text;
+    opacity: 0.4;
+    cursor: default;
 }
 
 .stop-generating-button {

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -324,11 +324,10 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
 }) => (
     <VSCodeButton
         className={classNames(styles.submitButton, className, disabled && styles.submitButtonDisabled)}
-        appearance="primary"
         type="button"
         disabled={disabled}
         onClick={onAbortMessageInProgress ?? onClick}
-        title={onAbortMessageInProgress ? 'Stop Generating' : disabled ? 'Message is empty' : 'Send Message'}
+        title={onAbortMessageInProgress ? 'Stop Generating' : disabled ? '' : 'Send Message'}
     >
         {onAbortMessageInProgress ? <i className="codicon codicon-debug-stop" /> : <SubmitSvg />}
     </VSCodeButton>


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1974

Updated styles for send-button so that:
- [x] Size doesn't change on click
- [x] Cursor updated to default
- [x] Opacity updated to 0.4 
- [x] Removed "Message is empty" [title] tooltip


https://github.com/sourcegraph/cody/assets/68532117/cdeb7581-8527-4635-a432-bebe246837a8


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- [ ] Size doesn't change on click
- [ ] Cursor is default (same as other disabled buttons in VS Code)
- [ ] Opacity is 0.4 (same as other disabled buttons in VS Code)
- [ ] No "Message is empty" [title] tooltip