### PR TITLE
change: rename chat panel command title

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -493,7 +493,7 @@
       {
         "command": "cody.chat.panel.new",
         "category": "Cody",
-        "title": "Start a New Chat Panel",
+        "title": "New Chat",
         "when": "cody.activated && config.cody.experimental.chatPanel",
         "group": "Cody",
         "icon": "$(new-comment-icon)"


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/cody/issues/1978

renamed chat panel command title from "Start a New Chat Panel" to "New Chat"

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

![image](https://github.com/sourcegraph/cody/assets/68532117/a9f91d9b-1b50-4a0c-87dc-700dca0c75f7)
