### PR TITLE
Chat: update embeddings and codebase identifiers

### DIFF
--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -43,10 +43,6 @@ export class CodebaseContext {
         private rerank?: (query: string, results: ContextResult[]) => Promise<ContextResult[]>
     ) {}
 
-    public tempHackGetEmbeddingsSearch(): EmbeddingsSearch | null {
-        return this.embeddings
-    }
-
     public getCodebase(): string | undefined {
         return this.codebase
     }

--- a/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
+++ b/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
@@ -1,0 +1,49 @@
+import {
+    EmbeddingsSearchResults,
+    SourcegraphGraphQLAPIClient,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
+import { GraphQLAPIClientConfig } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+
+export class CachedRemoteEmbeddingsClient {
+    private client: SourcegraphGraphQLAPIClient
+    private repoIdCache: Map<string, string> = new Map()
+
+    constructor(private config: GraphQLAPIClientConfig) {
+        this.client = new SourcegraphGraphQLAPIClient(config)
+    }
+
+    public getEndpoint(): string {
+        return this.config.serverEndpoint
+    }
+
+    public updateConfiguration(newConfig: GraphQLAPIClientConfig): void {
+        this.config = newConfig
+        this.client = new SourcegraphGraphQLAPIClient(newConfig)
+        this.repoIdCache.clear()
+    }
+
+    public async getRepoIdIfEmbeddingExists(codebase: string): Promise<string | Error | null> {
+        const cachedRepoId = this.repoIdCache.get(codebase)
+        if (cachedRepoId) {
+            return cachedRepoId
+        }
+
+        const repoID = await this.client.getRepoIdIfEmbeddingExists(codebase)
+        if (!(repoID instanceof Error) && repoID) {
+            this.repoIdCache.set(codebase, repoID)
+        }
+        return repoID
+    }
+
+    public search(
+        repoIDs: string[],
+        query: string,
+        codeResultsCount: number,
+        textResultsCount: number
+    ): Promise<EmbeddingsSearchResults | Error> {
+        if (repoIDs.length !== 1) {
+            throw new Error('Only one repoID is supported for now')
+        }
+        return this.client.legacySearchEmbeddings(repoIDs[0], query, codeResultsCount, textResultsCount)
+    }
+}

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -277,12 +277,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
         this.disposables = []
     }
 
