### PR TITLE
Test macOS 13 GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu
-          - runner: macos
+          - runner: ubuntu-latest
+          - runner: macos-latest-large
             shard: 1/2
-          - runner: macos
+          - runner: macos-latest-large
             shard: 2/2
-    runs-on: ${{ matrix.runner }}-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -111,9 +111,9 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e
-        if: matrix.runner == 'ubuntu'
+        if: matrix.runner == 'ubuntu-latest'
       - run: pnpm -C vscode run test:e2e
-        if: matrix.runner == 'windows' || matrix.runner == 'macos'
+        if: matrix.runner == 'windows' || matrix.runner == 'macos-latest-large'
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu, macos]
+        include:
+          - runner: ubuntu
+          - runner: macos
+            shard: 1/2
+          - runner: macos
+            shard: 2/2
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
Seeing if the [beefier macOS-13 runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) speed up the macOS checks…

macOS-13:

```
ci / test-unit (macos-13, 20) (pull_request) Successful in 2m
[Details](https://github.com/sourcegraph/cody/actions/runs/7109738333/job/19355131031?pr=2127)
ci / test-integration (macos-13) (pull_request) Successful in 1m
[Details](https://github.com/sourcegraph/cody/actions/runs/7109738333/job/19355130802?pr=2127)
ci / test-e2e (macos-13) (pull_request) Successful in 5m
[Details](https://github.com/sourcegraph/cody/actions/runs/7109738333/job/19355131436?pr=2127)
```

macOS-12:

```
ci / test-unit (macos, 20) (pull_request) Successful in 2m
[Details](https://github.com/sourcegraph/cody/actions/runs/7109831025/job/19355365427?pr=2127)
ci / test-integration (macos) (pull_request) Successful in 2m
[Details](https://github.com/sourcegraph/cody/actions/runs/7109831025/job/19355365349?pr=2127)
ci / test-e2e (macos) (pull_request) Successful in 6m
[Details](https://github.com/sourcegraph/cody/actions/runs/7109831025/job/19355365163?pr=2127)
```

Outcomes:
- Not a big enough speed increase to justify moving onto an unsupported beta runner
- Investigate skipping `ci / test-integration (macos)` as it only runs actual tests on main, but still spins up a job that takes 2 minutes: https://github.com/sourcegraph/cody/actions/runs/7109831025/job/19355365349?pr=2127
- Investigate sharding macOS step
- Investigate the following output in `ci / test-e2e (macOS)`

```
Slow test file: at-file-context-selecting.test.ts (1.2m)
  Slow test file: chat.test.ts (40.0s)
  Slow test file: history-new-ui.test.ts (27.0s)
Consider splitting slow test files to speed up parallel execution
```