### PR TITLE
Autocomplete: stop some dynamic multiline completions early

### DIFF
--- a/vscode/src/completions/can-use-partial-completion.ts
+++ b/vscode/src/completions/can-use-partial-completion.ts
@@ -7,6 +7,7 @@ import { InlineCompletionItemWithAnalytics } from './text-processing/process-inl
 export interface CanUsePartialCompletionParams {
     document: TextDocument
     docContext: DocumentContext
+    isDynamicMultilineCompletion?: boolean
 }
 
 /**

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -338,6 +338,7 @@ export interface ItemPostProcessingInfo {
         parent?: string
         grandparent?: string
         greatGrandparent?: string
+        lastAncestorOnTheSameLine?: string
     }
     // Syntax node types extracted from the tree-sitter parse-tree with the completion pasted.
     nodeTypesWithCompletion?: {
@@ -345,6 +346,7 @@ export interface ItemPostProcessingInfo {
         parent?: string
         grandparent?: string
         greatGrandparent?: string
+        lastAncestorOnTheSameLine?: string
     }
 }
 

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -107,6 +107,7 @@ export async function fetchAndProcessDynamicMultilineCompletions(
                             const completion = canUsePartialCompletion(initialCompletion, {
                                 document: providerOptions.document,
                                 docContext: updatedDocContext,
+                                isDynamicMultilineCompletion: true,
                             })
 
                             if (completion) {

--- a/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
+++ b/vscode/src/completions/text-processing/parse-and-truncate-completion.ts
@@ -1,4 +1,5 @@
 import { TextDocument } from 'vscode'
+import { SyntaxNode } from 'web-tree-sitter'
 
 import { DocumentContext } from '../get-current-doc-context'
 import { completionPostProcessLogger } from '../post-process-logger'
@@ -7,10 +8,12 @@ import { parseCompletion, ParsedCompletion } from './parse-completion'
 import { InlineCompletionItemWithAnalytics } from './process-inline-completions'
 import { normalizeStartLine, truncateMultilineCompletion } from './truncate-multiline-completion'
 import { truncateParsedCompletion } from './truncate-parsed-completion'
+import { getFirstLine } from './utils'
 
 export interface ParseAndTruncateParams {
     document: TextDocument
     docContext: DocumentContext
+    isDynamicMultilineCompletion?: boolean
 }
 
 export function parseAndTruncateCompletion(
@@ -21,6 +24,7 @@ export function parseAndTruncateCompletion(
         document,
         docContext,
         docContext: { multilineTrigger, completionPostProcessId, prefix },
+        isDynamicMultilineCompletion,
     } = params
 
     const multiline = Boolean(multilineTrigger)
@@ -44,6 +48,14 @@ export function parseAndTruncateCompletion(
             document,
             docContext,
         })
+
+        // Stop streaming _some_ unhelpful dynamic multiline completions by truncating the insert text early.
+        if (
+            isDynamicMultilineCompletion &&
+            isDynamicMultilineCompletionToStopStreaming(truncationResult.nodeToInsert)
+        ) {
+            truncationResult.insertText = getFirstLine(truncationResult.insertText)
+        }
 
         const initialLineCount = insertTextBeforeTruncation.split('\n').length
         const truncatedLineCount = truncationResult.insertText.split('\n').length
@@ -71,6 +83,7 @@ interface TruncateMultilineBlockParams {
 interface TruncateMultilineBlockResult {
     truncatedWith: 'tree-sitter' | 'indentation'
     insertText: string
+    nodeToInsert?: SyntaxNode
 }
 
 export function truncateMultilineBlock(params: TruncateMultilineBlockParams): TruncateMultilineBlockResult {
@@ -79,7 +92,7 @@ export function truncateMultilineBlock(params: TruncateMultilineBlockParams): Tr
     if (parsed.tree) {
         return {
             truncatedWith: 'tree-sitter',
-            insertText: truncateParsedCompletion({
+            ...truncateParsedCompletion({
                 completion: parsed,
                 docContext,
                 document,
@@ -93,4 +106,19 @@ export function truncateMultilineBlock(params: TruncateMultilineBlockParams): Tr
         truncatedWith: 'indentation',
         insertText: truncateMultilineCompletion(parsed.insertText, prefix, suffix, document.languageId),
     }
+}
+
+const NODE_TYPES_TO_STOP_STREAMING_AT_ROOT_NODE = new Set(['class_declaration'])
+
+/**
+ * Stop streaming dynamic multiline completions which leads to genereting a lot of lines
+ * and are unhelpful most of the time. Currently applicable to a number of node types
+ * at the root of the document.
+ */
+function isDynamicMultilineCompletionToStopStreaming(node?: SyntaxNode): boolean {
+    return Boolean(node && isRootNode(node.parent) && NODE_TYPES_TO_STOP_STREAMING_AT_ROOT_NODE.has(node.type))
+}
+
+function isRootNode(node: SyntaxNode | null): boolean {
+    return node?.parent === null
 }

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -11,6 +11,7 @@ import { completionPostProcessLogger } from '../post-process-logger'
 import { InlineCompletionItem } from '../types'
 
 import { dropParserFields, ParsedCompletion } from './parse-completion'
