### PR TITLE
Embeddings: Display indexing status in Enhanced Context Selector, query new index when done

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,9 @@ importers:
       '@sourcegraph/telemetry':
         specifier: ^0.13.0
         version: 0.13.0
+      '@storybook/preview-api':
+        specifier: ^7.6.2
+        version: 7.6.2
       '@types/stream-json':
         specifier: ^1.7.3
         version: 1.7.3
@@ -1070,12 +1073,10 @@ packages:
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-identifier@7.22.5:
     resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-option@7.22.5:
     resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
@@ -1143,7 +1144,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
@@ -3122,7 +3122,6 @@ packages:
       '@babel/helper-string-parser': 7.22.5
       '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
-    dev: true
 
   /@base2/pretty-print-object@1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -5554,6 +5553,17 @@ packages:
     resolution: {integrity: sha512-Br3XILhrtuL5Sdp91I04kKjJzSqU/N8gGL6B6nIfnuaHUvGMDuMCHAB+g7aoiyH5dnpDZ6yBVGNwtYAyJA+0Og==}
     dev: true
 
+  /@storybook/channels@7.6.2:
+    resolution: {integrity: sha512-pSVpnMAfMsImPyAorYPcfkZmBY34+eHmcj8Zab0m/36/M0AQrUq7VSxA+7KD3rhoZaJjioeouxqigjiznNAbZw==}
+    dependencies:
+      '@storybook/client-logger': 7.6.2
+      '@storybook/core-events': 7.6.2
+      '@storybook/global': 5.0.0
+      qs: 6.11.2
+      telejson: 7.2.0
+      tiny-invariant: 1.3.1
+    dev: false
+
   /@storybook/cli@7.0.26:
     resolution: {integrity: sha512-sZ136wRUYTdhhm/thegFoI47wOzl2X+K9eaiTTp0ARwnIUhXAPDQ0MKOD36hKbCX5T/pBE7r++7WoEReIbUDqQ==}
     dependencies:
@@ -5607,6 +5617,12 @@ packages:
     dependencies:
       '@storybook/global': 5.0.0
     dev: true
+
+  /@storybook/client-logger@7.6.2:
+    resolution: {integrity: sha512-9hlDm7q6jZPVBoqW8V7DTMNMsjMaL2t45h+I8veQhnC2ZW6g+lARXQQDHZpL6MKVkJn6mEA9F0nJBIknbQpqBQ==}
+    dependencies:
+      '@storybook/global': 5.0.0
+    dev: false
 
   /@storybook/codemod@7.0.26:
     resolution: {integrity: sha512-H9sV59FfGrGzGM+UZQclNglnc4cOkQvvF3EOWlR3BfDhx+STSB9VbCR308ygjUYw2TXZ2s5seCvHtVvA2yhILA==}
@@ -5685,6 +5701,12 @@ packages:
   /@storybook/core-events@7.0.26:
     resolution: {integrity: sha512-ckZszphEAYs9wp8tPVhayEMzk8JxCiQfzbq0S45sbdqdTrl40PmsOjv5iPNaUYElI/Stfz+v4gDCEUfOsxyC+w==}
     dev: true
+
+  /@storybook/core-events@7.6.2:
+    resolution: {integrity: sha512-JciGNDclg3hx+WkXsAzcCBYWk0xsyIbyCAwqN7XVHUpGndR/dl97Qum5MkO9kPb8r5toKpeBOQo5Kxo2GiE0dg==}
+    dependencies:
+      ts-dedent: 2.2.0
+    dev: false
 
   /@storybook/core-server@7.0.26:
     resolution: {integrity: sha512-QieqH19jBPZafxJVmCVK6GTYkRN/CJ8RQUvyRH2KNhqXP0tHYfL51FlU70ldo/vHX6Ax4Cje5hx/Nln9+DOMNg==}
@@ -5774,6 +5796,12 @@ packages:
       type-fest: 2.19.0
     dev: true
 
+  /@storybook/csf@0.1.2:
+    resolution: {integrity: sha512-ePrvE/pS1vsKR9Xr+o+YwdqNgHUyXvg+1Xjx0h9LrVx7Zq4zNe06pd63F5EvzTbCbJsHj7GHr9tkiaqm7U8WRA==}
+    dependencies:
+      type-fest: 2.19.0
+    dev: false
+
   /@storybook/docs-mdx@0.1.0:
     resolution: {integrity: sha512-JDaBR9lwVY4eSH5W8EGHrhODjygPd6QImRbwjAuJNEnY0Vw4ie3bPkeGfnacB3OBW6u/agqPv2aRlR46JcAQLg==}
     dev: true
@@ -5795,7 +5823,6 @@ packages:
 
   /@storybook/global@5.0.0:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
-    dev: true
 
   /@storybook/instrumenter@7.0.26:
     resolution: {integrity: sha512-7Ty0LTslgkm5RyH6CqTAKhWz/cF6wq/sNdMYKwvVZHWNZ2LKMtXD0RWM2caCPruAGOQ9+52H+3s4TZGKaPSSWQ==}
