### PR TITLE
Allow dotfiles to be included in context files list

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: You can @-mention files starting with a dot. [pull/2209](https://github.com/sourcegraph/cody/pull/2209)
 - Chat: You can @-mention files on Windows without generating an error. [pull/2197](https://github.com/sourcegraph/cody/pull/2197)
 
 ### Changed

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -13,7 +13,7 @@ const findWorkspaceFiles = async (cancellationToken: vscode.CancellationToken): 
     // TODO(toolmantim): Add support for the search.exclude option, e.g.
     // Object.keys(vscode.workspace.getConfiguration().get('search.exclude',
     // {}))
-    const fileExcludesPattern = '**/{.,*.env,.git,out/,dist/,bin/,snap,node_modules,__pycache__}**'
+    const fileExcludesPattern = '**/{*.env,.git,out/,dist/,bin/,snap,node_modules,__pycache__}**'
     // TODO(toolmantim): Check this performs with remote workspaces (do we need a UI spinner etc?)
     return vscode.workspace.findFiles('', fileExcludesPattern, undefined, cancellationToken)
 }

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -22,6 +22,10 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await chatInput.fill('@definitelydoesntexist')
     await expect(chatPanelFrame.getByRole('heading', { name: 'No matching files found' })).toBeVisible()
 
+    // Includes dotfiles after just "."
+    await chatInput.fill('@.')
+    await expect(chatPanelFrame.getByRole('button', { name: '.mydotfile' })).toBeVisible()
+
     // Symbol empty state
     await chatInput.fill('@#')
     await expect(chatPanelFrame.getByRole('heading', { name: 'Search for a symbol to include..' })).toBeVisible()

--- a/vscode/test/fixtures/workspace/.mydotfile
+++ b/vscode/test/fixtures/workspace/.mydotfile
@@ -1,0 +1,1 @@
+A dotfile for testing.

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -181,7 +181,12 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         // Get the string after the last '@' symbol
         const addFileInput = formInput.match(addFileRegex)?.[0]
 
-        if (!formInput.endsWith('@') && trailingNonAlphaNumericRegex.test(formInput) && !contextSelection?.length) {
+        if (
+            !formInput.endsWith('@') &&
+            !formInput.endsWith('.') &&
+            trailingNonAlphaNumericRegex.test(formInput) &&
+            !contextSelection?.length
+        ) {
             setContextSelection(null)
             return
         }


### PR DESCRIPTION
This should fix https://github.com/sourcegraph/cody/issues/2199, although I'm not certain if the behaviour is exactly correct, because:

1. Dot files appear to have been excluded specifically (@toolmantim you added `fileExcludesPattern` in `editor-context` so maybe have an opinion?)
2. Typing `@.` although showing dotfiles at the top, will also basically match every file because of the fuzzy patch

I also hit an issue (filed at https://github.com/sourcegraph/cody/issues/2208) while testing this.. The existing tests can fail depending on the full fs path to your Cody checkout. I think this is a bug but I'd like some confirmation before trying to fix.

## Test plan

- Run `pnpm test:unit` for the updated test
- Open chat, and type `@.` and verify dotfiles show up and can be selected (note: ignore rules currently exclude `.git*` so things like gitattributes won't show up)
