### PR TITLE
Fix symf index dir on Windows

### DIFF
--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -233,7 +233,13 @@ export class SymfRunner implements IndexedKeywordContextFetcher {
     }
 
     private getIndexDir(scopeDir: string): { indexDir: string; tmpDir: string } {
-        const absIndexedDir = path.resolve(scopeDir)
+        let absIndexedDir = path.resolve(scopeDir)
+        // On Windows, we can't use an absolute path with a dirve letter inside another path
+        // so we remove the colon, so `C:\foo\bar` just becomes `C\foo\bar` which is a valid
+        // sub-path in the index.
+        if (path.sep === path.win32.sep && absIndexedDir[1] === ':') {
+            absIndexedDir = absIndexedDir[0] + absIndexedDir.slice(2)
+        }
         return {
             indexDir: path.join(this.indexRoot, absIndexedDir),
             tmpDir: path.join(this.indexRoot, '.tmp', absIndexedDir),


### PR DESCRIPTION
We can't use an absolute path containing a colon as a sub-path, so just remove the colon.

@beyang @jdorfman I tested this manually, but couldn't find a nice way to get a test around this (I tried writing a test that tried to create an index and verify it existed, but it seemed to want to trigger downloads). If there's a reasonable way I could get a test around this, please let me know.

## Before:

![Screenshot 2023-12-08 110612](https://github.com/sourcegraph/cody/assets/1078012/31247620-5055-4b9c-b0b6-e9b1e5a0885a)

### After:

![Screenshot 2023-12-08 110532](https://github.com/sourcegraph/cody/assets/1078012/2705147e-c048-423c-835c-9f9ca5fa19d3)

![image](https://github.com/sourcegraph/cody/assets/1078012/4aef684a-6f23-48a9-b754-7a2419aba2b8)


## Test plan

- Run extension on Windows
- Open a project
- Type a query into the search box
- Ensure results appear and no errors in the console

