### PR TITLE
Adding endpoint for fetching feature flag

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -10,6 +10,7 @@ import { isRateLimitError } from '@sourcegraph/cody-shared/dist/sourcegraph-api/
 import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/dist/utils'
 import { Client, createClient } from '@sourcegraph/cody-shared/src/chat/client'
 import { registeredRecipes } from '@sourcegraph/cody-shared/src/chat/recipes/agent-recipes'
+import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 import { LogEventMode, setUserAgent } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import { BillingCategory, BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
@@ -469,6 +470,10 @@ export class Agent extends MessageHandler {
                 console.log('Completion provider is not initialized: unable to clear last candidate')
             }
             provider.clearLastCandidate()
+        })
+
+        this.registerRequest('featureFlags/getFeatureFlag', async ({ flagName }) => {
+            return featureFlagProvider.evaluateFeatureFlag(FeatureFlag[flagName as keyof typeof FeatureFlag])
         })
     }
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -49,6 +49,8 @@ export type Requests = {
 
     'graphql/currentUserIsPro': [null, boolean]
 
+    'featureFlags/getFeatureFlag': [{ flagName: string }, boolean | null]
+
     /**
      * @deprecated use 'telemetry/recordEvent' instead.
      */


### PR DESCRIPTION
It helps [PLG: Add "Upgrade to Cody Pro" and "Current Usage" settings buttons#149](https://github.com/sourcegraph/jetbrains/issues/149). In JetBrains plugin we need to be able to evaluate feature flags.
## Test plan
* Send request to agent's new `featureFlags/getFeatureFlag` endpoint
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