-    public async hackGetEmbeddingClientCandidates(
-        config: GraphQLAPIClientConfig
-    ): Promise<SourcegraphGraphQLAPIClient[]> {
-        return this.getEmbeddingClientCandidates(config)
-    }
-
     // Gets a list of GraphQL clients to interrogate for embeddings
     // availability.
     private getEmbeddingClientCandidates(config: GraphQLAPIClientConfig): Promise<SourcegraphGraphQLAPIClient[]> {
@@ -303,28 +297,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
     public onDidChangeStatus(callback: (provider: ContextStatusProvider) => void): vscode.Disposable {
         return this.contextStatusChangeEmitter.event(callback)
     }
-}
-
-export function hackGetCodebaseContext(
-    config: Config,
-    rgPath: string | null,
-    symf: IndexedKeywordContextFetcher | undefined,
-    editor: Editor,
-    chatClient: ChatClient,
-    platform: PlatformContext,
-    embeddingsClientCandidates: readonly SourcegraphGraphQLAPIClient[],
-    localEmbeddings: LocalEmbeddingsController | undefined
-): Promise<CodebaseContext | null> {
-    return getCodebaseContext(
-        config,
-        rgPath,
-        symf,
-        editor,
-        chatClient,
-        platform,
-        embeddingsClientCandidates,
-        localEmbeddings
-    )
 }
 
 /**
@@ -355,9 +327,8 @@ async function getCodebaseContext(
         return null
     }
 
-    // TODO: When SimpleChatContextProvider stops using hackGetCodebaseContext,
-    // it must start sending localEmbeddings.load directly to the embeddings
-    // controller.
+    // TODO: When we remove this class (ContextProvider), SimpleChatContextProvider
+    // should be updated to invoke localEmbeddings.load when the codebase changes
     const repoDirUri = gitDirectoryUri(workspaceRoot)
     const hasLocalEmbeddings = repoDirUri ? localEmbeddings?.load(repoDirUri) : false
     let embeddingsSearch = await EmbeddingsDetector.newEmbeddingsSearchClient(

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -6,11 +6,11 @@ import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { EmbeddingsSearch } from '@sourcegraph/cody-shared/src/embeddings'
 
 import { View } from '../../../webviews/NavBar'
 import { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import { logDebug } from '../../log'
+import { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 import { AuthStatus } from '../protocol'
 
 import { ChatPanelsManager, IChatPanelProvider } from './ChatPanelsManager'
@@ -33,7 +33,7 @@ export class ChatManager implements vscode.Disposable {
     constructor(
         { extensionUri, ...options }: SidebarChatOptions,
         private chatClient: ChatClient,
-        private embeddingsSearch: EmbeddingsSearch | null,
+        private embeddingsClient: CachedRemoteEmbeddingsClient,
         private localEmbeddings: LocalEmbeddingsController | null
     ) {
         logDebug(
@@ -48,7 +48,7 @@ export class ChatManager implements vscode.Disposable {
         this.chatPanelsManager = new ChatPanelsManager(
             this.options,
             this.chatClient,
-            this.embeddingsSearch,
+            this.embeddingsClient,
             this.localEmbeddings
         )
 
@@ -190,8 +190,7 @@ export class ChatManager implements vscode.Disposable {
             logDebug('ChatManager:revive', 'failed', { verbose: error })
 
             // When failed, create a new panel with restored session and dispose the old panel
-            const panelTitle = panel.title
-            await this.restorePanel(chatID, panelTitle)
+            await this.restorePanel(chatID, panel.title)
             panel.dispose()
         }
     }

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -6,7 +6,6 @@ import { CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { EmbeddingsSearch } from '@sourcegraph/cody-shared/src/embeddings'
 import { featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
 import { View } from '../../../webviews/NavBar'
@@ -14,6 +13,7 @@ import { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import { logDebug } from '../../log'
 import { createCodyChatTreeItems } from '../../services/treeViewItems'
 import { TreeViewProvider } from '../../services/TreeViewProvider'
+import { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 import { AuthStatus } from '../protocol'
 
 import { CodyChatPanelViewType } from './ChatManager'
@@ -62,7 +62,7 @@ export class ChatPanelsManager implements vscode.Disposable {
     constructor(
         { extensionUri, ...options }: SidebarChatOptions,
         private chatClient: ChatClient,
-        private readonly embeddingsSearch: EmbeddingsSearch | null,
+        private readonly embeddingsClient: CachedRemoteEmbeddingsClient,
         private readonly localEmbeddings: LocalEmbeddingsController | null
     ) {
         logDebug('ChatPanelsManager:constructor', 'init')
@@ -192,7 +192,7 @@ export class ChatPanelsManager implements vscode.Disposable {
                   ...this.options,
                   config: this.options.contextProvider.config,
                   chatClient: this.chatClient,
-                  embeddingsClient: this.embeddingsSearch,
+                  embeddingsClient: this.embeddingsClient,
                   localEmbeddings: this.localEmbeddings,
                   recipeAdapter: new SimpleChatRecipeAdapter(
                       this.options.editor,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -276,6 +276,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 logDebug('SimpleChatPanelProvider:onDidReceiveMessage', 'initialized')
                 await this.postChatModels()
                 void this.restoreSession(this.sessionID)
+
+                // HACK: this call is necessary to get the webview to set the chatID state,
+                // which is necessary on deserialization
+                this.postViewTranscript()
                 break
             case 'submit': {
                 const requestID = uuid.v4()

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -945,7 +945,7 @@ class ContextProvider implements IContextProvider {
         if (!this.embeddingsClient) {
             return []
         }
-        const codebase = this.codebaseStatusProvider.currentCodebase
+        const codebase = await this.codebaseStatusProvider?.currentCodebase()
         if (!codebase?.remote) {
             return []
         }

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -8,7 +8,8 @@ import {
 } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
 import { ContextFile, ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
-import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/src/utils'
+import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { convertGitCloneURLToCodebaseName, isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { repositoryRemoteUrl } from '../../repository/repositoryHelpers'
 import { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
@@ -139,17 +140,19 @@ export function getChatPanelTitle(lastDisplayText?: string, truncateTitle = true
  */
 export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusProvider {
     private disposables: vscode.Disposable[] = []
-    private _currentCodebase: CodebaseIdentifiers | null | undefined = undefined
-    private statusCallbacks: ((provider: ContextStatusProvider) => void)[] = []
+    private eventEmitter: vscode.EventEmitter<ContextStatusProvider> = new vscode.EventEmitter<ContextStatusProvider>()
 
-    // TODO(beyang): mix of dependency injection and direct vscode API access here
+    // undefined means uninitialized, null means current codebase is empty
+    private _currentCodebase: CodebaseIdentifiers | null | undefined = undefined
+
     constructor(
         private editor: Editor,
         private embeddingsClient: CachedRemoteEmbeddingsClient
     ) {
         this.disposables.push(
             vscode.window.onDidChangeActiveTextEditor(() => this.syncCodebase()),
-            vscode.workspace.onDidChangeWorkspaceFolders(() => this.syncCodebase())
+            vscode.workspace.onDidChangeWorkspaceFolders(() => this.syncCodebase()),
+            this.eventEmitter
         )
     }
 
@@ -161,66 +164,94 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
     }
 
     public onDidChangeStatus(callback: (provider: ContextStatusProvider) => void): Disposable {
-        this.statusCallbacks.push(callback)
-        return {
-            dispose: () => {
-                this.statusCallbacks = this.statusCallbacks.filter(cb => cb !== callback)
-            },
-        }
+        return this.eventEmitter.event(callback)
     }
