### PR TITLE
VS Code: hide experimental settings for stable releases

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -29,7 +29,7 @@
     "_build:webviews": "vite -c webviews/vite.config.ts build",
     "lint": "pnpm run lint:js",
     "lint:js": "NODE_OPTIONS=--max-old-space-size=4096 eslint --quiet --cache '**/*.[tj]s?(x)'",
-    "release": "ts-node ./scripts/release.ts",
+    "release": "ts-node-transpile-only ./scripts/release.ts",
     "download-wasm": "ts-node-transpile-only ./scripts/download-wasm-modules.ts",
     "release:dry-run": "pnpm run download-wasm && CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
     "storybook": "storybook dev -p 6007 --no-open --no-version-updates --no-release-notes",

--- a/vscode/scripts/release.ts
+++ b/vscode/scripts/release.ts
@@ -82,6 +82,25 @@ if (customDefaultSettingsFile) {
     writeJsonFileSync('package.json', packageJSON)
 }
 
+if (releaseType === ReleaseType.Stable) {
+    console.log('Removing experimental settings before the stable release...')
+
+    try {
+        const properties = packageJSON?.contributes?.configuration?.properties
+        if (properties) {
+            for (const key in properties) {
+                if (key.includes('.experimental.')) {
+                    delete properties[key]
+                }
+            }
+            fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2), 'utf8')
+        }
+    } catch (error) {
+        console.error('Error removing experimental settings', error)
+        process.exit(1) // Exit with a non-zero status code in case of an error
+    }
+}
+
 // Tokens are stored in the GitHub repository's secrets.
 const tokens = {
     vscode: dryRun ? 'dry-run' : process.env.VSCODE_MARKETPLACE_TOKEN,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -135,13 +135,10 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         // when something goes wrong, and to suppress event logging in the agent.
         // Rely on this flag sparingly.
         isRunningInsideAgent: getHiddenSetting('advanced.agent.running', false),
-        agentIDE: getHiddenSetting<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('cody.advanced.agent.ide'),
+        agentIDE: getHiddenSetting<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('advanced.agent.ide'),
         autocompleteTimeouts: {
-            multiline: getHiddenSetting<number | undefined>('cody.autocomplete.advanced.timeout.multiline', undefined),
-            singleline: getHiddenSetting<number | undefined>(
-                'cody.autocomplete.advanced.timeout.singleline',
-                undefined
-            ),
+            multiline: getHiddenSetting<number | undefined>('autocomplete.advanced.timeout.multiline', undefined),
+            singleline: getHiddenSetting<number | undefined>('autocomplete.advanced.timeout.singleline', undefined),
         },
     }
 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -21,6 +21,10 @@ interface ConfigGetter {
 export function getConfiguration(config: ConfigGetter = vscode.workspace.getConfiguration()): Configuration {
     const isTesting = process.env.CODY_TESTING === 'true'
 
+    function getHiddenSetting<T>(configKey: string, defaultValue?: T): T {
+        return config.get<T>(`cody.${configKey}` as any, defaultValue)
+    }
+
     let debugRegex: RegExp | null = null
     try {
         const debugPattern: string | null = config.get<string | null>(CONFIG_KEY.debugFilter, null)
@@ -34,15 +38,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
     } catch (error: any) {
         void vscode.window.showErrorMessage("Error parsing cody.debug.filter regex - using default '*'", error)
         debugRegex = new RegExp('.*')
-    }
-
-    let autocompleteExperimentalGraphContext: 'lsp-light' | 'bfg' | null = config.get(
-        CONFIG_KEY.autocompleteExperimentalGraphContext,
-        null
-    )
-    // Handle the old `true` option
-    if (autocompleteExperimentalGraphContext === true) {
-        autocompleteExperimentalGraphContext = 'lsp-light'
     }
 
     let autocompleteAdvancedProvider: Configuration['autocompleteAdvancedProvider'] = config.get(
@@ -63,6 +58,19 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         checkValidEnumValues(key, value)
     }
 
+    /**
+     * Hidden settings for internal use only.
+     */
+    const experimentalChatPanel = getHiddenSetting('experimental.chatPanel', isTesting)
+    let autocompleteExperimentalGraphContext: 'lsp-light' | 'bfg' | null = getHiddenSetting(
+        'autocomplete.experimental.graphContext',
+        null
+    )
+    // Handle the old `true` option
+    if (autocompleteExperimentalGraphContext === true) {
+        autocompleteExperimentalGraphContext = 'lsp-light'
+    }
+
     return {
         // NOTE: serverEndpoint is now stored in Local Storage instead but we will still keep supporting the one in confg
         // to use as fallback for users who do not have access to local storage
@@ -80,14 +88,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
             '*': true,
             scminput: false,
         }),
-        experimentalChatPanel: config.get(CONFIG_KEY.experimentalChatPanel, isTesting),
-        experimentalChatPredictions: config.get(CONFIG_KEY.experimentalChatPredictions, isTesting),
-        experimentalSearchPanel: config.get(CONFIG_KEY.experimentalNewSearch, isTesting),
-        experimentalSimpleChatContext: config.get(CONFIG_KEY.experimentalSimpleChatContext, isTesting),
         chatPreInstruction: config.get(CONFIG_KEY.chatPreInstruction),
-        experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),
-        experimentalNonStop: config.get(CONFIG_KEY.experimentalNonStop, isTesting),
-        experimentalLocalSymbols: config.get(CONFIG_KEY.experimentalLocalSymbols, false),
         commandCodeLenses: config.get(CONFIG_KEY.commandCodeLenses, false),
         editorTitleCommandIcon: config.get(CONFIG_KEY.editorTitleCommandIcon, true),
         autocompleteAdvancedProvider,
