### PR TITLE
Reduce noise in test logs

### DIFF
--- a/lib/shared/src/utils.test.ts
+++ b/lib/shared/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { convertGitCloneURLToCodebaseName } from './utils'
+import { convertGitCloneURLToCodebaseName, convertGitCloneURLToCodebaseNameOrError, isError } from './utils'
 
 describe('convertGitCloneURLToCodebaseName', () => {
     test('converts GitHub SSH URL', () => {
@@ -76,6 +76,6 @@ describe('convertGitCloneURLToCodebaseName', () => {
     })
 
     test('returns null for invalid URL', () => {
-        expect(convertGitCloneURLToCodebaseName('invalid')).toEqual(null)
+        expect(isError(convertGitCloneURLToCodebaseNameOrError('invalid'))).toBe(true)
     })
 })

--- a/lib/shared/src/utils.ts
+++ b/lib/shared/src/utils.ts
@@ -6,9 +6,23 @@ export const isError = (value: unknown): value is Error => value instanceof Erro
 // - "https://github.com/sourcegraph/deploy-sourcegraph-k8s.git"
 // - "git@github.com:sourcegraph/sourcegraph.git"
 export function convertGitCloneURLToCodebaseName(cloneURL: string): string | null {
-    if (!cloneURL) {
-        console.error(`Unable to determine the git clone URL for this workspace.\ngit output: ${cloneURL}`)
+    const result = convertGitCloneURLToCodebaseNameOrError(cloneURL)
+    if (isError(result)) {
+        if (result.message) {
+            if (result.cause) {
+                console.error(result.message, result.cause)
+            } else {
+                console.error(result.message)
+            }
+        }
         return null
+    }
+    return result
+}
+
+export function convertGitCloneURLToCodebaseNameOrError(cloneURL: string): string | Error {
+    if (!cloneURL) {
+        return new Error(`Unable to determine the git clone URL for this workspace.\ngit output: ${cloneURL}`)
     }
     try {
         // Handle common Git SSH URL format
@@ -36,9 +50,8 @@ export function convertGitCloneURLToCodebaseName(cloneURL: string): string | nul
         if (uri.hostname && uri.pathname) {
             return `${uri.hostname}${uri.pathname.replace('.git', '')}`
         }
-        return null
+        return new Error('')
     } catch (error) {
-        console.error(`Cody could not extract repo name from clone URL ${cloneURL}:`, error)
-        return null
+        return new Error(`Cody could not extract repo name from clone URL ${cloneURL}:`, { cause: error })
     }
 }


### PR DESCRIPTION
Previously, the tests always printed out a stack trace to stderr when running `src/utils.test.ts` even if the tests passed. I've been debugging CI failures lately and this error message has repeatedly been a red herring. This PR refactors the implementation so that we use a separate function for testing purposes that doesn't log to stderr.


## Test plan
Green CI.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
