### PR TITLE
Chat: Speed up chat panel debounce w/ trigger on leading edge too

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Support chat input history on "up" and "down" arrow keys again. [pull/2059](https://github.com/sourcegraph/cody/pull/2059)
 - Chat: Decreased debounce time for creating chat panels to improve responsiveness. [pull/2115](https://github.com/sourcegraph/cody/pull/2115)
 - Chat: Fix infinite loop when searching for symbols. [pull/2114](https://github.com/sourcegraph/cody/pull/2114)
+- Chat: Speed up chat panel debounce w/ trigger on leading edge too. [pull/2126](https://github.com/sourcegraph/cody/pull/2126)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -247,9 +247,13 @@ export class ChatManager implements vscode.Disposable {
 
     // For registering the commands for chat panels in advance
     private async createNewWebviewPanel(): Promise<void> {
-        const debounceCreatePanel = debounce(async () => {
-            await this.chatPanelsManager?.createWebviewPanel()
-        }, 250, { leading: true, trailing: true })
+        const debounceCreatePanel = debounce(
+            async () => {
+                await this.chatPanelsManager?.createWebviewPanel()
+            },
+            250,
+            { leading: true, trailing: true }
+        )
 
         if (this.chatPanelsManager) {
             await debounceCreatePanel()
@@ -257,9 +261,13 @@ export class ChatManager implements vscode.Disposable {
     }
 
     private async restorePanel(chatID: string, chatQuestion?: string): Promise<void> {
-        const debounceRestore = debounce(async (chatID: string, chatQuestion?: string) => {
-            await this.chatPanelsManager?.restorePanel(chatID, chatQuestion)
-        }, 250, { leading: true, trailing: true })
+        const debounceRestore = debounce(
+            async (chatID: string, chatQuestion?: string) => {
+                await this.chatPanelsManager?.restorePanel(chatID, chatQuestion)
+            },
+            250,
+            { leading: true, trailing: true }
+        )
 
         if (this.chatPanelsManager) {
             await debounceRestore(chatID, chatQuestion)

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -249,7 +249,7 @@ export class ChatManager implements vscode.Disposable {
     private async createNewWebviewPanel(): Promise<void> {
         const debounceCreatePanel = debounce(async () => {
             await this.chatPanelsManager?.createWebviewPanel()
-        }, 250)
+        }, 250, { leading: true, trailing: true })
 
         if (this.chatPanelsManager) {
             await debounceCreatePanel()
@@ -259,7 +259,7 @@ export class ChatManager implements vscode.Disposable {
     private async restorePanel(chatID: string, chatQuestion?: string): Promise<void> {
         const debounceRestore = debounce(async (chatID: string, chatQuestion?: string) => {
             await this.chatPanelsManager?.restorePanel(chatID, chatQuestion)
-        }, 1000)
+        }, 250, { leading: true, trailing: true })
 
         if (this.chatPanelsManager) {
             await debounceRestore(chatID, chatQuestion)


### PR DESCRIPTION
Follow up to #2115, this ensures we trigger chat panel creation and restoration straight away (on the leading edge of the timeout), and reduces the restoration timeout to match.

## Test plan

- Open new chat
- Open existing chat
- Reload window and ensure restores correct