### PR TITLE
VScode: Start up local embeddings less often

### DIFF
--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -38,7 +38,7 @@ interface RemoteEmbeddingsProvider {
 export interface LocalEmbeddingsProvider {
     kind: 'embeddings'
     type: 'local'
-    state: 'unconsented' | 'indexing' | 'ready'
+    state: 'indeterminate' | 'unconsented' | 'indexing' | 'ready'
 }
 
 interface SearchProvider {

--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -16,6 +16,7 @@ import {
     populatePreciseCodeContextTemplate,
 } from '../prompt/templates'
 import { Message } from '../sourcegraph-api'
+import { DOTCOM_URL } from '../sourcegraph-api/environments'
 import { EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
 import { UnifiedContextFetcher } from '../unified-context'
 import { isError } from '../utils'
@@ -147,7 +148,7 @@ export class CodebaseContext {
         query: string,
         options: ContextSearchOptions
     ): Promise<EmbeddingsSearchResult[]> {
-        if (this.localEmbeddings) {
+        if (this.config.serverEndpoint === DOTCOM_URL.toString() && this.localEmbeddings) {
             // TODO(dpc): Check whether the local embeddings index exists for
             // this repo before relying on it.
             // TODO(dpc): Fetch code and text results.

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -351,13 +351,13 @@ async function getCodebaseContext(
     }
 
     // TODO: When SimpleChatContextProvider stops using hackGetCodebaseContext,
-    // it must start sending localEmbeddings.load and setAccessToken directly to
-    // the embeddings controller.
+    // it must start sending localEmbeddings.load directly to the embeddings
+    // controller.
     const repoDirUri = gitDirectoryUri(workspaceRoot)
     let [embeddingsSearch, hasLocalEmbeddings] = await Promise.all([
         // Find an embeddings clients
         EmbeddingsDetector.newEmbeddingsSearchClient(embeddingsClientCandidates, codebase, workspaceRoot.fsPath),
-        repoDirUri ? localEmbeddings?.hasIndex(repoDirUri) : false,
+        repoDirUri ? localEmbeddings?.load(repoDirUri) : false,
     ])
     if (isError(embeddingsSearch)) {
         logDebug(

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -82,6 +82,8 @@ export class ContextProvider implements vscode.Disposable {
     ) {
         this.disposables.push(this.configurationChangeEvent)
 
+        this.localEmbeddings = (codebaseContext.localEmbeddings || undefined) as LocalEmbeddingsController | undefined
+
         this.currentWorkspaceRoot = ''
         this.disposables.push(
             vscode.window.onDidChangeActiveTextEditor(async () => {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -65,7 +65,7 @@ export class ContextProvider implements vscode.Disposable {
 
     protected disposables: vscode.Disposable[] = []
 
-    private localEmbeddings: LocalEmbeddingsController | undefined = undefined
+    public readonly localEmbeddings: LocalEmbeddingsController | undefined = undefined
 
     private statusAggregator: ContextStatusAggregator = new ContextStatusAggregator()
     private statusEmbeddings: vscode.Disposable | undefined = undefined

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -37,7 +37,11 @@ export class ChatManager implements vscode.Disposable {
         private embeddingsSearch: EmbeddingsSearch | null,
         private localEmbeddings: LocalEmbeddingsController | null
     ) {
-        logDebug('ChatManager:constructor', 'init')
+        logDebug(
+            'ChatManager:constructor',
+            'init',
+            localEmbeddings ? 'has local embeddings controller' : 'no local embeddings'
+        )
         this.options = { extensionUri, ...options }
 
         this.sidebarChat = new SidebarChatProvider(this.options)

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -116,6 +116,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         // Push context status to the webview when it changes.
         this.disposables.push(this.contextStatusAggregator.onDidChangeStatus(() => this.postContextStatusToWebView()))
         this.disposables.push(this.contextStatusAggregator)
+        logDebug('SimpleChatPanelProvider', 'created with local embeddings?', !!this.localEmbeddings)
         if (this.localEmbeddings) {
             this.disposables.push(this.contextStatusAggregator.addProvider(this.localEmbeddings))
         }
@@ -212,6 +213,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
     }
 
     private postContextStatusToWebView(): void {
+        logDebug(
+            'SimpleChatPanelProvider',
+            'postContextStatusToWebView',
+            JSON.stringify(this.contextStatusAggregator.status)
+        )
         void this.webview?.postMessage({
             type: 'enhanced-context',
             context: {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -113,6 +113,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         this.sessionID = this.chatModel.sessionID
         this.guardrails = guardrails
 
+        // Advise local embeddings to start up if necessary.
+        void this.localEmbeddings?.start()
+
         // Push context status to the webview when it changes.
         this.disposables.push(this.contextStatusAggregator.onDidChangeStatus(() => this.postContextStatusToWebView()))
         this.disposables.push(this.contextStatusAggregator)

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -119,7 +119,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         // Push context status to the webview when it changes.
         this.disposables.push(this.contextStatusAggregator.onDidChangeStatus(() => this.postContextStatusToWebView()))
         this.disposables.push(this.contextStatusAggregator)
-        logDebug('SimpleChatPanelProvider', 'created with local embeddings?', !!this.localEmbeddings)
         if (this.localEmbeddings) {
             this.disposables.push(this.contextStatusAggregator.addProvider(this.localEmbeddings))
         }

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -13,6 +13,7 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { CodeCompletionsClient, createClient as createCodeCompletionsClint } from './completions/client'
 import { PlatformContext } from './extension.common'
+import { LocalEmbeddingsController } from './local-context/local-embeddings'
 import { logDebug, logger } from './log'
 
 interface ExternalServices {
@@ -21,6 +22,7 @@ interface ExternalServices {
     chatClient: ChatClient
     codeCompletionsClient: CodeCompletionsClient
     guardrails: Guardrails
+    localEmbeddings: LocalEmbeddingsController | undefined
 
     /** Update configuration for all of the services in this interface. */
     onConfigurationChange: (newConfig: ExternalServicesConfiguration) => void
@@ -80,7 +82,7 @@ export async function configureExternalServices(
         rgPath ? platform.createLocalKeywordContextFetcher?.(rgPath, editor, chatClient) ?? null : null,
         rgPath ? platform.createFilenameContextFetcher?.(rgPath, editor, chatClient) ?? null : null,
         null,
-        localEmbeddings || null,
+        null,
         symf,
         undefined
     )
@@ -93,6 +95,7 @@ export async function configureExternalServices(
         chatClient,
         codeCompletionsClient,
         guardrails,
+        localEmbeddings,
         onConfigurationChange: newConfig => {
             sentryService?.onConfigurationChange(newConfig)
             openTelemetryService?.onConfigurationChange(newConfig)

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -2,14 +2,6 @@
  * The protocol for communicating between Cody and local embeddings.
  */
 
-export type HasIndexResult = IndexMetadata | null
-
-export interface IndexMetadata {
-    format: 'App' | 'LocalEmbeddings'
-    indexFilePath: string
-    repoName: string
-}
-
 export interface QueryResultSet {
     results: QueryResult[]
 }
@@ -30,8 +22,6 @@ export interface IndexRequest {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type Requests = {
     'embeddings/echo': [string, string]
-    // Query whether an index exists for the repo at the specified path.
-    'embeddings/has-index': [string, HasIndexResult]
     // Instruct local embeddings to index the specified repository path.
     'embeddings/index': [IndexRequest, undefined]
     // Searches for and loads an index for the specified repository name.

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -2,6 +2,14 @@
  * The protocol for communicating between Cody and local embeddings.
  */
 
+export type HasIndexResult = IndexMetadata | null
+
+export interface IndexMetadata {
+    format: 'App' | 'LocalEmbeddings'
+    indexFilePath: string
+    repoName: string
+}
+
 export interface QueryResultSet {
     results: QueryResult[]
 }
@@ -22,6 +30,8 @@ export interface IndexRequest {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type Requests = {
     'embeddings/echo': [string, string]
+    // Query whether an index exists for the repo at the specified path.
+    'embeddings/has-index': [string, HasIndexResult]
     // Instruct local embeddings to index the specified repository path.
     'embeddings/index': [IndexRequest, undefined]
     // Searches for and loads an index for the specified repository name.

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -51,7 +51,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
         }
         this.accessToken = token || undefined
         // TODO: Add a "drop token" for sign out
-        if (token && this.service) {
+        if (token && this.serviceStarted) {
             // TODO: Make the cody-engine reply to set-token.
             void (await this.getService()).request('embeddings/set-token', token)
         }
@@ -108,7 +108,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                     // For now flip to a checkmark so people don't generate
                     // a second index.
                     this.lastRepo.loadResult = true
-                    this.statusBar.fire(this)
+                    this.statusEvent.fire(this)
                 }
             } else {
                 // TODO(dpc): Handle these notifications.
@@ -194,15 +194,6 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
     }
 
     // Interactions with cody-engine
-
-    public async hasIndex(repoPath: vscode.Uri): Promise<boolean> {
-        if (!this.endpointIsDotcom) {
-            return false
-        }
-        const metadata = await (await this.getService()).request('embeddings/has-index', repoPath.fsPath)
-        logDebug('LocalEmbeddingsController', 'has-index', repoPath.fsPath, JSON.stringify(metadata))
-        return !!metadata
-    }
 
     public async index(): Promise<void> {
         if (!(this.endpointIsDotcom && this.lastRepo?.path && !this.lastRepo?.loadResult)) {

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -110,7 +110,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
         if (this.accessToken) {
             // Set the initial access token
             // cody-engine does not reply to this, but we just need it to
-            // happen in order, so void.
+            // happen in order.
             void service.request('embeddings/set-token', this.accessToken)
         }
         // TODO: Handle the "last codebase" as well
@@ -211,10 +211,11 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
         }
     }
 
-    public async load(repoPath: string | undefined): Promise<boolean> {
+    public async load(repoUri: vscode.Uri | undefined): Promise<boolean> {
         if (!this.endpointIsDotcom) {
             return false
         }
+        const repoPath = repoUri?.fsPath
         if (!repoPath) {
             return Promise.resolve(false)
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -166,6 +166,7 @@ const register = async (
     )
     const embeddingsSearch = codebaseContext?.tempHackGetEmbeddingsSearch() || null
     const localEmbeddings = contextProvider.context.localEmbeddings as LocalEmbeddingsController | null
+    logDebug('localEmbeddings', 'is it set', localEmbeddings)
 
     // Shared configuration that is required for chat views to send and receive messages
     const messageProviderOptions: MessageProviderOptions = {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -165,7 +165,7 @@ const register = async (
         undefined // Note, we do not pass LocalEmbeddingsController here to delay initializing it as long as possible
     )
     const embeddingsSearch = codebaseContext?.tempHackGetEmbeddingsSearch() || null
-    const localEmbeddings = contextProvider.context.localEmbeddings as LocalEmbeddingsController | null
+    const localEmbeddings = contextProvider.localEmbeddings as LocalEmbeddingsController | null
     logDebug('localEmbeddings', 'is it set', localEmbeddings)
 
     // Shared configuration that is required for chat views to send and receive messages

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -22,7 +22,6 @@ import { getActiveEditor } from './editor/active-editor'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { PlatformContext } from './extension.common'
 import { configureExternalServices } from './external-services'
-import { LocalEmbeddingsController } from './local-context/local-embeddings'
 import { logDebug } from './log'
 import { FixupController } from './non-stop/FixupController'
 import { showSetupNotification } from './notifications/setup-notification'
@@ -136,6 +135,7 @@ const register = async (
         chatClient,
         codeCompletionsClient,
         guardrails,
+        localEmbeddings,
         onConfigurationChange: externalServicesOnDidConfigurationChange,
     } = await configureExternalServices(initialConfig, rgPath, symfRunner, editor, platform)
 
@@ -165,7 +165,6 @@ const register = async (
         undefined // Note, we do not pass LocalEmbeddingsController here to delay initializing it as long as possible
     )
     const embeddingsSearch = codebaseContext?.tempHackGetEmbeddingsSearch() || null
-    const localEmbeddings = contextProvider.localEmbeddings as LocalEmbeddingsController | null
 
     // Shared configuration that is required for chat views to send and receive messages
     const messageProviderOptions: MessageProviderOptions = {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -166,7 +166,6 @@ const register = async (
     )
     const embeddingsSearch = codebaseContext?.tempHackGetEmbeddingsSearch() || null
     const localEmbeddings = contextProvider.localEmbeddings as LocalEmbeddingsController | null
-    logDebug('localEmbeddings', 'is it set', localEmbeddings)
 
     // Shared configuration that is required for chat views to send and receive messages
     const messageProviderOptions: MessageProviderOptions = {


### PR DESCRIPTION
The initial download for local embeddings can be arbitrarily slow, so we should avoid it until we are likely no need it and not block user interaction on it.

This ameliorates the startup cost of local embeddings in these ways:

- Cache the access token and don't start cody-engine, *just* to provide it a token.
- Cache the endpoint and don't start cody-engine for non-dotcom. (Should investigate adding it back for integration tests, though.)
- Add a hint from SimpleChatPanelProvider, to local embeddings, to start up when a chat panel provider is created. But do not block on that.
- When polled for local embeddings, respond that they're unavailable unless cody-engine has started.
 
## Test plan

1. Set the following configuration:

```
  "cody.debug.enable": true,
  "cody.debug.verbose": true,
  "cody.experimental.chatPanel": true,
  "cody.experimental.simpleChatContext": true,
```

2. Open a repo indexed by dotcom, open a new chat from the Cody sidebar, open the enhanced context selector. Embeddings, checked, "Inherited from ..." should appear. Chats should include remote embeddings context. (The precise context source can be verified in Output, Cody by Sourcegraph.)
3. Close the folder (File, Close Folder), open a new chat from the Cody sidebar, "No codebase loaded" should appear. Note, there's no design for this state so this will change later. Queries should still work, without embeddings context.
4. Open a git repo that was indexed by App that is not indexed on dotcom, open the enhanced context selector, after loading, Embeddings should appear checked. Chats should include local embeddings context.
5. Open a "private repo", specifically, git repo that has a default fetch URL, which is not indexed on dotcom, and not indexed by App. Open the enhanced context selector. After loading an Enable Embeddings button should appear. Click the button, indexing status should appear in the status bar.
6. After some indexing is done or failed, reload the window, open a new chat, open the enhanced context selector. Embeddings should appear checked. Queries should include local embeddings context.

Note: There is an issue with chat restore, I believe unrelated (also on trunk, [related Slack](https://sourcegraph.slack.com/archives/C05AGQYD528/p1701316056167949)) where restored chat panels are blank or not hosted by the SimpleChatPanelProvider. You can verify the panel host in Output, Cody by Sourcegraph, and look for SimpleChatPanelProvider messages.