### PR TITLE
Fix flaky e2e chat tests

### DIFF
--- a/vscode/test/e2e/chat.test.ts
+++ b/vscode/test/e2e/chat.test.ts
@@ -2,7 +2,7 @@ import { expect, Frame, FrameLocator, Page } from '@playwright/test'
 
 import * as mockServer from '../fixtures/mock-server'
 
-import { sidebarSignin } from './common'
+import { disableNotifications, sidebarSignin } from './common'
 import { test } from './helpers'
 
 test('shows appropriate rate limit message for free users', async ({ page, sidebar }) => {
@@ -41,6 +41,9 @@ test('shows appropriate rate limit message for pro users', async ({ page, sideba
  * Sets up a chat window ready for testing.
  */
 async function prepareChat(page: Page, sidebar: Frame): Promise<FrameLocator> {
+    // Turn off notifications because they can obscure the chat box
+    await disableNotifications(page)
+
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -28,3 +28,8 @@ const sidebarCodyRole = { name: /Cody.*/ }
 export const sidebarCody = (page: Page): Locator => page.getByRole('tab', sidebarCodyRole)
 
 export const codyEditorCommandButtonRole = { name: /Commands.*/ }
+
+export async function disableNotifications(page: Page): Promise<void> {
+    await page.getByRole('button', { name: 'Notifications' }).click()
+    await page.getByRole('button', { name: 'Toggle Do Not Disturb Mode' }).click()
+}

--- a/vscode/test/e2e/history-new-ui.test.ts
+++ b/vscode/test/e2e/history-new-ui.test.ts
@@ -1,12 +1,11 @@
 import { expect } from '@playwright/test'
 
-import { sidebarExplorer, sidebarSignin } from './common'
+import { disableNotifications, sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
 test('checks if chat history shows up in sidebar', async ({ page, sidebar }) => {
     // Turn off notification
-    await page.getByRole('button', { name: 'Notifications' }).click()
-    await page.getByRole('button', { name: 'Toggle Do Not Disturb Mode' }).click()
+    await disableNotifications(page)
 
     // Sign into Cody
     await sidebarSignin(page, sidebar)


### PR DESCRIPTION
This fixes two flakes in recent tests I added:

1. VS Code toast notifications obscuring the chatbox so the test could not click them.

The failure looked like:

```
 retrying click action, attempt #2
      waiting 20ms
      waiting for element to be visible, enabled and stable
      element is visible, enabled and stable
      scrolling into view if needed
      done scrolling
      <div title="Git (Extension)" class="notification-list…>Source: Git (Extension)</div> from <div class="notifications-toasts visible">…</div> subtree intercepts pointer events
```

This was fixed by turning on Do Not Disturb mode (something already done in another test, so I extracted a function and reused it).

2. Triggering rate limits in the second test sometimes not working.

This one was confusing. It appears that in e2e tests we stop the server, we just call `server.close()` which only prevents new connections. The server continues to run for any open connections. This could result in the next test from reusing some existing connections to the first server and creating some new connections to its own new server. For tests that modify state in the mock server (eg. to trigger rate limits) this would cause failures.

Adding unique IDs to the server and some logging resulted in this:

![flakytest](https://github.com/sourcegraph/cody/assets/1078012/2dd17c8d-ea23-4288-9434-27c8c2ec0256)

The fix is to ensure all existing connections to the server are closed when we close the server (by collecting them as they open and calling `destroy()` on them).


## Test plan

These are fixes to the test, green bots with no failures/retries indicate it works.
