### PR TITLE
Edit: Fix edit command palette

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -616,7 +616,7 @@
       "commandPalette": [
         {
           "command": "cody.command.edit-code",
-          "when": "cody.activated"
+          "when": "cody.activated && editorIsOpen"
         },
         {
           "command": "cody.command.explain-code",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -616,7 +616,7 @@
       "commandPalette": [
         {
           "command": "cody.command.edit-code",
-          "when": "cody.activated && editorTextFocus"
+          "when": "cody.activated"
         },
         {
           "command": "cody.command.explain-code",


### PR DESCRIPTION
## Description

Noticed by @toolmantim that it wasn't showing.

It is because the text focus moves to the command palette.

We show an error when no file is open so this should be fine to always show when activated

## Test plan

1. Open command palette
2. Check the command shows

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
