### PR TITLE
Autocomplete: fix multiline trigger position calculation

### DIFF
--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -106,9 +106,9 @@ function getPrefixLastNonEmptyCharPosition(prefix: string, cursorPosition: Posit
     const trimmedPrefix = prefix.trimEnd()
     const diffLength = prefix.length - trimmedPrefix.length
     if (diffLength === 0) {
-        return cursorPosition
+        return cursorPosition.translate(0, -1)
     }
 
     const prefixDiff = prefix.slice(-diffLength)
-    return cursorPosition.translate(-(lines(prefixDiff).length - 1), getLastLine(trimmedPrefix).length - 2)
+    return new Position(cursorPosition.line - (lines(prefixDiff).length - 1), getLastLine(trimmedPrefix).length - 1)
 }

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -1,12 +1,15 @@
 import dedent from 'dedent'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
+import * as Parser from 'web-tree-sitter'
 
 import { range } from '../testutils/textDocument'
+import { asPoint } from '../tree-sitter/parse-tree-cache'
+import { resetParsersCache } from '../tree-sitter/parser'
 
 import { getContextRange } from './doc-context-getters'
 import { getCurrentDocContext } from './get-current-doc-context'
-import { documentAndPosition } from './test-helpers'
+import { documentAndPosition, initTreeSitterParser } from './test-helpers'
 
 function testGetCurrentDocContext(code: string, context?: vscode.InlineCompletionContext) {
     const { document, position } = documentAndPosition(code)
@@ -34,7 +37,7 @@ describe('getCurrentDocContext', () => {
             nextNonEmptyLine: '',
             multilineTrigger: '{',
             multilineTriggerPosition: {
-                character: 23,
+                character: 22,
                 line: 0,
             },
             injectedPrefix: null,
@@ -54,7 +57,7 @@ describe('getCurrentDocContext', () => {
             nextNonEmptyLine: '}',
             multilineTrigger: '{',
             multilineTriggerPosition: {
-                character: 11,
+                character: 10,
                 line: 1,
             },
             injectedPrefix: null,
@@ -74,7 +77,7 @@ describe('getCurrentDocContext', () => {
             nextNonEmptyLine: '];',
             multilineTrigger: '[',
             multilineTriggerPosition: {
-                character: 13,
+                character: 12,
                 line: 0,
             },
             injectedPrefix: null,
@@ -94,7 +97,7 @@ describe('getCurrentDocContext', () => {
             nextNonEmptyLine: '];',
             multilineTrigger: '[',
             multilineTriggerPosition: {
-                character: 13,
+                character: 12,
                 line: 1,
             },
             injectedPrefix: null,
@@ -241,6 +244,53 @@ describe('getCurrentDocContext', () => {
         })
 
         expect(multilineTrigger).toBe(':')
-        expect(multilineTriggerPosition).toEqual({ line: 0, character: 34 })
+        expect(multilineTriggerPosition).toEqual({ line: 0, character: 33 })
+    })
+
+    describe('multiline trigger position verfified by the tree-sitter parser', () => {
+        let parser: Parser
+
+        beforeAll(async () => {
+            parser = await initTreeSitterParser()
+        })
+
+        afterAll(() => {
+            resetParsersCache()
+        })
+
+        it.each([
+            {
+                code: 'const restuls = {█',
+                triggerPosition: { line: 0, character: 16 },
+            },
+            {
+                code: 'const result = {\n  █',
+                triggerPosition: { line: 0, character: 15 },
+            },
+            {
+                code: 'const result = {\n    █',
+                triggerPosition: { line: 0, character: 15 },
+            },
+            {
+                code: 'const something = true\nfunction bubbleSort(█)',
+                triggerPosition: { line: 1, character: 19 },
+            },
+        ])('returns correct multiline trigger position', async ({ code, triggerPosition }) => {
+            const { document, position } = documentAndPosition(code)
+
+            const { multilineTrigger, multilineTriggerPosition } = getCurrentDocContext({
+                document,
+                position,
+                maxPrefixLength: 100,
+                maxSuffixLength: 100,
+                dynamicMultlilineCompletions: true,
+            })
+
+            const tree = parser.parse(document.getText())
+            const charAtTrigger = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!)).text
+
+            expect(charAtTrigger).toBe(multilineTrigger)
+            expect(multilineTriggerPosition).toEqual(triggerPosition)
+        })
     })
 })


### PR DESCRIPTION
## Context

- Fixes the multiline trigger position calculation logic and adds tree-sitter-powered tests to avoid checking the calculated position ourselves.
- Part of #1619 
- Follow-up for #1894 

## Test plan

Added unit tests.
