### PR TITLE
Chat: Reduce size of chats list blank copy

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -35,6 +35,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   say embeddings were not found while we work on improving chat.
   [pull/2099](https://github.com/sourcegraph/cody/pull/2099)
 - Commands: Expose commands in the VS Code command palette and clean up the context menu. [pull/1209](https://github.com/sourcegraph/cody/pull/2109)
+- Chat: Reduce size of chats list blank copy. [pull/2137](https://github.com/sourcegraph/cody/pull/2137)
 
 ## [0.16.3]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -243,7 +243,7 @@
     "viewsWelcome": [
       {
         "view": "cody.chat.tree.view",
-        "contents": "Chat alongside your code, attach files, add additional context, and try out different LLM providers.\n[New Chat](command:cody.chat.panel.new)\nTo learn more about chat, [read the docs](https://docs.sourcegraph.com/).",
+        "contents": "Chat alongside your code, attach files, add additional context, and try different chat models.\n[New Chat](command:cody.chat.panel.new)",
         "when": "cody.activated"
       }
     ],

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -16,9 +16,7 @@ export const sidebarSignin = async (page: Page, sidebar: Frame, enableNotificati
         await disableNotifications(page)
     }
 
-    await expect(
-        page.getByText('Chat alongside your code, attach files,')
-    ).toBeVisible()
+    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
 }
 
 // Selector for the Explorer button in the sidebar that would match on Mac and Linux

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -17,7 +17,7 @@ export const sidebarSignin = async (page: Page, sidebar: Frame, enableNotificati
     }
 
     await expect(
-        page.getByText('Chat alongside your code, attach files, add additional context, and try out diff')
+        page.getByText('Chat alongside your code, attach files,')
     ).toBeVisible()
 }
 

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -21,9 +21,7 @@ test('open the Custom Commands in sidebar and add new user recipe', async ({ pag
     await page.click('[aria-label="Cody"]')
 
     // Open the new chat panel
-    await expect(
-        page.getByText('Chat alongside your code, attach files,')
-    ).toBeVisible()
+    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
 
     await page.getByText('Custom commands').click()
 

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -22,7 +22,7 @@ test('open the Custom Commands in sidebar and add new user recipe', async ({ pag
 
     // Open the new chat panel
     await expect(
-        page.getByText('Chat alongside your code, attach files, add additional context, and try out diff')
+        page.getByText('Chat alongside your code, attach files,')
     ).toBeVisible()
 
     await page.getByText('Custom commands').click()

--- a/vscode/test/e2e/history-new-ui.test.ts
+++ b/vscode/test/e2e/history-new-ui.test.ts
@@ -16,9 +16,7 @@ test('checks if chat history shows up in sidebar', async ({ page, sidebar }) => 
     await page.click('[aria-label="Cody"]')
 
     // Open the new chat panel
-    await expect(
-        page.getByText('Chat alongside your code, attach files,')
-    ).toBeVisible()
+    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
 
     // Start a new chat and submit chat

--- a/vscode/test/e2e/history-new-ui.test.ts
+++ b/vscode/test/e2e/history-new-ui.test.ts
@@ -17,7 +17,7 @@ test('checks if chat history shows up in sidebar', async ({ page, sidebar }) => 
 
     // Open the new chat panel
     await expect(
-        page.getByText('Chat alongside your code, attach files, add additional context, and try out diff')
+        page.getByText('Chat alongside your code, attach files,')
     ).toBeVisible()
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
 


### PR DESCRIPTION
Tighten up the blank chat copy to make room for the search panel.

| Before | After |
| - | - |
| <img width="314" alt="Screenshot 2023-12-06 at 5 53 11 pm" src="https://github.com/sourcegraph/cody/assets/153/29746ee1-fb46-4279-a8fa-2734d0579af3"> | <img width="293" alt="Screenshot 2023-12-06 at 5 54 26 pm" src="https://github.com/sourcegraph/cody/assets/153/20a574e8-143e-4955-983f-3bbad0158ea6"> |

## Test plan

- Deleted all chats
- Viewed new chat copy