### PR TITLE
VScode: Enhanced context selector updates in new "not simplified" panel chats

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -109,7 +109,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     protected guardrails: Guardrails
     protected readonly editor: VSCodeEditor
     protected authProvider: AuthProvider
-    protected contextProvider: ContextProvider
+    protected readonly contextProvider: ContextProvider
     protected platform: Pick<PlatformContext, 'recipes'>
 
     protected chatModel: string | undefined = undefined

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -147,7 +147,8 @@ const register = async (
         rgPath,
         symfRunner,
         authProvider,
-        platform
+        platform,
+        localEmbeddings
     )
     disposables.push(contextProvider)
     disposables.push(new LocalAppSetupPublisher(contextProvider))


### PR DESCRIPTION
Fixes #2027 

## Test plan

1. Set the following VScode settings:

```
  "cody.debug.enable": true,
  "cody.debug.verbose": true,
  "cody.experimental.chatPanel": true,
```

Note `"cody.experimental.simpleChatContext"` is *not* present/enabled.

2. Open a repository which should have remote embeddings, for example sourcegraph/sourcegraph. Start a chat. Open the enhanced context selector. "Embeddings ... Inherited from github.com/sourcegraph/sourcegraph" should appear.
3. Open a repository which was indexed by App, that is *not* indexed on dotcom. Start a chat. Open the enhanced context selector. After a delay to download and start cody-engine, "Embeddings" should appear with a checkmark.
4. Open a repository that is not indexed by App or dotcom. Start a chat. Open the enhanced context selector. You should get a promotion to "Enable Embeddings". (Clicking that button may crash cody-engine, that is a separate issue.)
5. Close the folder (File, Close Folder), start a chat, open enhanced context. The dialog should show a checkbox but list no context providers.

The same test plan should work with `cody.experimental.simpleChatContext` turned on, although step 5 will show a slighly different busy indicator.