### PR TITLE
Make abort work in the simplified chat panel

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -69,6 +69,16 @@ export class SimpleChatModel {
         })
     }
 
+    public removeLastMessageIfHuman(): void {
+        const lastMessage = this.messagesWithContext.at(-1)
+        if (!lastMessage) {
+            return
+        }
+        if (lastMessage.message.speaker === 'human') {
+            this.messagesWithContext.pop()
+        }
+    }
+
     public getLastHumanMessages(): MessageWithContext | undefined {
         return this.messagesWithContext.findLast(message => message.message.speaker === 'human')
     }

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -69,16 +69,6 @@ export class SimpleChatModel {
         })
     }
 
-    public removeLastMessageIfHuman(): void {
-        const lastMessage = this.messagesWithContext.at(-1)
-        if (!lastMessage) {
-            return
-        }
-        if (lastMessage.message.speaker === 'human') {
-            this.messagesWithContext.pop()
-        }
-    }
-
     public getLastHumanMessages(): MessageWithContext | undefined {
         return this.messagesWithContext.findLast(message => message.message.speaker === 'human')
     }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -526,11 +526,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 },
                 error: (partialResponse, error) => {
                     if (isAbortError(error)) {
-                        if (partialResponse.length === 0) {
-                            this.chatModel.removeLastMessageIfHuman()
-                        } else {
-                            this.chatModel.addBotMessage({ text: partialResponse })
-                        }
+                        this.chatModel.addBotMessage({ text: partialResponse })
                         this.postViewTranscript()
                         return
                     }
@@ -774,11 +770,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 },
                 error: (partialResponse: string, error: Error) => {
                     if (isAbortError(error)) {
-                        if (partialResponse.length === 0) {
-                            this.chatModel.removeLastMessageIfHuman()
-                        } else {
-                            this.chatModel.addBotMessage({ text: partialResponse })
-                        }
+                        this.chatModel.addBotMessage({ text: partialResponse })
                         this.postViewTranscript()
                         return
                     }


### PR DESCRIPTION
https://github.com/sourcegraph/cody/assets/1646931/757f0780-946f-4eac-93ff-9761caeece26

* Abort now works in the simplified chat panel
* Fixes a possible race condition where an error in local embeddings search seems sometimes to result in empty context, even if remote embedding search yields results

## Test plan

- [ ] Test aborting an in-progress message
  - [ ] If the message is in-progress, the partial message should be adopted
  - [ ] If the message was still empty, the last human question should be removed
- [ ] Test asking a follow-up question after aborting in each of the above cases

Note: the context fetching step (prior to response generation) cannot yet be aborted.