### PR TITLE
Agent: fix URI fallback for autocomplete requests

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -293,7 +293,21 @@ export class Agent extends MessageHandler {
                 console.log('Completion provider is not initialized')
                 return { items: [] }
             }
-            const document = this.workspace.getDocument(vscode.Uri.parse(params.uri))
+            const uri =
+                typeof params.uri === 'string'
+                    ? vscode.Uri.parse(params.uri)
+                    : params?.filePath
+                    ? vscode.Uri.file(params.filePath)
+                    : undefined
+            if (!uri) {
+                console.log(
+                    `No uri provided for autocomplete request ${JSON.stringify(
+                        params
+                    )}. To fix this problem, set the 'uri' property.`
+                )
+                return { items: [] }
+            }
+            const document = this.workspace.getDocument(uri)
             if (!document) {
                 console.log('No document found for file path', params.uri, [...this.workspace.allUris()])
                 return { items: [] }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -135,6 +135,7 @@ export interface CompletionItemParams {
 
 export interface AutocompleteParams {
     uri: string
+    filePath?: string
     position: Position
     // Defaults to 'Automatic' for autocompletions which were not explicitly
     // triggered.


### PR DESCRIPTION
We recently moved from `filePath` to `uri` in the agent while supporting old clients by automatically recovering the URI from `filePath`. This PR fixes a bug in that recovery logic that was causing autocomplete to not work.


## Test plan
Green CI
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
