### PR TITLE
update enhance context display copy

### DIFF
--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -55,7 +55,7 @@ export const EnhancedContext: React.FunctionComponent<{
     const fileCount = filteredFiles.length
     const lines = `${lineCount} line` + (lineCount > 1 ? 's' : '')
     const files = `${fileCount} file` + (fileCount > 1 ? 's' : '')
-    const title = lineCount ? `${lines} from ${files}` : `from ${files}`
+    const title = lineCount ? `${lines} from ${files}` : `${files}`
 
     return (
         <TranscriptAction


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1984

Suggested by @toolmantim 

> As an interim, we can at least remove the word "from" in "▶ from ${n} files" — as "from" is only meant to be used in the form "{x} lines from {n{ files"

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

### Before

<img width="538" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/058cbf93-3362-41cc-bf2b-a52ef082d70d">


### After

<img width="675" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/420a7c36-750a-44cd-be6e-07570d3e9a93">

