### PR TITLE
Add a test for non-dotCom chat rate limit

### DIFF
--- a/vscode/test/e2e/chat.test.ts
+++ b/vscode/test/e2e/chat.test.ts
@@ -5,36 +5,34 @@ import * as mockServer from '../fixtures/mock-server'
 import { disableNotifications, sidebarSignin } from './common'
 import { test } from './helpers'
 
-test('shows appropriate rate limit message for free users', async ({ page, sidebar }) => {
-    const chatFrame = await prepareChat(page, sidebar)
-
+test('shows upgrade rate limit message for free users', async ({ page, sidebar }) => {
     await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/free`, {
         method: 'POST',
     })
 
-    await page.keyboard.type('Hello')
-    await page.keyboard.press('Enter')
-
-    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).toBeVisible()
-    await expect(chatFrame.getByText('Unable to Send Message')).not.toBeVisible()
-    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).toBeVisible()
-    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+    const chatFrame = await prepareChat(page, sidebar)
+    await sendChatMessage(page)
+    await expectUpgradeRateLimitMessage(chatFrame)
 })
 
-test('shows appropriate rate limit message for pro users', async ({ page, sidebar }) => {
-    const chatFrame = await prepareChat(page, sidebar)
-
+test('shows standard rate limit message for pro users', async ({ page, sidebar }) => {
     await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit/pro`, {
         method: 'POST',
     })
 
-    await page.keyboard.type('Hello')
-    await page.keyboard.press('Enter')
+    const chatFrame = await prepareChat(page, sidebar)
+    await sendChatMessage(page)
+    await expectStandardRateLimitMessage(chatFrame)
+})
 
-    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).not.toBeVisible()
-    await expect(chatFrame.getByText('Unable to Send Message')).toBeVisible()
-    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).not.toBeVisible()
-    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+test('shows standard rate limit message for non-dotCom users', async ({ page, sidebar }) => {
+    await fetch(`${mockServer.SERVER_URL}/.test/completions/triggerRateLimit`, {
+        method: 'POST',
+    })
+
+    const chatFrame = await prepareChat(page, sidebar)
+    await sendChatMessage(page)
+    await expectStandardRateLimitMessage(chatFrame)
 })
 
 /**
@@ -64,9 +62,34 @@ async function prepareChat(page: Page, sidebar: Frame): Promise<FrameLocator> {
     // Open the new chat panel
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
 
+    // Find the chat iframe inside the editor iframe
     const chatFrameLocator = page.frameLocator('iframe.webview').frameLocator('iframe')
 
+    // Put focus in the chat textbox
     await chatFrameLocator.getByRole('textbox', { name: 'Chat message' }).click()
 
     return chatFrameLocator
+}
+
+async function sendChatMessage(page: Page): Promise<void> {
+    await page.keyboard.type('Hello')
+    await page.keyboard.press('Enter')
+}
+
+async function expectStandardRateLimitMessage(chatFrame: FrameLocator): Promise<void> {
+    // Standard error
+    await expect(chatFrame.getByText('Unable to Send Message')).toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+    // No upgrade options
+    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).not.toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).not.toBeVisible()
+}
+
+async function expectUpgradeRateLimitMessage(chatFrame: FrameLocator): Promise<void> {
+    // Upgrade options
+    await expect(chatFrame.getByText('UPGRADE TO CODY PRO')).toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Upgrade' })).toBeVisible()
+    await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
+    // No standard error
+    await expect(chatFrame.getByText('Unable to Send Message')).not.toBeVisible()
 }


### PR DESCRIPTION
Adds an extra test for the rate limit for a non-dotcom instance (where the `x-is-cody-pro-user` header will not be set and upgrade options should not be shown).

## Test plan

- New automated test, run with `pnpm test:e2e`