### PR TITLE
VSCode: Send `embeddings/initialize` to the local embeddings controller

### DIFF
--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.2.10377'
+const defaultBfgVersion = '5.2.11713'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -2,6 +2,18 @@
  * The protocol for communicating between Cody and local embeddings.
  */
 
+export interface InitializeParams {
+    codyGatewayEndpoint: string
+    appIndexPath?: string
+    indexPath: string
+    chunkingPolicy?: ChunkingPolicy
+}
+
+export interface ChunkingPolicy {
+    maxFileSizeBytes: number
+    pathsToExcludeRegexp: string
+}
+
 export interface QueryResultSet {
     results: QueryResult[]
 }
@@ -23,9 +35,11 @@ export interface IndexRequest {
 export type Requests = {
     'embeddings/echo': [string, string]
     // Instruct local embeddings to index the specified repository path.
-    'embeddings/index': [IndexRequest, undefined]
+    'embeddings/index': [IndexRequest, {}]
+    // Initializes the local embeddings service. You must call this first.
+    'embeddings/initialize': [InitializeParams, {}]
     // Searches for and loads an index for the specified repository name.
-    'embeddings/load': [string, boolean]
+    'embeddings/load': [string, {}]
     // Queries loaded index.
     'embeddings/query': [string, QueryResultSet]
     // Sets the Sourcegraph access token.

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -160,7 +160,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                 break
             case 'win32':
                 paths = {
-                    indexPath: `${process.env.LOCALAPPDATA}/com.sourcegraph.cody/embeddings`,
+                    indexPath: `${process.env.LOCALAPPDATA}\\com.sourcegraph.cody\\embeddings`,
                     // Note, there was no Cody App on Windows, so we do not search for App indexes.
                 }
                 break


### PR DESCRIPTION
Rolls cody-engine to v5.2.11713.

cody-engine used to enumerate indices on startup, which slows down engine startup for autocompletes. Instead, enumerate indexes in an `embeddings/initialize` method.

## Test plan

- Set `"cody.debug.enable": true, "cody.debug.verbose": true,`
- Open a repository with App embeddings and chat, check that local embeddings context appears
- Open a repository with local embeddings and chat, check that local embeddings context appears
- Open a repository with no embeddings and click Enable Embeddings and check that indexing happens and then queries work

You can verify when local embeddings is returning results with Cmd-Shift-P, Output: Show Output Channels... Cody by Sourcegraph and looking for messages like `LocalEmbeddingsController: returning 15 results`.