### PR TITLE
Mark Upgrade/Usage links as dot-com only

### DIFF
--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
 import { AuthStatus } from '../chat/protocol'
 
@@ -54,6 +55,13 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
         const updatedTree: vscode.TreeItem[] = []
         this.treeNodes = updatedTree // Set this before any awaits so last call here always wins regardless of async scheduling.
         for (const item of this.treeItems) {
+            if (item.requireDotCom) {
+                const isConnectedtoDotCom = this.authStatus?.endpoint && isDotCom(this.authStatus?.endpoint)
+                if (!isConnectedtoDotCom) {
+                    continue
+                }
+            }
+
             if (item.requireFeature && !(await this.featureFlagProvider.evaluateFeatureFlag(item.requireFeature))) {
                 continue
             }

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -20,6 +20,7 @@ export interface CodySidebarTreeItem {
     isNestedItem?: string
     requireFeature?: FeatureFlag
     requireUpgradeAvailable?: boolean
+    requireDotCom?: boolean
 }
 
 /**
@@ -65,6 +66,7 @@ const supportItems: CodySidebarTreeItem[] = [
         description: 'Upgrade to Pro',
         icon: 'zap',
         command: { command: 'cody.show-page', args: ['upgrade'] },
+        requireDotCom: true,
         requireUpgradeAvailable: true,
         requireFeature: FeatureFlag.CodyPro,
     },
@@ -72,6 +74,7 @@ const supportItems: CodySidebarTreeItem[] = [
         title: 'Usage',
         icon: 'pulse',
         command: { command: 'cody.show-page', args: ['usage'] },
+        requireDotCom: true,
         requireFeature: FeatureFlag.CodyPro,
     },
     {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/2203

@kalanchan I don't have an enterprise account, are you able to test they're not showing now?

I'm also assuming the issue was specifically for the sidebar, but let me know if not (the other places tied to rate limiting are supposed to appear based on the presence of the Pro header that shouldn't exist for non-dot-com users).

## Test plan

- Login as a dotCom user
- Verify Usage link is visible in sidebar (and if not Pro, the Upgrade link)
- Login as enterprise user
- Verify both links are not visible

