### PR TITLE
change: display sorted commands in ui

### DIFF
--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -221,7 +221,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             // Show the list of prompts to the user using a quick pick menu
             const { selectedItem: selectedPrompt, input: userPrompt } = await showCommandMenu([
                 menu_separators.commands,
-                ...commands,
+                ...commands.sort((a, b) => a.label.localeCompare(b.label)),
                 menu_separators.settings,
                 menu_options.config,
             ])

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -121,7 +121,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             break
                         }
 
-                        prompts = prompts.reduce(groupPrompts, []).map(addInstructions)
+                        prompts = prompts.reduce(groupPrompts, []).map(addInstructions).sort()
 
                         // mark last prompts as last in group before adding another group
                         const lastPrompt = prompts.at(-1)

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -461,5 +461,5 @@ function filterChatCommands(chatCommands: [string, CodyPrompt][], query: string)
     const matchingCommands: [string, CodyPrompt][] = chatCommands.filter(
         ([key, command]) => key === 'separator' || command.slashCommand?.toLowerCase().startsWith(slashCommand)
     )
-    return matchingCommands
+    return matchingCommands.sort()
 }


### PR DESCRIPTION
small UI update: sort commands and prompts alphabetically when on display

Sort commands and prompts alphabetically in the commands menu and chat to improve discoverability and visibility.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before 

Commands are currently not displayed as sorted, making it hard to find when the command list grows longer 

![image](https://github.com/sourcegraph/cody/assets/68532117/6a9645d5-1e42-4f31-9723-e2474b74834b)

![image](https://github.com/sourcegraph/cody/assets/68532117/faedf4a8-476a-4cc8-90ff-0376567ac5eb)

### After

Commands are displayed as sorted in both chat selection box and command menu

![image](https://github.com/sourcegraph/cody/assets/68532117/1b760e9f-663b-4a7a-adf6-96c0d42a5ef4)


![image](https://github.com/sourcegraph/cody/assets/68532117/16309736-20a1-4c7e-aade-28ba491e9d87)
