### PR TITLE
Clarify pre-release builds in changelog

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-All notable changes to Sourcegraph Cody will be documented in this file.
-
-Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versions and `major.ODD_NUMBER.patch` for pre-release versions.
+This is a log of all notable changes to Cody for VS Code. [Unreleased] changes are included in the nightly pre-release builds.
 
 ## [Unreleased]
 


### PR DESCRIPTION
This cleans up the changelog language around versions, removing the mention of odd version numbers that aren't actually included in this document, and instead mentioning that it's the `[Unreleased]` features that may be included.

This will also help when we link directly to the changelog in #2025

## Test plan

- None required