### PR TITLE
Edit: Rename diff view from Fixup to Edit

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -843,13 +843,13 @@ export class FixupController
             'vscode.diff',
             tempDocUri,
             task.fixupFile.uri,
-            'Cody Fixup Diff View - ' + task.id,
+            'Cody Edit Diff View - ' + task.id,
             {
                 preview: true,
                 preserveFocus: false,
                 selection: task.selectionRange,
-                label: 'Cody Fixup Diff View',
-                description: 'Cody Fixup Diff View: ' + task.fixupFile.uri.fsPath,
+                label: 'Cody Edit Diff View',
+                description: 'Cody Edit Diff View: ' + task.fixupFile.uri.fsPath,
             }
         )
     }

--- a/vscode/test/e2e/task-controller.test.ts
+++ b/vscode/test/e2e/task-controller.test.ts
@@ -65,7 +65,7 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     // Diff view button
     await page.locator('a').filter({ hasText: 'replace hello with goodbye' }).click()
     await page.getByRole('button', { name: 'Show diff for fixup' }).click()
-    await expect(page.getByText(/^Cody Fixup Diff View.*/)).toBeVisible()
+    await expect(page.getByText(/^Cody Edit Diff View.*/)).toBeVisible()
 
     // Accept fixup button on Click
     await page.locator('a').filter({ hasText: 'replace hello with goodbye' }).click()


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/1949

## Description

Renames the diff view title
<img width="673" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/a1b7c552-a1fb-4dd6-81f5-0bd64dcf47cc">

Reflects how we brand "Edit" and doesn't confuse user

## Test plan

1. Create an edit
2. Click the diff button

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
