### PR TITLE
Fix "Release Notes" label & link for pre-releases in sidebar

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: You can @-mention files on Windows without generating an error. [pull/2197](https://github.com/sourcegraph/cody/pull/2197)
+- Fix "Release Notes" label & link for pre-releases in sidebar. [pull/2210](https://github.com/sourcegraph/cody/pull/2210)
 
 ### Changed
 

--- a/vscode/scripts/release.ts
+++ b/vscode/scripts/release.ts
@@ -113,7 +113,7 @@ if (!tokens.vscode || !tokens.openvsx) {
 
 // The insiders build is the stable version suffixed with "-" and the Unix time.
 //
-// For example: 0.4.4 in package.json -> 0.4.4-1689391131.
+// For example: 0.4.4 in package.json -> 0.5.1689391131
 const insidersVersion = semver.inc(packageJSONVersion, 'minor')?.replace(/\.\d+$/, `.${Math.ceil(Date.now() / 1000)}`)
 if (!insidersVersion) {
     console.error('Could not increment version for insiders release.')

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -2,8 +2,8 @@ import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/Featur
 
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
+import { releaseNotesURL, releaseType, version } from '../version'
 
-import { getProcessInfo } from './LocalAppDetector'
 import { localStorage } from './LocalStorageProvider'
 
 export type CodyTreeItemType = 'command' | 'support' | 'search' | 'chat'
@@ -85,12 +85,12 @@ const supportItems: CodySidebarTreeItem[] = [
         command: { command: 'workbench.action.openGlobalKeybindings', args: ['@ext:sourcegraph.cody-ai'] },
     },
     {
-        title: 'Release Notes',
-        description: `v${getProcessInfo().extensionVersion}`,
+        title: `${releaseType(version) === 'stable' ? 'Release' : 'Pre-Release'} Notes`,
+        description: `v${version}`,
         icon: 'github',
         command: {
             command: 'vscode.open',
-            args: [`https://github.com/sourcegraph/cody/releases/tag/vscode-v${getProcessInfo().extensionVersion}`],
+            args: [releaseNotesURL(version)],
         },
     },
     {

--- a/vscode/src/version.test.ts
+++ b/vscode/src/version.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { version as packageVersion } from '../package.json'
+
+import { majorMinorVersion, releaseNotesURL, releaseType, version } from './version'
+
+describe('version', () => {
+    it('returns the version from JSON', () => {
+        expect(version).toEqual(packageVersion)
+    })
+})
+
+describe('majorMinorVersion', () => {
+    it('returns the first two components', () => {
+        expect(majorMinorVersion('0.2.1')).toEqual('0.2')
+        expect(majorMinorVersion('4.2.1')).toEqual('4.2')
+        expect(majorMinorVersion('4.3.1689391131')).toEqual('4.3')
+    })
+})
+
+describe('releaseType', () => {
+    it('returns stable if no dash', () => {
+        expect(releaseType('4.2.1')).toEqual('stable')
+    })
+    it('returns insiders if it is an odd minor version', () => {
+        expect(releaseType('4.3.1689391131')).toEqual('insiders')
+    })
+})
+
+describe('releaseNotesURL', () => {
+    it('returns GitHub release notes for stable builds', () => {
+        expect(releaseNotesURL('4.2.1')).toEqual('https://github.com/sourcegraph/cody/releases/tag/vscode-v4.2.1')
+    })
+    it('returns changelog for insiders builds', () => {
+        expect(releaseNotesURL('4.3.1689391131')).toEqual(
+            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
+        )
+    })
+})

--- a/vscode/src/version.ts
+++ b/vscode/src/version.ts
@@ -1,0 +1,19 @@
+import { version as packageVersion } from '../package.json'
+
+export type ReleaseType = 'stable' | 'insiders'
+
+export const version = packageVersion
+
+export const majorVersion = (version: string): string => version.split('.')[0]
+
+export const minorVersion = (version: string): string => version.split('.')[1]
+
+export const majorMinorVersion = (version: string): string => [majorVersion(version), minorVersion(version)].join('.')
+
+export const releaseType = (version: string): ReleaseType =>
+    Number(minorVersion(version)) % 2 === 1 ? 'insiders' : 'stable'
+
+export const releaseNotesURL = (version: string): string =>
+    releaseType(version) === 'stable'
+        ? `https://github.com/sourcegraph/cody/releases/tag/vscode-v${version}`
+        : 'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -229,10 +229,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 />
             ) : (
                 <>
-                    <Notices
-                        extensionVersion={config?.extensionVersion}
-                        probablyNewInstall={!!userHistory && Object.entries(userHistory).length === 0}
-                    />
+                    <Notices probablyNewInstall={!!userHistory && Object.entries(userHistory).length === 0} />
                     {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
                     {view === 'chat' && (
                         <EnhancedContextEventHandlers.Provider

--- a/vscode/webviews/Notices/VersionUpdatedNotice.tsx
+++ b/vscode/webviews/Notices/VersionUpdatedNotice.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { majorMinorVersion, releaseNotesURL, version } from '../../src/version'
+
 import { Notice } from './Notice'
 
 import styles from './VersionUpdatedNotice.module.css'
@@ -32,47 +34,22 @@ const useShowNotice = (currentVersion: string, probablyNewInstall: boolean): [bo
     return [showNotice, setDismissed]
 }
 
-const whatsNewURL = (version: string): string => {
-    /**
-     * Our nightlies don't have tags or release notes on GH, so we just link to our
-     * GH releases page for lack of a better option
-     * */
-    if (version.includes('-')) {
-        return 'https://github.com/sourcegraph/cody/releases'
-    }
-
-    /**
-     * At the top of each GitHub release notes we include a link to the
-     * release's blog post for that point release (e.g. 0.8.x). So even
-     * if they update from 0.7.1 -> 0.8.3 they'll have a blog post link handy
-     */
-    return `https://github.com/sourcegraph/cody/releases/tag/vscode-v${version}`
-}
-
 interface VersionUpdateNoticeProps {
-    version: string
     probablyNewInstall: boolean
 }
 
-export const VersionUpdatedNotice: React.FunctionComponent<VersionUpdateNoticeProps> = ({
-    version,
-    probablyNewInstall,
-}) => {
-    /* Only consider the first two components */
-    const majorMinorVersion = version.split('.').slice(0, 2).join('.')
+export const VersionUpdatedNotice: React.FunctionComponent<VersionUpdateNoticeProps> = ({ probablyNewInstall }) => {
+    const [showNotice, setDismissed] = useShowNotice(majorMinorVersion(version), probablyNewInstall)
 
-    const [showNotice, setDismissed] = useShowNotice(majorMinorVersion, probablyNewInstall)
-
-    /* Ignore 0.6, this all begins with 0.7+ */
-    if (!showNotice || majorMinorVersion === '0.6') {
+    if (!showNotice) {
         return undefined
     }
 
     return (
         <Notice
             icon={<Icon />}
-            title={`Cody updated to v${majorMinorVersion}`}
-            linkHref={whatsNewURL(version)}
+            title={`Cody updated to v${majorMinorVersion(version)}`}
+            linkHref={releaseNotesURL(version)}
             linkText="See what’s new →"
             linkTarget="_blank"
             onDismiss={setDismissed}

--- a/vscode/webviews/Notices/index.tsx
+++ b/vscode/webviews/Notices/index.tsx
@@ -4,13 +4,12 @@ import { VersionUpdatedNotice } from './VersionUpdatedNotice'
 import styles from './index.module.css'
 
 interface NoticesProps {
-    extensionVersion: string
     probablyNewInstall: boolean
 }
 
-export const Notices: React.FunctionComponent<NoticesProps> = ({ extensionVersion, probablyNewInstall }) => (
+export const Notices: React.FunctionComponent<NoticesProps> = ({ probablyNewInstall }) => (
     <div className={styles.notices}>
-        <VersionUpdatedNotice version={extensionVersion} probablyNewInstall={probablyNewInstall} />
+        <VersionUpdatedNotice probablyNewInstall={probablyNewInstall} />
         <OnboardingAutocompleteNotice />
     </div>
 )


### PR DESCRIPTION
Fixes #2025

* Links to changelog for pre-release builds
* Label pre-release builds with "Pre-Release Notes" instead of "Release Notes"
* Removes some dupe version/URL code

| Before | After |
| - | - |
| <img width="379" alt="Screenshot 2023-12-08 at 11 37 50 pm" src="https://github.com/sourcegraph/cody/assets/153/a085ba2b-d63a-4695-b42b-28bb4534eedb"> | <img width="379" alt="Screenshot 2023-12-08 at 11 36 35 pm" src="https://github.com/sourcegraph/cody/assets/153/2375a2e0-355c-4485-a27f-1f8d8aba1318"> |
| Links to [Non-Existent Release](https://github.com/sourcegraph/cody/releases/tag/vscode-v0.19.1689391131) | Links to [Changelog](https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md) |

## Test plan

- Changed package.json `version`
- Reloaded extension, verified treeitem, clicked treeitem
- Verify update notice shows in chat properly