### PR TITLE
add telemetry for LLM selection and CTA clicks

### DIFF
--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -18,9 +18,11 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
 }) => {
     const [currentModel, setCurrentModel] = useState(models.find(m => m.default) || models[0])
 
-    const isCodyProUser = userInfo.isDotComUser && userInfo.isCodyProUser
+    // TODO remove at GA
+    const isReady = false
+    const isCodyProUser = !isReady || (userInfo.isDotComUser && userInfo.isCodyProUser)
     const isEnterpriseUser = !userInfo.isDotComUser
-    const showCodyProBadge = !isEnterpriseUser && !isCodyProUser
+    const showCodyProBadge = !isEnterpriseUser && !isCodyProUser && isReady
 
     const handleChange = useCallback(
         (event: any): void => {

--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -28,7 +28,7 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                 getVSCodeAPI().postMessage({ command: 'links', value: 'https://sourcegraph.com/cody/subscription' })
                 getVSCodeAPI().postMessage({
                     command: 'event',
-                    eventName: 'CodyVSCodeExtension:upgradeCTA:clicked',
+                    eventName: 'CodyVSCodeExtension:upgradeLLMChoiceCTA:clicked',
                     properties: { limit_type: 'chat_commands' },
                 })
                 return

--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -25,11 +25,20 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
     const handleChange = useCallback(
         (event: any): void => {
             if (showCodyProBadge) {
-                console.log('Cody Pro badge clicked')
                 getVSCodeAPI().postMessage({ command: 'links', value: 'https://sourcegraph.com/cody/subscription' })
+                getVSCodeAPI().postMessage({
+                    command: 'event',
+                    eventName: 'CodyVSCodeExtension:upgradeCTA:clicked',
+                    properties: { limit_type: 'chat_commands' },
+                })
                 return
             }
             const selectedModel = models[event.target?.selectedIndex]
+            getVSCodeAPI().postMessage({
+                command: 'event',
+                eventName: 'CodyVSCodeExtension:chooseLLM:clicked',
+                properties: { LLM_provider: selectedModel.model },
+            })
             onCurrentChatModelChange(selectedModel)
             setCurrentModel(selectedModel)
         },
@@ -60,6 +69,13 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                 className={styles.dropdownContainer}
                 onChange={handleChange}
                 title={isEnterpriseUser ? tooltips.disabled.enterpriseUser : undefined}
+                onClick={() =>
+                    getVSCodeAPI().postMessage({
+                        command: 'event',
+                        eventName: 'CodyVSCodeExtension:openLLMDropdown:clicked',
+                        properties: undefined,
+                    })
+                }
             >
                 {models?.map((option, index) => (
                     <VSCodeOption

--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -18,11 +18,9 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
 }) => {
     const [currentModel, setCurrentModel] = useState(models.find(m => m.default) || models[0])
 
-    // TODO remove at GA
-    const isReady = false
-    const isCodyProUser = !isReady || (userInfo.isDotComUser && userInfo.isCodyProUser)
+    const isCodyProUser = userInfo.isDotComUser && userInfo.isCodyProUser
     const isEnterpriseUser = !userInfo.isDotComUser
-    const showCodyProBadge = !isEnterpriseUser && !isCodyProUser && isReady
+    const showCodyProBadge = !isEnterpriseUser && !isCodyProUser
 
     const handleChange = useCallback(
         (event: any): void => {


### PR DESCRIPTION
feat: add telemetry for LLM selection and CTA clicks

Track events when users click on the Cody Pro upgrade CTA and when they select an AI model from the dropdown.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->


https://github.com/sourcegraph/cody/assets/68532117/976a5981-db66-4697-b115-e46859ba7643

