### PR TITLE
Autocomplete: Fix dynamic multiline feature flag typo

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -20,7 +20,7 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoderExtendedTokenWindow = 'cody-autocomplete-starcoder-extended-token-window',
     CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
     CodyAutocompleteDisableRecyclingOfPreviousRequests = 'cody-autocomplete-disable-recycling-of-previous-requests',
-    CodyAutocompleteDynamicMultilineCompletions = 'cody-autocomplete-dynamic-multline-completions',
+    CodyAutocompleteDynamicMultilineCompletions = 'cody-autocomplete-dynamic-multiline-completions',
     CodyPro = 'cody-pro',
     CodyChatMockTest = 'cody-chat-mock-test',
 }


### PR DESCRIPTION

## Test plan

Only fixing a typo. The FF is not used yet.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
