### PR TITLE
Don't duplicate @-filenames when pressing tab if the whole string has been typed

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -261,7 +261,9 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 const symbolName = isFileType ? '' : `#${selected.fileName}`
                 // Add empty space at the end to end the file matching process
                 const fileDisplayText = `@${selected.path?.relative}${range}${symbolName}`
-                const inputSuffix = input.slice(input.lastIndexOf(fileDisplayText), -1)
+                const inputSuffix = input.includes(fileDisplayText)
+                    ? input.slice(input.lastIndexOf(fileDisplayText) + fileDisplayText.length, -1)
+                    : ''
                 const newInput = `${inputPrefix}${fileDisplayText}${inputSuffix} `
 
                 // we will use the newInput as key to check if the file still exists in formInput on submit

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: You can @-mention files starting with a dot. [pull/2209](https://github.com/sourcegraph/cody/pull/2209)
+- Chat: Typing a complete filename when @-mentioning files and then pressing `<tab>` will no longer duplicate the filename [pull/2218](https://github.com/sourcegraph/cody/pull/2218)
 - Autocomplete: Fixes an issue where changing user accounts caused some configuration issues. [pull/2182](https://github.com/sourcegraph/cody/pull/2182)
 - Fixes an issue where focusing the VS Code extension window caused unexpected errors when connected to an Enterprise instance. [pull/2182](https://github.com/sourcegraph/cody/pull/2182)
 - Chat: You can @-mention files on Windows without generating an error. [pull/2197](https://github.com/sourcegraph/cody/pull/2197)

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -57,4 +57,12 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await expect(
         chatPanelFrame.getByText('Explain @lib/batches/env/var.go and @lib/codeintel/tools/lsif-visualize/visualize.go')
     ).toBeVisible()
+
+    // Check pressing tab after typing a complete filename.
+    // https://github.com/sourcegraph/cody/issues/2200
+    await chatInput.focus()
+    await chatInput.clear()
+    await chatInput.type('@Main.java', { delay: 50 })
+    await chatInput.press('Tab')
+    await expect(chatInput).toHaveValue('@Main.java ')
 })


### PR DESCRIPTION
This code was using `input.lastIndexOf(fileDisplayText)` to find the location of the text to compute the suffix, but it didn't take into account the length, so any time input contained fileDisplayText, the contents of fileDisplayText would become duplicated.

(@abeatrix the original code was added as part of a fix for https://github.com/sourcegraph/cody/issues/1973 - in my testing that still seems to work correctly with my change, but let me know if I've misunderstood).

Fixes https://github.com/sourcegraph/cody/issues/2200


## Test plan

- Run `pnpm test:unit at-file` or
- Open the chat window
- Type "@" followed by a **complete** filename including the very last character
- Press `<tab>` to accept the file
- Ensure the chat input does not contain the filename duplicated
