### PR TITLE
Commands: Expose commands in the VS Code command palette and clean up the context menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   longer need to have the Cody App open. Note, the sidebar chat indicator may
   say embeddings were not found while we work on improving chat.
   [pull/2099](https://github.com/sourcegraph/cody/pull/2099)
+- Commands: Expose commands in the VS Code command palette and clean up the context menu. [pull/1209](https://github.com/sourcegraph/cody/pull/2109)
 
 ## [0.16.3]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -284,49 +284,49 @@
       },
       {
         "command": "cody.command.edit-code",
-        "category": "Ask Cody",
+        "category": "Cody Command",
         "title": "Edit Code",
         "when": "cody.activated && editorTextFocus",
         "icon": "$(wand)"
       },
       {
         "command": "cody.command.explain-code",
-        "category": "Ask Cody",
+        "category": "Cody Command",
         "title": "Explain Code",
         "icon": "$(output)",
         "when": "cody.activated && editorFocus"
       },
       {
         "command": "cody.command.generate-tests",
-        "category": "Ask Cody",
+        "category": "Cody Command",
         "title": "Generate Unit Tests",
         "icon": "$(package)",
         "when": "cody.activated && editorTextFocus"
       },
       {
         "command": "cody.command.document-code",
-        "category": "Ask Cody",
+        "category": "Cody Command",
         "title": "Document Code",
         "icon": "$(book)",
         "when": "cody.activated && editorTextFocus"
       },
       {
         "command": "cody.command.smell-code",
-        "category": "Ask Cody",
+        "category": "Cody Command",
         "title": "Find Code Smells",
         "icon": "$(symbol-keyword)",
         "when": "cody.activated && editorFocus"
       },
       {
         "command": "cody.action.commands.custom.menu",
-        "category": "Ask Cody",
+        "category": "Cody Command",
         "title": "Custom Commands",
         "icon": "$(tools)",
         "when": "cody.activated && workspaceFolderCount > 0"
       },
       {
         "command": "cody.command.context-search",
-        "category": "Ask Cody",
+        "category": "Cody",
         "title": "Codebase Context Search",
         "when": "cody.activated && workspaceFolderCount > 0"
       },
@@ -620,11 +620,11 @@
         },
         {
           "command": "cody.command.explain-code",
-          "when": "false"
+          "when": "cody.activated && editorIsOpen"
         },
         {
           "command": "cody.command.context-search",
-          "when": "false"
+          "when": "cody.activated && editorIsOpen"
         },
         {
           "command": "cody.command.inline-touch",
@@ -632,15 +632,15 @@
         },
         {
           "command": "cody.command.smell-code",
-          "when": "false"
+          "when": "cody.activated && editorIsOpen"
         },
         {
           "command": "cody.command.generate-tests",
-          "when": "false"
+          "when": "cody.activated && editorIsOpen"
         },
         {
           "command": "cody.command.document-code",
-          "when": "false"
+          "when": "cody.activated && editorIsOpen"
         },
         {
           "command": "cody.action.commands.custom.menu",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -704,6 +704,11 @@
       ],
       "cody.submenu": [
         {
+          "command": "cody.chat.panel.new",
+          "when": "cody.activated",
+          "group": "ask"
+        },
+        {
           "command": "cody.command.explain-code",
           "when": "cody.activated",
           "group": "command"
@@ -731,7 +736,7 @@
         {
           "command": "cody.action.commands.custom.menu",
           "when": "cody.activated",
-          "group": "command"
+          "group": "custom-commands"
         },
         {
           "command": "cody.focus",
@@ -745,7 +750,7 @@
         },
         {
           "command": "cody.inline.new",
-          "when": "cody.activated",
+          "when": "cody.activated && config.cody.inlineChat.enabled",
           "group": "ask"
         }
       ],


### PR DESCRIPTION
* Removes the old "Ask Cody" wording
* Adds Cody’s built-in commands to the VS Code command palette (which users have tried to search in with user testing)
* Cleans up the context menu

| Before | After |
| - | - |
| <img width="609" alt="Screenshot 2023-12-05 at 8 08 13 pm" src="https://github.com/sourcegraph/cody/assets/153/6eb338ab-8cf1-4286-a891-4398b84e08c6"> | <img width="591" alt="Screenshot 2023-12-05 at 8 07 43 pm" src="https://github.com/sourcegraph/cody/assets/153/e4447ea4-efed-4be2-8504-3ef044ae1de4"> |
| <img width="629" alt="Screenshot 2023-12-05 at 8 12 50 pm" src="https://github.com/sourcegraph/cody/assets/153/c611beaf-52ae-4609-9e34-394c320354a1"> | <img width="659" alt="Screenshot 2023-12-05 at 8 12 19 pm" src="https://github.com/sourcegraph/cody/assets/153/9c10343d-ce50-41bf-be1b-63fd0b1a8bcf"> |

## Test plan

- Opened command palette and filtered for Cody
- Opened keyboard shortcut
- Ran the commands