### PR TITLE
BFG: increase resilience

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -33,10 +33,8 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
     const paths = envPaths('Cody')
     try {
         const gitdirPath = path.join(workspaceRoot.fsPath, '.git')
-        const gitdir = await fspromises.stat(gitdirPath)
-        if (gitdir.isDirectory()) {
-            vscode_shim.addGitRepository(workspaceRoot, 'fake_vscode_shim_commit')
-        }
+        await fspromises.stat(gitdirPath)
+        vscode_shim.addGitRepository(workspaceRoot, 'fake_vscode_shim_commit')
     } catch {
         /* ignore */
     }

--- a/agent/src/bfg/BfgRetriever.test.ts
+++ b/agent/src/bfg/BfgRetriever.test.ts
@@ -9,7 +9,7 @@ import * as rimraf from 'rimraf'
 import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
-import { bfgIndexingPromise, BfgRetriever } from '../../../vscode/src/completions/context/retrievers/bfg/bfg-retriever'
+import { BfgRetriever } from '../../../vscode/src/completions/context/retrievers/bfg/bfg-retriever'
 import { getCurrentDocContext } from '../../../vscode/src/completions/get-current-doc-context'
 import { initTreeSitterParser } from '../../../vscode/src/completions/test-helpers'
 import { TextDocumentWithUri } from '../../../vscode/src/jsonrpc/TextDocumentWithUri'
@@ -95,8 +95,6 @@ describe('BfgRetriever', async () => {
         })
 
         const bfg = new BfgRetriever(extensionContext as vscode.ExtensionContext)
-
-        await bfgIndexingPromise
 
         const document = agent.workspace.agentTextDocument(new TextDocumentWithUri(uri))
         assert(document.getText().length > 0)


### PR DESCRIPTION
Previously, our BFG integration had a chance of failing in certain cases. Specifically, I was seeing errors when we sent concurrent `bfg/revision/didChange` requests. This PR adds a try/catch to that block along with a few other defensive changes to make BFG more resilient overall.


## Test plan

Manually tested by running the evaluation suite with parallel `revision/didChange` results and confirmed that it recovers.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
