### PR TITLE
Chat: Update message input placeholder to mention slash commands

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -35,6 +35,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   say embeddings were not found while we work on improving chat.
   [pull/2099](https://github.com/sourcegraph/cody/pull/2099)
 - Commands: Expose commands in the VS Code command palette and clean up the context menu. [pull/1209](https://github.com/sourcegraph/cody/pull/2109)
+- Chat: Update message input placeholder to mention slash commands. [pull/2142](https://github.com/sourcegraph/cody/pull/2142)
 
 ## [0.16.3]
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -269,7 +269,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     chatModels,
 }) => {
     const inputRef = useRef<HTMLTextAreaElement>(null)
-    const placeholder = 'Message (type @ to include files)'
+    const placeholder = 'Message (@ to include code, / for commands)'
 
     useEffect(() => {
         if (autoFocus) {


### PR DESCRIPTION
Now commands are staying in for release, time to update the input placeholder:

| Before | After |
| - | - |
| <img width="436" alt="Screenshot 2023-12-06 at 8 23 21 pm" src="https://github.com/sourcegraph/cody/assets/153/90386905-c3bd-4bdc-886e-713743441775"> | <img width="436" alt="Screenshot 2023-12-06 at 8 22 02 pm" src="https://github.com/sourcegraph/cody/assets/153/08f036db-00c1-4121-bf9c-47400c27e77e"> |

## Test plan

- Opened a chat
- Inspected placeholder