### PR TITLE
telemetry: add v2 interactionID support

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -27,7 +27,7 @@
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/persister-fs": "^6.0.6",
     "@sourcegraph/cody-shared": "workspace:*",
-    "@sourcegraph/telemetry": "^0.13.0",
+    "@sourcegraph/telemetry": "^0.14.0",
     "commander": "^11.1.0",
     "csv-writer": "^1.6.0",
     "env-paths": "^3.0.0",

--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
     "@opentelemetry/api": "^1.7.0",
-    "@sourcegraph/telemetry": "^0.13.0",
+    "@sourcegraph/telemetry": "^0.14.0",
     "date-fns": "^2.30.0",
     "dompurify": "^3.0.4",
     "highlight.js": "^10.7.3",

--- a/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.test.ts
+++ b/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.test.ts
@@ -12,6 +12,7 @@ describe('handleExportModeTransforms', () => {
                 feature: 'Bar',
                 parameters: {
                     version: 0,
+                    interactionID: 'abcde',
                     metadata: [
                         {
                             key: 'foo',
@@ -31,6 +32,7 @@ describe('handleExportModeTransforms', () => {
         // Modified
         expect(events[0].parameters.privateMetadata).toBeUndefined()
         expect(events[0].parameters.metadata?.pop()?.value).toBe(1)
+        expect(events[0].parameters.interactionID).toBeUndefined()
     })
 
     it('5.2.2-5.2.3', () => {
@@ -40,6 +42,7 @@ describe('handleExportModeTransforms', () => {
                 feature: 'Bar',
                 parameters: {
                     version: 0,
+                    interactionID: 'abcde',
                     metadata: [
                         {
                             key: 'foo',
@@ -58,6 +61,7 @@ describe('handleExportModeTransforms', () => {
 
         // Modified
         expect(events[0].parameters.metadata?.pop()?.value).toBe(1)
+        expect(events[0].parameters.interactionID).toBeUndefined()
         // Not modified
         expect(events[0].parameters.privateMetadata).toBeDefined()
     })
@@ -69,6 +73,7 @@ describe('handleExportModeTransforms', () => {
                 feature: 'Bar',
                 parameters: {
                     version: 0,
+                    interactionID: 'abcde',
                     metadata: [
                         {
                             key: 'foo',
@@ -88,5 +93,6 @@ describe('handleExportModeTransforms', () => {
         // Not modified
         expect(events[0].parameters.metadata?.pop()?.value).toBe(1.234)
         expect(events[0].parameters.privateMetadata).toBeDefined()
+        expect(events[0].parameters.interactionID).toBe('abcde')
     })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: workspace:*
         version: link:../lib/shared
       '@sourcegraph/telemetry':
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.14.0
+        version: 0.14.0
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -246,8 +246,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0
       '@sourcegraph/telemetry':
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.14.0
+        version: 0.14.0
       date-fns:
         specifier: ^2.30.0
         version: 2.30.0
@@ -383,8 +383,8 @@ importers:
         specifier: workspace:*
         version: link:../lib/ui
       '@sourcegraph/telemetry':
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.14.0
+        version: 0.14.0
       '@storybook/preview-api':
         specifier: ^7.6.2
         version: 7.6.2
@@ -5119,8 +5119,8 @@ packages:
     resolution: {integrity: sha512-FQ1/Ued4I02R0JkrHHofDN163juVxUnPALzfxPZrDZUHv+c3jHjfZhmTHEz+Wd+g3b7MFk0fkj36nZSnvPyU8A==}
     dev: true
 
-  /@sourcegraph/telemetry@0.13.0:
-    resolution: {integrity: sha512-PNLBUFYv/BCYIjatFGs7QpgT0sGuC6/P3V2YJ+sVNYc7n8hz2I/GLOsEUepVMIgYagsAtFVV24yrUkDLT82YoA==}
+  /@sourcegraph/telemetry@0.14.0:
+    resolution: {integrity: sha512-pxkIzjBx4Ari7JLDoEocYFaYFav5svHFo39fJvv89A9DuFRMrE0EM/4zP9zvgKPrVZuxwupk1vWe1yWl8QbZ4Q==}
     dependencies:
       rxjs: 7.8.1
     dev: false
@@ -8073,7 +8073,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@1.1.4:
@@ -10139,6 +10139,14 @@ packages:
     dev: true
     optional: true
 
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fstream@1.0.12:
     resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
     engines: {node: '>=0.6'}
@@ -11375,7 +11383,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-mock@27.5.1:
@@ -14580,7 +14588,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /route-recognizer@0.3.4:
@@ -16173,7 +16181,7 @@ packages:
       postcss: 8.4.25
       rollup: 3.26.2
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vite@4.4.3(@types/node@20.5.7):
@@ -16209,7 +16217,7 @@ packages:
       postcss: 8.4.25
       rollup: 3.26.2
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vitest@0.33.0(jsdom@22.1.0):

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1188,7 +1188,7 @@
     "@sentry/node": "^7.66.0",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/cody-ui": "workspace:*",
-    "@sourcegraph/telemetry": "^0.13.0",
+    "@sourcegraph/telemetry": "^0.14.0",
     "@storybook/preview-api": "^7.6.2",
     "@types/stream-json": "^1.7.3",
     "@vscode/codicons": "^0.0.29",

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -106,7 +106,12 @@ describe('logger', () => {
             },
             { agent: true, hasV2Event: true }
         )
-        expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'suggested', expect.anything())
+        expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'suggested', {
+            version: 0,
+            interactionID: expect.any(String),
+            metadata: expect.anything(),
+            privateMetadata: expect.anything(),
+        })
 
         expect(logSpy).toHaveBeenCalledWith(
             'CodyVSCodeExtension:completion:accepted',
@@ -123,7 +128,12 @@ describe('logger', () => {
             },
             { agent: true, hasV2Event: true }
         )
-        expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'accepted', expect.anything())
+        expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'accepted', {
+            version: 0,
+            interactionID: expect.any(String),
+            metadata: expect.anything(),
+            privateMetadata: expect.anything(),
+        })
     })
 
     it('reuses the completion ID for the same completion', () => {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -39,14 +39,16 @@ declare const CompletionLogID: unique symbol
 export type CompletionItemID = string & { _opaque: typeof CompletionItemID }
 declare const CompletionItemID: unique symbol
 
-interface SharedEventPayload {
+interface InteractionIDPayload {
     /**
      * An ID to uniquely identify a suggest completion. Note: It is possible for this ID to be part
      * of two suggested events. This happens when the exact same completion text is shown again at
      * the exact same location. We count this as the same completion and thus use the same ID.
      */
     id: CompletionAnalyticsID | null
+}
 
+interface SharedEventPayload extends InteractionIDPayload {
     /** Eventual Sourcegraph instance OpenTelemetry trace id */
     traceId?: string
 
@@ -100,6 +102,14 @@ interface SharedEventPayload {
 
     /** A list of known completion providers that are also enabled with this user. */
     otherCompletionProviders: string[]
+}
+
+/**
+ * hasInteractionID helps extracting analytics interaction ID from parameters
+ * that extend SharedEventPayload.
+ */
+function hasInteractionID(params: any): params is InteractionIDPayload {
+    return 'id' in params
 }
 
 /** Emitted when a completion was suggested to the user and printed onto the screen */
@@ -285,6 +295,12 @@ function writeCompletionEvent<Name extends string, LegacyParams extends {}>(
         agent: true,
         hasV2Event: true, // this helper translates the event for us
     })
+    /**
+     * Extract interaction ID from the full legacy params for convenience
+     */
+    if (params && hasInteractionID(legacyParams)) {
+        params.interactionID = legacyParams.id?.toString()
+    }
     /**
      * New telemetry automatically adds extension context - we do not need to
      * include platform in the name of the event. However, we MUST prefix the


### PR DESCRIPTION
As of 5.2.4, V2 telemetry has a notion of "interaction ID" as a first-class citizen to align series of events and to provide an explicit string-value field for propagating a UUID-style interaction ID. See https://github.com/sourcegraph/telemetry/pull/4, https://github.com/sourcegraph/sourcegraph/pull/58539, https://github.com/sourcegraph/sourcegraph/pull/58016 and https://docs.sourcegraph.com/dev/background-information/telemetry/protocol#telemetrygateway-v1-EventInteraction

This change adds support for it in Cody, and makes sure the mechanism is compatible pre-5.2.4 instances. It also extracts `id` from `params` in completion events into the first-class field.

## Test plan

Unit tests