### PR TITLE
plg: fix incorrect commands for admin buttons

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -701,6 +701,10 @@
         {
           "command": "cody.guardrails.debug",
           "when": "config.cody.experimental.guardrails && editorHasSelection"
+        },
+        {
+          "command": "cody.show-page",
+          "when": "false"
         }
       ],
       "editor/context": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -377,6 +377,13 @@
         "when": "cody.activated"
       },
       {
+        "command": "cody.show-page",
+        "category": "Cody",
+        "title": "Show Admin Pages",
+        "group": "Cody",
+        "when": "cody.activated"
+      },
+      {
         "command": "cody.comment.add",
         "title": "Ask Cody",
         "category": "Cody Inline Chat",

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -64,14 +64,14 @@ const supportItems: CodySidebarTreeItem[] = [
         title: 'Upgrade',
         description: 'Upgrade to Pro',
         icon: 'zap',
-        command: { command: 'cody.account.upgrade' },
+        command: { command: 'cody.show-page', args: ['upgrade'] },
         requireUpgradeAvailable: true,
         requireFeature: FeatureFlag.CodyPro,
     },
     {
         title: 'Usage',
         icon: 'pulse',
-        command: { command: 'cody.account.usage' },
+        command: { command: 'cody.show-page', args: ['usage'] },
         requireFeature: FeatureFlag.CodyPro,
     },
     {


### PR DESCRIPTION
Replaced `usage` and `upgrade` commands with the proper registered command `show-page`

Before:

https://github.com/sourcegraph/cody/assets/51868853/8134b68e-229b-4fc0-bf06-c05765938c9c

After:

https://github.com/sourcegraph/cody/assets/51868853/44590675-759c-4bae-8eda-7dd796fe0a23



## Test plan
N/A
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
