### PR TITLE
Agent: single instances of AgentTextDocument per uri

### DIFF
--- a/agent/src/AgentTextDocument.ts
+++ b/agent/src/AgentTextDocument.ts
@@ -10,6 +10,9 @@ import * as vscode_shim from './vscode-shim'
 // use vscode-languageserver-textdocument is because it doesn't implement all
 // the properties/functions that vscode.TextDocument has. For example, lineAt is
 // missing in vscode-languageserver-textdocument
+// NOTE: There should only be one instance of an AgentTextDocument per uri so that
+// all references have a consistent view on a document. Use AgentWorkspaceDocuments
+// to get a reference to a new or existing instance.
 export class AgentTextDocument implements vscode.TextDocument {
     constructor(public readonly textDocument: TextDocumentWithUri) {
         this.content = textDocument.content ?? ''
@@ -19,21 +22,41 @@ export class AgentTextDocument implements vscode.TextDocument {
         this.languageId = getLanguageForFileName(this.fileName)
         this.offsets = new DocumentOffsets(textDocument.underlying)
         this.lineCount = this.offsets.lineCount()
+        this.underlying = textDocument
     }
-    private readonly content: string
-    private readonly offsets: DocumentOffsets
-    public readonly uri: vscode.Uri
-    public readonly fileName: string
-    public readonly lineCount: number
-    public readonly isUntitled: boolean
-    public readonly languageId: string
 
-    public readonly version: number = 0
+    public underlying: TextDocumentWithUri
+    private content: string
+    private offsets: DocumentOffsets
+    public uri: vscode.Uri
+    public fileName: string
+    public lineCount: number
+    public isUntitled: boolean
+    public languageId: string
+
+    public version = 0
     public readonly isDirty: boolean = false
     public readonly isClosed: boolean = false
+
     public save(): Thenable<boolean> {
         throw new Error('Method not implemented.')
     }
+
+    // updates the content of an AgentTextDocument so that all references to this instance held throughout
+    // agent see a consistent view on a text document, rather than different instances of this class per
+    // document with different views.
+    public update(textDocument: TextDocumentWithUri): void {
+        this.content = textDocument.content ?? ''
+        this.uri = textDocument.uri
+        this.fileName = textDocument.uri.fsPath
+        this.isUntitled = false
+        this.languageId = getLanguageForFileName(this.fileName)
+        this.offsets = new DocumentOffsets(textDocument.underlying)
+        this.lineCount = this.offsets.lineCount()
+        this.underlying = textDocument
+        this.version++
+    }
+
     public readonly eol: vscode.EndOfLine = vscode_shim.EndOfLine.LF
     public lineAt(position: vscode.Position | number): vscode.TextLine {
         const line = typeof position === 'number' ? position : position.line
@@ -62,13 +85,16 @@ export class AgentTextDocument implements vscode.TextDocument {
             text,
         }
     }
+
     public offsetAt(position: vscode.Position): number {
         return this.offsets.offset(position)
     }
+
     public positionAt(offset: number): vscode.Position {
         const { line, character } = this.offsets.position(offset)
         return new vscode_shim.Position(line, character)
     }
+
     public getText(range?: vscode.Range | undefined): string {
         if (range === undefined) {
             return this.content
@@ -78,12 +104,15 @@ export class AgentTextDocument implements vscode.TextDocument {
         const text = this.content.slice(start, end)
         return text
     }
+
     public getWordRangeAtPosition(position: vscode.Position, regex?: RegExp | undefined): vscode.Range | undefined {
         throw new Error('Method not implemented.')
     }
+
     public validateRange(range: vscode.Range): vscode.Range {
         throw new Error('Method not implemented.')
     }
+
     public validatePosition(position: vscode.Position): vscode.Position {
         throw new Error('Method not implemented.')
     }

--- a/agent/src/bfg/BfgRetriever.test.ts
+++ b/agent/src/bfg/BfgRetriever.test.ts
@@ -96,7 +96,7 @@ describe('BfgRetriever', async () => {
 
         const bfg = new BfgRetriever(extensionContext as vscode.ExtensionContext)
 
-        const document = agent.workspace.agentTextDocument(new TextDocumentWithUri(uri))
+        const document = agent.workspace.getDocument(new TextDocumentWithUri(uri).uri)!
         assert(document.getText().length > 0)
         const offset = content.indexOf(CURSOR)
         assert(offset >= 0, content)

--- a/agent/src/editor.ts
+++ b/agent/src/editor.ts
@@ -38,7 +38,7 @@ export class AgentEditor implements Editor {
         if (this.agent.workspace.activeDocumentFilePath === null) {
             return undefined
         }
-        return this.agent.workspace.getDocument(this.agent.workspace.activeDocumentFilePath)
+        return this.agent.workspace.getDocument(this.agent.workspace.activeDocumentFilePath)?.underlying
     }
 
     public getActiveTextEditor(): ActiveTextEditor | null {
@@ -60,7 +60,7 @@ export class AgentEditor implements Editor {
         }
 
         const doc = this.agent.workspace.getDocumentFromUriString(uri.toString())
-        return Promise.resolve(doc?.content)
+        return Promise.resolve(doc?.getText())
     }
 
     public getActiveTextEditorSelection(): ActiveTextEditorSelection | null {

--- a/vscode/src/completions/persistence-tracker.ts
+++ b/vscode/src/completions/persistence-tracker.ts
@@ -155,7 +155,6 @@ export class PersistenceTracker implements vscode.Disposable {
         if (!documentCompletions) {
             return
         }
-
         // Create a list of changes that can be mutated by the `updateRangeMultipleChanges` function
         const mutableChanges = event.contentChanges.map(change => ({
             range: change.range,


### PR DESCRIPTION
Extracted from https://github.com/sourcegraph/cody/pull/2017/commits/64406749bebf2f79d53bf6d9f2140c93119cd80e, this brings the AgentTextDocument more in-line with vscode TextDocument references. This addresses a dangerous issue where multiple instances of an AgentTextDocument can exist for a given uri with a different view of the actual document (primarily, different text contents), resulting in operations happening on stale data.

## Test plan

Tested as part of https://github.com/sourcegraph/cody/pull/2017 through autocomplete (with specific emphasis on the state of data when computing persistence events)