@@ -5872,6 +5899,25 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
     dev: true
+
+  /@storybook/preview-api@7.6.2:
+    resolution: {integrity: sha512-5scmFblrBKBLQSZVlwNUCXhos8GJ8alzMSs0msAbguytjWEuNQ2EKoO7EoO3wvaYf7K3mkOg082RU9nH8SM6mg==}
+    dependencies:
+      '@storybook/channels': 7.6.2
+      '@storybook/client-logger': 7.6.2
+      '@storybook/core-events': 7.6.2
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      '@storybook/types': 7.6.2
+      '@types/qs': 6.9.6
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: false
 
   /@storybook/preview@7.0.26:
     resolution: {integrity: sha512-9Uaxl/MEMYqjLlKAeAF2ATuaM0yQagXUfu2bEOpuor2ys9XoisDkvB7jfsCVqMZHeQ+mCdYyBICHhgqzxcO2Zg==}
@@ -6017,6 +6063,15 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
+  /@storybook/types@7.6.2:
+    resolution: {integrity: sha512-GlEkG4D/BFuPrLGpTkrfmeLM/fEki0FTnMs1SgNQL10wl6Y98EDJWvCItPVPBoGBERpShxEmkSi2HmcySWZgsA==}
+    dependencies:
+      '@storybook/channels': 7.6.2
+      '@types/babel__core': 7.1.20
+      '@types/express': 4.17.17
+      file-system-cache: 2.3.0
+    dev: false
+
   /@testing-library/dom@8.20.1:
     resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
     engines: {node: '>=12'}
@@ -6095,26 +6150,22 @@ packages:
       '@types/babel__generator': 7.0.2
       '@types/babel__template': 7.0.2
       '@types/babel__traverse': 7.0.15
-    dev: true
 
   /@types/babel__generator@7.0.2:
     resolution: {integrity: sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==}
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@types/babel__template@7.0.2:
     resolution: {integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==}
     dependencies:
       '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
-    dev: true
 
   /@types/babel__traverse@7.0.15:
     resolution: {integrity: sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==}
     dependencies:
       '@babel/types': 7.22.5
-    dev: true
 
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -8693,7 +8744,6 @@ packages:
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-    dev: true
 
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -9827,7 +9877,6 @@ packages:
     dependencies:
       fs-extra: 11.1.1
       ramda: 0.29.0
-    dev: true
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -12262,7 +12311,6 @@ packages:
 
   /map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
-    dev: true
 
   /map-visit@1.0.0:
     resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
@@ -12441,7 +12489,6 @@ packages:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
     dependencies:
       map-or-similar: 1.5.0
-    dev: true
 
   /meow@10.1.5:
     resolution: {integrity: sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==}
@@ -14034,7 +14081,6 @@ packages:
 
   /ramda@0.29.0:
     resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
-    dev: true
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -15353,7 +15399,6 @@ packages:
 
   /synchronous-promise@2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
-    dev: true
 
   /tabbable@5.3.3:
     resolution: {integrity: sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==}
@@ -15423,6 +15468,12 @@ packages:
       memoizerific: 1.11.3
     dev: true
 
+  /telejson@7.2.0:
+    resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
+    dependencies:
+      memoizerific: 1.11.3
+    dev: false
+
   /temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -15465,6 +15516,10 @@ packages:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  /tiny-invariant@1.3.1:
+    resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+    dev: false
+
   /tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
@@ -15493,7 +15548,6 @@ packages:
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
-    dev: true
 
   /to-object-path@0.3.0:
     resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
@@ -15579,7 +15633,6 @@ packages:
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-    dev: true
 
   /ts-node@10.9.1(@types/node@20.4.0)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -15736,7 +15789,6 @@ packages:
   /type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
-    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1190,6 +1190,7 @@
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/cody-ui": "workspace:*",
     "@sourcegraph/telemetry": "^0.13.0",
+    "@storybook/preview-api": "^7.6.2",
     "@types/stream-json": "^1.7.3",
     "@vscode/codicons": "^0.0.29",
     "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -97,6 +97,14 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
             }),
             this.contextStatusChangeEmitter
         )
