### PR TITLE
simple chat: sync webview config and auth status on update

### DIFF
--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -252,7 +252,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
             this.config = await getFullConfig()
 
             // check if the new configuration change is valid or not
-            const authStatus = this.authProvider.getAuthStatus()
             const localProcess = getProcessInfo()
             const configForWebview: ConfigurationSubsetForWebview & LocalEnv = {
                 ...localProcess,
@@ -262,7 +261,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
 
             // update codebase context on configuration change
             await this.updateCodebaseContext()
-            await this.webview?.postMessage({ type: 'config', config: configForWebview, authStatus })
 
             logDebug('Cody:publishConfig', 'configForWebview', { verbose: configForWebview })
         }

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -9,7 +9,6 @@ import { ChatSubmitType } from '@sourcegraph/cody-ui/src/Chat'
 import { View } from '../../../webviews/NavBar'
 import { getFileContextFiles, getOpenTabsContextFile, getSymbolContextFiles } from '../../editor/utils/editor-context'
 import { logDebug } from '../../log'
-import { getProcessInfo } from '../../services/LocalAppDetector'
 import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
 import { createCodyChatTreeItems } from '../../services/treeViewItems'
@@ -21,7 +20,7 @@ import {
 } from '../../services/utils/codeblock-action-tracker'
 import { openExternalLinks, openFilePath, openLocalFileWithRange } from '../../services/utils/workspace-action'
 import { MessageErrorType, MessageProvider, MessageProviderOptions } from '../MessageProvider'
-import { ConfigurationSubsetForWebview, ExtensionMessage, LocalEnv, WebviewMessage } from '../protocol'
+import { AuthStatus, ConfigurationSubsetForWebview, ExtensionMessage, LocalEnv, WebviewMessage } from '../protocol'
 
 import { getChatPanelTitle } from './chat-helpers'
 import { chatHistory } from './ChatHistoryManager'
@@ -173,8 +172,17 @@ export class ChatPanelProvider extends MessageProvider {
     }
 
     /**
+     * Update webview with the latest config, chat models, and authStatus
+     * This is triggered everytime announceNewAuthStatus in authProvider is fired
+     */
+    public syncWebviewConfig(authStatus: AuthStatus, configForWebview: ConfigurationSubsetForWebview & LocalEnv): void {
+        void this.handleChatModels()
+        void this.webview?.postMessage({ type: 'config', config: configForWebview, authStatus })
+    }
+
+    /**
      * For Webview panel only
-     * This sent the initiate contextStatus and config to webview
+     * This sent the initiate contextStatus to webview
      */
     private handleWebviewContext(): void {
         const authStatus = this.authProvider.getAuthStatus()
@@ -192,18 +200,6 @@ export class ChatPanelProvider extends MessageProvider {
         void this.webview?.postMessage({
             type: 'contextStatus',
             contextStatus,
-        })
-
-        const localProcess = getProcessInfo()
-        const config: ConfigurationSubsetForWebview & LocalEnv = {
-            ...localProcess,
-            debugEnable: this.contextProvider.config.debugEnable,
-            serverEndpoint: this.contextProvider.config.serverEndpoint,
-        }
-        void this.webview?.postMessage({
-            type: 'config',
-            config,
-            authStatus,
         })
     }
 


### PR DESCRIPTION
Update the ChatPanelProvider and SimpleChatPanelProvider to sync the latest config, chat models, and auth status to the webview whenever the announceNewAuthStatus event fires in the auth provider. This keeps the webview in sync with the latest user auth state.

Currently, simple chat panels are not getting auth / config updated on change.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

1. Log into your S2 account in cody
2. ask cody a question
3. Switch to an account that is rate limited on dot com
4. ask cody a question
5. The expected behavior is to see the rate limit error message instead of the getting response back from the S2 instance

### Before

https://github.com/sourcegraph/cody/assets/68532117/fce2c6c6-6a51-48a1-93c7-ac9ebc4e7aff

### After


https://github.com/sourcegraph/cody/assets/68532117/d8b339d1-6511-4484-9783-d0c97212c92c

### Doesn't affect current chat panel provider

https://github.com/sourcegraph/cody/assets/68532117/665dd9f9-7e9a-4b92-a439-8e9758606a42


