### PR TITLE
Chat: Fix message input overlapping with enhanced context button

### DIFF
--- a/lib/ui/src/Chat.module.css
+++ b/lib/ui/src/Chat.module.css
@@ -36,7 +36,6 @@
 }
 
 .submit-button {
-    opacity: 0.8;
     border: none;
     cursor: pointer;
 
@@ -56,10 +55,6 @@
     background: none;
     border: none;
     cursor: pointer;
-}
-
-.submit-button:hover {
-    opacity: 1;
 }
 
 .suggestions {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Decreased debounce time for creating chat panels to improve responsiveness. [pull/2115](https://github.com/sourcegraph/cody/pull/2115)
 - Chat: Fix infinite loop when searching for symbols. [pull/2114](https://github.com/sourcegraph/cody/pull/2114)
 - Chat: Speed up chat panel debounce w/ trigger on leading edge too. [pull/2126](https://github.com/sourcegraph/cody/pull/2126)
+- Chat: Fix message input overlapping with enhanced context button. [pull/2141](https://github.com/sourcegraph/cody/pull/2141)
 
 ### Changed
 

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -106,13 +106,12 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
     color: var(--vscode-input-foreground);
     border: 1px solid transparent;
     border-radius: 2px;
-    padding: 0.5rem;
+    /* Extra right padding to ensure it doesn't overlap with enhanced context button */
+    padding: 0.5rem 32px 0.5rem 0.5rem;
     font: inherit;
     width: 100%;
     overflow: hidden;
-
     min-height: 3.5rem;
-
     /* Place on top of each other */
     grid-area: 1 / 1 / 2 / 2;
 }
@@ -196,7 +195,6 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
 .submit-button {
     background: var(--vscode-button-background);
     color: var(--vscode-button-foreground);
-
     display: flex;
     justify-content: center;
 }
@@ -211,19 +209,8 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
     cursor: default;
 }
 
-.stop-generating-button {
-    padding: 0;
-    border-radius: 1rem;
-
-    animation: fadeInSlideUp 1s 1;
-}
-
-.stop-generating-button > i {
-    margin-right: 0.25rem;
-}
-
-.stop-generating-button:active {
-    transition: all 0.5s linear;
+.submit-button svg {
+    opacity: 1;
 }
 
 .thumbs-down-feedback-container {
@@ -238,15 +225,4 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
        not-allowed after you submit feedback. So we reset it back to the
        default cursor to fit in nicer with standard VS Code native behaviour */
     cursor: default;
-}
-
-@keyframes fadeInSlideUp {
-    from {
-        opacity: 0;
-        margin-top: var(--spacing);
-    }
-    to {
-        opacity: 1;
-        margin: 0;
-    }
 }


### PR DESCRIPTION
This fixes the message input overlapping the enhanced context button, and cleans up the send button to be consistent with VS Code styles.

Before:

https://github.com/sourcegraph/cody/assets/153/b1781cf9-b27a-4529-90af-e420a29f1a91

After:

https://github.com/sourcegraph/cody/assets/153/fdeb6f79-b424-4a25-a31a-83bbff1555f1

## Test plan

- Opened chat
- Typed in message input
- Hovered and clicked send button