+
     public get status(): ContextGroup[] {
-        const codebase = this.currentCodebase
-        return codebase?.remote
-            ? [
-                  {
-                      name: codebase.local,
-                      providers: [
-                          {
-                              kind: 'embeddings',
-                              type: 'remote',
-                              state: 'ready',
-                              origin: this.embeddingsClient.getEndpoint(),
-                              remoteName: codebase.remote,
-                          },
-                      ],
-                  },
-              ]
-            : []
-    }
-
-    public get currentCodebase(): CodebaseIdentifiers | null {
         if (this._currentCodebase === undefined) {
-            this._currentCodebase = CodebaseStatusProvider.fetchCurrentCodebase(this.editor)
+            void this.syncCodebase()
+            return []
         }
-        for (const s of this.statusCallbacks) {
-            s(this)
+        const codebase = this._currentCodebase
+        if (codebase?.remote && codebase?.remoteRepoId) {
+            return [
+                {
+                    name: codebase.local,
+                    providers: [
+                        {
+                            kind: 'embeddings',
+                            type: 'remote',
+                            state: 'ready',
+                            origin: this.embeddingsClient.getEndpoint(),
+                            remoteName: codebase.remote,
+                        },
+                    ],
+                },
+            ]
         }
-        return this._currentCodebase
+        if (!codebase?.remote || isDotCom(this.embeddingsClient.getEndpoint())) {
+            // Dotcom users or no remote codebase name: remote embeddings omitted from context
+            return []
+        }
+        // Enterprise users where no repo ID is found for the desired remote codebase name: no-match context group
+        return [
+            {
+                name: codebase.local,
+                providers: [
+                    {
+                        kind: 'embeddings',
+                        type: 'remote',
+                        state: 'no-match',
+                        origin: this.embeddingsClient.getEndpoint(),
+                        remoteName: codebase.remote,
+                    },
+                ],
+            },
+        ]
     }
 
-    private syncCodebase(): void {
-        const newCodebase = CodebaseStatusProvider.fetchCurrentCodebase(this.editor)
-        if (newCodebase === this._currentCodebase) {
+    public async currentCodebase(): Promise<CodebaseIdentifiers | null> {
+        if (this._currentCodebase === undefined) {
+            // lazy initialization
+            await this.syncCodebase()
+        }
+        return this._currentCodebase || null
+    }
+
+    private async syncCodebase(): Promise<void> {
+        const workspaceRoot = this.editor.getWorkspaceRootUri()
+        if (
+            this._currentCodebase !== undefined &&
+            workspaceRoot?.fsPath === this._currentCodebase?.local &&
+            this._currentCodebase?.remoteRepoId
+        ) {
+            // do nothing if local codebase identifier is unchanged and we have a remote repo ID
             return
         }
-        this._currentCodebase = newCodebase
-        for (const s of this.statusCallbacks) {
-            s(this)
-        }
-    }
 
-    private static fetchCurrentCodebase(editor: Editor): CodebaseIdentifiers | null {
-        const workspaceRoot = editor.getWorkspaceRootUri()
-        if (!workspaceRoot) {
-            return null
+        let newCodebase: CodebaseIdentifiers | null = null
+        if (workspaceRoot) {
+            newCodebase = { local: workspaceRoot.fsPath }
+            const remoteUrl = repositoryRemoteUrl(workspaceRoot)
+            if (remoteUrl) {
+                newCodebase.remote = convertGitCloneURLToCodebaseName(remoteUrl) || undefined
+                if (newCodebase.remote) {
+                    const repoId = await this.embeddingsClient.getRepoIdIfEmbeddingExists(newCodebase.remote)
+                    if (!isError(repoId)) {
+                        newCodebase.remoteRepoId = repoId ?? undefined
+                    }
+                }
+            }
         }
-        const remoteUrl = repositoryRemoteUrl(workspaceRoot)
-        if (!remoteUrl) {
-            return null
-        }
-        return {
-            local: workspaceRoot.fsPath,
-            remote: convertGitCloneURLToCodebaseName(remoteUrl) || undefined,
+
+        // codebase local identifier changed, fire callbacks
+        const shouldAlert =
+            this._currentCodebase?.local !== newCodebase?.local ||
+            this._currentCodebase?.remote !== newCodebase?.remote ||
+            this._currentCodebase?.remoteRepoId !== newCodebase?.remoteRepoId
+        this._currentCodebase = newCodebase
+        if (shouldAlert) {
+            this.eventEmitter.fire(this)
         }
     }
 }
@@ -228,4 +259,5 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
 interface CodebaseIdentifiers {
     local: string
     remote?: string
+    remoteRepoId?: string
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -8,8 +8,9 @@ import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/e
 import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
 import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
 
+import { CachedRemoteEmbeddingsClient } from './chat/CachedRemoteEmbeddingsClient'
 import { ChatManager, CodyChatPanelViewType } from './chat/chat-view/ChatManager'
-import { ContextProvider, hackGetCodebaseContext } from './chat/ContextProvider'
+import { ContextProvider } from './chat/ContextProvider'
 import { FixupManager } from './chat/FixupViewProvider'
 import { MessageProviderOptions } from './chat/MessageProvider'
 import {
@@ -153,19 +154,6 @@ const register = async (
     disposables.push(contextProvider)
     await contextProvider.init()
 
-    // Hacks to get embeddings clients
-    const codebaseContext = await hackGetCodebaseContext(
-        initialConfig,
-        rgPath,
-        symfRunner,
-        editor,
-        chatClient,
-        platform,
-        await contextProvider.hackGetEmbeddingClientCandidates(initialConfig),
-        undefined // Note, we do not pass LocalEmbeddingsController here to delay initializing it as long as possible
-    )
-    const embeddingsSearch = codebaseContext?.tempHackGetEmbeddingsSearch() || null
-
     // Shared configuration that is required for chat views to send and receive messages
     const messageProviderOptions: MessageProviderOptions = {
         chat: chatClient,
@@ -181,13 +169,15 @@ const register = async (
     await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyChatMockTest)
 
     const fixupManager = new FixupManager(messageProviderOptions)
+
+    const embeddingsClient = new CachedRemoteEmbeddingsClient(initialConfig)
     const chatManager = new ChatManager(
         {
             ...messageProviderOptions,
             extensionUri: context.extensionUri,
         },
         chatClient,
-        embeddingsSearch,
+        embeddingsClient,
         localEmbeddings || null
     )
 
@@ -545,6 +535,7 @@ const register = async (
             platform.onConfigurationChange?.(newConfig)
             symfRunner?.setSourcegraphAuth(newConfig.serverEndpoint, newConfig.accessToken)
             void localEmbeddings?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
+            embeddingsClient.updateConfiguration(newConfig)
         },
     }
 }


### PR DESCRIPTION
![image](https://github.com/sourcegraph/cody/assets/1646931/c19d1148-8173-483b-b9f0-32283d2df300)

Fixes https://github.com/sourcegraph/cody/issues/2107

Previously, `SimpleChatPanelProvider` accepted an instance of `EmbeddingsSearch`, which was extracted from the `CodebaseContext` instance created on startup.
* `EmbeddingsSearch` instances are tied to a specific codebase.
* When the current codebase changes (e.g., file in a separate repo was opened or a new repo was added to the workspace), this approach does not update the `EmbeddingsSearch` instance held by `SimpleChatPanelProvider`.
* As a result, the remote embeddings context was fetched from the old codebase

This patch modifies `SimpleChatPanelProvider` to switch out `EmbeddingsSearch` for `CachedRemoteEmbeddingsClient`, which wraps a `SourcegraphGraphQLAPIClient` instance.
* The current codebase is now provided (to `SimpleChatPanelProvider`) by a new helper class `CodebaseStatusProvider`.
* When the user codebase changes, the `CodebaseStatusProvider` updates and also signals to `SimpleChatPanelProvider` this change has occurred...
* ...so the remote embeddings search can target the new active codebase.

The second commit fixes a bug where the new chat panel was not restoring properly on startup.

## Test plan

- [ ] Create a single folder workspace
- [ ] Start a chat asking about that folder
- [ ] Add a new repo and switch to a file in that repo
- [ ] Check that the context status has updated. Ask a question about the new codebase
- [ ] Switch to more files and check that the context status and chat functions properly
- [ ] Try adding a repo subdirectory. Cody should *not* target the new repository, because it should not refer to files outside the scope of the workspace folder