### PR TITLE
Chat: Show onboarding glowy dot guide until first time opening Enhanced Context

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Enhanced Context used to turn off automatically after the first chat. Now it stays enabled until you disable it. [pull/2069](https://github.com/sourcegraph/cody/pull/2069)
+- Chat: Show onboarding glowy dot guide until first time opening Enhanced Context. [pull/2097](https://github.com/sourcegraph/cody/pull/2097)
 
 ## [0.16.3]
 

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -181,6 +181,13 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
         },
         [events, enabled]
     )
+
+    const hasOpenedBeforeKey = 'enhanced-context-settings.has-opened-before'
+    const hasOpenedBefore = localStorage.getItem(hasOpenedBeforeKey) === 'true'
+    if (isOpen && !hasOpenedBefore) {
+        localStorage.setItem(hasOpenedBeforeKey, 'true')
+    }
+
     return (
         <div className={classNames(popupStyles.popupHost)}>
             <PopupFrame
@@ -216,7 +223,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 title="Configure Enhanced Context"
             >
                 <i className="codicon codicon-sparkle" />
-                {/* Show this dot if the popover has never been opened: <div className={styles.glowyDot}/> */}
+                {isOpen || hasOpenedBefore ? null : <div className={styles.glowyDot} />}
             </VSCodeButton>
         </div>
     )


### PR DESCRIPTION
To help people discover Enhanced Context, this adds an onboarding glowy dot until the user has opened it for the first time. After it's been opened the first time it is never shown again.

https://github.com/sourcegraph/cody/assets/153/ff255c92-8f74-45a3-8942-715c922349b1

Fixes #2083

## Test plan

- Open chat
- See glowy dot
- Open enhanced context
- See glowy dot disappear
- Reload window
- See glowy dot not visible