### PR TITLE
Replace windows-arm64 with windows-x84 binary

### DIFF
--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -57,7 +57,12 @@ export async function downloadBfg(context: vscode.ExtensionContext): Promise<str
             ['aarch64', 'arm64'],
             ['x86_64', 'x64'],
         ])
-        const rfc795Arch = archRenames.get(arch ?? '') ?? arch
+        let rfc795Arch = archRenames.get(arch ?? '') ?? arch
+        if (rfc795Arch === 'arm64' && platform === 'win') {
+            // On Windows Arm PCs, we rely on emulation and use the x64 binary.
+            // See https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation
+            rfc795Arch = 'x64'
+        }
 
         const bfgContainingDir = path.join(context.globalStorageUri.fsPath, 'cody-engine')
         const bfgVersion = config.get<string>('cody.experimental.cody-engine.version', defaultBfgVersion)


### PR DESCRIPTION
Previously, we tried to download a non-existent windows-arm64 binary,
  which resulted in a 404 error for end users. This PR fixes the problem
  by using the windows-x84 binary instead. This works because Windows
  Arm PCs support x86 emulation https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation

Fixes https://github.com/sourcegraph/cody/issues/2022


## Test plan

Test it on Windows using Parallels Desktop on Apple Silicon.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
