### PR TITLE
Add rate limit upgrade for code edits

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,7 @@
   "eslint.lintTask.enable": false,
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.codeActionsOnSave.mode": "problems",
   "eslint.options": { "cache": true },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -344,7 +344,14 @@
       {
         "command": "cody.show-page",
         "category": "Cody",
-        "title": "Show Admin Pages",
+        "title": "Open Account Page",
+        "group": "Cody",
+        "when": "cody.activated"
+      },
+      {
+        "command": "cody.show-rate-limit-modal",
+        "category": "Cody",
+        "title": "Show Rate Limit Modal",
         "group": "Cody",
         "when": "cody.activated"
       },
@@ -580,6 +587,10 @@
         },
         {
           "command": "cody.show-page",
+          "when": "false"
+        },
+        {
+          "command": "cody.show-rate-limit-modal",
           "when": "false"
         }
       ],

--- a/vscode/src/chat/FixupViewProvider.ts
+++ b/vscode/src/chat/FixupViewProvider.ts
@@ -140,7 +140,7 @@ export class FixupProvider extends MessageProvider {
      * Will allow the user to view the error in more detail if needed.
      */
     protected handleError(error: Error): void {
-        this.editor.controllers.fixups?.error(this.task.id, error.toString())
+        this.editor.controllers.fixups?.error(this.task.id, error)
     }
 
     protected handleCodyCommands(): void {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -366,18 +366,29 @@ const register = async (
         vscode.commands.registerCommand(
             'cody.show-rate-limit-modal',
             async (userMessage: string, retryMessage: string, upgradeAvailable: boolean) => {
-                const selected = await vscode.window.showInformationMessage(
-                    upgradeAvailable ? 'Upgrade to Cody Pro' : 'Rate Limit Exceeded',
-                    {
-                        modal: true,
-                        detail: `${userMessage}\n\nUpgrade to Cody Pro for unlimited autocomplete suggestions, chat messages and commands.\n\n${retryMessage}`,
-                    },
-                    'Upgrade',
-                    'See Plans'
-                )
-                // Both options go to the same URL
-                if (selected) {
-                    void vscode.env.openExternal(vscode.Uri.parse(ACCOUNT_UPGRADE_URL.toString()))
+                if (upgradeAvailable) {
+                    const option = await vscode.window.showInformationMessage(
+                        'Upgrade to Cody Pro',
+                        {
+                            modal: true,
+                            detail: `${userMessage}\n\nUpgrade to Cody Pro for unlimited autocomplete suggestions, chat messages and commands.\n\n${retryMessage}`,
+                        },
+                        'Upgrade',
+                        'See Plans'
+                    )
+                    // Both options go to the same URL
+                    if (option) {
+                        void vscode.env.openExternal(vscode.Uri.parse(ACCOUNT_UPGRADE_URL.toString()))
+                    }
+                } else {
+                    const option = await vscode.window.showInformationMessage(
+                        'Rate Limit Exceeded',
+                        { modal: true, detail: `${userMessage}\n\n${retryMessage}` },
+                        'Learn More'
+                    )
+                    if (option) {
+                        void vscode.env.openExternal(vscode.Uri.parse(ACCOUNT_LIMITS_INFO_URL.toString()))
+                    }
                 }
             }
         ),

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -362,6 +362,26 @@ const register = async (
             void vscode.env.openExternal(vscode.Uri.parse(url.toString()))
         }),
 
+        // Account links
+        vscode.commands.registerCommand(
+            'cody.show-rate-limit-modal',
+            async (userMessage: string, retryMessage: string, upgradeAvailable: boolean) => {
+                const selected = await vscode.window.showInformationMessage(
+                    upgradeAvailable ? 'Upgrade to Cody Pro' : 'Rate Limit Exceeded',
+                    {
+                        modal: true,
+                        detail: `${userMessage} ${retryMessage}`,
+                    },
+                    'Upgrade',
+                    'See Plans'
+                )
+                // Both options go to the same URL
+                if (selected) {
+                    void vscode.env.openExternal(vscode.Uri.parse(ACCOUNT_UPGRADE_URL.toString()))
+                }
+            }
+        ),
+
         // Register URI Handler (vscode://sourcegraph.cody-ai)
         vscode.window.registerUriHandler({
             handleUri: async (uri: vscode.Uri) => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -370,7 +370,7 @@ const register = async (
                     upgradeAvailable ? 'Upgrade to Cody Pro' : 'Rate Limit Exceeded',
                     {
                         modal: true,
-                        detail: `${userMessage} ${retryMessage}`,
+                        detail: `${userMessage}\n\nUpgrade to Cody Pro for unlimited autocomplete suggestions, chat messages and commands.\n\n${retryMessage}`,
                     },
                     'Upgrade',
                     'See Plans'

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -220,7 +220,7 @@ export class FixupController
         const MAX_SPIN_COUNT_PER_TASK = 5
         if (task.spinCount >= MAX_SPIN_COUNT_PER_TASK) {
             telemetryService.log('CodyVSCodeExtension:fixup:respin', { count: task.spinCount })
-            return this.error(task.id, `Cody tried ${task.spinCount} times but failed to edit the file`)
+            return this.error(task.id, new Error(`Cody tried ${task.spinCount} times but failed to edit the file`))
         }
         void vscode.window.showInformationMessage('Cody will rewrite to include your changes')
         this.setTaskState(task, CodyTaskState.working)
@@ -693,13 +693,13 @@ export class FixupController
         this.setTaskState(task, CodyTaskState.finished)
     }
 
-    public error(id: taskID, message: string): void {
+    public error(id: taskID, error: Error): void {
         const task = this.tasks.get(id)
         if (!task) {
             return
         }
 
-        task.error = message
+        task.error = error
         this.setTaskState(task, CodyTaskState.error)
     }
 
@@ -709,7 +709,7 @@ export class FixupController
             return
         }
 
-        void vscode.window.showErrorMessage('Error applying edits:', { modal: true, detail: task.error })
+        void vscode.window.showErrorMessage('Applying Edits Failed', { modal: true, detail: task.error.message })
     }
 
     private skipFormatting(id: taskID): void {

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -26,7 +26,7 @@ export class FixupTask {
     /** The text of the last completed turn of the LLM, if any */
     public replacement: string | undefined
     /** The error attached to the fixup, if any */
-    public error: string | undefined
+    public error: Error | undefined
     /**
      * If text has been received from the LLM and a diff has been computed,
      * it is cached here. Diffs are recomputed lazily and may be stale.

--- a/vscode/src/non-stop/codelenses.ts
+++ b/vscode/src/non-stop/codelenses.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { isRateLimitError } from '@sourcegraph/cody-shared/dist/sourcegraph-api/errors'
+
 import { getSingleLineRange } from '../services/InlineAssist'
 
 import { FixupTask } from './FixupTask'
@@ -35,7 +37,7 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
             return [title, retry, undo, accept]
         }
         case CodyTaskState.error: {
-            const title = getErrorLens(codeLensRange, task.id)
+            const title = getErrorLens(codeLensRange, task)
             const discard = getDiscardLens(codeLensRange, task.id)
             return [title, discard]
         }
@@ -45,12 +47,28 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
 }
 
 // List of lenses
-function getErrorLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
+function getErrorLens(codeLensRange: vscode.Range, task: FixupTask): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: '$(warning) Applying edits failed',
-        command: 'cody.fixup.codelens.error',
-        arguments: [id],
+    if (isRateLimitError(task.error)) {
+        if (task.error.upgradeIsAvailable) {
+            lens.command = {
+                title: '⚡️ Upgrade to Cody Pro',
+                command: 'cody.show-rate-limit-modal',
+                arguments: [task.error.userMessage, task.error.retryMessage, task.error.upgradeIsAvailable],
+            }
+        } else {
+            lens.command = {
+                title: '$(warning) Rate Limit Exceeded',
+                command: 'cody.show-rate-limit-modal',
+                arguments: [task.error.userMessage, task.error.retryMessage, task.error.upgradeIsAvailable],
+            }
+        }
+    } else {
+        lens.command = {
+            title: '$(warning) Applying Edits Failed',
+            command: 'cody.fixup.codelens.error',
+            arguments: [task.id],
+        }
     }
     return lens
 }


### PR DESCRIPTION
This adds an update CTA to code edits.

Fixes #2123

Free user rate limit:

https://github.com/sourcegraph/cody/assets/153/31a1650a-fe9b-4567-90ee-4c4fb3ff5ef2

Pro user rate limit:

https://github.com/sourcegraph/cody/assets/153/304cb79d-1eb0-4aab-9cd8-89def9abf6ff

## Test plan

- Ran as free rate limited user. Run doc command. Click code lens. Click dialog options.
- Ran as pro rate limited user. Run doc command. Click code lens. Click dialog options.