### PR TITLE
change: reuse empty "New Chat" panel

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Enhanced Context used to turn off automatically after the first chat. Now it stays enabled until you disable it. [pull/2069](https://github.com/sourcegraph/cody/pull/2069)
+- Chat: Reuse existing New Chat panel to prevent having multiple new chats open at once. [pull/2087](https://github.com/sourcegraph/cody/pull/2087)
 
 ## [0.16.3]
 

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -214,7 +214,6 @@ export class ChatPanelProvider extends MessageProvider {
         }
         // selection is available to pro only at Dec GA
         const isCodyProFeatureFlagEnabled = await this.featureFlagProvider?.evaluateFeatureFlag(FeatureFlag.CodyPro)
-        console.log(isCodyProFeatureFlagEnabled, 'isCodyProFeatureFlagEnabled')
         const models = ChatModelProvider.get(authStatus.endpoint, this.chatModel)?.map(model => {
             return {
                 ...model,

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -138,6 +138,15 @@ export class ChatPanelsManager implements vscode.Disposable {
             }
         }
 
+        // Reuse existing "New Chat" panel if there is an empty one
+        const emptyNewChatProvider = Array.from(this.panelProvidersMap.values()).find(
+            p => p.webviewPanel?.title === 'New Chat'
+        )
+        if (!chatID && !panel && this.panelProvidersMap.size && emptyNewChatProvider) {
+            emptyNewChatProvider.webviewPanel?.reveal()
+            return emptyNewChatProvider
+        }
+
         logDebug('ChatPanelsManager:createWebviewPanel', this.panelProvidersMap.size.toString())
 
         // Get the view column of the current active chat panel so that we can open a new one on top of it

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -144,6 +144,9 @@ export class ChatPanelsManager implements vscode.Disposable {
         )
         if (!chatID && !panel && this.panelProvidersMap.size && emptyNewChatProvider) {
             emptyNewChatProvider.webviewPanel?.reveal()
+            this.activePanelProvider = emptyNewChatProvider
+            this.options.contextProvider.webview = emptyNewChatProvider.webview
+            void this.selectTreeItem(emptyNewChatProvider.sessionID)
             return emptyNewChatProvider
         }
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/1969

Reuse the empty New Chat panel when there is one available to prevent having multiple new chats open at once 

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Click on the New Chat button when there is a "New Chat" available should reveal the existing one instead of creating a new one:

https://github.com/sourcegraph/cody/assets/68532117/95f7ee4a-a848-479d-923b-87f88dd54963

