### PR TITLE
chat: fix abort

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -552,8 +552,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 error: (partialResponse, error) => {
                     if (isAbortError(error)) {
                         this.chatModel.addBotMessage({ text: partialResponse })
+                    } else {
+                        this.postError(error, 'transcript')
                     }
-                    this.postError(error, 'transcript')
                     this.postViewTranscript()
                 },
             })
@@ -818,8 +819,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 error: (partialResponse: string, error: Error) => {
                     if (isAbortError(error)) {
                         this.chatModel.addBotMessage({ text: partialResponse })
+                    } else {
+                        this.postError(error, 'transcript')
                     }
-                    this.postError(error, 'transcript')
                     this.postViewTranscript()
                 },
             })


### PR DESCRIPTION
Before / After

<img width="758" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/c8eb647a-c25e-4863-8d1d-f508625a4238">

<img width="758" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/a1ff107a-4bce-46f6-a240-901ca3feecfa">


## Test plan

- [ ] Test clicking the stop button mid-generation and verify it stops with no user visible error