### PR TITLE
fix: truncate long panel title

### DIFF
--- a/vscode/src/chat/chat-view/chat-helpers.test.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.test.ts
@@ -90,10 +90,10 @@ describe('getChatPanelTitle', () => {
         expect(result).toEqual('New Chat')
     })
 
-    test('long titles will not get truncated', () => {
-        const longTitle = 'This is a very long title that should get truncated'
+    test('long titles will be truncated', () => {
+        const longTitle = 'This is a very long title that should get truncated by the function'
         const result = getChatPanelTitle(longTitle)
-        expect(result).toEqual(longTitle)
+        expect(result).toEqual('This is a very long title...')
     })
 
     test('keeps command key', () => {
@@ -121,9 +121,8 @@ describe('getChatPanelTitle', () => {
     })
 
     test('truncates long title with multiple markdown links', () => {
-        const title =
-            'Explain the relationship between [_@foo/bar.py_](command:vscode.open?foo/bar.py) and [_@foo/bar_test.py_](command:vscode.open?foo/bar_test.py)'
+        const title = 'Explain the relationship...'
         const result = getChatPanelTitle(title)
-        expect(result).toEqual('Explain the relationship between @foo/bar.py and @foo/bar_test.py')
+        expect(result).toEqual('Explain the relationship....')
     })
 })

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -118,5 +118,5 @@ export function getChatPanelTitle(lastDisplayText?: string): string {
     const MARKDOWN_LINK_REGEX = /\[_(.+?)_]\((.+?)\)/g
     lastDisplayText = lastDisplayText.replaceAll(MARKDOWN_LINK_REGEX, '$1')?.trim()
     // truncate title that is too long
-    return lastDisplayText.length > 25 ? lastDisplayText.slice(0, 25) + '...' : lastDisplayText
+    return lastDisplayText.length > 25 ? lastDisplayText.slice(0, 25).trim() + '...' : lastDisplayText
 }

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -118,5 +118,5 @@ export function getChatPanelTitle(lastDisplayText?: string): string {
     const MARKDOWN_LINK_REGEX = /\[_(.+?)_]\((.+?)\)/g
     lastDisplayText = lastDisplayText.replaceAll(MARKDOWN_LINK_REGEX, '$1')?.trim()
     // truncate title that is too long
-    return lastDisplayText
+    return lastDisplayText.length > 25 ? lastDisplayText.slice(0, 25) + '...' : lastDisplayText
 }


### PR DESCRIPTION
We will need to truncate the panel title if it's too long or the close button will be hidden in the editor to close the chat panel

<img width="2004" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/e6a10488-067a-4e90-9274-d5e3b678646a">

No button to close the chat panel:

<img width="1007" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/3b379d25-6910-4256-accb-b21cf0fc5a14">


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Tests updated.

Close button to show up again even if the title is too long:

<img width="787" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/5679dc2c-8430-44b4-bf11-74747225853a">
