### PR TITLE
fix: migrate to chat history manager

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Embeddings indexes can be generated and stored locally in repositories with a default fetch URL that is not already indexed by sourcegraph.com through the Enhanced Context selector. [pull/2069](https://github.com/sourcegraph/cody/pull/2069)
+- Support chat input history on "up" and "down" arrow keys again. [pull/2059](https://github.com/sourcegraph/cody/pull/2059)
 
 ### Changed
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -137,8 +137,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
 
     public async clearAndRestartSession(): Promise<void> {
         await this.saveTranscriptToChatHistory()
-        this.createNewChatID()
         this.cancelCompletion()
+        this.createNewChatID()
         this.isMessageInProgress = false
         this.transcript.reset()
         this.handleSuggestions([])
@@ -166,10 +166,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (!history || chatID === this.sessionID) {
             return
         }
-        if (!this.transcript.isEmpty) {
-            await this.saveTranscriptToChatHistory()
-            this.cancelCompletion()
-        }
+        await this.saveTranscriptToChatHistory()
+        this.cancelCompletion()
         this.createNewChatID(chatID)
         this.transcript = Transcript.fromJSON(history)
         this.chatModel = this.transcript.chatModel
@@ -779,10 +777,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Send history to view
      */
     private sendHistory(): void {
-        this.handleHistory({
-            chat: {},
-            input: chatHistory.getInput(),
-        })
+        const userHistory = chatHistory.localHistory
+        if (userHistory) {
+            this.handleHistory(userHistory)
+        }
     }
 
     /**

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -10,12 +10,7 @@ import { newInteraction } from '@sourcegraph/cody-shared/src/chat/prompts/utils'
 import { Recipe, RecipeID, RecipeType } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { Interaction } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
-import {
-    ChatEventSource,
-    ChatHistory,
-    ChatMessage,
-    UserLocalHistory,
-} from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatEventSource, ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Typewriter } from '@sourcegraph/cody-shared/src/chat/typewriter'
 import { reformatBotMessageForChat, reformatBotMessageForEdit } from '@sourcegraph/cody-shared/src/chat/viewHelpers'
 import { annotateAttribution, Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
@@ -35,6 +30,7 @@ import { telemetryService } from '../services/telemetry'
 import { telemetryRecorder } from '../services/telemetry-v2'
 import { TestSupport } from '../test-support'
 
+import { chatHistory } from './chat-view/ChatHistoryManager'
 import { ContextProvider } from './ContextProvider'
 import { countGeneratedCode } from './utils'
 
@@ -86,10 +82,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     public sessionID = new Date(Date.now()).toUTCString()
     public currentRequestID: string | undefined = undefined
 
-    // input and chat history are shared across all MessageProvider instances
-    protected static inputHistory: string[] = []
-    protected static chatHistory: ChatHistory = {}
-
     private isMessageInProgress = false
     private cancelCompletionCallback: (() => void) | null = null
 
@@ -129,15 +121,13 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     }
 
     protected async init(chatID?: string): Promise<void> {
-        this.loadChatHistory()
+        if (chatID) {
+            await this.restoreSession(chatID)
+        }
         this.sendTranscript()
         this.sendHistory()
         await this.contextProvider.init()
         await this.sendCodyCommands()
-
-        if (chatID) {
-            await this.restoreSession(chatID)
-        }
     }
 
     private get isDotComUser(): boolean {
@@ -159,9 +149,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     }
 
     public async clearHistory(): Promise<void> {
-        MessageProvider.chatHistory = {}
-        MessageProvider.inputHistory = []
-        await localStorage.removeChatHistory()
+        await chatHistory.clear()
         // Reset the current transcript
         this.transcript = new Transcript()
         await this.clearAndRestartSession()
@@ -174,10 +162,16 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Restores a session from a chatID
      */
     public async restoreSession(chatID: string): Promise<void> {
-        await this.saveTranscriptToChatHistory()
-        this.cancelCompletion()
+        const history = chatHistory.getChat(chatID)
+        if (!history || chatID === this.sessionID) {
+            return
+        }
+        if (!this.transcript.isEmpty) {
+            await this.saveTranscriptToChatHistory()
+            this.cancelCompletion()
+        }
         this.createNewChatID(chatID)
-        this.transcript = Transcript.fromJSON(MessageProvider.chatHistory[chatID])
+        this.transcript = Transcript.fromJSON(history)
         this.chatModel = this.transcript.chatModel
         await this.transcript.toJSON()
         this.sendTranscript()
@@ -734,7 +728,6 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         if (this.transcript.isEmpty) {
             return
         }
-        MessageProvider.chatHistory[this.sessionID] = await this.transcript.toJSON()
         await this.saveChatHistory()
         this.sendHistory()
     }
@@ -743,33 +736,18 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      * Save chat history
      */
     private async saveChatHistory(): Promise<void> {
-        const userHistory = {
-            chat: MessageProvider.chatHistory,
-            input: MessageProvider.inputHistory,
-        }
-        await localStorage.setChatHistory(userHistory)
+        const json = await this.transcript.toJSON()
+        await chatHistory.saveChat(json)
     }
 
     /**
      * Delete history from current chat history and local storage
      */
     protected async deleteHistory(chatID: string): Promise<void> {
-        delete MessageProvider.chatHistory[chatID]
-        await localStorage.deleteChatHistory(chatID)
+        await chatHistory.deleteChat(chatID)
         this.sendHistory()
         telemetryService.log('CodyVSCodeExtension:deleteChatHistoryButton:clicked', undefined, { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.deleteChatHistoryButton', 'clicked')
-    }
-
-    /**
-     * Loads chat history from local storage
-     */
-    private loadChatHistory(): void {
-        const localHistory = localStorage.getChatHistory()
-        if (localHistory) {
-            MessageProvider.chatHistory = localHistory?.chat
-            MessageProvider.inputHistory = localHistory.input
-        }
     }
 
     /**
@@ -778,9 +756,9 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
     public async exportHistory(): Promise<void> {
         telemetryService.log('CodyVSCodeExtension:exportChatHistoryButton:clicked', undefined, { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.exportChatHistoryButton', 'clicked')
-        const historyJson = MessageProvider.chatHistory
+        const historyJson = localStorage.getChatHistory()?.chat
         const exportPath = await vscode.window.showSaveDialog({ filters: { 'Chat History': ['json'] } })
-        if (!exportPath) {
+        if (!exportPath || !historyJson) {
             return
         }
         try {
@@ -802,8 +780,8 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
      */
     private sendHistory(): void {
         this.handleHistory({
-            chat: MessageProvider.chatHistory,
-            input: MessageProvider.inputHistory,
+            chat: {},
+            input: chatHistory.getInput(),
         })
     }
 

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -24,13 +24,13 @@ export class ChatHistoryManager {
         await localStorage.deleteChatHistory(chatID)
     }
 
+    // HumanInputHistory is the history list when user presses "up" in the chat input box
     public async saveHumanInputHistory(input: string): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory()
         history.input.push(input)
         await localStorage.setChatHistory(history)
         return history
     }
-
     public getHumanInputHistory(): string[] {
         const history = localStorage.getChatHistory()
         if (!history) {

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -25,4 +25,36 @@ export class ChatHistoryManager {
         await localStorage.setChatHistory(history)
         return history
     }
+
+    public async deleteChat(chatID: string): Promise<void> {
+        await localStorage.deleteChatHistory(chatID)
+    }
+
+    // Remove chat history with input history
+    public async clear(): Promise<void> {
+        await localStorage.removeChatHistory()
+    }
+
+    public async saveInput(input: string): Promise<UserLocalHistory> {
+        let history = localStorage.getChatHistory()
+        if (!history) {
+            history = {
+                chat: {},
+                input: [],
+            }
+        }
+        history.input.push(input)
+        await localStorage.setChatHistory(history)
+        return history
+    }
+
+    public getInput(): string[] {
+        const history = localStorage.getChatHistory()
+        if (!history) {
+            return []
+        }
+        return history.input
+    }
 }
+
+export const chatHistory = new ChatHistoryManager()

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -10,11 +10,7 @@ export class ChatHistoryManager {
 
     public getChat(sessionID: string): TranscriptJSON | null {
         const chatHistory = this.localHistory
-        if (!chatHistory) {
-            return null
-        }
-
-        return chatHistory.chat[sessionID]
+        return chatHistory?.chat ? chatHistory.chat[sessionID] : null
     }
 
     public async saveChat(chat: TranscriptJSON): Promise<UserLocalHistory> {

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -4,8 +4,12 @@ import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/m
 import { localStorage } from '../../services/LocalStorageProvider'
 
 export class ChatHistoryManager {
+    public get localHistory(): UserLocalHistory | null {
+        return localStorage.getChatHistory()
+    }
+
     public getChat(sessionID: string): TranscriptJSON | null {
-        const chatHistory = localStorage.getChatHistory()
+        const chatHistory = this.localHistory
         if (!chatHistory) {
             return null
         }
@@ -14,13 +18,7 @@ export class ChatHistoryManager {
     }
 
     public async saveChat(chat: TranscriptJSON): Promise<UserLocalHistory> {
-        let history = localStorage.getChatHistory()
-        if (!history) {
-            history = {
-                chat: {},
-                input: [],
-            }
-        }
+        const history = localStorage.getChatHistory()
         history.chat[chat.id] = chat
         await localStorage.setChatHistory(history)
         return history
@@ -30,30 +28,24 @@ export class ChatHistoryManager {
         await localStorage.deleteChatHistory(chatID)
     }
 
-    // Remove chat history with input history
-    public async clear(): Promise<void> {
-        await localStorage.removeChatHistory()
-    }
-
-    public async saveInput(input: string): Promise<UserLocalHistory> {
-        let history = localStorage.getChatHistory()
-        if (!history) {
-            history = {
-                chat: {},
-                input: [],
-            }
-        }
+    public async saveHumanInputHistory(input: string): Promise<UserLocalHistory> {
+        const history = localStorage.getChatHistory()
         history.input.push(input)
         await localStorage.setChatHistory(history)
         return history
     }
 
-    public getInput(): string[] {
+    public getHumanInputHistory(): string[] {
         const history = localStorage.getChatHistory()
         if (!history) {
             return []
         }
         return history.input
+    }
+
+    // Remove chat history and input history
+    public async clear(): Promise<void> {
+        await localStorage.removeChatHistory()
     }
 }
 

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -22,6 +22,7 @@ import { MessageErrorType, MessageProvider, MessageProviderOptions } from '../Me
 import { ConfigurationSubsetForWebview, ExtensionMessage, LocalEnv, WebviewMessage } from '../protocol'
 
 import { getChatPanelTitle } from './chat-helpers'
+import { chatHistory } from './ChatHistoryManager'
 import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {
@@ -141,7 +142,7 @@ export class ChatPanelProvider extends MessageProvider {
     ): Promise<void> {
         logDebug('ChatPanelProvider:onHumanMessageSubmitted', 'chat', { verbose: { text, submitType } })
 
-        MessageProvider.inputHistory.push(text)
+        await chatHistory.saveInput(text)
 
         if (submitType === 'suggestion') {
             const args = { requestID: this.currentRequestID }
@@ -248,7 +249,7 @@ export class ChatPanelProvider extends MessageProvider {
             type: 'history',
             messages: userHistory,
         })
-        void this.treeView.updateTree(createCodyChatTreeItems(userHistory))
+        void this.treeView.updateTree(createCodyChatTreeItems())
     }
 
     /**

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -142,7 +142,7 @@ export class ChatPanelProvider extends MessageProvider {
     ): Promise<void> {
         logDebug('ChatPanelProvider:onHumanMessageSubmitted', 'chat', { verbose: { text, submitType } })
 
-        await chatHistory.saveInput(text)
+        await chatHistory.saveHumanInputHistory(text)
 
         if (submitType === 'suggestion') {
             const args = { requestID: this.currentRequestID }

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -29,6 +29,7 @@ import {
     WebviewMessage,
 } from '../protocol'
 
+import { chatHistory } from './ChatHistoryManager'
 import { addWebviewViewHTML } from './ChatManager'
 
 export interface SidebarChatWebview extends Omit<vscode.Webview, 'postMessage'> {
@@ -237,7 +238,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
             verbose: { text, submitType, addEnhancedContext },
         })
 
-        MessageProvider.inputHistory.push(text)
+        await chatHistory.saveInput(text)
 
         if (submitType === 'suggestion') {
             const args = { requestID: this.currentRequestID }

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -238,7 +238,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
             verbose: { text, submitType, addEnhancedContext },
         })
 
-        await chatHistory.saveInput(text)
+        await chatHistory.saveHumanInputHistory(text)
 
         if (submitType === 'suggestion') {
             const args = { requestID: this.currentRequestID }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -355,7 +355,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             type: 'history',
             messages: allHistory,
         })
-        await this.treeView.updateTree(createCodyChatTreeItems(allHistory))
+        await this.treeView.updateTree(createCodyChatTreeItems())
     }
 
     public async clearAndRestartSession(): Promise<void> {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -405,7 +405,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const args = { requestID }
             telemetryService.log('CodyVSCodeExtension:chatPredictions:used', args, { hasV2Event: true })
         }
-
+        await this.history.saveHumanInputHistory(text)
         this.chatModel.addHumanMessage({ text })
         // trigger the context progress indicator
         void this.postViewTranscript({ speaker: 'assistant' })

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -68,8 +68,8 @@ export class LocalStorage {
     }
 
     public getChatHistory(): UserLocalHistory {
-        const history = this.storage.get<UserLocalHistory>(this.KEY_LOCAL_HISTORY, { chat: {}, input: [] })
-        return history
+        const history = this.storage.get<UserLocalHistory | null>(this.KEY_LOCAL_HISTORY, null)
+        return history || { chat: {}, input: [] }
     }
 
     public async setChatHistory(history: UserLocalHistory): Promise<void> {

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -67,8 +67,8 @@ export class LocalStorage {
         await this.storage.update(this.CODY_ENDPOINT_HISTORY, [...historySet])
     }
 
-    public getChatHistory(): UserLocalHistory | null {
-        const history = this.storage.get<UserLocalHistory | null>(this.KEY_LOCAL_HISTORY, null)
+    public getChatHistory(): UserLocalHistory {
+        const history = this.storage.get<UserLocalHistory>(this.KEY_LOCAL_HISTORY, { chat: {}, input: [] })
         return history
     }
 

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -1,10 +1,10 @@
-import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
 
 import { envInit } from './LocalAppDetector'
+import { localStorage } from './LocalStorageProvider'
 
 export type CodyTreeItemType = 'command' | 'support' | 'search' | 'chat'
 
@@ -37,9 +37,13 @@ export function getCodyTreeItems(type: CodyTreeItemType): CodySidebarTreeItem[] 
 }
 
 // functon to create chat tree items from user chat history
-export function createCodyChatTreeItems(userHistory: UserLocalHistory): CodySidebarTreeItem[] {
+export function createCodyChatTreeItems(): CodySidebarTreeItem[] {
+    const userHistory = localStorage.getChatHistory()?.chat
+    if (!userHistory) {
+        return []
+    }
     const chatTreeItems: CodySidebarTreeItem[] = []
-    const chatHistoryEntries = [...Object.entries(userHistory.chat)]
+    const chatHistoryEntries = [...Object.entries(userHistory)]
     chatHistoryEntries.forEach(([id, entry]) => {
         const lastHumanMessage = entry?.interactions?.findLast(interaction => interaction?.humanMessage)
         if (lastHumanMessage?.humanMessage.displayText && lastHumanMessage?.humanMessage.text) {

--- a/vscode/test/e2e/history-new-ui.test.ts
+++ b/vscode/test/e2e/history-new-ui.test.ts
@@ -32,4 +32,14 @@ test('checks if chat history shows up in sidebar', async ({ page, sidebar }) => 
         page.getByText('Chat alongside your code, attach files, add additional context, and try out diff')
     ).toBeVisible()
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
+
+    // Start a new chat and submit chat
+    await page.getByRole('tab', { name: 'New Chat' }).getByTitle('New Chat').locator('div').hover()
+    await page.keyboard.type('Hey')
+    await page.keyboard.press('Enter')
+
+    // Check if chat shows up in sidebar chat history tree view
+    await expect(
+        page.getByRole('treeitem', { name: 'Hey' }).locator('div').filter({ hasText: 'Hey' }).nth(3)
+    ).toBeVisible()
 })

--- a/vscode/test/integration/commands.test.ts
+++ b/vscode/test/integration/commands.test.ts
@@ -28,9 +28,9 @@ suite('Commands', function () {
         await vscode.commands.executeCommand('cody.command.explain-code')
 
         // Check the chat transcript contains markdown
-        const humanMessage = await getTranscript(0)
-        assert.match(humanMessage.displayText || '', /^\/explain/)
-
+        // const humanMessage = await getTranscript(0)
+        // assert.match(humanMessage.displayText || '', /^\/explain/)
+        assert.match((await getTranscript(0)).displayText || '', /^\/explain/)
         await waitUntil(async () => assistantRegex.test((await getTranscript(1)).displayText || ''))
     })
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1968

This PR focused on simplify chat history handling by moving the old chat history handling in MessageProvider to the new Chat History Manager.

Removed redundant chat history code and use shared chatHistory module instead. This simplifies the MessageProvider by removing duplicated chat history logic.

This also fixes issue described in the attached issue as previously, we would save chat history as group instead of individual chat, so a new group can overwritten the old one, unable to keep history across panels in sync.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Follow instructions in attached issue