### PR TITLE
Autocomplete: Use OpenTelemtry traceparent logic

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -3,7 +3,7 @@ import fetch from 'isomorphic-fetch'
 import { TelemetryEventInput } from '@sourcegraph/telemetry'
 
 import { ConfigurationWithAccessToken } from '../../configuration'
-import { getTraceparent, startAsyncSpan } from '../../tracing'
+import { addTraceparent, startAsyncSpan } from '../../tracing'
 import { isError } from '../../utils'
 import { DOTCOM_URL, isDotCom, isLocalApp } from '../environments'
 
@@ -636,10 +636,8 @@ export class SourcegraphGraphQLAPIClient {
         } else if (this.anonymousUserID) {
             headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID)
         }
-        const traceparent = getTraceparent()
-        if (traceparent) {
-            headers.set('traceparent', traceparent)
-        }
+
+        addTraceparent(headers)
         addCustomUserAgent(headers)
 
         const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1]
@@ -664,10 +662,7 @@ export class SourcegraphGraphQLAPIClient {
         const url = buildGraphQLUrl({ request: query, baseUrl: this.dotcomUrl.href })
         const headers = new Headers()
         addCustomUserAgent(headers)
-        const traceparent = getTraceparent()
-        if (traceparent) {
-            headers.set('traceparent', traceparent)
-        }
+        addTraceparent(headers)
 
         const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1]
 

--- a/lib/shared/src/tracing/index.ts
+++ b/lib/shared/src/tracing/index.ts
@@ -1,4 +1,4 @@
-import opentelemetry, { SpanStatusCode } from '@opentelemetry/api'
+import opentelemetry, { context, propagation, SpanStatusCode } from '@opentelemetry/api'
 
 const INSTRUMENTATION_SCOPE_NAME = 'cody'
 const INSTRUMENTATION_SCOPE_VERSION = '0.1'
@@ -35,10 +35,10 @@ export function startAsyncSpan<T>(name: string, fn: () => T | Promise<T>): Promi
  * Create a Trace Context compliant traceparent header value.
  * c.f. https://www.w3.org/TR/trace-context/#examples-of-http-traceparent-headers
  */
-export function getTraceparent(): string | null {
-    const activeIds = getActiveTraceAndSpanId()
-    if (activeIds) {
-        return `00-${activeIds.traceId}-${activeIds.spanId}-01`
-    }
-    return null
+export function addTraceparent(headers: Headers): void {
+    propagation.inject(context.active(), headers, {
+        set(carrier, key, value) {
+            carrier.set(key, value)
+        },
+    })
 }

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -14,7 +14,7 @@ import {
     TimeoutError,
     TracedError,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { getActiveTraceAndSpanId, getTraceparent } from '@sourcegraph/cody-shared/src/tracing'
+import { addTraceparent, getActiveTraceAndSpanId } from '@sourcegraph/cody-shared/src/tracing'
 
 import { fetch } from '../fetch'
 
@@ -74,10 +74,8 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
         }
         if (tracingFlagEnabled) {
             headers.set('X-Sourcegraph-Should-Trace', '1')
-            const traceparent = getTraceparent()
-            if (traceparent) {
-                headers.set('traceparent', traceparent)
-            }
+
+            addTraceparent(headers)
         }
 
         // We enable streaming only for Node environments right now because it's hard to make


### PR DESCRIPTION
Let's not roll our own if we don't have to 😅 

## Test plan
 
- Add yourself to the `cody-autocomplete-tracing` feature flag
- Observe that a `traceparent` is appended to the request (I used console.log to validate since my proxyman isn't working anymore)


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
