### PR TITLE
Search: Only show search instructions on hover or focus

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Search: Only show search instructions on hover or focus [pull/2212](https://github.com/sourcegraph/cody/pull/2212)
+
 ## [0.18.1]
 
 ### Added

--- a/vscode/webviews/SearchPanel.module.css
+++ b/vscode/webviews/SearchPanel.module.css
@@ -59,6 +59,7 @@
     display: none;
 }
 
+.outer-container:hover .instructions,
 .outer-container:focus-within .instructions {
     display: block;
 }

--- a/vscode/webviews/SearchPanel.module.css
+++ b/vscode/webviews/SearchPanel.module.css
@@ -56,6 +56,11 @@
     line-height: 1.4;
     margin: 0 1rem;
     color: var(--vscode-search-resultsInfoForeground);
+    display: none;
+}
+
+.outer-container:focus-within .instructions {
+    display: block;
 }
 
 .search-result-row-inner {

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -250,7 +250,7 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
             </form>
             {!searching && query.trim().length === 0 && (
                 <p className={styles.instructions}>
-                    Search using natural language queries, for example “password hashing” or "connection retries"
+                    Search for code using a natural language query, such as “password hashing”, "connection retries", a symbol name, or a topic.
                 </p>
             )}
             {!searching && results.length === 0 && query.trim().length !== 0 && (

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -250,7 +250,8 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
             </form>
             {!searching && query.trim().length === 0 && (
                 <p className={styles.instructions}>
-                    Search for code using a natural language query, such as “password hashing”, "connection retries", a symbol name, or a topic.
+                    Search for code using a natural language query, such as “password hashing”, "connection retries", a
+                    symbol name, or a topic.
                 </p>
             )}
             {!searching && results.length === 0 && query.trim().length !== 0 && (


### PR DESCRIPTION
The search instructions take a lot of permanent visual space/noise when not in use, so this hides the search instructions until you hover or focus within that panel.

https://github.com/sourcegraph/cody/assets/153/625daf2a-ce61-4314-bf2a-2e76a0301ff7

## Test plan

- Hovered over panel
- Focused in panel