### PR TITLE
log chat rate limit events

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -47,7 +47,9 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     if (res.statusCode === 429) {
                         // Check for explicit false, because if the header is not set, there
                         // is no upgrade available.
-                        const upgradeIsAvailable = res.headers['x-is-cody-pro-user'] === 'false'
+                        const upgradeIsAvailable =
+                            typeof res.headers['x-is-cody-pro-user'] !== undefined &&
+                            res.headers['x-is-cody-pro-user'] === 'false'
                         const retryAfter = res.headers['retry-after']
                         const limit = res.headers['x-ratelimit-limit'] ? res.headers['x-ratelimit-limit'][0] : undefined
                         const error = new RateLimitError(

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { ChatError, RateLimitError } from '@sourcegraph/cody-shared'
 
@@ -10,21 +10,35 @@ import styles from './ErrorItem.module.css'
  * An error message shown in the chat.
  */
 export const ErrorItem: React.FunctionComponent<{
-    error: string | ChatError
+    error: ChatError
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     userInfo?: UserAccountInfo
     postMessage?: ApiPostMessage
 }> = React.memo(function ErrorItemContent({ error, ChatButtonComponent, userInfo, postMessage }) {
-    return typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage ? (
-        <RateLimitErrorItem
-            error={error as RateLimitError}
-            ChatButtonComponent={ChatButtonComponent}
-            postMessage={postMessage}
-        />
-    ) : (
+    if (typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage) {
+        return (
+            <RateLimitErrorItem
+                error={error as RateLimitError}
+                ChatButtonComponent={ChatButtonComponent}
+                postMessage={postMessage}
+                userInfo={userInfo}
+            />
+        )
+    }
+
+    return <RequestErrorItem error={error.message} />
+})
+
+/**
+ * Renders a generic error message for chat request failures.
+ */
+export const RequestErrorItem: React.FunctionComponent<{
+    error: string
+}> = React.memo(function ErrorItemContent({ error }) {
+    return (
         <div className="cody-chat-error">
             <span>Request failed: </span>
-            {typeof error === 'string' ? error : error.message}
+            {error}
         </div>
     )
 })
@@ -40,7 +54,37 @@ export const RateLimitErrorItem: React.FunctionComponent<{
 }> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent, userInfo, postMessage }) {
     // Only show Upgrades if both the error said an upgrade was available and we know the user
     // has not since upgraded.
+
     const canUpgrade = error.upgradeIsAvailable && userInfo?.isCodyProUser !== true
+    const isEnterpriseUser = userInfo?.isDotComUser !== true
+    const tier = isEnterpriseUser ? 'enterprise' : userInfo?.isCodyProUser ? 'pro' : 'free'
+
+    // Only log once on mount
+    React.useEffect(() => {
+        // Log as abuseUsageLimit if pro user run into rate limit
+        postMessage({
+            command: 'event',
+            eventName: userInfo?.isCodyProUser
+                ? 'CodyVSCodeExtension:abuseUsageLimitCTA:shown'
+                : 'CodyVSCodeExtension:upsellUsageLimitCTA:shown',
+            properties: { limit_type: 'chat_commands', tier },
+        })
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    const onButtonClick = useCallback(
+        (page: 'upgrade' | 'rate-limits'): void => {
+            postMessage({ command: 'show-page', page })
+            postMessage({
+                command: 'event',
+                eventName: 'CodyVSCodeExtension:upsellUsageLimitCTA:clicked',
+                properties: { limit_type: 'chat_commands', page, tier },
+            })
+        },
+        [postMessage, tier]
+    )
+
     return (
         <div className={styles.errorItem}>
             <h1>{canUpgrade ? 'Upgrade to Cody Pro' : 'Unable to Send Message'}</h1>
@@ -51,14 +95,14 @@ export const RateLimitErrorItem: React.FunctionComponent<{
                         <ChatButtonComponent
                             label="Upgrade"
                             action=""
-                            onClick={() => postMessage({ command: 'show-page', page: 'upgrade' })}
+                            onClick={() => onButtonClick('upgrade')}
                             appearance="primary"
                         />
                     )}
                     <ChatButtonComponent
                         label="Learn More"
                         action=""
-                        onClick={() => postMessage({ command: 'show-page', page: 'rate-limits' })}
+                        onClick={() => onButtonClick('rate-limits')}
                         appearance="secondary"
                     />
                 </div>

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -14,7 +14,7 @@ export const ErrorItem: React.FunctionComponent<{
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     userInfo?: UserAccountInfo
     postMessage?: ApiPostMessage
-}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent, userInfo, postMessage }) {
+}> = React.memo(function ErrorItemContent({ error, ChatButtonComponent, postMessage }) {
     if (typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage) {
         return (
             <RateLimitErrorItem
@@ -53,9 +53,8 @@ export const RateLimitErrorItem: React.FunctionComponent<{
 }> = React.memo(function RateLimitErrorItemContent({ error, ChatButtonComponent, userInfo, postMessage }) {
     // Only show Upgrades if both the error said an upgrade was available and we know the user
     // has not since upgraded.
-
-    const canUpgrade = error.upgradeIsAvailable && userInfo?.isCodyProUser !== true
     const isEnterpriseUser = userInfo?.isDotComUser !== true
+    const canUpgrade = error.upgradeIsAvailable && !userInfo?.isCodyProUser
     const tier = isEnterpriseUser ? 'enterprise' : userInfo?.isCodyProUser ? 'pro' : 'free'
 
     // Only log once on mount
@@ -73,14 +72,14 @@ export const RateLimitErrorItem: React.FunctionComponent<{
     }, [])
 
     const onButtonClick = useCallback(
-        (page: 'upgrade' | 'rate-limits'): void => {
+        (page: 'upgrade' | 'rate-limits', call_to_action: 'upgrade' | 'learn-more'): void => {
             // Log click event
-            const action = page === 'upgrade' ? 'upgrade' : 'learn-more'
             postMessage({
                 command: 'event',
                 eventName: 'CodyVSCodeExtension:upsellUsageLimitCTA:clicked',
-                properties: { limit_type: 'chat_commands', 'call-to-action': action, tier },
+                properties: { limit_type: 'chat_commands', call_to_action, tier },
             })
+
             // open the page in browser
             postMessage({ command: 'show-page', page })
         },
@@ -97,14 +96,14 @@ export const RateLimitErrorItem: React.FunctionComponent<{
                         <ChatButtonComponent
                             label="Upgrade"
                             action=""
-                            onClick={() => onButtonClick('upgrade')}
+                            onClick={() => onButtonClick('upgrade', 'upgrade')}
                             appearance="primary"
                         />
                     )}
                     <ChatButtonComponent
                         label="Learn More"
                         action=""
-                        onClick={() => onButtonClick('rate-limits')}
+                        onClick={() => onButtonClick('rate-limits', 'learn-more')}
                         appearance="secondary"
                     />
                 </div>

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -21,7 +21,6 @@ export const ErrorItem: React.FunctionComponent<{
                 error={error as RateLimitError}
                 ChatButtonComponent={ChatButtonComponent}
                 postMessage={postMessage}
-                userInfo={userInfo}
             />
         )
     }
@@ -75,12 +74,15 @@ export const RateLimitErrorItem: React.FunctionComponent<{
 
     const onButtonClick = useCallback(
         (page: 'upgrade' | 'rate-limits'): void => {
-            postMessage({ command: 'show-page', page })
+            // Log click event
+            const action = page === 'upgrade' ? 'upgrade' : 'learn-more'
             postMessage({
                 command: 'event',
                 eventName: 'CodyVSCodeExtension:upsellUsageLimitCTA:clicked',
-                properties: { limit_type: 'chat_commands', page, tier },
+                properties: { limit_type: 'chat_commands', 'call-to-action': action, tier },
             })
+            // open the page in browser
+            postMessage({ command: 'show-page', page })
         },
         [postMessage, tier]
     )

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -19,7 +19,7 @@ import { BlinkingCursor, LoadingContext } from './BlinkingCursor'
 import { CodeBlocks } from './CodeBlocks'
 import { FileLinkProps } from './components/ContextFiles'
 import { EnhancedContext } from './components/EnhancedContext'
-import { ErrorItem } from './ErrorItem'
+import { ErrorItem, RequestErrorItem } from './ErrorItem'
 import { PreciseContexts, SymbolLinkProps } from './PreciseContext'
 
 import styles from './TranscriptItem.module.css'
@@ -161,12 +161,16 @@ export const TranscriptItem: React.FunctionComponent<
                 </div>
             )}
             {message.error ? (
-                <ErrorItem
-                    error={message.error}
-                    ChatButtonComponent={ChatButtonComponent}
-                    userInfo={userInfo}
-                    postMessage={postMessage}
-                />
+                typeof message.error === 'string' ? (
+                    <RequestErrorItem error={message.error} />
+                ) : (
+                    <ErrorItem
+                        error={message.error}
+                        ChatButtonComponent={ChatButtonComponent}
+                        userInfo={userInfo}
+                        postMessage={postMessage}
+                    />
+                )
             ) : (
                 <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
                     {message.displayText && !message.error ? (

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -103,7 +103,9 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
         if (response.status === 429) {
             // Check for explicit false, because if the header is not set, there
             // is no upgrade available.
-            const upgradeIsAvailable = response.headers.get('x-is-cody-pro-user') === 'false'
+            const upgradeIsAvailable =
+                response.headers.get('x-is-cody-pro-user') === 'false' &&
+                typeof response.headers.get('x-is-cody-pro-user') !== undefined
             const retryAfter = response.headers.get('retry-after')
             const limit = response.headers.get('x-ratelimit-limit')
             throw new RateLimitError(

--- a/vscode/test/e2e/chat.test.ts
+++ b/vscode/test/e2e/chat.test.ts
@@ -5,7 +5,7 @@ import * as mockServer from '../fixtures/mock-server'
 import { disableNotifications, sidebarSignin } from './common'
 import { test } from './helpers'
 
-test('shows appropriate rate limit message for free users', async ({ page, sidebar }) => {
+test('shows appropriate rate limit message for dotcom free users', async ({ page, sidebar }) => {
     const chatFrame = await prepareChat(page, sidebar)
 
     await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/free`, {
@@ -21,10 +21,26 @@ test('shows appropriate rate limit message for free users', async ({ page, sideb
     await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
 })
 
-test('shows appropriate rate limit message for pro users', async ({ page, sidebar }) => {
+test('shows appropriate rate limit message for dotcom pro users', async ({ page, sidebar }) => {
     const chatFrame = await prepareChat(page, sidebar)
 
     await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/pro`, {
+        method: 'POST',
+    })
+
+    await page.keyboard.type('Hello')
+    await page.keyboard.press('Enter')
+
+    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).not.toBeVisible()
+    await expect(chatFrame.getByText('Unable to Send Message')).toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).not.toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+})
+
+test('shows appropriate rate limit message for enterprise users', async ({ page, sidebar }) => {
+    const chatFrame = await prepareChat(page, sidebar)
+
+    await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/enterprise`, {
         method: 'POST',
     })
 

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -77,7 +77,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     })
 
     let chatRateLimited = false
-    let chatRateLimitPro = false
+    let chatRateLimitPro: boolean | undefined = false
     app.post('/.api/completions/stream', (req, res) => {
         if (chatRateLimited) {
             res.setHeader('retry-after', new Date().toString())
@@ -108,6 +108,11 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
     app.post('/.test/completions/triggerRateLimit/pro', (req, res) => {
         chatRateLimited = true
         chatRateLimitPro = true
+        res.sendStatus(200)
+    })
+    app.post('/.test/completions/triggerRateLimit/enterprise', (req, res) => {
+        chatRateLimited = true
+        chatRateLimitPro = undefined
         res.sendStatus(200)
     })
 


### PR DESCRIPTION
add: log Cody chat rate limit related events

Log  Cody chat rate limit events

Added `CodyVSCodeExtension:upsellUsageLimitCTA:shown` and `CodyVSCodeExtension:upsellUsageLimitCTA:clicked` to chat_commands

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

https://github.com/sourcegraph/cody/assets/68532117/287966cf-5ae8-422f-b1bd-9194db51fd18


