### PR TITLE
fix: invert notification toggle logic

### DIFF
--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -12,7 +12,7 @@ export const sidebarSignin = async (page: Page, sidebar: Frame, enableNotificati
     await page.getByRole('combobox', { name: 'input' }).press('Enter')
 
     // Turn off notification
-    if (enableNotifications) {
+    if (!enableNotifications) {
         await disableNotifications(page)
     }
 


### PR DESCRIPTION
The notification toggle logic was inverted, so notifications were being enabled when they should have been disabled. This fixes the logic to disable notifications when intended.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

all e2e tests should be passing