### PR TITLE
fix: use default selection range for python doc

### DIFF
--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -210,12 +210,7 @@ export function addSelectionToPrompt(prompt: string, code: string): string {
 /**
  * Gets the range to use for inserting documentation from the doc command.
  *
- * For Python files, returns a range starting on the line after the selection,
- * at the first non-whitespace character. This will insert the documentation
- * on the next line instead of directly in the selection as python docstring
- * is added below the function definition.
- *
- * For other languages, returns the original selection range unmodified.
+ * Returns the original selection range unmodified.
  */
 function getDocCommandRange(editor: vscode.TextEditor, selection: vscode.Selection): vscode.Selection {
     const startLine = selection.start.line
@@ -224,9 +219,9 @@ function getDocCommandRange(editor: vscode.TextEditor, selection: vscode.Selecti
     // move the current selection to the defined selection in the text editor document
     if (editor) {
         const visibleRange = editor.visibleRanges
-        // reveal the range of the selection minus 5 lines if visibleRange doesn't contain the selection
+        // reveal the range of the selection if visibleRange doesn't contain the selection
         if (!visibleRange.some(range => range.contains(selection))) {
-            // reveal the range of the selection minus 5 lines
+            // reveal the range of the selection
             editor?.revealRange(selection, vscode.TextEditorRevealType.InCenter)
         }
     }

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -141,7 +141,7 @@ export class CommandRunner implements vscode.Disposable {
             return
         }
 
-        const range = this.kind === 'doc' ? getDocCommandRange(this.editor, selection, doc.languageId) : selection
+        const range = this.kind === 'doc' ? getDocCommandRange(this.editor, selection) : selection
         const intent: FixupIntent = this.kind === 'doc' ? 'doc' : 'edit'
         const instruction = insertMode ? addSelectionToPrompt(this.command.prompt, code) : this.command.prompt
         const source = this.kind as ChatEventSource
@@ -217,12 +217,8 @@ export function addSelectionToPrompt(prompt: string, code: string): string {
  *
  * For other languages, returns the original selection range unmodified.
  */
-function getDocCommandRange(
-    editor: vscode.TextEditor,
-    selection: vscode.Selection,
-    languageId?: string
-): vscode.Selection {
-    const startLine = languageId === 'python' ? selection.start.line + 1 : selection.start.line
+function getDocCommandRange(editor: vscode.TextEditor, selection: vscode.Selection): vscode.Selection {
+    const startLine = selection.start.line
     const pos = new vscode.Position(startLine, 0)
 
     // move the current selection to the defined selection in the text editor document


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/2100

The getDocCommandRange function that is used for setting the range for the /doc comment was modified to always return the default selection range instead of trying to move to the line below the function for python.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

Try to run the doc command in python code, the doc string should be added above the function name instead of below