### PR TITLE
Chat: Close the Enhanced Context popover on chat input focus

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -67,7 +67,7 @@ interface ChatProps extends ChatClassNames {
     contextSelection?: ContextFile[] | null
     UserContextSelectorComponent?: React.FunctionComponent<UserContextSelectorProps>
     chatModels?: ChatModelProvider[]
-    EnhancedContextSettings?: React.FunctionComponent<{}>
+    EnhancedContextSettings?: React.FunctionComponent<{ isOpen: boolean; setOpen: (open: boolean) => void }>
     ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
     onCurrentChatModelChange?: (model: ChatModelProvider) => void
     userInfo?: UserAccountInfo
@@ -104,6 +104,7 @@ export interface ChatUITextAreaProps {
     onInput: React.FormEventHandler<HTMLElement>
     setValue?: (value: string) => void
     onKeyDown?: (event: React.KeyboardEvent<HTMLElement>, caretPosition: number | null) => void
+    onFocus?: (event: React.FocusEvent<HTMLElement>) => void
     chatModels?: ChatModelProvider[]
 }
 
@@ -518,6 +519,9 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
 
     const isGettingStartedComponentVisible = transcript.length === 0 && GettingStartedComponent !== undefined
 
+    // isContextSettingsOpen state
+    const [isEnhancedContextOpen, setIsEnhancedContextOpen] = useState(false)
+
     return (
         <div className={classNames(className, styles.innerContainer)}>
             {!isCodyEnabled && CodyNotEnabledNotice ? (
@@ -614,13 +618,17 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                             required={true}
                             disabled={needsEmailVerification || !isCodyEnabled}
                             onInput={onChatInput}
+                            onFocus={() => setIsEnhancedContextOpen(false)}
                             onKeyDown={onChatKeyDown}
                             setValue={inputHandler}
                             chatModels={chatModels}
                         />
                         {EnhancedContextSettings && (
                             <div className={styles.contextButton}>
-                                <EnhancedContextSettings />
+                                <EnhancedContextSettings
+                                    isOpen={isEnhancedContextOpen}
+                                    setOpen={setIsEnhancedContextOpen}
+                                />
                             </div>
                         )}
                     </div>

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -519,7 +519,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
 
     const isGettingStartedComponentVisible = transcript.length === 0 && GettingStartedComponent !== undefined
 
-    // isContextSettingsOpen state
     const [isEnhancedContextOpen, setIsEnhancedContextOpen] = useState(false)
 
     return (

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Enhanced Context used to turn off automatically after the first chat. Now it stays enabled until you disable it. [pull/2069](https://github.com/sourcegraph/cody/pull/2069)
+- Chat: Close the Enhanced Context popover on chat input focus. [pull/2091](https://github.com/sourcegraph/cody/pull/2091)
 
 ## [0.16.3]
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -265,6 +265,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     required,
     onInput,
     onKeyDown,
+    onFocus,
     chatModels,
 }) => {
     const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -311,6 +312,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                 required={required}
                 onInput={onInput}
                 onKeyDown={onTextAreaKeyDown}
+                onFocus={onFocus}
                 placeholder={placeholder}
                 aria-label="Chat message"
                 title="" // Set to blank to avoid HTML5 error tooltip "Please fill in this field"

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -33,9 +33,9 @@ export default meta
 
 interface SingleTileArgs {
     name: string
-    kind: 'embeddings' | 'graph' |'search'
-    type: 'local' |'remote'
-    state: 'indeterminate' | 'unconsented' | 'indexing' |'ready' | 'no-match'
+    kind: 'embeddings' | 'graph' | 'search'
+    type: 'local' | 'remote'
+    state: 'indeterminate' | 'unconsented' | 'indexing' | 'ready' | 'no-match'
     origin: string
     remoteName: string
 }
@@ -111,7 +111,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
                             right: 20,
                         }}
                     >
-                        <EnhancedContextSettings isOpen={args.isOpen} setOpen={()=> {}}/>
+                        <EnhancedContextSettings isOpen={args.isOpen} setOpen={() => {}} />
                     </div>
                 </EnhancedContextEventHandlers.Provider>
             </EnhancedContextContext.Provider>
@@ -166,7 +166,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                     right: 20,
                 }}
             >
-                <EnhancedContextSettings isOpen={true} setOpen={()=> {}} />
+                <EnhancedContextSettings isOpen={true} setOpen={() => {}} />
             </div>
         </EnhancedContextContext.Provider>
     ),

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -31,8 +31,18 @@ const meta: Meta<typeof EnhancedContextSettings> = {
 
 export default meta
 
-export const SingleTile: StoryObj<typeof EnhancedContextSettings> = {
+interface SingleTileArgs {
+    name: string
+    kind: 'embeddings' | 'graph' |'search'
+    type: 'local' |'remote'
+    state: 'indeterminate' | 'unconsented' | 'indexing' |'ready' | 'no-match'
+    origin: string
+    remoteName: string
+}
+
+export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArgs> = {
     args: {
+        isOpen: true,
         name: '~/sourcegraph',
         kind: 'embeddings',
         type: 'remote',
@@ -41,6 +51,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings> = {
         remoteName: 'github.com/sourcegraph/sourcegraph',
     },
     argTypes: {
+        isOpen: { control: 'boolean' },
         name: { control: 'text' },
         kind: {
             options: ['embeddings', 'graph', 'search'],
@@ -100,7 +111,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings> = {
                             right: 20,
                         }}
                     >
-                        <EnhancedContextSettings isOpen={true} />
+                        <EnhancedContextSettings isOpen={args.isOpen} setOpen={()=> {}}/>
                     </div>
                 </EnhancedContextEventHandlers.Provider>
             </EnhancedContextContext.Provider>
@@ -155,7 +166,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                     right: 20,
                 }}
             >
-                <EnhancedContextSettings isOpen={true} />
+                <EnhancedContextSettings isOpen={true} setOpen={()=> {}} />
             </div>
         </EnhancedContextContext.Provider>
     ),

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -100,7 +100,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings> = {
                             right: 20,
                         }}
                     >
-                        <EnhancedContextSettings />
+                        <EnhancedContextSettings isOpen={true} />
                     </div>
                 </EnhancedContextEventHandlers.Provider>
             </EnhancedContextContext.Provider>
@@ -155,7 +155,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                     right: 20,
                 }}
             >
