### PR TITLE
VSCode: Do not parse Windows file paths as URIs

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: You can @-mention files on Windows without generating an error. [pull/2197](https://github.com/sourcegraph/cody/pull/2197)
+
 ### Changed
 
 ## [0.18.1]

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -174,7 +174,7 @@ export class VSCodeEditor implements Editor<FixupController, CommandsController>
         }
 
         // Get the text from document by file Uri
-        const vscodeUri = vscode.Uri.parse(fileUri.fsPath)
+        const vscodeUri = vscode.Uri.file(fileUri.fsPath)
         const doc = await vscode.workspace.openTextDocument(vscodeUri)
         return doc.getText(range)
     }


### PR DESCRIPTION
Fixes #2184. `Uri.parse` parses URIs, `Uri.file` takes a file path and turns it into a URI. For UNIX-style paths, `Uri.parse` works fine, but for Windows file paths, parsing them as URIs is wrong; the the drive separator is URL-encoded and the URI is unusable, etc.

https://github.com/sourcegraph/cody/assets/55120/417332a4-9c10-4728-a2de-b24bfb8d4fb3

## Test plan

1. Open a workspace, start a chat
2. @-mention a file in the workspace
3. The file should be included in the chat context, Cody can see the content, etc.