### PR TITLE
Search: Style and UX improvements to the search panel

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -35,6 +35,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   say embeddings were not found while we work on improving chat.
   [pull/2099](https://github.com/sourcegraph/cody/pull/2099)
 - Commands: Expose commands in the VS Code command palette and clean up the context menu. [pull/1209](https://github.com/sourcegraph/cody/pull/2109)
+- Search: Style and UX improvements to the search panel. [pull/2138](https://github.com/sourcegraph/cody/pull/2138)
 
 ## [0.16.3]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -229,7 +229,7 @@
         {
           "type": "webview",
           "id": "cody.search",
-          "name": "Search (experimental)",
+          "name": "Natural Language Search (Experimental)",
           "visibility": "visible",
           "when": "cody.activated"
         },

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -51,7 +51,7 @@ export async function getSymfPath(context: vscode.ExtensionContext): Promise<str
         await vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: 'Downloading semantic code search utility, symf',
+                title: 'Downloading Cody search engine (symf)',
                 cancellable: false,
             },
             async progress => {

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -77,7 +77,7 @@ class IndexManager {
         void vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: `Cody: building search index for ${prettyScopeDir}`,
+                title: `Building Cody search index for ${prettyScopeDir}`,
                 cancellable: false,
             },
             async () => {

--- a/vscode/webviews/SearchPanel.module.css
+++ b/vscode/webviews/SearchPanel.module.css
@@ -15,14 +15,20 @@
     display: grid;
 }
 
+.input-row {
+    gap: 0.3rem;
+    padding: 0.5rem 0.5rem 0.5rem 1rem;
+}
+
 .search-input {
     color: var(--vscode-input-foreground);
     background-color: var(--vscode-input-background);
     border-color: var(--vscode-input-border, transparent);
     resize: none;
     border-radius: 2px;
-    height: 1.3em;
-    padding: 8px 8px 8px 8px;
+    box-sizing: border-box;
+    height: 26px;
+    padding: 4px 6px;
     font: inherit;
 }
 
@@ -45,14 +51,32 @@
     border-color: var(--vscode-inputOption-activeBorder, transparent);
 }
 
+.instructions {
+    font-size: 13px;
+    line-height: 1.4;
+    margin: 0 1rem;
+    color: var(--vscode-search-resultsInfoForeground);
+}
+
 .search-result-row-inner {
     height: 22px;
     display: flex;
     position: relative;
 }
 
+.search-result-row {
+    cursor: pointer;
+    user-select: none;
+}
+
 .search-result-row:hover {
     background-color: var(--vscode-list-hoverBackground);
+}
+
+body[data-vscode-theme-kind='vscode-high-contrast-light'] .search-result-row:hover,
+body[data-vscode-theme-kind='vscode-high-contrast'] .search-result-row:hover {
+    outline: 1px dashed var(--vscode-contrastActiveBorder);
+    outline-offset: -1px;
 }
 
 .search-result-row-inner-selected {
@@ -103,24 +127,16 @@
 }
 
 .filematch-label {
-    vertical-align: center;
+    display: flex;
+    align-items: center;
 }
 
 .filematch-icon {
     color: var(--vscode-banner-iconForeground);
-}
-
-.filematch-icon > i {
-    vertical-align: 'text-bottom';
+    line-height: 1;
 }
 
 .filematch-description {
-    font-size: 0.9em;
+    font-size: 12px;
     color: var(--vscode-search-resultsInfoForeground);
-}
-
-.input-row {
-    border-top: solid 1px var(--vscode-sideBarSectionHeader-border);
-    gap: 0.3rem;
-    padding: 0.75rem 0.75rem 1rem 0.75rem;
 }

--- a/vscode/webviews/SearchPanel.module.css
+++ b/vscode/webviews/SearchPanel.module.css
@@ -115,20 +115,22 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .search-result-row:hover {
 }
 
 .search-result-twistie-noindent {
-    padding-left: 0px;
+    padding-left: 0;
 }
 
 .search-result-content {
     height: 100%;
     line-height: 22px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     overflow: hidden;
 }
 
 .filematch-label {
     display: flex;
     align-items: center;
+    gap: 0.25rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .filematch-icon {
@@ -139,4 +141,8 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .search-result-row:hover {
 .filematch-description {
     font-size: 12px;
     color: var(--vscode-search-resultsInfoForeground);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    flex: 1; /* Let this one ellipsis before the label */
 }

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -63,6 +63,7 @@ const debouncedDoSearch = debounce(doSearch, SEARCH_DEBOUNCE_MS)
 
 export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
     const [query, setQuery] = React.useState('')
+    const [searching, setSearching] = React.useState(false)
     const [results, setResults] = React.useState<SearchPanelFile[]>([])
     const [selectedResult, setSelectedResult] = React.useState<[number, number]>([-1, -1])
     const [collapsedFileResults, setCollapsedFileResults] = React.useState<{ [key: number]: boolean }>({})
@@ -73,11 +74,14 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
     // Update search results when query changes
     useEffect(() => {
         if (query.trim().length === 0) {
+            setSearching(false)
             setResults([])
             setSelectedResult([-1, -1])
             return
         }
+        setSearching(true)
         debouncedDoSearch(vscodeAPI, query, resultsCache, cachedResults => {
+            setSearching(false)
             setResults(cachedResults)
         })
     }, [vscodeAPI, resultsCache, query])
@@ -88,6 +92,7 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
             switch (message.type) {
                 case 'update-search-results': {
                     if (message.query === query) {
+                        setSearching(false)
                         setResults(message.results)
                         setSelectedResult([-1, -1])
                     }
@@ -235,7 +240,7 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
             <form className={styles.inputRow}>
                 <div className={styles.searchInputContainer}>
                     <textarea
-                        placeholder="Type a keyword query or describe what you're looking for"
+                        placeholder="Search"
                         className={styles.searchInput}
                         onChange={onInputChange}
                         onKeyDown={onInputKeyDown}
@@ -243,6 +248,16 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                     />
                 </div>
             </form>
+            {
+                !searching && query.trim().length === 0 && (
+                    <p className={styles.instructions}>Search using natural language queries, for example “password hashing” or "connection retries"</p>
+                )
+            }
+            {
+                !searching && results.length === 0 && query.trim().length !== 0 && (
+                    <p className={styles.instructions}>No results found</p>
+                )
+            }
             <div className={styles.searchResultsContainer}>
                 {results.map((result, fileIndex) => (
                     <>
@@ -250,8 +265,8 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                         <div
                             key={`${result.uriString}`}
                             className={styles.searchResultRow}
-                            onKeyDown={e => e.key === 'Enter' && setSelectedResult([fileIndex, 0])}
-                            onClick={() => setSelectedResult([fileIndex, -1])}
+                            onKeyDown={e => { if (e.key === 'Enter') { toggleFileExpansion(fileIndex); setSelectedResult([fileIndex, 0]) }}}
+                            onClick={() => { toggleFileExpansion(fileIndex); setSelectedResult([fileIndex, -1]) }}
                         >
                             <div
                                 className={`${styles.searchResultRowInner} ${

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -248,16 +248,14 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                     />
                 </div>
             </form>
-            {
-                !searching && query.trim().length === 0 && (
-                    <p className={styles.instructions}>Search using natural language queries, for example “password hashing” or "connection retries"</p>
-                )
-            }
-            {
-                !searching && results.length === 0 && query.trim().length !== 0 && (
-                    <p className={styles.instructions}>No results found</p>
-                )
-            }
+            {!searching && query.trim().length === 0 && (
+                <p className={styles.instructions}>
+                    Search using natural language queries, for example “password hashing” or "connection retries"
+                </p>
+            )}
+            {!searching && results.length === 0 && query.trim().length !== 0 && (
+                <p className={styles.instructions}>No results found</p>
+            )}
             <div className={styles.searchResultsContainer}>
                 {results.map((result, fileIndex) => (
                     <>
@@ -265,8 +263,16 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                         <div
                             key={`${result.uriString}`}
                             className={styles.searchResultRow}
-                            onKeyDown={e => { if (e.key === 'Enter') { toggleFileExpansion(fileIndex); setSelectedResult([fileIndex, 0]) }}}
-                            onClick={() => { toggleFileExpansion(fileIndex); setSelectedResult([fileIndex, -1]) }}
+                            onKeyDown={e => {
+                                if (e.key === 'Enter') {
+                                    toggleFileExpansion(fileIndex)
+                                    setSelectedResult([fileIndex, 0])
+                                }
+                            }}
+                            onClick={() => {
+                                toggleFileExpansion(fileIndex)
+                                setSelectedResult([fileIndex, -1])
+                            }}
                         >
                             <div
                                 className={`${styles.searchResultRowInner} ${
@@ -293,9 +299,13 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                                         <span className={styles.filematchIcon}>
                                             <i className="codicon codicon-file-code" />
                                         </span>
-                                        <span className={styles.filematchTitle} title={result.basename}>{result.basename}</span>
+                                        <span className={styles.filematchTitle} title={result.basename}>
+                                            {result.basename}
+                                        </span>
                                         <span className={styles.filematchDescription}>
-                                            {result.wsname && <span title={result.wsname}>{result.wsname}&nbsp;&middot;&nbsp;</span>}
+                                            {result.wsname && (
+                                                <span title={result.wsname}>{result.wsname}&nbsp;&middot;&nbsp;</span>
+                                            )}
                                             <span title={result.dirname}>{result.dirname}</span>
                                         </span>
                                     </div>

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -293,12 +293,10 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                                         <span className={styles.filematchIcon}>
                                             <i className="codicon codicon-file-code" />
                                         </span>
-                                        &nbsp;
-                                        <span className={styles.filematchTitle}>{result.basename}</span>
+                                        <span className={styles.filematchTitle} title={result.basename}>{result.basename}</span>
                                         <span className={styles.filematchDescription}>
-                                            &nbsp;
-                                            {result.wsname && <span>{result.wsname}&nbsp;&middot;&nbsp;</span>}
-                                            <span>{result.dirname}</span>
+                                            {result.wsname && <span title={result.wsname}>{result.wsname}&nbsp;&middot;&nbsp;</span>}
+                                            <span title={result.dirname}>{result.dirname}</span>
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
A raft of small cleanups to the search UX:

- Fix search input size to match VS Code
- Make whole rows clickable
- Fix pointer and text selection on rows
- Add high contrast hover border
- Add blank words as well as "No results"
- Improve notification copy
- Fix file icon vertical alignment
- Fix truncation of long paths

https://github.com/sourcegraph/cody/assets/153/89ef33ee-ff5f-4c0e-8466-4cb38667d265

## Test plan

- Ran a search
- Matched no results
- Matched some results
- Clicked rows
- Hovered over truncated results