### PR TITLE
fix: decrease chat panel creation debounce time

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Display OS specific keybinding in chat welcome message. [pull/2051](https://github.com/sourcegraph/cody/pull/2051)
 - Embeddings indexes can be generated and stored locally in repositories with a default fetch URL that is not already indexed by sourcegraph.com through the Enhanced Context selector. [pull/2069](https://github.com/sourcegraph/cody/pull/2069)
 - Support chat input history on "up" and "down" arrow keys again. [pull/2059](https://github.com/sourcegraph/cody/pull/2059)
+- Decreased debounce time for creating chat panels to improve responsiveness.
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -288,7 +288,7 @@ export class ChatManager implements vscode.Disposable {
     private async createNewWebviewPanel(): Promise<void> {
         const debounceCreatePanel = debounce(async () => {
             await this.chatPanelsManager?.createWebviewPanel()
-        }, 1000)
+        }, 250)
 
         if (this.chatPanelsManager) {
             await debounceCreatePanel()


### PR DESCRIPTION
The debounce time for creating new chat panels was decreased from 1000ms to 250ms. This should make the chat panels feel more responsive when opening multiple in quick succession.

We previously defaulted it to 1000ms because of some start-up issues that caused loading issues on panel creation time, but recent improvement allows us to lower this debouce time.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try opening multiple windows to confirm the windows can still be started up sucessfully.