### PR TITLE
Chat: Line break folder names in Enhanced Context popover

### DIFF
--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -66,7 +66,7 @@ const ContextGroupComponent: React.FunctionComponent<{ group: ContextGroup; allG
 
     return (
         <>
-            <dt title={group.name}>
+            <dt title={group.name} className={styles.lineBreakAll}>
                 <i className="codicon codicon-folder" /> {groupName}
             </dt>
             <dd>


### PR DESCRIPTION
Prevents long paths from expanding the width of the popover.

<img width="348" alt="Screenshot 2023-12-05 at 5 13 54 pm" src="https://github.com/sourcegraph/cody/assets/153/28055d8a-fc6e-4651-91c8-6ece99149587">

## Test plan

- Developer tool inspected edit the folder name in Enhanced Context
- Checked it wrapped and didn't force the size of the popover to increase