### PR TITLE
fix: chat show up in tree view on submit

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -424,6 +424,8 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     } else {
                         const newInput = selectedCommand?.slashCommand
                         setFormInput(newInput || formInput)
+                        setDisplayCommands(null)
+                        setSelectedChatCommand(-1)
                     }
                 }
                 return
@@ -469,7 +471,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             }
 
             // Loop through input history on up arrow press
-            if (!inputHistory.length) {
+            if (!inputHistory?.length) {
                 return
             }
 

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -570,7 +570,11 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             )}
 
             <form className={classNames(styles.inputRow, inputRowClassName)}>
-                {!displayCommands && suggestions !== undefined && suggestions.length !== 0 && SuggestionButton ? (
+                {!displayCommands &&
+                !contextSelection &&
+                suggestions !== undefined &&
+                suggestions.length !== 0 &&
+                SuggestionButton ? (
                     <div className={styles.suggestions}>
                         {suggestions.map((suggestion: string) =>
                             suggestion.trim().length > 0 ? (
@@ -589,7 +593,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     </div>
                 )}
                 <div className={styles.textAreaContainer}>
-                    {displayCommands && ChatCommandsComponent && formInput && (
+                    {displayCommands && ChatCommandsComponent && formInput.startsWith('/') && (
                         <ChatCommandsComponent
                             chatCommands={displayCommands}
                             selectedChatCommand={selectedChatCommand}

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -13,9 +13,12 @@ export class ChatHistoryManager {
         return chatHistory?.chat ? chatHistory.chat[sessionID] : null
     }
 
-    public async saveChat(chat: TranscriptJSON): Promise<UserLocalHistory> {
+    public async saveChat(chat: TranscriptJSON, input?: string): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory()
         history.chat[chat.id] = chat
+        if (input) {
+            history.input.push(input)
+        }
         await localStorage.setChatHistory(history)
         return history
     }

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -295,8 +295,6 @@ export class ChatPanelsManager implements vscode.Disposable {
 
     private disposeProvider(chatID: string): void {
         if (chatID === this.activePanelProvider?.sessionID) {
-            this.activePanelProvider.webviewPanel?.dispose()
-            this.activePanelProvider.dispose()
             this.activePanelProvider = undefined
         }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -773,15 +773,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             if (!recipeMessages) {
                 return
             }
-            await this.clearAndRestartSession()
-            const { humanMessage, prompt } = recipeMessages
             const displayText = this.editor.getActiveTextEditorSelection()
                 ? createDisplayTextWithFileSelection(humanChatInput, this.editor.getActiveTextEditorSelection())
                 : humanChatInput
+            const { humanMessage, prompt } = recipeMessages
             this.chatModel.addHumanMessage(humanMessage.message, displayText)
             if (humanMessage.newContextUsed) {
                 this.chatModel.setNewContextUsed(humanMessage.newContextUsed)
             }
+            await this.saveSession()
             this.postViewTranscript()
 
             this.sendLLMRequest(prompt, {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -366,7 +366,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
     }
 
     private async onInitialized(): Promise<void> {
-        await this.restoreSession(this.sessionID)
+        await this.restoreSession(this.sessionID, false)
         await this.postChatModels()
         await this.saveSession()
         await this.postCodyCommands()
@@ -383,12 +383,14 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
      * current in-progress completion. If the chat does not exist, then this
      * is a no-op.
      */
-    public async restoreSession(sessionID: string): Promise<void> {
+    public async restoreSession(sessionID: string, cancelOngoingCompletion = true): Promise<void> {
         const oldTranscript = this.history.getChat(sessionID)
         if (!oldTranscript) {
             return
         }
-        this.cancelInProgressCompletion()
+        if (cancelOngoingCompletion) {
+            this.cancelInProgressCompletion()
+        }
         const newModel = await newChatModelfromTranscriptJSON(oldTranscript, this.defaultModelID)
         this.chatModel = newModel
         this.sessionID = newModel.sessionID

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -906,7 +906,7 @@ class ContextProvider implements IContextProvider {
         const searchContext: ContextItem[] = []
         let localEmbeddingsError
         let remoteEmbeddingsError
-
+        searchContext.push(...(await this.getReadmeContext()))
         logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
         const localEmbeddingsResults = this.searchEmbeddingsLocal(text)
         const remoteEmbeddingsResults = this.searchEmbeddingsRemote(text)
@@ -1158,8 +1158,9 @@ class ContextProvider implements IContextProvider {
 
     private async getReadmeContext(): Promise<ContextItem[]> {
         // global pattern for readme file
-        const readmeGlobalPattern = '{README,readme,Readme}.*'
+        const readmeGlobalPattern = '{README,README.,readme.,Readm.}*'
         const readmeUri = (await vscode.workspace.findFiles(readmeGlobalPattern, undefined, 1)).at(0)
+        console.log('Searching for readme file...', readmeUri)
         if (!readmeUri) {
             return []
         }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -474,7 +474,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             ? createDisplayTextWithFileLinks(userContextFiles, text)
             : createDisplayTextWithFileSelection(text, this.editor.getActiveTextEditorSelection())
         this.chatModel.addHumanMessage({ text }, displayText)
-        await this.saveSession(displayText)
+        await this.saveSession(text)
         // trigger the context progress indicator
         this.postViewTranscript({ speaker: 'assistant', text: '' })
         await this.generateAssistantResponse(requestID, userContextFiles, addEnhancedContext)

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -893,7 +893,6 @@ class ContextProvider implements IContextProvider {
         let localEmbeddingsError
         let remoteEmbeddingsError
 
-        searchContext.push(...(await this.getReadmeContext()))
         logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
         const localEmbeddingsResults = this.searchEmbeddingsLocal(text)
         const remoteEmbeddingsResults = this.searchEmbeddingsRemote(text)
@@ -1094,7 +1093,6 @@ class ContextProvider implements IContextProvider {
         // global pattern for readme file
         const readmeGlobalPattern = '{README,readme,Readme}.*'
         const readmeUri = (await vscode.workspace.findFiles(readmeGlobalPattern, undefined, 1)).at(0)
-        console.log(readmeUri, 'readmeUri')
         if (!readmeUri) {
             return []
         }


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/2148 https://github.com/sourcegraph/cody/issues/2150 https://github.com/sourcegraph/cody/issues/2170 https://github.com/sourcegraph/cody/issues/2169

Fix issues where:
- chats don't appear until stream ends (simplified chat) #2148
-  active chats block new chats being started (simplified chat) #2150
- getReadmeContext is slow

Changse included:
- saveSession after human submission instead of only saving chat after assistant has responded
- combine saveAndPostHistory and saveSession
- limit getReadmeContext to 1 file at root of repo using global pattern

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->

- ask Cody a question
- before Cody has responded, the tree view has already been updated with the new session added
- you can start a new chat panel while waiting for Cody to response
- you cannot create multiple empty new chat panels
- you can delete chat history from tree view
- you can press up to loop through your input history

https://github.com/sourcegraph/cody/assets/68532117/2b62cc8e-c5ce-483c-97ed-fcada0bec22a

