### PR TITLE
Edit: Only affix non-whitespace changes to ranges

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -30,6 +30,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Chat: The commands display box in the chat input box now uses the same styles as the @ command results box. [pull/1962](https://github.com/sourcegraph/cody/pull/1962)
 - Chat: Fix chat command selection to only filter on '/' prefix. [pull/1980](https://github.com/sourcegraph/cody/pull/1980)
 - Chat: Improve @-file completion to better preserve input value. [pull/1980](https://github.com/sourcegraph/cody/pull/1980)
+- Edit: Fixed an issue where Cody could incorrectly produce edits when repositioning code or moving your cursor onto new lines. [pull/2005](https://github.com/sourcegraph/cody/pull/2005)
 
 ### Changed
 

--- a/vscode/src/non-stop/tracked-range.test.ts
+++ b/vscode/src/non-stop/tracked-range.test.ts
@@ -219,6 +219,14 @@ describe('Tracked Range', () => {
         it('should track single character insertion after the range as a range expansion', () => {
             expect(track('[hell]() world', 'o', { supportRangeAffix: true })).toBe('[hello] world')
         })
+
+        it('should not track whitespace insertion before the range as a range expansion', () => {
+            expect(track('( )[llo] world', '  \n', { supportRangeAffix: true })).toBe('  \n[llo] world')
+        })
+
+        it('should not track whitespace insertion after the range as a range expansion', () => {
+            expect(track('[hello]( )', '  \n', { supportRangeAffix: true })).toBe('[hello]  \n')
+        })
     })
 })
 

--- a/vscode/src/non-stop/tracked-range.ts
+++ b/vscode/src/non-stop/tracked-range.ts
@@ -57,8 +57,8 @@ export function updateRange(range: vscode.Range, change: TextChange, options: Up
     const insertedLineBreaks = lines.length - 1
 
     // Handle edits
-    // support combining the appended change with the original range
-    if (options.supportRangeAffix && change.range.start.isEqual(range.end)) {
+    // support combining non-whitespace appended changes with the original range
+    if (options.supportRangeAffix && change.range.start.isEqual(range.end) && change.text.trim().length > 0) {
         return new vscode.Range(
             range.start,
             change.range.end.translate(
@@ -69,8 +69,8 @@ export function updateRange(range: vscode.Range, change: TextChange, options: Up
             )
         )
     }
-    // support combining the prepended change with the original range
-    if (options.supportRangeAffix && change.range.end.isEqual(range.start)) {
+    // support combining non-whitespace prepended changes with the original range
+    if (options.supportRangeAffix && change.range.end.isEqual(range.start) && change.text.trim().length > 0) {
         return new vscode.Range(
             change.range.start,
             range.end.translate(


### PR DESCRIPTION
## Description

We want to allow affixing non-whitespace characters and including that in the edit selection range (e.g. `export` before a function, or a JSDoc above an identifier).

We do not want to affix whitespace characters, as this may be from the user moving their cursor onto a different line, or repositioning the code.

### Before

https://github.com/sourcegraph/cody/assets/9516420/aab05bc5-4c19-4a93-ac41-53de10b3dc60


### After

https://github.com/sourcegraph/cody/assets/9516420/2db9a97f-85d0-41a2-b905-e151938135ce




## Test plan

1. Create fixup
2. Move cursor to start of range
3. Enter non-whitespace characters and see range expands

1. Create fixup
2. Move cursor to start of range
3. Enter whitespace characters and see range does not expand

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
