### PR TITLE
Autocomplete: Document manual completion trigger action

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -485,6 +485,12 @@
         "when": "cody.activated && config.cody.autocomplete && config.cody.debug.enable && editorHasFocus && !editorReadonly"
       },
       {
+        "command": "cody.autocomplete.manual-trigger",
+        "category": "Cody",
+        "title": "Trigger Autocomplete at Cursor",
+        "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+      },
+      {
         "command": "cody.chat.panel.new",
         "category": "Cody",
         "title": "Start a New Chat Panel",


### PR DESCRIPTION
Closes #1979

Since we use a custom action that's different from the default "trigger inline suggestion" feature so we can detect that code branch, we should add it as a command as well. The only confusing thing now is that if you search for "trigger", you will see two commands (Both will work but the Cody specific one will be logged as a manual completion triggered via the action where as the other will log the same as hovering over an existing completion).

As a benefit, this documents the keyboard shortcut. 

## Test plan

<img width="780" alt="Screenshot 2023-11-29 at 11 05 29" src="https://github.com/sourcegraph/cody/assets/458591/0bbc9736-e690-4468-b40d-180425881f6b">

<img width="1021" alt="Screenshot 2023-11-29 at 11 04 44" src="https://github.com/sourcegraph/cody/assets/458591/72e6b79e-e457-4650-9c54-3ca1ecfca0b3">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
