### PR TITLE
Autocomplete: extended multiline triggers inside brackets

### DIFF
--- a/agent/src/bfg/BfgRetriever.test.ts
+++ b/agent/src/bfg/BfgRetriever.test.ts
@@ -108,7 +108,7 @@ describe('BfgRetriever', async () => {
             position,
             maxPrefixLength: 10_000,
             maxSuffixLength: 1_000,
-            dynamicMultlilineCompletions: false,
+            dynamicMultilineCompletions: false,
         })
         const maxChars = 1_000
         const maxMs = 100

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -35,7 +35,7 @@ const docContext = getCurrentDocContext({
     position,
     maxPrefixLength: 100,
     maxSuffixLength: 100,
-    dynamicMultlilineCompletions: false,
+    dynamicMultilineCompletions: false,
 })
 
 const defaultOptions = {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -57,7 +57,7 @@ export async function createInlineCompletionItemProvider({
         bfgMixedContextFlag,
         localMixedContextFlag,
         disableRecyclingOfPreviousRequests,
-        dynamicMultlilineCompletionsFlag,
+        dynamicMultilineCompletionsFlag,
     ] = await Promise.all([
         createProviderConfig(config, client, authProvider.getAuthStatus().configOverwrites),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteContextLspLight),
@@ -85,8 +85,8 @@ export async function createInlineCompletionItemProvider({
                 ? 'local-mixed'
                 : 'jaccard-similarity'
 
-        const dynamicMultlilineCompletions =
-            config.autocompleteExperimentalDynamicMultilineCompletions || dynamicMultlilineCompletionsFlag
+        const dynamicMultilineCompletions =
+            config.autocompleteExperimentalDynamicMultilineCompletions || dynamicMultilineCompletionsFlag
 
         const completionsProvider = new InlineCompletionItemProvider({
             providerConfig,
@@ -99,7 +99,7 @@ export async function createInlineCompletionItemProvider({
             isRunningInsideAgent: config.isRunningInsideAgent,
             contextStrategy,
             createBfgRetriever,
-            dynamicMultlilineCompletions,
+            dynamicMultilineCompletions,
         })
 
         const documentFilters = await getInlineCompletionItemProviderFilters(config.autocompleteLanguages)

--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -69,7 +69,7 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
         currentLinePrefix.trim() === '' &&
         currentLineSuffix.trim() === '' &&
         openingBracketMatch &&
-        // Only trigger multiline suggestions when the new current line is indented
+        // Only trigger multiline suggestions when the next non-empty line is indented the same or less
         indentation(prevNonEmptyLine) < indentation(currentLinePrefix) &&
         // Only trigger multiline suggestions when the next non-empty line is indented less
         // than the block start line (the newly created block is empty).
@@ -92,7 +92,7 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
         currentLineSuffix.trim() === '' &&
         // Only trigger multiline suggestions for the beginning of blocks
         isBlockStartActive &&
-        // Only trigger multiline suggestions when the new current line is indented
+        // Only trigger multiline suggestions when the next non-empty line is indented the same or less
         indentation(prevNonEmptyLine) < indentation(currentLinePrefix) &&
         // Only trigger multiline suggestions when the next non-empty line is indented less
         // than the block start line (the newly created block is empty).

--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -16,7 +16,7 @@ import {
 interface DetectMultilineParams {
     docContext: LinesContext & DocumentDependentContext
     languageId: string
-    dynamicMultlilineCompletions: boolean
+    dynamicMultilineCompletions: boolean
     position: Position
 }
 
@@ -26,7 +26,7 @@ interface DetectMultilineResult {
 }
 
 export function detectMultiline(params: DetectMultilineParams): DetectMultilineResult {
-    const { docContext, languageId, dynamicMultlilineCompletions, position } = params
+    const { docContext, languageId, dynamicMultilineCompletions, position } = params
     const {
         prefix,
         prevNonEmptyLine,
@@ -45,7 +45,7 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
     // Don't fire multiline completion for method or function invocations
     // see https://github.com/sourcegraph/cody/discussions/358#discussioncomment-6519606
     if (
-        !dynamicMultlilineCompletions &&
+        !dynamicMultilineCompletions &&
         !currentLinePrefix.trim().match(FUNCTION_KEYWORDS) &&
         checkInvocation.match(FUNCTION_OR_METHOD_INVOCATION_REGEX)
     ) {
@@ -75,7 +75,7 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
         // than the block start line (the newly created block is empty).
         indentation(prevNonEmptyLine) >= indentation(nextNonEmptyLine)
 
-    if ((dynamicMultlilineCompletions && isNewLineOpeningBracketMatch) || isSameLineOpeningBracketMatch) {
+    if ((dynamicMultilineCompletions && isNewLineOpeningBracketMatch) || isSameLineOpeningBracketMatch) {
         return {
             multilineTrigger: openingBracketMatch[0],
             multilineTriggerPosition: getPrefixLastNonEmptyCharPosition(prefix, position),
@@ -98,7 +98,7 @@ export function detectMultiline(params: DetectMultilineParams): DetectMultilineR
         // than the block start line (the newly created block is empty).
         indentation(prevNonEmptyLine) >= indentation(nextNonEmptyLine)
 
-    if ((dynamicMultlilineCompletions && nonEmptyLineEndsWithBlockStart) || isEmptyLineAfterBlockStart) {
+    if ((dynamicMultilineCompletions && nonEmptyLineEndsWithBlockStart) || isEmptyLineAfterBlockStart) {
         return {
             multilineTrigger: blockStart,
             multilineTriggerPosition: getPrefixLastNonEmptyCharPosition(prefix, position),

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -8,7 +8,7 @@ import { asPoint } from '../tree-sitter/parse-tree-cache'
 import { resetParsersCache } from '../tree-sitter/parser'
 
 import { getContextRange } from './doc-context-getters'
-import { getCurrentDocContext } from './get-current-doc-context'
+import { DocumentContext, getCurrentDocContext } from './get-current-doc-context'
 import { documentAndPosition, initTreeSitterParser } from './test-helpers'
 
 function testGetCurrentDocContext(code: string, context?: vscode.InlineCompletionContext) {
@@ -232,23 +232,35 @@ describe('getCurrentDocContext', () => {
         `)
     })
 
-    it('detect the multiline trigger for python with `dynamicMultlilineCompletions` enabled', () => {
-        const { document, position } = documentAndPosition('def greatest_common_divisor(a, b):█', 'python')
-
-        const { multilineTrigger, multilineTriggerPosition } = getCurrentDocContext({
-            document,
-            position,
-            maxPrefixLength: 100,
-            maxSuffixLength: 100,
-            dynamicMultlilineCompletions: true,
-        })
-
-        expect(multilineTrigger).toBe(':')
-        expect(multilineTriggerPosition).toEqual({ line: 0, character: 33 })
-    })
-
-    describe('multiline trigger position verfified by the tree-sitter parser', () => {
+    describe('multiline triggers', () => {
         let parser: Parser
+
+        interface PrepareTestParams {
+            code: string
+            dynamicMultlilineCompletions: boolean
+            langaugeId?: string
+        }
+
+        interface PrepareTestResult {
+            docContext: DocumentContext
+            tree: Parser.Tree
+        }
+
+        function prepareTest(params: PrepareTestParams): PrepareTestResult {
+            const { dynamicMultlilineCompletions, code, langaugeId } = params
+            const { document, position } = documentAndPosition(code, langaugeId)
+
+            const tree = parser.parse(document.getText())
+            const docContext = getCurrentDocContext({
+                document,
+                position,
+                maxPrefixLength: 100,
+                maxSuffixLength: 100,
+                dynamicMultlilineCompletions,
+            })
+
+            return { tree, docContext }
+        }
 
         beforeAll(async () => {
             parser = await initTreeSitterParser()
@@ -258,39 +270,122 @@ describe('getCurrentDocContext', () => {
             resetParsersCache()
         })
 
-        it.each([
-            {
-                code: 'const restuls = {█',
-                triggerPosition: { line: 0, character: 16 },
-            },
-            {
-                code: 'const result = {\n  █',
-                triggerPosition: { line: 0, character: 15 },
-            },
-            {
-                code: 'const result = {\n    █',
-                triggerPosition: { line: 0, character: 15 },
-            },
-            {
-                code: 'const something = true\nfunction bubbleSort(█)',
-                triggerPosition: { line: 1, character: 19 },
-            },
-        ])('returns correct multiline trigger position', ({ code, triggerPosition }) => {
-            const { document, position } = documentAndPosition(code)
+        describe('with enabled dynamicMultlilineCompletions', () => {
+            it.each([
+                dedent`
+                    def greatest_common_divisor(a, b):█
+                `,
+                dedent`
+                    def greatest_common_divisor(a, b):
+                        if a == 0:█
+                `,
+                dedent`
+                    def bubbleSort(arr):
+                        n = len(arr)
+                        for i in range(n-1):
+                            █
+                `,
+            ])('detect the multiline trigger for python', code => {
+                const {
+                    tree,
+                    docContext: { multilineTrigger, multilineTriggerPosition },
+                } = prepareTest({ code, dynamicMultlilineCompletions: true, langaugeId: 'python' })
 
-            const { multilineTrigger, multilineTriggerPosition } = getCurrentDocContext({
-                document,
-                position,
-                maxPrefixLength: 100,
-                maxSuffixLength: 100,
-                dynamicMultlilineCompletions: true,
+                const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
+                expect(multilineTrigger).toBe(triggerNode.text)
             })
 
-            const tree = parser.parse(document.getText())
-            const charAtTrigger = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!)).text
+            it.each([
+                {
+                    code: 'const restuls = {█',
+                    triggerPosition: { line: 0, character: 16 },
+                },
+                {
+                    code: 'const result = {\n  █',
+                    triggerPosition: { line: 0, character: 15 },
+                },
+                {
+                    code: 'const result = {\n    █',
+                    triggerPosition: { line: 0, character: 15 },
+                },
+                {
+                    code: 'const something = true\nfunction bubbleSort(█)',
+                    triggerPosition: { line: 1, character: 19 },
+                },
+            ])('returns correct multiline trigger position', ({ code, triggerPosition }) => {
+                const {
+                    tree,
+                    docContext: { multilineTrigger, multilineTriggerPosition },
+                } = prepareTest({ code, dynamicMultlilineCompletions: true })
 
-            expect(charAtTrigger).toBe(multilineTrigger)
-            expect(multilineTriggerPosition).toEqual(triggerPosition)
+                const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
+                expect(multilineTrigger).toBe(triggerNode.text)
+                expect(multilineTriggerPosition).toEqual(triggerPosition)
+            })
+
+            it.each([
+                dedent`
+                    detectMultilineTrigger(
+                        █
+                    )
+                `,
+                dedent`
+                    const oddNumbers = [
+                        █
+                    ]
+                `,
+                dedent`
+                    type Whatever = {
+                        █
+                    }
+                `,
+            ])('detects the multiline trigger on the new line inside of parentheses', code => {
+                const {
+                    tree,
+                    docContext: { multilineTrigger, multilineTriggerPosition },
+                } = prepareTest({ code, dynamicMultlilineCompletions: true })
+
+                const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
+                expect(triggerNode.text).toBe(multilineTrigger)
+            })
+        })
+
+        describe('with disabled dynamicMultlilineCompletions', () => {
+            it.each([
+                dedent`
+                    detectMultilineTrigger(
+                        █
+                    )
+                `,
+                dedent`
+                    const oddNumbers = [
+                        █
+                    ]
+                `,
+            ])('does not detect the multiline trigger on the new line inside of parentheses', code => {
+                const { multilineTrigger } = prepareTest({ code, dynamicMultlilineCompletions: false }).docContext
+                expect(multilineTrigger).toBeNull()
+            })
+
+            it.each([
+                dedent`
+                    detectMultilineTrigger(█)
+                `,
+                dedent`
+                    const oddNumbers = [█]
+                `,
+                dedent`
+                    const result = {█}
+                `,
+            ])('detects the multiline trigger on the current line inside of parentheses', code => {
+                const {
+                    tree,
+                    docContext: { multilineTrigger, multilineTriggerPosition },
+                } = prepareTest({ code, dynamicMultlilineCompletions: true })
+
+                const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
+                expect(triggerNode.text).toBe(multilineTrigger)
+            })
         })
     })
 })

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -296,23 +296,11 @@ describe('getCurrentDocContext', () => {
             })
 
             it.each([
-                {
-                    code: 'const results = {█',
-                    triggerPosition: { line: 0, character: 16 },
-                },
-                {
-                    code: 'const result = {\n  █',
-                    triggerPosition: { line: 0, character: 15 },
-                },
-                {
-                    code: 'const result = {\n    █',
-                    triggerPosition: { line: 0, character: 15 },
-                },
-                {
-                    code: 'const something = true\nfunction bubbleSort(█)',
-                    triggerPosition: { line: 1, character: 19 },
-                },
-            ])('returns correct multiline trigger position', ({ code, triggerPosition }) => {
+                'const results = {█',
+                'const result = {\n  █',
+                'const result = {\n    █',
+                'const something = true\nfunction bubbleSort(█)',
+            ])('returns correct multiline trigger position', code => {
                 const {
                     tree,
                     docContext: { multilineTrigger, multilineTriggerPosition },
@@ -320,7 +308,6 @@ describe('getCurrentDocContext', () => {
 
                 const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
                 expect(multilineTrigger).toBe(triggerNode.text)
-                expect(multilineTriggerPosition).toEqual(triggerPosition)
             })
 
             it.each([
@@ -367,25 +354,18 @@ describe('getCurrentDocContext', () => {
                 expect(multilineTrigger).toBeNull()
             })
 
-            it.each([
-                dedent`
-                    detectMultilineTrigger(█)
-                `,
-                dedent`
-                    const oddNumbers = [█]
-                `,
-                dedent`
-                    const result = {█}
-                `,
-            ])('detects the multiline trigger on the current line inside of parentheses', code => {
-                const {
-                    tree,
-                    docContext: { multilineTrigger, multilineTriggerPosition },
-                } = prepareTest({ code, dynamicMultilineCompletions: true })
+            it.each(['detectMultilineTrigger(█)', 'const oddNumbers = [█]', 'const result = {█}'])(
+                'detects the multiline trigger on the current line inside of parentheses',
+                code => {
+                    const {
+                        tree,
+                        docContext: { multilineTrigger, multilineTriggerPosition },
+                    } = prepareTest({ code, dynamicMultilineCompletions: true })
 
-                const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
-                expect(triggerNode.text).toBe(multilineTrigger)
-            })
+                    const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
+                    expect(triggerNode.text).toBe(multilineTrigger)
+                }
+            )
         })
     })
 })

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -20,7 +20,7 @@ function testGetCurrentDocContext(code: string, context?: vscode.InlineCompletio
         maxPrefixLength: 100,
         maxSuffixLength: 100,
         context,
-        dynamicMultlilineCompletions: false,
+        dynamicMultilineCompletions: false,
     })
 }
 
@@ -214,7 +214,7 @@ describe('getCurrentDocContext', () => {
             position,
             maxPrefixLength: 140,
             maxSuffixLength: 60,
-            dynamicMultlilineCompletions: false,
+            dynamicMultilineCompletions: false,
         })
         const contextRange = getContextRange(document, docContext)
 
@@ -237,7 +237,7 @@ describe('getCurrentDocContext', () => {
 
         interface PrepareTestParams {
             code: string
-            dynamicMultlilineCompletions: boolean
+            dynamicMultilineCompletions: boolean
             langaugeId?: string
         }
 
@@ -247,7 +247,7 @@ describe('getCurrentDocContext', () => {
         }
 
         function prepareTest(params: PrepareTestParams): PrepareTestResult {
-            const { dynamicMultlilineCompletions, code, langaugeId } = params
+            const { dynamicMultilineCompletions, code, langaugeId } = params
             const { document, position } = documentAndPosition(code, langaugeId)
 
             const tree = parser.parse(document.getText())
@@ -256,7 +256,7 @@ describe('getCurrentDocContext', () => {
                 position,
                 maxPrefixLength: 100,
                 maxSuffixLength: 100,
-                dynamicMultlilineCompletions,
+                dynamicMultilineCompletions,
             })
 
             return { tree, docContext }
@@ -270,7 +270,7 @@ describe('getCurrentDocContext', () => {
             resetParsersCache()
         })
 
-        describe('with enabled dynamicMultlilineCompletions', () => {
+        describe('with enabled dynamicMultilineCompletions', () => {
             it.each([
                 dedent`
                     def greatest_common_divisor(a, b):█
@@ -289,7 +289,7 @@ describe('getCurrentDocContext', () => {
                 const {
                     tree,
                     docContext: { multilineTrigger, multilineTriggerPosition },
-                } = prepareTest({ code, dynamicMultlilineCompletions: true, langaugeId: 'python' })
+                } = prepareTest({ code, dynamicMultilineCompletions: true, langaugeId: 'python' })
 
                 const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
                 expect(multilineTrigger).toBe(triggerNode.text)
@@ -316,7 +316,7 @@ describe('getCurrentDocContext', () => {
                 const {
                     tree,
                     docContext: { multilineTrigger, multilineTriggerPosition },
-                } = prepareTest({ code, dynamicMultlilineCompletions: true })
+                } = prepareTest({ code, dynamicMultilineCompletions: true })
 
                 const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
                 expect(multilineTrigger).toBe(triggerNode.text)
@@ -343,14 +343,14 @@ describe('getCurrentDocContext', () => {
                 const {
                     tree,
                     docContext: { multilineTrigger, multilineTriggerPosition },
-                } = prepareTest({ code, dynamicMultlilineCompletions: true })
+                } = prepareTest({ code, dynamicMultilineCompletions: true })
 
                 const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
                 expect(triggerNode.text).toBe(multilineTrigger)
             })
         })
 
-        describe('with disabled dynamicMultlilineCompletions', () => {
+        describe('with disabled dynamicMultilineCompletions', () => {
             it.each([
                 dedent`
                     detectMultilineTrigger(
@@ -363,7 +363,7 @@ describe('getCurrentDocContext', () => {
                     ]
                 `,
             ])('does not detect the multiline trigger on the new line inside of parentheses', code => {
-                const { multilineTrigger } = prepareTest({ code, dynamicMultlilineCompletions: false }).docContext
+                const { multilineTrigger } = prepareTest({ code, dynamicMultilineCompletions: false }).docContext
                 expect(multilineTrigger).toBeNull()
             })
 
@@ -381,7 +381,7 @@ describe('getCurrentDocContext', () => {
                 const {
                     tree,
                     docContext: { multilineTrigger, multilineTriggerPosition },
-                } = prepareTest({ code, dynamicMultlilineCompletions: true })
+                } = prepareTest({ code, dynamicMultilineCompletions: true })
 
                 const triggerNode = tree.rootNode.descendantForPosition(asPoint(multilineTriggerPosition!))
                 expect(triggerNode.text).toBe(multilineTrigger)

--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -285,7 +285,7 @@ describe('getCurrentDocContext', () => {
                         for i in range(n-1):
                             █
                 `,
-            ])('detect the multiline trigger for python', code => {
+            ])('detects the multiline trigger for python', code => {
                 const {
                     tree,
                     docContext: { multilineTrigger, multilineTriggerPosition },
@@ -297,7 +297,7 @@ describe('getCurrentDocContext', () => {
 
             it.each([
                 {
-                    code: 'const restuls = {█',
+                    code: 'const results = {█',
                     triggerPosition: { line: 0, character: 16 },
                 },
                 {

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -32,14 +32,14 @@ interface GetCurrentDocContextParams {
     /* A number representing the maximum length of the suffix to get from the document. */
     maxSuffixLength: number
     context?: vscode.InlineCompletionContext
-    dynamicMultlilineCompletions: boolean
+    dynamicMultilineCompletions: boolean
 }
 
 /**
  * Get the current document context based on the cursor position in the current document.
  */
 export function getCurrentDocContext(params: GetCurrentDocContextParams): DocumentContext {
-    const { document, position, maxPrefixLength, maxSuffixLength, context, dynamicMultlilineCompletions } = params
+    const { document, position, maxPrefixLength, maxSuffixLength, context, dynamicMultilineCompletions } = params
     const offset = document.offsetAt(position)
 
     // TODO(philipp-spiess): This requires us to read the whole document. Can we limit our ranges
@@ -102,7 +102,7 @@ export function getCurrentDocContext(params: GetCurrentDocContextParams): Docume
     return getDerivedDocContext({
         position,
         languageId: document.languageId,
-        dynamicMultlilineCompletions,
+        dynamicMultilineCompletions,
         documentDependentContext: {
             prefix,
             suffix,
@@ -115,7 +115,7 @@ interface GetDerivedDocContextParams {
     languageId: string
     position: vscode.Position
     documentDependentContext: DocumentDependentContext
-    dynamicMultlilineCompletions: boolean
+    dynamicMultilineCompletions: boolean
 }
 
 /**
@@ -123,7 +123,7 @@ interface GetDerivedDocContextParams {
  * Used if the document context needs to be calculated for the updated text but there's no `document` instance for that.
  */
 export function getDerivedDocContext(params: GetDerivedDocContextParams): DocumentContext {
-    const { position, documentDependentContext, languageId, dynamicMultlilineCompletions } = params
+    const { position, documentDependentContext, languageId, dynamicMultilineCompletions } = params
     const linesContext = getLinesContext(documentDependentContext)
 
     return {
@@ -133,7 +133,7 @@ export function getDerivedDocContext(params: GetDerivedDocContextParams): Docume
         ...detectMultiline({
             docContext: { ...linesContext, ...documentDependentContext },
             languageId,
-            dynamicMultlilineCompletions,
+            dynamicMultilineCompletions,
             position,
         }),
     }

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -80,7 +80,7 @@ export function params(
         position,
         maxPrefixLength: 1000,
         maxSuffixLength: 1000,
-        dynamicMultlilineCompletions: false,
+        dynamicMultilineCompletions: false,
         context: takeSuggestWidgetSelectionIntoAccount
             ? {
                   triggerKind: 0,

--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -26,7 +26,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             position,
             maxPrefixLength: 100,
             maxSuffixLength: 100,
-            dynamicMultlilineCompletions: false,
+            dynamicMultilineCompletions: false,
             context: lastTriggerSelectedCompletionInfo
                 ? {
                       triggerKind: vscode.InlineCompletionTriggerKind.Automatic,

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -46,7 +46,7 @@ export interface InlineCompletionsParams {
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
-    dynamicMultlilineCompletions?: boolean
+    dynamicMultilineCompletions?: boolean
 
     // Callbacks to accept completions
     handleDidAcceptCompletionItem?: (
@@ -176,7 +176,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         handleDidPartiallyAcceptCompletionItem,
         artificialDelay,
         completionIntent,
-        dynamicMultlilineCompletions,
+        dynamicMultilineCompletions,
     } = params
 
     tracer?.({ params: { document, position, triggerKind, selectedCompletionInfo } })
@@ -277,7 +277,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         triggerKind,
         providerConfig,
         docContext,
-        dynamicMultlilineCompletions,
+        dynamicMultilineCompletions,
     })
     tracer?.({
         completers: completionProviders.map(({ options }) => ({
@@ -323,19 +323,19 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 interface GetCompletionProvidersParams
     extends Pick<
         InlineCompletionsParams,
-        'document' | 'position' | 'triggerKind' | 'providerConfig' | 'dynamicMultlilineCompletions'
+        'document' | 'position' | 'triggerKind' | 'providerConfig' | 'dynamicMultilineCompletions'
     > {
     docContext: DocumentContext
 }
 
 function getCompletionProviders(params: GetCompletionProvidersParams): Provider[] {
-    const { document, position, triggerKind, providerConfig, docContext, dynamicMultlilineCompletions } = params
+    const { document, position, triggerKind, providerConfig, docContext, dynamicMultilineCompletions } = params
 
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
         docContext,
         document,
         position,
-        dynamicMultlilineCompletions,
+        dynamicMultilineCompletions,
     }
 
     if (docContext.multilineTrigger) {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -121,7 +121,7 @@ export interface CodyCompletionItemProviderConfig {
     // Feature flags
     completeSuggestWidgetSelection?: boolean
     disableRecyclingOfPreviousRequests?: boolean
-    dynamicMultlilineCompletions?: boolean
+    dynamicMultilineCompletions?: boolean
 }
 
 interface CompletionRequest {
@@ -159,7 +159,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     constructor({
         completeSuggestWidgetSelection = true,
         disableRecyclingOfPreviousRequests = false,
-        dynamicMultlilineCompletions = false,
+        dynamicMultilineCompletions = false,
         tracer = null,
         createBfgRetriever,
         ...config
@@ -168,7 +168,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             ...config,
             completeSuggestWidgetSelection,
             disableRecyclingOfPreviousRequests,
-            dynamicMultlilineCompletions,
+            dynamicMultilineCompletions,
             tracer,
             isRunningInsideAgent: config.isRunningInsideAgent ?? false,
         }
@@ -298,7 +298,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 maxSuffixLength: this.config.providerConfig.contextSizeHints.suffixChars,
                 // We ignore the current context selection if completeSuggestWidgetSelection is not enabled
                 context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,
-                dynamicMultlilineCompletions: this.config.dynamicMultlilineCompletions,
+                dynamicMultilineCompletions: this.config.dynamicMultilineCompletions,
             })
 
             const completionIntent = getCompletionIntent({
@@ -341,7 +341,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     completeSuggestWidgetSelection: takeSuggestWidgetSelectionIntoAccount,
                     artificialDelay,
                     completionIntent,
-                    dynamicMultlilineCompletions: this.config.dynamicMultlilineCompletions,
+                    dynamicMultilineCompletions: this.config.dynamicMultilineCompletions,
                 })
 
                 // Avoid any further work if the completion is invalidated already.

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -35,7 +35,7 @@ const defaultRequestParams: RequestParams = {
         position,
         maxPrefixLength: 100,
         maxSuffixLength: 100,
-        dynamicMultlilineCompletions: false,
+        dynamicMultilineCompletions: false,
     }),
     selectedCompletionInfo: undefined,
 }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -144,7 +144,7 @@ export class AnthropicProvider extends Provider {
         if (prompt.length > this.promptChars) {
             throw new Error(`prompt length (${prompt.length}) exceeded maximum character length (${this.promptChars})`)
         }
-        const { dynamicMultlilineCompletions, multiline } = this.options
+        const { dynamicMultilineCompletions, multiline } = this.options
 
         const requestParams: CodeCompletionsParams = {
             temperature: 0.5,
@@ -163,7 +163,7 @@ export class AnthropicProvider extends Provider {
         }
 
         let fetchAndProcessCompletionsImpl = fetchAndProcessCompletions
-        if (dynamicMultlilineCompletions) {
+        if (dynamicMultilineCompletions) {
             // If the feature flag is enabled use params adjusted for the experiment.
             Object.assign(requestParams, DYNAMIC_MULTLILINE_COMPLETIONS_ARGS)
 

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -274,7 +274,7 @@ function getUpdatedDocContext(params: GetUpdatedDocumentContextParams): Document
     const updatedDocContext = getDerivedDocContext({
         languageId: document.languageId,
         position: updatedPosition,
-        dynamicMultlilineCompletions: true,
+        dynamicMultilineCompletions: true,
         documentDependentContext: {
             prefix: prefix + firstLine,
             // Remove the characters that are being replaced by the completion

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -159,7 +159,7 @@ export class FireworksProvider extends Provider {
         snippets: ContextSnippet[],
         tracer?: CompletionProviderTracer
     ): Promise<InlineCompletionItemWithAnalytics[]> {
-        const { multiline, dynamicMultlilineCompletions } = this.options
+        const { multiline, dynamicMultilineCompletions } = this.options
         const prompt = this.createPrompt(snippets)
 
         const model =
@@ -192,7 +192,7 @@ export class FireworksProvider extends Provider {
         }
 
         let fetchAndProcessCompletionsImpl = fetchAndProcessCompletions
-        if (dynamicMultlilineCompletions) {
+        if (dynamicMultilineCompletions) {
             // If the feature flag is enabled use params adjusted for the experiment.
             Object.assign(requestParams, DYNAMIC_MULTLILINE_COMPLETIONS_ARGS)
 

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -64,7 +64,7 @@ export interface ProviderOptions {
     n: number
 
     // feature flags
-    dynamicMultlilineCompletions?: boolean
+    dynamicMultilineCompletions?: boolean
 }
 
 export abstract class Provider {

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -114,7 +114,7 @@ ${OPENING_CODE_TAG}${infillBlock}`
         tracer?: CompletionProviderTracer
     ): Promise<InlineCompletionItemWithAnalytics[]> {
         const prompt = this.createPrompt(snippets)
-        const { dynamicMultlilineCompletions, multiline } = this.options
+        const { dynamicMultilineCompletions, multiline } = this.options
 
         const requestParams: CodeCompletionsParams = {
             messages: [{ speaker: 'human', text: prompt }],
@@ -126,7 +126,7 @@ ${OPENING_CODE_TAG}${infillBlock}`
         }
 
         let fetchAndProcessCompletionsImpl = fetchAndProcessCompletions
-        if (dynamicMultlilineCompletions) {
+        if (dynamicMultilineCompletions) {
             // If the feature flag is enabled use params adjusted for the experiment.
             Object.assign(requestParams, DYNAMIC_MULTLILINE_COMPLETIONS_ARGS)
 

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -49,7 +49,7 @@ function docState(prefix: string, suffix: string = ';'): RequestParams {
             position,
             maxPrefixLength: 100,
             maxSuffixLength: 100,
-            dynamicMultlilineCompletions: false,
+            dynamicMultilineCompletions: false,
         }),
         selectedCompletionInfo: undefined,
     }


### PR DESCRIPTION
## Context

- Enables generation of the multiline completions inside brackets when the cursor is on the new empty line inside them. This change is behind the `dynamicMultilineCompletions` feature flag.
- With the improved context, this change should lead to more correct completions from the type system POV.
- Improved units around detecting the multiline trigger with and without the `dynamicMultilineCompletions` feature flag.
- Builds on top of #1894 
- Closes https://github.com/sourcegraph/cody/issues/1999

```ts
generateContext(
    █
)

const oddNumbers = [
    █
]
```

## Screenshots

![multiline-arguments](https://github.com/sourcegraph/cody/assets/3846380/bec07a3e-5a80-4030-a9fa-3bc08092597c)

![multiline-arrays](https://github.com/sourcegraph/cody/assets/3846380/2e53ab5b-7db7-475e-927d-4cd6ca6c223a)

## Test plan

- Added new unit tests.
- Test it locally by setting `cody.autocomplete.experimental.dynamicMultilineCompletions` to true and generating completions similar to examples on screenshots.
