### PR TITLE
fix: open file with range in simple chat

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -333,7 +333,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 void openExternalLinks(message.value)
                 break
             case 'openFile':
-                await openFilePath(message.filePath, this.webviewPanel?.viewColumn)
+                await openFilePath(message.filePath, this.webviewPanel?.viewColumn, message.range)
                 break
             case 'openLocalFileWithRange':
                 await openLocalFileWithRange(message.filePath, message.range)


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/2093

fix: open file with range in SimpleChatPanelProvider

Added the missing range parameter to the openFile command handler in SimpleChatPanelProvider and pass it to the openFilePath function. This allows opening a file to a specific range.


## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try clicking on the context with range to see if the file opens at the correct range.


https://github.com/sourcegraph/cody/assets/68532117/e6ce69e7-29a1-422c-8d03-870407e33c12