@@ -101,35 +102,44 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
             CONFIG_KEY.autocompleteCompleteSuggestWidgetSelection,
             true
         ),
-        autocompleteExperimentalSyntacticPostProcessing: config.get(
-            CONFIG_KEY.autocompleteExperimentalSyntacticPostProcessing,
-            true
-        ),
-        autocompleteExperimentalGraphContext,
-        autocompleteExperimentalDynamicMultilineCompletions: config.get(
-            CONFIG_KEY.autocompleteExperimentalDynamicMultilineCompletions,
-            false
-        ),
 
         // NOTE: Inline Chat will be deprecated soon - Do not enable inline-chat when experimental.chatPanel is enabled
-        inlineChat:
-            config.get(CONFIG_KEY.inlineChatEnabled, false) !== config.get(CONFIG_KEY.experimentalChatPanel, isTesting),
+        inlineChat: config.get(CONFIG_KEY.inlineChatEnabled, false) !== experimentalChatPanel,
         codeActions: config.get(CONFIG_KEY.codeActionsEnabled, true),
 
         /**
-         * UNDOCUMENTED FLAGS
+         * Hidden settings for internal use only.
          */
+
+        autocompleteExperimentalGraphContext,
+        experimentalChatPanel: getHiddenSetting('experimental.chatPanel', isTesting),
+        experimentalChatPredictions: getHiddenSetting('experimental.chatPredictions', isTesting),
+        experimentalSearchPanel: getHiddenSetting('experimental.newSearch', isTesting),
+        experimentalSimpleChatContext: getHiddenSetting('experimental.simpleChatContext', isTesting),
+
+        experimentalGuardrails: getHiddenSetting('experimental.guardrails', isTesting),
+        experimentalNonStop: getHiddenSetting('experimental.nonStop', isTesting),
+        experimentalLocalSymbols: getHiddenSetting('experimental.localSymbols', false),
+
+        autocompleteExperimentalSyntacticPostProcessing: getHiddenSetting(
+            'autocomplete.experimental.syntacticPostProcessing',
+            true
+        ),
+        autocompleteExperimentalDynamicMultilineCompletions: getHiddenSetting(
+            'autocomplete.experimental.dynamicMultilineCompletions',
+            false
+        ),
 
         // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
         // We currently use this flag for the agent to provide more helpful error messages
         // when something goes wrong, and to suppress event logging in the agent.
         // Rely on this flag sparingly.
-        isRunningInsideAgent: config.get<boolean>('cody.advanced.agent.running' as any, false),
-        agentIDE: config.get<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('cody.advanced.agent.ide' as any),
+        isRunningInsideAgent: getHiddenSetting('advanced.agent.running', false),
+        agentIDE: getHiddenSetting<'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'>('cody.advanced.agent.ide'),
         autocompleteTimeouts: {
-            multiline: config.get<number | undefined>('cody.autocomplete.advanced.timeout.multiline' as any, undefined),
-            singleline: config.get<number | undefined>(
-                'cody.autocomplete.advanced.timeout.singleline' as any,
+            multiline: getHiddenSetting<number | undefined>('cody.autocomplete.advanced.timeout.multiline', undefined),
+            singleline: getHiddenSetting<number | undefined>(
+                'cody.autocomplete.advanced.timeout.singleline',
                 undefined
             ),
         },


### PR DESCRIPTION
## Context

- Removes experimental settings from the `package.json` file before stable releases.
- [Slack thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1701398005070439)

## Test plan

Tested it locally using a dry-run release.
