### PR TITLE
ensure error message makes it through to chat view

### DIFF
--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -4,7 +4,7 @@ import { PromptMixin } from '../../prompt/prompt-mixin'
 import { Message } from '../../sourcegraph-api'
 
 import { Interaction, InteractionJSON } from './interaction'
-import { ChatMessage } from './messages'
+import { ChatMessage, errorToChatError } from './messages'
 
 export interface TranscriptJSONScope {
     includeInferredRepository: boolean
@@ -158,11 +158,7 @@ export class Transcript {
             text: 'Failed to generate a response due to server error.',
             // Serializing normal errors will lose name/message so
             // just read them off manually and attach the rest of the fields.
-            error: {
-                ...error,
-                message: error.message,
-                name: error.name,
-            },
+            error: errorToChatError(error),
         })
     }
 

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -31,6 +31,10 @@ export interface ChatError {
     kind?: string
     name: string
     message: string
+
+    // Prevent Error from being passed as ChatError.
+    // Errors should be converted using errorToChatError.
+    isChatErrorGuard: 'isChatErrorGuard'
 }
 
 export interface ChatMetadata {
@@ -62,3 +66,17 @@ export type ChatEventSource =
     | 'code-lens'
     | CodyDefaultCommands
     | RecipeID
+
+/**
+ * Converts an Error to a ChatError. Note that this cannot be done naively,
+ * because some of the Error object's keys are typically not enumerable, and so
+ * would be omitted during serialization.
+ */
+export function errorToChatError(error: Error): ChatError {
+    return {
+        isChatErrorGuard: 'isChatErrorGuard',
+        ...error,
+        message: error.message,
+        name: error.name,
+    }
+}

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -10,7 +10,7 @@ import styles from './ErrorItem.module.css'
  * An error message shown in the chat.
  */
 export const ErrorItem: React.FunctionComponent<{
-    error: ChatError
+    error: Omit<ChatError, 'isChatErrorGuard'>
     ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     userInfo?: UserAccountInfo
     postMessage?: ApiPostMessage

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { ChatError, ChatMessage } from '@sourcegraph/cody-shared'
 import { TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { InteractionJSON } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
+import { errorToChatError } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { reformatBotMessageForChat } from '@sourcegraph/cody-shared/src/chat/viewHelpers'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
 
@@ -72,7 +73,7 @@ export class SimpleChatModel {
         })
     }
 
-    public addErrorAsBotMessage(error: ChatError): void {
+    public addErrorAsBotMessage(error: Error): void {
         const lastMessage = this.messagesWithContext.at(-1)?.message
         const lastAssistantMessage = lastMessage?.speaker === 'assistant' ? lastMessage : undefined
         // Remove the last assistant message
@@ -81,7 +82,7 @@ export class SimpleChatModel {
         }
         // Then add a new assistant message with error added
         this.messagesWithContext.push({
-            error,
+            error: errorToChatError(error),
             message: {
                 ...lastAssistantMessage,
                 speaker: 'assistant',


### PR DESCRIPTION
We were dropping error messages from Cody chat, because Error objects omit all fields when serialized.

Before/after:

<img width="584" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/102c61d4-36af-483c-bbb2-66755a2429db">

<img width="583" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/d0f5673d-560f-410d-be7c-744ad6f81db9">


## Test plan

Tested locally (see screenshots) by posting an error to the view in `sendLLMRequest`.