-                <EnhancedContextSettings />
+                <EnhancedContextSettings isOpen={true} />
             </div>
         </EnhancedContextContext.Provider>
     ),

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -17,7 +17,7 @@ import styles from './EnhancedContextSettings.module.css'
 
 interface EnhancedContextSettingsProps {
     isOpen: boolean
-    setOpen?: (open: boolean) => void
+    setOpen: (open: boolean) => void
 }
 
 export function defaultEnhancedContextContext(): EnhancedContextContextT {

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -15,7 +15,10 @@ import { PopupFrame } from '../Popups/Popup'
 import popupStyles from '../Popups/Popup.module.css'
 import styles from './EnhancedContextSettings.module.css'
 
-interface EnhancedContextSettingsProps {}
+interface EnhancedContextSettingsProps {
+    isOpen: boolean
+    setOpen?: (open: boolean) => void
+}
 
 export function defaultEnhancedContextContext(): EnhancedContextContextT {
     return {
@@ -166,11 +169,13 @@ const ContextProviderComponent: React.FunctionComponent<{ provider: ContextProvi
     )
 }
 
-export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSettingsProps> = (): React.ReactNode => {
+export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSettingsProps> = ({
+    isOpen,
+    setOpen,
+}): React.ReactNode => {
     const events = useEnhancedContextEventHandlers()
     const context = useEnhancedContextContext()
     const [enabled, setEnabled] = React.useState<boolean>(useEnhancedContextEnabled())
-    const [isOpen, setOpen] = React.useState(false)
     const enabledChanged = React.useCallback(
         (event: any): void => {
             const shouldEnable = !!event.target?.checked
@@ -185,7 +190,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
         <div className={classNames(popupStyles.popupHost)}>
             <PopupFrame
                 isOpen={isOpen}
-                onDismiss={() => setOpen(!isOpen)}
+                onDismiss={() => setOpen(false)}
                 classNames={[popupStyles.popupTrail, styles.enhancedContextSettingsPopup]}
             >
                 <div className={styles.enhancedContextInnerContainer}>

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -170,6 +170,9 @@ button {
 :global .codicon-database::before {
     content: '\eace';
 }
+:global .codicon-sparkles::before {
+    content: '\ec10';
+}
 :global .codicon-symbol-structure::before {
     content: '\ea91';
 }

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -170,7 +170,7 @@ button {
 :global .codicon-database::before {
     content: '\eace';
 }
-:global .codicon-sparkles::before {
+:global .codicon-sparkle::before {
     content: '\ec10';
 }
 :global .codicon-symbol-structure::before {


### PR DESCRIPTION
Updates the Enhanced Context popover so it closes when the chat message input is focused, removing an extra click.

Before:

https://github.com/sourcegraph/cody/assets/153/9e06b6da-3f6c-4ab7-b495-ac92fad9c4eb 

After:

https://github.com/sourcegraph/cody/assets/153/46b6a469-cb44-4e51-b7f5-912622fa2a2c

## Test plan

- Start a new chat
- Click the enhanced context button
- Click the text input
- Click the enhanced context button again
- Click close button