### PR TITLE
VS Code: Cody release v0.16.3

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## [0.16.3]
+
+### Added
+
+### Fixed
+
+### Changed
+
+- Reverting back to v0.16.1 due to critical issue found in v0.16.2.
+
 ## [0.16.2]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Reverting back to v0.16.1, due to critical issue found in v0.16.2. 

Release will be built off of branch `kalan/vscode-0.16.3` which was branched from git tag `vscode-v0.16.1`
![CleanShot 2023-12-01 at 14 43 46@2x](https://github.com/sourcegraph/cody/assets/51868853/eca9d53f-1be3-4f5f-ba33-a2e8c4749947)


Thread for more context:
https://sourcegraph.slack.com/archives/C05AGQYD528/p1701464754444749


## Test plan
Ensure the diff has only version bump and changelog updates.


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
