### PR TITLE
embeddings (wip): use query expansion for chat questions

### DIFF
--- a/e2e-inspector/src/QualityMetrics.tsx
+++ b/e2e-inspector/src/QualityMetrics.tsx
@@ -22,11 +22,12 @@ export const QualityMetrics: React.FunctionComponent<QualityMetricsProps> = ({ v
     return (
         <div className={classNames(styles.qualityMetricsContainer, variantToClass[variant])}>
             <div className={styles.qualityMetric}>
-                <Ratio
-                    numerator={aggregatedResults.incorrectAnswers + aggregatedResults.partialAnswers}
-                    denominator={aggregatedResults.numInteractions}
-                />
-                <div className={styles.qualityMetricLabel}>incorrect or partial answers</div>
+                <Ratio numerator={aggregatedResults.incorrectAnswers} denominator={aggregatedResults.numInteractions} />
+                <div className={styles.qualityMetricLabel}>incorrect answers</div>
+            </div>
+            <div className={styles.qualityMetric}>
+                <Ratio numerator={aggregatedResults.partialAnswers} denominator={aggregatedResults.numInteractions} />
+                <div className={styles.qualityMetricLabel}>partial answers</div>
             </div>
             <div className={styles.qualityMetric}>
                 <Ratio numerator={aggregatedResults.missingFacts} denominator={aggregatedResults.facts} />

--- a/e2e/src/test-cases/index.ts
+++ b/e2e/src/test-cases/index.ts
@@ -41,6 +41,7 @@ export function initialize(): void {
     require('./numpy')
     require('./pytorch')
     require('./embeddings')
+    require('./single-question')
     /* eslint-enable @typescript-eslint/no-require-imports */
 }
 

--- a/e2e/src/test-cases/single-question.ts
+++ b/e2e/src/test-cases/single-question.ts
@@ -1,0 +1,171 @@
+import { addTestCase, literalFacts } from '.'
+
+addTestCase('Single Question: Access tokens', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'How I access the Sourcegraph API using an access token?',
+            facts: literalFacts('Authorization'),
+            answerSummary:
+                'Access tokens allow users to make authenticated requests to the API using the `Authorization` header.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Chat Models', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'What chat models and providers are available to use with Cody?',
+            facts: literalFacts('anthropic', 'openai'),
+            answerSummary:
+                'Cody supports Anthropic and OpenAI as model providers. Cody supports Anthropic Claude, and OpenAI GPT3.5 and GPT4 as chat models.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Notebook sharing', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'How I update the notebook share settings via the API?',
+            facts: literalFacts('graphql'),
+            answerSummary:
+                'You can update the share settings by updating the `namespace` and `public` settings via the GraphQL API.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Embeddings chunking', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'How do we chunk files for embeddings?',
+            facts: literalFacts('SplitIntoEmbeddableChunks'),
+            answerSummary:
+                'The chunking algorithm for embeddings is implemented in the `SplitIntoEmbeddableChunks` function.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Syntax highlighting', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'Which library do we use for syntax highlighting?',
+            facts: literalFacts('syntect'),
+            answerSummary: 'We use the `syntect` Rust library to highlight the code.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Background worker', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'What is the recommended way to add a background worker?',
+            facts: literalFacts('store', 'handler'),
+            answerSummary: `The most common way to use a worker is to use the database-backed store defined in \`dbworker/store.Store\`. Here is an incomplete list of steps needed to add a background worker:
+1. Create a jobs table
+2. Write the model definition and scan function
+3. Configure the store
+4. Create the store
+5. Write the handler
+6. Configure the worker and resetter
+7. Register the worker and resetter
+`,
+        },
+    ],
+})
+
+addTestCase('Single Question: Notebooks telemetry', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'Which telemetry do we collect for notebooks?',
+            facts: literalFacts('views', 'star', 'block'),
+            answerSummary: `We collect the following telemetry information:
+- Notebook Page Views,
+- Notebooks List Page Views,
+- Embedded Notebook Page Views,
+- Notebooks Created Count,
+- Notebook Added Stars Count,
+- Notebook Added Markdown Blocks Count,
+- Notebook Added Query Blocks Count,
+- Notebook Added File Blocks Count,
+- Notebook Added Symbol Blocks Count,
+`,
+        },
+    ],
+})
+
+addTestCase('Single Question: Sourcegraph query display', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'Is there a way to nicely display the Sourcegraph search query on frontend?',
+            facts: literalFacts('SyntaxHighlightedSearchQuery'),
+            answerSummary:
+                'Yes, you can use the `SyntaxHighlightedSearchQuery` React component to nicely display Sourcegraph search queries with syntax highlighting.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Code Monitor queries', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'Which types of queries are allowed for Code Monitors?',
+            facts: literalFacts('diff', 'commit'),
+            answerSummary: 'Code Monitors support diff and commit queries.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Embeddings storage', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question: 'Where are embeddings indexes stored?',
+            facts: literalFacts('s3', 'gcs'),
+            answerSummary: 'Embeddings indexes are stored in the configured blob storage (S3 and GCS).',
+        },
+    ],
+})
+
+addTestCase('Single Question: Listing files and fetching their content', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question:
+                'I need to list all the files in a particular repo and fetch their contents. How can I do this efficiently in Sourcegraph using Go?',
+            facts: literalFacts('readfile', 'readdir', 'gitserver'),
+            answerSummary:
+                'The most efficient way to list the files would be to use the gitserver `ReadDir` method. To get the file content you can use the gitserver `ReadFile` method.',
+        },
+    ],
+})
+
+addTestCase('Single Question: Structural search implementation', {
+    codebase: 'github.com/sourcegraph/sourcegraph',
+    context: 'embeddings',
+    transcript: [
+        {
+            question:
+                'Which library does structural search use under the hood and which language is it implemented in?',
+            facts: literalFacts('comby', 'ocaml'),
+            answerSummary: 'Structural search uses the `comby` library under the hood which is implemented in OCaml.',
+        },
+    ],
+})

