### PR TITLE
fix: revive simple chat panel

### DIFF
--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -218,17 +218,20 @@ export class ChatManager implements vscode.Disposable {
      * Creates a new webview panel for chat.
      */
     public async createWebviewPanel(chatID?: string, chatQuestion?: string): Promise<IChatPanelProvider | undefined> {
-        if (!this.chatPanelsManager) {
-            return undefined
-        }
-        return this.chatPanelsManager.createWebviewPanel(chatID, chatQuestion)
+        logDebug('SimpleChatPanelProvider:createWebviewPanel', 'creating')
+        return this.chatPanelsManager?.createWebviewPanel(chatID, chatQuestion)
     }
 
     public async revive(panel: vscode.WebviewPanel, chatID: string): Promise<void> {
-        this.createChatPanelsManger()
-        if (this.chatPanelsManager) {
+        try {
+            if (!this.chatPanelsManager) {
+                throw new Error('ChatPanelsManager is not initialized')
+            }
             await this.chatPanelsManager.revive(panel, chatID)
-            telemetryService.log('CodyVSCodeExtension:chatPanelsManger:revive', undefined, { hasV2Event: true })
+            telemetryService.log('CodyVSCodeExtension:chatPanelsManger:revived', undefined, { hasV2Event: true })
+        } catch (error) {
+            panel.dispose()
+            logDebug('SimpleChatPanelProvider:revive', 'failed', { error })
         }
     }
 

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -383,14 +383,7 @@ export class ChatPanelProvider extends MessageProvider {
         activePanelViewColumn?: vscode.ViewColumn,
         chatID?: string,
         lastQuestion?: string
-    ): Promise<vscode.WebviewPanel | undefined> {
-        // Create the webview panel only if the user is logged in.
-        // Allows users to login via the sidebar webview.
-        if (!this.authProvider.getAuthStatus()?.isLoggedIn || !this.contextProvider.config.experimentalChatPanel) {
-            await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, false)
-            return
-        }
-
+    ): Promise<vscode.WebviewPanel> {
         telemetryService.log('CodyVSCodeExtension:createWebviewPanel:clicked', undefined, { hasV2Event: true })
 
         // Checks if the webview panel already exists and is visible.
@@ -425,10 +418,10 @@ export class ChatPanelProvider extends MessageProvider {
      * Revives the chat panel when the extension is reactivated.
      * Registers the existing webviewPanel and sets the chatID.
      */
-    public async revive(webviewPanel: vscode.WebviewPanel, chatID: string): Promise<vscode.WebviewPanel | undefined> {
-        telemetryService.log('CodyVSCodeExtension:ChatPanelProvider:revive', undefined, { hasV2Event: true })
+    public async revive(webviewPanel: vscode.WebviewPanel, chatID: string): Promise<void> {
+        logDebug('ChatPanelProvider:revive', 'reviving webview panel')
         this.startUpChatID = chatID
-        return this.registerWebviewPanel(webviewPanel)
+        await this.registerWebviewPanel(webviewPanel)
     }
 
     /**

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -69,6 +69,10 @@ export class SimpleChatModel {
         })
     }
 
+    public getLastHumanMessages(): MessageWithContext | undefined {
+        return this.messagesWithContext.findLast(message => message.message.speaker === 'human')
+    }
+
     public updateLastHumanMessage(message: Omit<Message, 'speaker'>): void {
         const lastMessage = this.messagesWithContext.at(-1)
         if (!lastMessage) {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -404,6 +404,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         // trigger the context progress indicator
         void this.postViewTranscript({ speaker: 'assistant' })
         await this.generateAssistantResponse(requestID, userContextFiles, addEnhancedContext)
+        // Set the title of the webview panel to the current text
+        if (this.webviewPanel) {
+            this.webviewPanel.title = getChatPanelTitle(text)
+        }
     }
 
     private async handleEdit(requestID: string, text: string): Promise<void> {


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1701316056167949

- Revived simple chat panel when extension is reactivated by registering existing webviewPanel and setting chatID. 
- Added error handling in revive method to dispose panel and log debug message on failure.
- Updated related methods to handle null chatPanelsManager.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Enable SimpleChatPanel
2. Ask Cody a question and keep the new chat panel opened
3. Reload VS Code
4. You should see the chat has been restored
5. Check Output Channel to confirm the view is created by SimpleChatPanel 

## Demo

https://github.com/sourcegraph/cody/assets/68532117/24a9ac6f-988d-437e-8879-27a43be55d36


