### PR TITLE
chore: Bump up macOS e2e runner instance size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: ubuntu-latest
-          # macOS is slow so we shard tests across two runners
-          - runner: macos-latest-large
+        # Use a single large mac for e2e tests as it runs in 4m instead of 6m (as of 2023-12-06)
+        runner: [ubuntu-latest, macos-latest-large]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu
+          - runner: ubuntu-latest
           # macOS is slow so we shard tests across two runners
-          - runner: macos
-            shard: 1/2
-          - runner: macos
-            shard: 2/2
-    runs-on: ${{ matrix.runner }}-latest
+          - runner: macos-latest-large
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -112,9 +109,9 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e
-        if: matrix.runner == 'ubuntu'
-      - run: pnpm -C vscode run test:e2e --shard ${{ matrix.shard }}
-        if: matrix.runner == 'macos'
+        if: matrix.runner == 'ubuntu-latest'
+      - run: pnpm -C vscode run test:e2e
+        if: matrix.runner == 'macos-latest-large'
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
   test-e2e:
     runs-on: ubuntu-latest
-    name: 'test-e2e (ubuntu)'
+    name: 'test-e2e (ubuntu)' # required to match the GitHub PR status check requirement
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -114,7 +114,8 @@ jobs:
   #
   # fixme(toolmantim): We should dedupe this Mac job with the above job using a
   # matrix after Cody 1.0.0. It wasn't done beforehand because it requires
-  # updating the required status checks for merging PRs.
+  # updating the required status checks for merging PRs. Ideally it would just
+  # be https://github.com/sourcegraph/cody/blob/21a40be7297da70f310350e2557a069ea06326ce/.github/workflows/ci.yml#L76
   test-e2e-macos:
     runs-on: macos-latest-large
     name: 'test-e2e (macos)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,8 @@ jobs:
         if: github.ref == 'refs/heads/main' && (matrix.runner == 'windows' || matrix.runner == 'macos')
 
   test-e2e:
-    strategy:
-      fail-fast: false
-      matrix:
-        # Use a single large mac for e2e tests as it runs in 4m instead of 6m (as of 2023-12-06)
-        runner: [ubuntu-latest, macos-latest-large]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
+    name: 'test-e2e (ubuntu)'
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -107,9 +103,48 @@ jobs:
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e
-        if: matrix.runner == 'ubuntu-latest'
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: playwright-recordings ${{ matrix.runner }}
+          path: playwright/**/*.webm
+
+  # Use a single large mac for e2e tests as it runs in 4m instead of 6m (as of
+  # 2023-12-06)
+  #
+  # fixme(toolmantim): We should dedupe this Mac job with the above job using a
+  # matrix after Cody 1.0.0. It wasn't done beforehand because it requires
+  # updating the required status checks for merging PRs.
+  test-e2e-macos:
+    runs-on: macos-latest-large
+    name: 'test-e2e (macos)'
+    timeout-minutes: 15
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .tool-versions
+      - uses: pnpm/action-setup@v2
+      - id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v0
+      - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        shell: bash
+        id: pnpm-cache
+      - name: Cache pnpm store
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-store-
+      - run: pnpm install
       - run: pnpm -C vscode run test:e2e
-        if: matrix.runner == 'macos-latest-large'
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu, macos]
+        include:
+          - runner: ubuntu
+          # macOS is slow so we shard tests across two runners
+          - runner: macos
+            shard: 1/2
+          - runner: macos
+            shard: 2/2
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 15
     permissions:
@@ -107,8 +113,8 @@ jobs:
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e
         if: matrix.runner == 'ubuntu'
-      - run: pnpm -C vscode run test:e2e
-        if: matrix.runner == 'windows' || matrix.runner == 'macos'
+      - run: pnpm -C vscode run test:e2e --shard ${{ matrix.shard }}
+        if: matrix.runner == 'macos'
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
Follow on from #2127, #2146 and #2147, this increases the macOS runner size which takes the macOS tests from 6m to 4m.

I've broken this out into its own single change, because it requires us update our required checks.

## Test plan

- N/A