+
+        if (this.localEmbeddings) {
+            this.disposables.push(
+                this.localEmbeddings.onChange(_ => {
+                    void this.updateCodebaseContext()
+                })
+            )
+        }
     }
 
     public get context(): CodebaseContext {
@@ -158,9 +166,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
 
         this.codebaseContext = codebaseContext
 
-        // TODO: CodebaseContext should be a CodebaseContextStatusProvider,
-        // but aggregator uses vscode EventEmitter and can't live in lib/shared.
-        // After #1717 move the status aggregation close to the context.
         this.statusEmbeddings?.dispose()
         if (this.localEmbeddings && !this.codebaseContext.embeddings) {
             // Add status from local embeddings when:

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -101,7 +101,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
         if (this.localEmbeddings) {
             this.disposables.push(
                 this.localEmbeddings.onChange(_ => {
-                    void this.updateCodebaseContext()
+                    void this.forceUpdateCodebaseContext()
                 })
             )
         }

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -104,15 +104,12 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                 this.statusBar = undefined
                 setTimeout(() => statusBar.hide(), 30_000)
 
-                if (this.lastRepo) {
-                    // TODO: Load the index after indexing completes
-                    // https://github.com/sourcegraph/cody/issues/1972
-                    // This can race with intervening loads, etc.
-                    // For now flip to a checkmark so people don't generate
-                    // a second index.
-                    this.lastRepo.loadResult = true
-                    this.statusEvent.fire(this)
+                if (this.pathBeingIndexed && (!this.lastRepo || this.lastRepo.path === this.pathBeingIndexed)) {
+                    void this.eagerlyLoad(this.pathBeingIndexed)
                 }
+
+                this.pathBeingIndexed = undefined
+                this.statusEvent.fire(this)
             } else {
                 // TODO(dpc): Handle these notifications.
                 logDebug('LocalEmbeddingsController', JSON.stringify(obj))

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -30,6 +30,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings> = {
         remoteName: 'github.com/sourcegraph/sourcegraph',
     },
     argTypes: {
+        name: { control: 'text' },
         kind: {
             options: ['embeddings', 'graph', 'search'],
             control: 'select',
@@ -46,6 +47,8 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings> = {
             options: ['indeterminate', 'unconsented', 'indexing', 'ready', 'no-match'],
             control: 'select',
         },
+        origin: { control: 'text' },
+        remoteName: { control: 'text' },
     },
     render: function Render() {
         const [args, updateArgs] = useArgs()

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -152,13 +152,17 @@ const ContextProviderComponent: React.FunctionComponent<{ provider: ContextProvi
 export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSettingsProps> = (): React.ReactNode => {
     const events = useEnhancedContextEventHandlers()
     const context = useEnhancedContextContext()
-    const enabled = useEnhancedContextEnabled()
+    const [enabled, setEnabled] = React.useState<boolean>(useEnhancedContextEnabled())
     const [isOpen, setOpen] = React.useState(false)
     const enabledChanged = React.useCallback(
         (event: any): void => {
-            events.onEnabledChange(event.target?.checked)
+            const shouldEnable = !!event.target?.checked
+            if (enabled !== shouldEnable) {
+                events.onEnabledChange(shouldEnable)
+                setEnabled(shouldEnable)
+            }
         },
-        [events]
+        [events, enabled]
     )
     return (
         <div className={classNames(popupStyles.popupHost)}>

--- a/vscode/webviews/Popups/Popup.module.css
+++ b/vscode/webviews/Popups/Popup.module.css
@@ -37,6 +37,8 @@
     border-bottom: 1px solid var(--vscode-widget-border);
 
     /* no box shadow on this, it relies on overlapping the rest of the popup */
+
+    z-index: 1;
 }
 
 .popup-host {

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -39,6 +39,7 @@ button {
  */
 
 :root {
+    --vscode-button-background: #007acc;
     --vscode-button-secondaryBackground: #3a3d41;
     --vscode-button-secondaryForeground: #ffffff;
     --vscode-button-secondaryHoverBackground: #45494e;


### PR DESCRIPTION
- Load local embedding indexes once indexing completes. Fixes #1972.
- Cleans up some UI cruft:
  - 'Enabled' events do not spam if there is no change.
  - Click events on the enhanced context status button don't bubble to the popup.
  - The pointy bit of the pop-up sits on top of the border around the enhanced context status button.
- Storybook:
  - You can interact with and edit an Enhanced Context Status tile.
  - The Enhanced Context Status button has the indicator color when enabled.

![Screenshot 2023-12-01 at 17 59 56](https://github.com/sourcegraph/cody/assets/55120/74a674f5-33fa-498c-8430-7920287433ba)

## Test plan

Manual test:

0. Enable new chat UI.
1. Open a repository not indexed on dotcom or by App. Open a file from the workspace (to work around #2032)
2. Start a chat. Open the Enhanced Context Settings widget.
3. After cody-engine starts and the Enable Embeddings button appears, click on it. The tile should change to "indexing" and indexing status should appear in the status bar.
4. When indexing is done, the tile should change to a checkmark.
5. Enter a chat. Results from local context should appear. (You can triple verify this by enabling verbose logging, opening the Output panel, changing the topic to Cody by Sourcegraph, and checking for LocalEmbeddingsController log messages.)

Note, step 3 may be blocked by cody-engine crashing before this step. If that happens, `LocalEmbeddingsController ... Process exited` appears in Cody by Sourcegraph verbose output. You can do a custom build of cody-engine and set `  "cody.experimental.cody-engine.path"` to point to it.

*Storybook changes*

```
$ pnpm storybook
```

Open the Enhanced Context/Single tile story and confirm above. 