--- a/e2e/src/test-results.ts
+++ b/e2e/src/test-results.ts
@@ -63,12 +63,14 @@ function logResult(label: string, partial: number, total: number, opts: ColorOpt
 }
 
 export function logAggregateResults(aggregateResults: AggregateTestResults): void {
-    logResult(
-        'Incorrect or partial answers (LLM judge)',
-        aggregateResults.incorrectAnswers + aggregateResults.partialAnswers,
-        aggregateResults.numInteractions,
-        { goodRatioThreshold: 0.05, okRatioThreshold: 0.2 }
-    )
+    logResult('Incorrect answers (LLM judge)', aggregateResults.incorrectAnswers, aggregateResults.numInteractions, {
+        goodRatioThreshold: 0.05,
+        okRatioThreshold: 0.2,
+    })
+    logResult('Partial answers (LLM judge)', aggregateResults.partialAnswers, aggregateResults.numInteractions, {
+        goodRatioThreshold: 0.05,
+        okRatioThreshold: 0.2,
+    })
     logResult('Missing facts', aggregateResults.missingFacts, aggregateResults.facts, {
         goodRatioThreshold: 0.05,
         okRatioThreshold: 0.2,

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -1,4 +1,5 @@
 import { CodebaseContext } from '../codebase-context'
+import { QueryExpander } from '../codebase-context/query-expansion'
 import { ConfigurationWithAccessToken } from '../configuration'
 import { Editor } from '../editor'
 import { PrefilledOptions, withPreselectedOptions } from '../editor/withPreselectedOptions'
@@ -90,7 +91,19 @@ export async function createClient({
         const embeddingsSearch = repoId
             ? new SourcegraphEmbeddingsSearchClient(graphqlClient, config.codebase || repoId, repoId, undefined, true)
             : null
-        const codebaseContext = new CodebaseContext(config, config.codebase, embeddingsSearch, null, null, null, null)
+        const codebaseContext = new CodebaseContext(
+            config,
+            config.codebase,
+            embeddingsSearch,
+            null,
+            null,
+            null,
+            null,
+            undefined,
+            undefined,
+            undefined,
+            new QueryExpander(chatClient)
+        )
 
         const intentDetector = new SourcegraphIntentDetectorClient(graphqlClient, completionsClient)
 

--- a/lib/shared/src/chat/recipes/chat-question.ts
+++ b/lib/shared/src/chat/recipes/chat-question.ts
@@ -76,8 +76,21 @@ export class ChatQuestion implements Recipe {
         this.debug('ChatQuestion:getContextMessages', 'addEnhancedContext', addEnhancedContext)
         if (addEnhancedContext) {
             const codebaseContextMessages = await codebaseContext.getCombinedContextMessages(text, numResults)
-            contextMessages.push(...codebaseContextMessages)
+
+            // TODO: Use a feature flag.
+            const useContextWithExpandedQuery = true
+            if (useContextWithExpandedQuery) {
+                const contextWithExpandedQuery = await codebaseContext.getContextWithExpandedQuery(
+                    text,
+                    numResults,
+                    codebaseContextMessages
+                )
+                contextMessages.push(...contextWithExpandedQuery)
+            } else {
+                contextMessages.push(...codebaseContextMessages)
+            }
         }
+
         const isEditorContextRequired = intentDetector.isEditorContextRequired(text)
         this.debug('ChatQuestion:getContextMessages', 'isEditorContextRequired', isEditorContextRequired)
         if (isEditorContextRequired) {

--- a/lib/shared/src/chat/useClient.ts
+++ b/lib/shared/src/chat/useClient.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CodebaseContext } from '../codebase-context'
+import { QueryExpander } from '../codebase-context/query-expansion'
 import { isErrorLike } from '../common'
 import { ConfigurationWithAccessToken } from '../configuration'
 import { Editor, NoopEditor } from '../editor'
@@ -301,7 +302,9 @@ export const useClient = ({
                 null,
                 null,
                 undefined,
-                unifiedContextFetcherClient
+                unifiedContextFetcherClient,
+                undefined,
+                new QueryExpander(chatClient)
             )
 
             const { humanChatInput = '', prefilledOptions } = options ?? {}

--- a/lib/shared/src/codebase-context/query-expansion.ts
+++ b/lib/shared/src/codebase-context/query-expansion.ts
@@ -1,0 +1,49 @@
+import { ChatClient } from '../chat/chat'
+
+import { ContextMessage } from './messages'
+
+export class QueryExpander {
+    constructor(private chatClient: ChatClient) {}
+
+    public async expandQuery(query: string, pseudoRelevantContextMessages: ContextMessage[]): Promise<string> {
+        const promptContext = pseudoRelevantContextMessages
+            .filter(message => message.speaker === 'human')
+            .map(message => message.text ?? '')
+            .join('\n\n')
+
+        const passage = await new Promise<string>((resolve, reject) => {
+            let responseText = ''
+            this.chatClient?.chat(
+                [
+                    {
+                        speaker: 'human',
+                        text: expandQueryWithContextPrompt
+                            .replace('{context}', promptContext)
+                            .replace('{query}', query),
+                    },
+                    { speaker: 'assistant', text: 'Passage:' },
+                ],
+                {
+                    onChange: (text: string) => {
+                        responseText = text
+                    },
+                    onComplete: () => {
+                        resolve(responseText.trim())
+                    },
+                    onError: (error: Error) => reject(error),
+                },
+                {
+                    temperature: 0,
+                    fast: true,
+                }
+            )
+        })
+
+        return passage
+    }
+}
+
+const expandQueryWithContextPrompt = `Write a passage that answers the given query based on the context:
+Context: {context}
+Query: {query}
+`

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { ContextGroup, ContextStatusProvider } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
+import { QueryExpander } from '@sourcegraph/cody-shared/src/codebase-context/query-expansion'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { EmbeddingsDetector } from '@sourcegraph/cody-shared/src/embeddings/EmbeddingsDetector'
@@ -392,6 +393,8 @@ async function getCodebaseContext(
         // Use local embeddings if we have them.
         ((await hasLocalEmbeddings) && localEmbeddings) || null,
         symf,
-        undefined
+        undefined,
+        undefined,
+        new QueryExpander(chatClient)
     )
 }

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -1,5 +1,6 @@
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
+import { QueryExpander } from '@sourcegraph/cody-shared/src/codebase-context/query-expansion'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
@@ -84,7 +85,9 @@ export async function configureExternalServices(
         null,
         null,
         symf,
-        undefined
+        undefined,
+        undefined,
+        new QueryExpander(chatClient)
     )
 
     const guardrails = new SourcegraphGuardrailsClient(graphqlClient)


### PR DESCRIPTION
In this PR, we experiment with query expansion as an alternative way to query embeddings for chat questions. The strategy is as follows:

- Use the original user query to get embedding results (pseudo-relevant context).
- Use the pseudo-relevant context with the original query to generate an answer (by prompting a fast LLM, which is not visible to the user).
- Use the generated answer as the new query for embeddings (relevant context).
- Use the relevant context and the original query to generate the final answer.

Additionally, I tested the query expansion strategy on embeddings with the included code header (relevant PR: https://github.com/sourcegraph/sourcegraph/pull/54568).

## Metrics

Metrics were collected using the `e2e` tool in the Cody repo. We used the test cases added in this PR and ran each test case 5 times. Here is the command: `pnpm run start --runs 5 --label "single question"`.

### Base
Incorrect answers (LLM judge): 25/60 (42%)
Partial answers (LLM judge): 12/60 (20%)
Missing facts: 53/105 (50%)
Hallucinated entities: 5/95 (5%)

### Expanded query
Incorrect answers (LLM judge): 12/60 (20%)
Partial answers (LLM judge): 16/60 (27%)
Missing facts: 42/105 (40%)
Hallucinated entities: 11/94 (12%)

### Base w/ code header embeddings
Incorrect answers (LLM judge): 20/60 (33%)
Partial answers (LLM judge): 25/60 (42%)
Missing facts: 61/105 (58%)
Hallucinated entities: 7/68 (10%)

### Expanded query w/ code header embeddings
Incorrect answers (LLM judge): 14/60 (23%)
Partial answers (LLM judge): 16/60 (27%)
Missing facts: 33/105 (31%)
Hallucinated entities: 20/132 (15%)

## Discussion

_We collected the metrics on only 12 test cases. We'd need at least 10-20 additional test cases for a reliable interpretation of the results._

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
_TODO_