+import { findLastAncestorOnTheSameRow } from './truncate-parsed-completion'
 import { collapseDuplicativeWhitespace, removeTrailingWhitespace, trimUntilSuffix } from './utils'
 
 export interface ProcessInlineCompletionsParams {
@@ -63,7 +64,7 @@ interface ProcessItemParams {
 
 export function processCompletion(completion: ParsedCompletion, params: ProcessItemParams): ParsedCompletion {
     const { document, position, docContext } = params
-    const { prefix, suffix, currentLineSuffix, multilineTrigger } = docContext
+    const { prefix, suffix, currentLineSuffix, multilineTrigger, multilineTriggerPosition } = docContext
     let { insertText } = completion
 
     if (completion.insertText.length === 0) {
@@ -82,12 +83,20 @@ export function processCompletion(completion: ParsedCompletion, params: ProcessI
 
     // Use the parse tree WITHOUT the pasted completion to get surrounding node types.
     // Helpful to optimize the completion AST triggers for higher CAR.
-    completion.nodeTypes = getNodeTypesInfo(position, getCachedParseTreeForDocument(document)?.tree)
+    completion.nodeTypes = getNodeTypesInfo({
+        position,
+        parseTree: getCachedParseTreeForDocument(document)?.tree,
+        multilineTriggerPosition,
+    })
 
     // Use the parse tree WITH the pasted completion to get surrounding node types.
     // Helpful to understand CAR for incomplete code snippets.
     // E.g., `const value = ` does not produce a valid AST, but `const value = 'someValue'` does
-    completion.nodeTypesWithCompletion = getNodeTypesInfo(position, completion.tree)
+    completion.nodeTypesWithCompletion = getNodeTypesInfo({
+        position,
+        parseTree: completion.tree,
+        multilineTriggerPosition,
+    })
 
     if (multilineTrigger) {
         insertText = removeTrailingWhitespace(insertText)
@@ -108,10 +117,15 @@ export function processCompletion(completion: ParsedCompletion, params: ProcessI
     return { ...completion, insertText }
 }
 
-function getNodeTypesInfo(
-    position: Position,
+interface GetNodeTypesInfoParams {
+    position: Position
     parseTree?: Tree
-): InlineCompletionItemWithAnalytics['nodeTypes'] | undefined {
+    multilineTriggerPosition: Position | null
+}
+
+function getNodeTypesInfo(params: GetNodeTypesInfoParams): InlineCompletionItemWithAnalytics['nodeTypes'] | undefined {
+    const { position, parseTree, multilineTriggerPosition } = params
+
     const positionBeforeCursor = asPoint({
         line: position.line,
         character: Math.max(0, position.character - 1),
@@ -122,12 +136,17 @@ function getNodeTypesInfo(
 
         if (captures.length > 0) {
             const [atCursor, ...parents] = captures
+            const lastAncestorOnTheSameLine = findLastAncestorOnTheSameRow(
+                parseTree.rootNode,
+                asPoint(multilineTriggerPosition || position)
+            )
 
             return {
                 atCursor: atCursor.node.type,
                 parent: parents[0]?.node.type,
                 grandparent: parents[1]?.node.type,
                 greatGrandparent: parents[2]?.node.type,
+                lastAncestorOnTheSameLine: lastAncestorOnTheSameLine?.type,
             }
         }
     }


### PR DESCRIPTION
## Context

- Disabled dynamic multiline completions for class declarations at the root of the file because they are most often unhelpful and huge.
- Closes https://github.com/sourcegraph/cody/issues/1924

## Test plan

- Tested manually:
  - Set the `cody.autocomplete.experimental.dynamicMultilineCompletions` setting to `true`.
  - Generate a completion for `class █` as the root of any Typescript file.
  - Verify that a singleline completion is generated.
  - Verify that `function █` generates a multiline completion.
- Going to add unit tests for this case here: https://github.com/sourcegraph/cody/issues/1920
