### PR TITLE
Handle context file searching using forward slashes on Windows

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: You can @-mention files on Windows without generating an error. [pull/2197](https://github.com/sourcegraph/cody/pull/2197)
+- Chat: You can @-mention files on Windows using backslashes instead of forward slashes [pull/2215](https://github.com/sourcegraph/cody/pull/2215)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,7 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: You can @-mention files on Windows without generating an error. [pull/2197](https://github.com/sourcegraph/cody/pull/2197)
-- Chat: You can @-mention files on Windows using backslashes instead of forward slashes [pull/2215](https://github.com/sourcegraph/cody/pull/2215)
+- Chat: You can @-mention files on Windows using backslashes and displayed filenames will use backslashes [pull/2215](https://github.com/sourcegraph/cody/pull/2215)
 
 ### Changed
 

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -184,7 +184,7 @@ function createContextFilePath(uri: vscode.Uri): ContextFile['path'] {
 }
 
 /**
- * Returna a relative path using the correct slash direction for the current platform.
+ * Returns a relative path using the correct slash direction for the current platform.
  */
 function asRelativePath(uri: vscode.Uri): string {
     let relativePath = vscode.workspace.asRelativePath(uri.fsPath)

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -48,9 +48,7 @@ export async function getFileContextFiles(
 
     // On Windows, if the user has typed forward slashes, map them to backslashes before
     // running the search so they match the real paths.
-    if (path.sep === path.win32.sep) {
-        query = query.replaceAll(path.posix.sep, path.win32.sep)
-    }
+    query = query.replaceAll(path.posix.sep, path.sep)
 
     const results = fuzzysort.go(query, uris, {
         key: 'fsPath',

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -187,7 +187,6 @@ function createContextFilePath(uri: vscode.Uri): ContextFile['path'] {
 
 /**
  * Returna a relative path using the correct slash direction for the current platform.
- * @returns
  */
 function asRelativePath(uri: vscode.Uri): string {
     let relativePath = vscode.workspace.asRelativePath(uri.fsPath)

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -1,4 +1,4 @@
-import { basename, dirname } from 'path'
+import path, { basename, dirname } from 'path'
 
 import fuzzysort from 'fuzzysort'
 import { throttle } from 'lodash'
@@ -44,6 +44,12 @@ export async function getFileContextFiles(
 
     if (!uris) {
         return []
+    }
+
+    // On Windows, if the user has typed forward slashes, map them to backslashes before
+    // running the search so they match the real paths.
+    if (path.sep === path.win32.sep) {
+        query = query.replaceAll(path.posix.sep, path.win32.sep)
     }
 
     const results = fuzzysort.go(query, uris, {

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -181,6 +181,21 @@ function createContextFilePath(uri: vscode.Uri): ContextFile['path'] {
     return {
         basename: basename(uri.fsPath),
         dirname: dirname(uri.fsPath),
-        relative: vscode.workspace.asRelativePath(uri.fsPath),
+        relative: asRelativePath(uri),
     }
+}
+
+/**
+ * Returna a relative path using the correct slash direction for the current platform.
+ * @returns
+ */
+function asRelativePath(uri: vscode.Uri): string {
+    let relativePath = vscode.workspace.asRelativePath(uri.fsPath)
+    // asRelativePath returns forward slashes on Windows but we want to
+    // render a native path like VS Code does in the file quick-pick.
+    if (path.sep === path.win32.sep) {
+        relativePath = relativePath.replaceAll(path.posix.sep, path.win32.sep)
+    }
+
+    return relativePath
 }

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -190,9 +190,7 @@ function asRelativePath(uri: vscode.Uri): string {
     let relativePath = vscode.workspace.asRelativePath(uri.fsPath)
     // asRelativePath returns forward slashes on Windows but we want to
     // render a native path like VS Code does in the file quick-pick.
-    if (path.sep === path.win32.sep) {
-        relativePath = relativePath.replaceAll(path.posix.sep, path.win32.sep)
-    }
+    relativePath = relativePath.replaceAll(path.posix.sep, path.sep)
 
     return relativePath
 }

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import { expect } from '@playwright/test'
 
 import { sidebarSignin } from './common'
@@ -33,6 +35,16 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
+
+    // Forward slashes work
+    await chatInput.fill('@lib/batches/env')
+    await expect(chatPanelFrame.getByRole('button', { name: 'lib/batches/env/var.go' })).toBeVisible()
+
+    // Backslashes work on Windows
+    if (path.sep === path.win32.sep) {
+        await chatInput.fill('@lib\\batches\\env')
+        await expect(chatPanelFrame.getByRole('button', { name: 'lib/batches/env/var.go' })).toBeVisible()
+    }
 
     // Keyboard nav
     await chatInput.type('Explain @vgo', { delay: 50 }) // without this delay the following Enter submits the form instead of selecting

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -86,5 +86,5 @@ test('@-file empty state', async ({ page, sidebar }) => {
 })
 
 function withPlatformSlashes(input: string) {
-    return path.sep === path.win32.sep ? input.replaceAll(path.posix.sep, path.win32.sep) : input
+    return input.replaceAll(path.posix.sep, path.sep)
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/2198


## Test plan

- Run `pnpm test:e2e at-file` to run updated test, or:
- On Windows, open chat and try to attach a file in chat using backslashes and forward slashes for searching filenames
