### PR TITLE
Change "Restart Chat Session" icon and add a confirmation

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -42,6 +42,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Command: Editor title icon will only show up in non-readonly file editor views. [pull/1909](https://github.com/sourcegraph/cody/pull/1909)
 - Chat: Include text in dotCom chat events. [pull/1910](https://github.com/sourcegraph/cody/pull/1910)
 - Chat: Replaced vscode links with custom "cody.chat.open.file" protocol when displaying file names in chat. [pull/1919](https://github.com/sourcegraph/cody/pull/1919)
+- Chat: Change "Restart Chat Session" icon and add a confirmation. [pull/2002](https://github.com/sourcegraph/cody/pull/2002)
 
 ## [0.16.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -549,9 +549,9 @@
       {
         "command": "cody.chat.restart",
         "category": "Cody",
-        "title": "Restart Chat Session",
+        "title": "Restart Chat Session...",
         "group": "Cody",
-        "icon": "$(refresh)",
+        "icon": "$(clear-all)",
         "when": "cody.activated && cody.hasChatHistory && config.cody.experimental.chatPanel"
       }
     ],

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -388,6 +388,14 @@ const register = async (
         }),
         // Commands
         vscode.commands.registerCommand('cody.chat.restart', async () => {
+            const confirmation = await vscode.window.showWarningMessage(
+                'Restart Chat Session',
+                { modal: true, detail: 'Restarting the chat session will erase the chat transcript.' },
+                'Restart Chat Session'
+            )
+            if (!confirmation) {
+                return
+            }
             await chatManager.clearAndRestartSession()
             telemetryService.log('CodyVSCodeExtension:chatTitleButton:clicked', { name: 'clear' }, { hasV2Event: true })
             telemetryRecorder.recordEvent('cody.interactive.clear', 'clicked', { privateMetadata: { name: 'clear' } })


### PR DESCRIPTION
This changes the current icon from `reload` (which is too close to a browser reload) to `clear-all` (which isn't perfect but looks more destructive). It also adds a confirmation dialog:

| Before | After |
| - | - |
| <img width="372" alt="Screenshot 2023-11-30 at 4 09 59 pm" src="https://github.com/sourcegraph/cody/assets/153/8a704d00-ed72-4557-aa62-7e2bf85175c6"> | <img width="372" alt="Screenshot 2023-11-30 at 4 10 24 pm" src="https://github.com/sourcegraph/cody/assets/153/e1795346-f551-4657-aede-adf879bd202c"> |

| Confirmation |
| - |
| <img width="1238" alt="Screenshot 2023-11-30 at 4 03 17 pm" src="https://github.com/sourcegraph/cody/assets/153/7a97ad51-84ce-428f-8974-b63f484c5a57"> |

## Test plan

- Viewed the button
- Clicked the button, verify prompt cancel does nothing
- Clicked the button, verify "Restart Chat Session" does the action
- Typed `/reset` and verify it doesn't ask for confirmation