### PR TITLE
Replace "Sign Out" with an account dialog

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -92,11 +92,15 @@ To run the agent in testing mode, define the following environment variables:
 Run `pnpm run agent jsonrpc --help` to get more information about all available
 `--recording-*` options.
 
-## Updating agent tests
+## Updating the Polly HTTP Recordings
 
-If agent tests are failing in CI for non-agent related PRs then you may need to update
-the HTTP recordings. For example, this can happen when we make changes to the prompt
-the agent test to not be able to replay the autocomplete requests from old reordigns.
+If agent tests are failing in CI for non-agent related PRs (e.g. `PollyError:
+[Polly] [adapter:node-http] Recording for the following request is not found and
+recordIfMissing is false` errors) then you may need to update the HAR HTTP
+recordings. For example, this can happen when we make changes to the prompt the
+agent test to not be able to replay the autocomplete requests from old
+recordings.
+
 To fix this problem, update the HTTP recordings with the following command:
 
 ```sh
@@ -107,10 +111,10 @@ CODY_RECORDING_MODE=record pnpm run test      # run tests to update recordings
 pnpm run test                                 # confirm that tests are passing when replaying HTTP traffic
 ```
 
-Please post in #wg-cody-agent if you have problems getting the agent tests to pass after recording.
-Worst case, feel free to disable the agent tests by uncomming a block of code in
-`index.test.ts`. Ssee comment in the code for more details about how to disable
-agent tests.
+Please post in #wg-cody-agent if you have problems getting the agent tests to
+pass after recording. Worst case, feel free to disable the agent tests by
+uncommenting the block of code in `index.test.ts`. See comment in the code for
+more details about how to disable agent tests.
 
 ## Miscellaneous notes
 

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -55,7 +55,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 324,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -72,35 +72,35 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteProductVersion"
         },
         "response": {
-          "bodySize": 136,
+          "bodySize": 146,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 136,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxuYmFvFGBkbGuoZGugYW8aZ6RroGacYppoaGFoYpqYlKtbW1AAAAAP//AwDACBkySQAAAA==\"]"
+            "size": 146,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxuYmFvFGBkbGuoZGugYW8aZ6RroGacYppoaGFoYpqYlKtbU=\",\"tQAAAAD//w==\",\"AwDACBkySQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:33.000Z",
+              "expires": "2024-12-11T08:59:22.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8d485024-2599-4bd2-b14f-fa18c58788f2"
+              "value": "ee1d2b05-eb94-4a1a-b3c1-9b8e3578ed6f"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:33.000Z",
+              "expires": "2023-12-11T09:29:22.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "dT.M9QJ8V0zgMKf4BIGpezv0E0igyB3kAayBzgHwrQw-1702277433-0-AYBV/vxngW2UiSD79vIVP4gDr09giXqyDy71z+Xg5JNAEPpU0zEeUm+o9uq6xODE3vzgthA/F3ajzWUnmauR488="
+              "value": "86VfBgdg2Lo3kxHwMKM4bFJFnXxIGioXEVSFOWFVekE-1702285162-0-AVl8YOCAtNfbqtJOKHeSKd+I301xzjiEVwiyG78UhrNLFzUtMnISAV63I4lpiJD/W3Xr0vckzJKSjLl6yhCjr20="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:22 GMT"
             },
             {
               "name": "content-type",
@@ -124,7 +124,7 @@
             },
             {
               "name": "retry-after",
-              "value": "152"
+              "value": "476"
             },
             {
               "name": "access-control-allow-credentials",
@@ -141,12 +141,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8d485024-2599-4bd2-b14f-fa18c58788f2; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=ee1d2b05-eb94-4a1a-b3c1-9b8e3578ed6f; Expires=Wed, 11 Dec 2024 08:59:22 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=dT.M9QJ8V0zgMKf4BIGpezv0E0igyB3kAayBzgHwrQw-1702277433-0-AYBV/vxngW2UiSD79vIVP4gDr09giXqyDy71z+Xg5JNAEPpU0zEeUm+o9uq6xODE3vzgthA/F3ajzWUnmauR488=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=86VfBgdg2Lo3kxHwMKM4bFJFnXxIGioXEVSFOWFVekE-1702285162-0-AVl8YOCAtNfbqtJOKHeSKd+I301xzjiEVwiyG78UhrNLFzUtMnISAV63I4lpiJD/W3Xr0vckzJKSjLl6yhCjr20=; path=/; expires=Mon, 11-Dec-23 09:29:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -162,15 +162,15 @@
             },
             {
               "name": "x-trace",
-              "value": "9010588174884c4371a52ad13fe5e218"
+              "value": "01a73b55d1537870f61857c8358e7e2a"
             },
             {
               "name": "x-trace-span",
-              "value": "45e36fd9f89d139f"
+              "value": "8bb9df81a8186865"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9010588174884c4371a52ad13fe5e218"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/01a73b55d1537870f61857c8358e7e2a"
             },
             {
               "name": "x-xss-protection",
@@ -194,7 +194,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb442a69f65d-NRT"
+              "value": "833c87f87e194ffd-MEL"
             },
             {
               "name": "content-encoding",
@@ -207,8 +207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:32.846Z",
-        "time": 252,
+        "startedDateTime": "2023-12-11T08:59:22.056Z",
+        "time": 315,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -216,7 +216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 252
+          "wait": 315
         }
       },
       {
@@ -267,7 +267,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 324,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -284,247 +284,35 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
         },
         "response": {
-          "bodySize": 222,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 222,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lw=\",\"JKetpnU5wSuJLuVnZyqzxkHf0ANHH7DjRnVqCS07NR26KzljTYMGUby3FsV3wZERa9gEmbj1HNQiBvicfQEAAP//\",\"AwBhzrhaoAAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "44b32adc-6eca-44ad-93a8-f659a2f612c0"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "r9G6RDXxk6cPNHu5y.SHJvdgaxf1ITJOg7up7XMCr2k-1702277433-0-AeqH1UHbxtBgNgTyGqUIBIz1U5ohzxcWUAzb0GHIOPRkU3iN05VNoUhaVAE3FwlQkVN3ijicxdgH1R2DHK2F8+w="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "152"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=44b32adc-6eca-44ad-93a8-f659a2f612c0; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=r9G6RDXxk6cPNHu5y.SHJvdgaxf1ITJOg7up7XMCr2k-1702277433-0-AeqH1UHbxtBgNgTyGqUIBIz1U5ohzxcWUAzb0GHIOPRkU3iN05VNoUhaVAE3FwlQkVN3ijicxdgH1R2DHK2F8+w=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ebf66b46363231c83128baa13cb67d10"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "cf756c9ecf1492c5"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ebf66b46363231c83128baa13cb67d10"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb472c7aafab-NRT"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:33.348Z",
-        "time": 226,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 226
-        }
-      },
-      {
-        "_id": "26f7093bcc1d125e7768f46a33e590e8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 318,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "318"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 337,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
           "bodySize": 212,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
             "size": 212,
-            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:33.000Z",
+              "expires": "2024-12-11T08:59:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5e2e81db-a356-4b2d-8f7b-675e1f58de82"
+              "value": "96146077-728f-482b-aada-5fb1844a86ba"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:33.000Z",
+              "expires": "2023-12-11T09:29:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8lBCm7ws914gJndDvUIjznIu.oaRo5ZPzOjCAL5arLw-1702277433-0-AfPzyrOEo8ohGOEsQFv2kzDnCxRX7iy9jr2XVoYqn2esujkFZZoPbFk2Yi1Ook8O+9r5lCA59TZnnOdXuaGkhzA="
+              "value": "dLxQ0A.FNDy326eUqXB3zcBjVtvh_51zxP5SHnjW8Uk-1702285163-0-Ac37SxnJzwgR25Kr7iyX8o7o2ASN2LMNetpOb7Z3qmBeYvdYQOZm+KwNDaDRZVuy306wzAJnhgRoJf+kn9hmcZM="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:23 GMT"
             },
             {
               "name": "content-type",
@@ -548,7 +336,7 @@
             },
             {
               "name": "retry-after",
-              "value": "152"
+              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -565,12 +353,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5e2e81db-a356-4b2d-8f7b-675e1f58de82; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=96146077-728f-482b-aada-5fb1844a86ba; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=8lBCm7ws914gJndDvUIjznIu.oaRo5ZPzOjCAL5arLw-1702277433-0-AfPzyrOEo8ohGOEsQFv2kzDnCxRX7iy9jr2XVoYqn2esujkFZZoPbFk2Yi1Ook8O+9r5lCA59TZnnOdXuaGkhzA=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=dLxQ0A.FNDy326eUqXB3zcBjVtvh_51zxP5SHnjW8Uk-1702285163-0-Ac37SxnJzwgR25Kr7iyX8o7o2ASN2LMNetpOb7Z3qmBeYvdYQOZm+KwNDaDRZVuy306wzAJnhgRoJf+kn9hmcZM=; path=/; expires=Mon, 11-Dec-23 09:29:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -586,15 +374,15 @@
             },
             {
               "name": "x-trace",
-              "value": "99cce8e34f938820d32cb83fcc66036c"
+              "value": "c36812171614f0118261b74172ee63e8"
             },
             {
               "name": "x-trace-span",
-              "value": "9bf0de4dacf359b7"
+              "value": "351deba02a0d3023"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/99cce8e34f938820d32cb83fcc66036c"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c36812171614f0118261b74172ee63e8"
             },
             {
               "name": "x-xss-protection",
@@ -618,7 +406,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb472a06afbe-NRT"
+              "value": "833c87fd2b8b1f6e-MEL"
             },
             {
               "name": "content-encoding",
@@ -631,8 +419,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:33.354Z",
-        "time": 231,
+        "startedDateTime": "2023-12-11T08:59:22.821Z",
+        "time": 292,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -640,7 +428,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 231
+          "wait": 292
         }
       },
       {
@@ -691,7 +479,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 337,
+          "headersSize": 354,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -717,26 +505,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:33.000Z",
+              "expires": "2024-12-11T08:59:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "4130c925-ebb0-489f-a6a8-24995ddd4c2c"
+              "value": "e14b07ae-2118-4903-b544-a653f4670a1b"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:33.000Z",
+              "expires": "2023-12-11T09:29:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "x5frC_SNYUvG6Whzk96EvzjezBEvX_s45fVSjuhT3V0-1702277433-0-ASyP+T8FeRJFDO/axGDnmmSVZQU3Lawn7kFF7zL9xFlt7PbpOEq/JsTrjGQ3TjUsW7S8pkdx+UKnB8eVNdbolZk="
+              "value": "eok8nhisOwypyNxZUuBi3evOAURv6KbD7uMqXRA_jEY-1702285163-0-Ae1lQ3bz0uHmzKyVXB2QNj62zQzkFlohkiUq3NnOd97t0QWntKDwb7FJsEIB7NiQ4SmfaPPx0QCLznSX1XfKWQs="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:23 GMT"
             },
             {
               "name": "content-type",
@@ -760,7 +548,7 @@
             },
             {
               "name": "retry-after",
-              "value": "152"
+              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -777,12 +565,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4130c925-ebb0-489f-a6a8-24995ddd4c2c; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=e14b07ae-2118-4903-b544-a653f4670a1b; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=x5frC_SNYUvG6Whzk96EvzjezBEvX_s45fVSjuhT3V0-1702277433-0-ASyP+T8FeRJFDO/axGDnmmSVZQU3Lawn7kFF7zL9xFlt7PbpOEq/JsTrjGQ3TjUsW7S8pkdx+UKnB8eVNdbolZk=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=eok8nhisOwypyNxZUuBi3evOAURv6KbD7uMqXRA_jEY-1702285163-0-Ae1lQ3bz0uHmzKyVXB2QNj62zQzkFlohkiUq3NnOd97t0QWntKDwb7FJsEIB7NiQ4SmfaPPx0QCLznSX1XfKWQs=; path=/; expires=Mon, 11-Dec-23 09:29:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -798,15 +586,15 @@
             },
             {
               "name": "x-trace",
-              "value": "6cd41fb7864e8e5a83404c6cc4f66f40"
+              "value": "998e9aa87e92606776073236e837b50d"
             },
             {
               "name": "x-trace-span",
-              "value": "0bbb0f881d6ed8c3"
+              "value": "e7b70f14f2886058"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6cd41fb7864e8e5a83404c6cc4f66f40"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/998e9aa87e92606776073236e837b50d"
             },
             {
               "name": "x-xss-protection",
@@ -830,7 +618,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb4728326875-NRT"
+              "value": "833c87fd3daa299f-MEL"
             },
             {
               "name": "content-encoding",
@@ -843,8 +631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:33.355Z",
-        "time": 231,
+        "startedDateTime": "2023-12-11T08:59:22.826Z",
+        "time": 288,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -852,7 +640,219 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 231
+          "wait": 288
+        }
+      },
+      {
+        "_id": "26f7093bcc1d125e7768f46a33e590e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 318,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "318"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:23.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "bb3700b5-833b-4e65-aed6-f52e2fd05666"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "8w1ED0jce0bZ618aDpWXFt7N_asMrsRk2EBY2Dtvl4c-1702285163-1-AZdmQ5tkIvlaxBGPE0tqhy9yo1ApaBn8Wn7aE0bqTuVawHRmjELtPecnx4Uq2mfUzbNFuXG+UP/Tc0AACNpJmxk="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "475"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=bb3700b5-833b-4e65-aed6-f52e2fd05666; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=8w1ED0jce0bZ618aDpWXFt7N_asMrsRk2EBY2Dtvl4c-1702285163-1-AZdmQ5tkIvlaxBGPE0tqhy9yo1ApaBn8Wn7aE0bqTuVawHRmjELtPecnx4Uq2mfUzbNFuXG+UP/Tc0AACNpJmxk=; path=/; expires=Mon, 11-Dec-23 09:29:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "07e876ad565f40ed4fcbc3e975ef6d90"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5674a9e71daace65"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/07e876ad565f40ed4fcbc3e975ef6d90"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c87fd3dbe5ac8-MEL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:22.825Z",
+        "time": 296,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 296
         }
       },
       {
@@ -903,7 +903,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 317,
+          "headersSize": 334,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -920,35 +920,35 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
         },
         "response": {
-          "bodySize": 302,
+          "bodySize": 276,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 302,
-            "text": "[\"H4sIAAAAAAAAAyyOy07DMBREfwXNOkooohtLEaDSHRSESMX21r5tjPyIru2KKMq/oxB2M2cxZyYYygQ1QRcRDrlLLEu1BgrHr4PT33Hz9tk=\",\"/bw+tS0q9JSOLPZs2ew9WQeVpXAFY9PgaDyQZyg8R2+D1Te7GAOPqEBXyiTdxwsU+pyHpJpmZam+2NyXU0ksOobMIdc6+qY02+3m7vbh2t6jgo5mfJe4D3RybKDO5BJXGMR6kvH/yQReA8zqr/Wf//Gy4GUV8zzPvwAAAP//\",\"AwDJyTrR9AAAAA==\"]"
+            "size": 276,
+            "text": "[\"H4sIAAAAAAAAAzSOPWvDQBBE/0qYWliYJM2BiBt3RgnBNmnXd2vrzH2IvT0HIfTfg3Hczbxi3sxwpAQzw1YRTnooLPfqHQyOP32w17z+3Nup/+06NBioHFn82bPbRvIBRqVyA+fLGGjqKTIM9j6+7KqlggZ0IyU5fO9gMKiOxbTtg5XVxetQT7Ww2JyUk65sjm1t1++vH7fuDQ1sdtOX5G2iU2D3tI3iI8n0/2AGPwJ0ozmHSEl9vE9hWZblDwAA//8DAD3SxSPkAAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:33.000Z",
+              "expires": "2024-12-11T08:59:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "49dcee37-4728-401a-adfd-e03c0af88671"
+              "value": "62322717-0b76-4221-a1bf-4bb5af5a6c98"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:33.000Z",
+              "expires": "2023-12-11T09:29:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8oEWw3v5nm07ajlTY7EJxk08za0nRDjYkrLMCdKxI0M-1702277433-0-ActY6sutPoyH8gBBAw9kgUbxwd0a6ONbw9qAKuvFf844gsUifC+V3BHFBnb/u7hkObwcfb3T5hpff1cQeT9vp0U="
+              "value": "xz6n_waHOlbEx2kD3c9mMWdX1uXAilRiphF5NBmZ5z0-1702285164-0-AcZ6XKz5cShXemUR7tXlw2HRS74E71PSg5UeVaXhQ0weRpB0xRga5uf3fMgm/BIjULYsKXY0Y2P3kkG42fL4FpQ="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
             },
             {
               "name": "content-type",
@@ -972,7 +972,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -989,12 +989,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=49dcee37-4728-401a-adfd-e03c0af88671; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=62322717-0b76-4221-a1bf-4bb5af5a6c98; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=8oEWw3v5nm07ajlTY7EJxk08za0nRDjYkrLMCdKxI0M-1702277433-0-ActY6sutPoyH8gBBAw9kgUbxwd0a6ONbw9qAKuvFf844gsUifC+V3BHFBnb/u7hkObwcfb3T5hpff1cQeT9vp0U=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=xz6n_waHOlbEx2kD3c9mMWdX1uXAilRiphF5NBmZ5z0-1702285164-0-AcZ6XKz5cShXemUR7tXlw2HRS74E71PSg5UeVaXhQ0weRpB0xRga5uf3fMgm/BIjULYsKXY0Y2P3kkG42fL4FpQ=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1010,15 +1010,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3dc138ac81bae39c8193fb6b36adafd7"
+              "value": "14fda9914859b0b794bd09d1cd6962c3"
             },
             {
               "name": "x-trace-span",
-              "value": "9247e2da8386ce20"
+              "value": "5ae8ed2976d95ce5"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3dc138ac81bae39c8193fb6b36adafd7"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/14fda9914859b0b794bd09d1cd6962c3"
             },
             {
               "name": "x-xss-protection",
@@ -1042,7 +1042,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb48ada6afab-NRT"
+              "value": "833c8801afe72b31-MEL"
             },
             {
               "name": "content-encoding",
@@ -1055,8 +1055,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:33.591Z",
-        "time": 225,
+        "startedDateTime": "2023-12-11T08:59:23.546Z",
+        "time": 304,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1064,7 +1064,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 225
+          "wait": 304
         }
       },
       {
@@ -1115,7 +1115,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1141,26 +1141,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:33.000Z",
+              "expires": "2024-12-11T08:59:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "9ffbf61d-7628-4fcf-910d-7e8377a50d30"
+              "value": "058d5eac-7716-4845-9375-f61d3d2e226c"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:33.000Z",
+              "expires": "2023-12-11T09:29:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "v_UAVxHFsmeiBtm._IYeb1oMp4UYuIcNJ0zeDhbF7N8-1702277433-0-AVYeW90Ru68pJr19MM9b/v5KggvJ80MOOx3RiclsZNGQ0BUs8jfxaQ6rpBZb7sdG4ausOkj7dNzYqSsAc5Nbx3E="
+              "value": "JJtolQT7iSyg3yk4QpoxIOJ.UmrLjH3mK_foMEEASbI-1702285164-0-AVW8tKVHkYHoOPC2FQg9tEgekzwkQuR4cNgDZ57J4rdZDXR7nHfpWwdxwcSu4mfp3FWJZqjILwbOwa4AVD5tKkI="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
             },
             {
               "name": "content-type",
@@ -1184,7 +1184,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1201,12 +1201,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=9ffbf61d-7628-4fcf-910d-7e8377a50d30; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=058d5eac-7716-4845-9375-f61d3d2e226c; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=v_UAVxHFsmeiBtm._IYeb1oMp4UYuIcNJ0zeDhbF7N8-1702277433-0-AVYeW90Ru68pJr19MM9b/v5KggvJ80MOOx3RiclsZNGQ0BUs8jfxaQ6rpBZb7sdG4ausOkj7dNzYqSsAc5Nbx3E=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=JJtolQT7iSyg3yk4QpoxIOJ.UmrLjH3mK_foMEEASbI-1702285164-0-AVW8tKVHkYHoOPC2FQg9tEgekzwkQuR4cNgDZ57J4rdZDXR7nHfpWwdxwcSu4mfp3FWJZqjILwbOwa4AVD5tKkI=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1222,15 +1222,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b059060d2673d7f5f11409c7c7119c96"
+              "value": "84871854a125323bd780ab86ff3a429b"
             },
             {
               "name": "x-trace-span",
-              "value": "5c8d8f9a700af2e4"
+              "value": "c1db2f52e175ebfe"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b059060d2673d7f5f11409c7c7119c96"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/84871854a125323bd780ab86ff3a429b"
             },
             {
               "name": "x-xss-protection",
@@ -1254,7 +1254,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb48aa115ead-NRT"
+              "value": "833c8801ad612b30-MEL"
             },
             {
               "name": "content-encoding",
@@ -1267,8 +1267,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:33.583Z",
-        "time": 256,
+        "startedDateTime": "2023-12-11T08:59:23.548Z",
+        "time": 321,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1276,426 +1276,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 256
-        }
-      },
-      {
-        "_id": "457ee78ea180e105401d1713fa553a05",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 171,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "171"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "52457695-6930-4737-955d-24b57402c62c"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "XOMpwgryEXV7I4V53vpt37nhrYiPDVHuNC_uTP_fapo-1702277434-0-Aey9YtNQ2LbKaAYgwh0GL37qCKh8Yb4mfnuAFDNcDBvdw0lCTbCBFcQvZlB4bqIQfdgeeF3jMqE34+F7e/1Xdso="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "151"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=52457695-6930-4737-955d-24b57402c62c; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=XOMpwgryEXV7I4V53vpt37nhrYiPDVHuNC_uTP_fapo-1702277434-0-Aey9YtNQ2LbKaAYgwh0GL37qCKh8Yb4mfnuAFDNcDBvdw0lCTbCBFcQvZlB4bqIQfdgeeF3jMqE34+F7e/1Xdso=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6de366e001620b44c77a326ad0118592"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1fc6496523929b71"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6de366e001620b44c77a326ad0118592"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb4a3be9dfdd-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:33.836Z",
-        "time": 266,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 266
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 318,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 735,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 735,
-            "text": "[\"H4sIAAAAAAAA/4xVUXLrOAy7i7/LC+QAvcTOftASYnMiSy5JJfF2evcdJZn3Jq9Pcb8FQ4AI0J9DZOfh8DngzKmyI76DvSreE082HP75HA==\",\"Mi8YDkMocaMLRgoz+/A2NDyGw5GT4evtF2xMZaSVJ5BdxMNMrGAjm4t6qG79Lw2sYaZ5G1Xib5hrfULJlOtKVvWMjZB5TIh90pvqVUuX7wbg6iWUZU1wUMSRa3IyZw0lQh+SyErVgEl5nfsX8khnMfGi5KUqXcRnysUxlnKyvq27eeV8kjx1YZOuoXtYVuQmeEfh46pQsiM7jWyIlDhPFOEILiXvvOfTc914rk7jcaJFrrvDaBHilLou7iMlcwUvkieaxGlM7XDnEywjImmp3oc+zGdc6ITtUvSF3Ae2XDLUZln3SCPGOvXpHAkLXDfCdS3qryPZWkZLCSdy2Iu+KTsoySJuhGsAIiIdW/pg/hSl/VH2kv8yjvRfwWnHzPMtW+ZFAi01uSTJLUK3Iyn5xXpoOVM2v6OFs5Nt2flKs0xzkmn+gd0WPpOIkbWrmEOAGXk5IRtJDqlGkGRzzgEkEdnlKOgzfPfsyuFn6hBvu0MRZEV/X3y/ojW4tr2b2JHDtuNPWmOOkpo29Pvyl/GJ3dqmCFtIraDlSKviLKUaKT4q7NWa/6gSTreI+X1DtrBy9bk9a2h/IKoGfW39T/p/v77+DwAA//8RG8BUywYAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6ad6fca0-0dde-46c9-a9ac-de00bacf2fb2"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Uxfa3l9lHGPey1Xz1dJJIX3DykiqwEkFDprz2ob012g-1702277434-0-AU4p9601mi314lLd7h0wzNgyQsMqrSuNLPDH4t1BdgPN/JBhRa0Ci6wbp+qfhKzeLlkKux9OcTbbPESA6jRJXmE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "151"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6ad6fca0-0dde-46c9-a9ac-de00bacf2fb2; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Uxfa3l9lHGPey1Xz1dJJIX3DykiqwEkFDprz2ob012g-1702277434-0-AU4p9601mi314lLd7h0wzNgyQsMqrSuNLPDH4t1BdgPN/JBhRa0Ci6wbp+qfhKzeLlkKux9OcTbbPESA6jRJXmE=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "54272d4302ccefaf061bd0201c0e5d71"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f60af9e9d38f96e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/54272d4302ccefaf061bd0201c0e5d71"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb4a39c9f619-NRT"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:33.831Z",
-        "time": 304,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 304
+          "wait": 321
         }
       },
       {
@@ -1746,7 +1327,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1763,34 +1344,34 @@
           "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 38,
+          "bodySize": 37,
           "content": {
             "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:34.000Z",
+              "expires": "2024-12-11T08:59:24.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2a828fe1-37ce-48d6-ae17-99088587b27c"
+              "value": "b546b5a9-1d21-4232-8618-76dd93cae311"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
+              "expires": "2023-12-11T09:29:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "X4HjnDgYgimPccDuwWZ9f9XmRkK9PDc3Iv3wfFdM4XY-1702277434-0-AbOpDSk4WshA2iE+zZ7XhKeTrV5AcOPJ7ziV74a/rXQWmUwDYp/cokVS4/3dlOLV3b7FTnVQ3eU1oFqEY+vuPR4="
+              "value": "vfqjViaYlggjJbWLcmuN0dLNlxux35GyLpCOUv1ZfXw-1702285164-0-AVCUnYFQ9N9mQa+zTo2Kxbw+GV/zmY5w9qwPw0Yhj2StXWu/brmGfCx/KjZxHm1BirluTUrfu4PEtNszvji/1Ls="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
             },
             {
               "name": "content-type",
@@ -1798,7 +1379,7 @@
             },
             {
               "name": "content-length",
-              "value": "38"
+              "value": "37"
             },
             {
               "name": "connection",
@@ -1814,7 +1395,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1831,12 +1412,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2a828fe1-37ce-48d6-ae17-99088587b27c; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=b546b5a9-1d21-4232-8618-76dd93cae311; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=X4HjnDgYgimPccDuwWZ9f9XmRkK9PDc3Iv3wfFdM4XY-1702277434-0-AbOpDSk4WshA2iE+zZ7XhKeTrV5AcOPJ7ziV74a/rXQWmUwDYp/cokVS4/3dlOLV3b7FTnVQ3eU1oFqEY+vuPR4=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=vfqjViaYlggjJbWLcmuN0dLNlxux35GyLpCOUv1ZfXw-1702285164-0-AVCUnYFQ9N9mQa+zTo2Kxbw+GV/zmY5w9qwPw0Yhj2StXWu/brmGfCx/KjZxHm1BirluTUrfu4PEtNszvji/1Ls=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1852,15 +1433,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c07e421b10503f87fdc23975e7bc6f28"
+              "value": "8a00151cdf548252403e09f2ff26a99e"
             },
             {
               "name": "x-trace-span",
-              "value": "6d769ded3ba895b8"
+              "value": "7ab5d5316fc236c2"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c07e421b10503f87fdc23975e7bc6f28"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a00151cdf548252403e09f2ff26a99e"
             },
             {
               "name": "x-xss-protection",
@@ -1884,7 +1465,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb4a3989f629-NRT"
+              "value": "833c8803a8ff2b34-MEL"
             }
           ],
           "headersSize": 1236,
@@ -1893,8 +1474,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:33.833Z",
-        "time": 340,
+        "startedDateTime": "2023-12-11T08:59:23.859Z",
+        "time": 295,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1902,7 +1483,426 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 340
+          "wait": 295
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 335,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 715,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 715,
+            "text": "[\"H4sIAAAAAA==\",\"AAD/lJRRbvM4DITv4ufyAjlAL7HYB5qa2ERkySWpJEbRuy/sFPvjL2CneTOgoUyOvuFnlzi4O312uHJuHEjv4GiG98yDd6d/PrvCE7pT52CTkeqtwHzUuXvr1hJ0p7CGr7f/hVLTQjf05JrQsx0LuUWVOs0ZAcpchsbD+hEosuyWDjbL7uF3p1JLoAT17Ejb1ZQQkNBa/tSeOftxU2kpPKnQ1HJo1gL6PtJafP8iFoE7Rb2gOGmR3BJIiwcXAWlCCT0r9v0xXi3RScMJdwESEp2rUcBDy7D/728HjMvlL91Po3QobSZvdsVCKNxnpP1bAxkTwhbCfa4Wxw8rIwdNVS5bu7vaj6ZyIQ+2oKjNtgG5xbjaIyuQ1Bx2YPT6zsYej2dRLkG+lOA7jTqMWYfxV2Yl9O1Atc2E+wzTCSU4P8NvXHrTtKt6uE0eBp60DDRoUJ/Xw6fBQtKoRgbRGb6rn62mJkHeehfTeQOWDJxg5LCrCohFaivxSiC2YN2D+vNAk96xP+Ra+1LUcOaWY8NB6trmw0Xy2kwwGM/js8TpautZMygM+2b2ufY0r7vGbxoyEhvYycdqIS0OefvZdhjLYc4eRBTc6ILlVu0gZL835YW9mtQ32gyySF5pq2eaDVetbSXio8GfjjxbfRG11xhbyV6Xxi9knH/G79+vr/8CAAD//2YV22fMBgAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:24.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1cf536bf-d79f-43ae-a424-cd5b2f699936"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:24.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "3cm0C0ZfJYMEOizLwFrGaNqKumenW0Xq6Vrq7oFYP2g-1702285164-0-AcKM08aA0dFOPItGR1SbpGnGm/FD3bnEVzPbHMtQkhkosYmDNKsPczV4O6wriwuQFTGk1RbMXhap9KKC/o0YT2w="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "474"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1cf536bf-d79f-43ae-a424-cd5b2f699936; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=3cm0C0ZfJYMEOizLwFrGaNqKumenW0Xq6Vrq7oFYP2g-1702285164-0-AcKM08aA0dFOPItGR1SbpGnGm/FD3bnEVzPbHMtQkhkosYmDNKsPczV4O6wriwuQFTGk1RbMXhap9KKC/o0YT2w=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "162c8d984da26894a35692e3ba197cf1"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "b36e1b309ba62136"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/162c8d984da26894a35692e3ba197cf1"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c880399a45aa8-MEL"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:23.858Z",
+        "time": 303,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 303
+        }
+      },
+      {
+        "_id": "457ee78ea180e105401d1713fa553a05",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 171,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "171"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:24.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "98d95c76-a514-4b1e-a482-f68946b50429"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:24.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ssDRDPnQ3bnJ4Nso6wYISPE7sYB6DQtoRcaUkTonrtc-1702285164-1-AV+fJbT3SIwTHA4QAbrFzKDqmFluTfEwFQqheWoof+yNfLa+ktZGyYS5xMe0vkOgYinZLdgJRA2D1e2jwOXx9zo="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "474"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=98d95c76-a514-4b1e-a482-f68946b50429; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ssDRDPnQ3bnJ4Nso6wYISPE7sYB6DQtoRcaUkTonrtc-1702285164-1-AV+fJbT3SIwTHA4QAbrFzKDqmFluTfEwFQqheWoof+yNfLa+ktZGyYS5xMe0vkOgYinZLdgJRA2D1e2jwOXx9zo=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1fb4e7c93cfe1f6a9f0971ec1471bfc7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "7d03bcb2e1002932"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1fb4e7c93cfe1f6a9f0971ec1471bfc7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c8803ad7929a3-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:23.861Z",
+        "time": 633,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 633
         }
       },
       {
@@ -1953,7 +1953,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1978,26 +1978,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:34.000Z",
+              "expires": "2024-12-11T08:59:24.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2cc306b7-727b-4777-a533-40c99580a91d"
+              "value": "fdf7f9d1-6e1d-478e-9e5f-f58f0da944ea"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
+              "expires": "2023-12-11T09:29:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "PFdCQrXr2jPw3pJAwgIRn7VxpsU08NG.ikm19OG_KwU-1702277434-0-AQKTeVAunCxDzyL67ght5FjpVicFHnAqVo9lwu2cmj1Fc4+Nx4OZxUBSjPza/zGtKi1kS8bDXP3UL6I00QyvAT0="
+              "value": "d0kZP0csEMYQLJEb6sqoKurOeU6oGBmeIf4PSOnk0ZE-1702285164-0-AVagRR6gdYhN68cisfOJDdnJr8T8cBQRPtSbwlXlV9bhJXyj62bUDEbeWEW5fLZmEVUbZqq+AbaTKzHw4JEhoMo="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
             },
             {
               "name": "content-type",
@@ -2021,7 +2021,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2038,12 +2038,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2cc306b7-727b-4777-a533-40c99580a91d; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=fdf7f9d1-6e1d-478e-9e5f-f58f0da944ea; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=PFdCQrXr2jPw3pJAwgIRn7VxpsU08NG.ikm19OG_KwU-1702277434-0-AQKTeVAunCxDzyL67ght5FjpVicFHnAqVo9lwu2cmj1Fc4+Nx4OZxUBSjPza/zGtKi1kS8bDXP3UL6I00QyvAT0=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=d0kZP0csEMYQLJEb6sqoKurOeU6oGBmeIf4PSOnk0ZE-1702285164-0-AVagRR6gdYhN68cisfOJDdnJr8T8cBQRPtSbwlXlV9bhJXyj62bUDEbeWEW5fLZmEVUbZqq+AbaTKzHw4JEhoMo=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2059,15 +2059,15 @@
             },
             {
               "name": "x-trace",
-              "value": "434e925963e81a329cb43df3adcea77e"
+              "value": "8ccba42b21af24ae72843ded3eafa449"
             },
             {
               "name": "x-trace-span",
-              "value": "d98fbb63327a3ace"
+              "value": "772d96c30c217bd9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/434e925963e81a329cb43df3adcea77e"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8ccba42b21af24ae72843ded3eafa449"
             },
             {
               "name": "x-xss-protection",
@@ -2091,7 +2091,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb4c19998a27-NRT"
+              "value": "833c8807aa8929b9-MEL"
             }
           ],
           "headersSize": 1236,
@@ -2100,8 +2100,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.120Z",
-        "time": 258,
+        "startedDateTime": "2023-12-11T08:59:24.503Z",
+        "time": 289,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2109,628 +2109,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 258
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "4a34ca04-f685-4fd4-8d87-54ff7151c1c5"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OTfiKqBn.mPdaxh8ec8tiQHtBOR704EVn_WN5dGA__g-1702277434-0-AZagjBvUZgYuo+P3Ye9N4KRm4IjvG29j1ettN7Q5bzZ2lHuI1QGyLvIbJX/YvjXuw+A//uwlI/kkKvkGQwf4Y0A="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "151"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4a34ca04-f685-4fd4-8d87-54ff7151c1c5; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=OTfiKqBn.mPdaxh8ec8tiQHtBOR704EVn_WN5dGA__g-1702277434-0-AZagjBvUZgYuo+P3Ye9N4KRm4IjvG29j1ettN7Q5bzZ2lHuI1QGyLvIbJX/YvjXuw+A//uwlI/kkKvkGQwf4Y0A=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "aa2c817b73b79f8d4de8dcf2779a721a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "0339ccb84c379dca"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/aa2c817b73b79f8d4de8dcf2779a721a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb4c1abc0ad8-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:34.127Z",
-        "time": 259,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 259
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "62ef6fb8-ae43-4968-8611-a70fcdd6cc28"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "3.9yJCGZdleMN8D27VMfF618nU32sAGsjKlF9SXH6Vs-1702277434-1-ATRC/ffB8RLkgQEdRTtfr22HchkldF6TE2D6DnIQet7rv+z5Wfsg0hqXnNz+AH+0syibJw0W+hN48iy9FvU3C64="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "151"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=62ef6fb8-ae43-4968-8611-a70fcdd6cc28; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=3.9yJCGZdleMN8D27VMfF618nU32sAGsjKlF9SXH6Vs-1702277434-1-ATRC/ffB8RLkgQEdRTtfr22HchkldF6TE2D6DnIQet7rv+z5Wfsg0hqXnNz+AH+0syibJw0W+hN48iy9FvU3C64=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "692561189ed9e62a77e4c68f68607a32"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d21334e7d3dcef9a"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/692561189ed9e62a77e4c68f68607a32"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb4c18ef80b4-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:34.129Z",
-        "time": 270,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 270
-        }
-      },
-      {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "9b605e72-62a1-4b17-859c-87e85b280920"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "QK6Jop9faFGHqLSzECfk30jmAhlO3DVy.yBwjlz3xmM-1702277434-0-AVHo4XYQmjSbNnHqW0iR4zRLoYzfdAkwjm7w7XZMLYbmYAHy9CQa5pkFCTzMJmnglSZ4EWMUouceMPBczN5X8DE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "151"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=9b605e72-62a1-4b17-859c-87e85b280920; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=QK6Jop9faFGHqLSzECfk30jmAhlO3DVy.yBwjlz3xmM-1702277434-0-AVHo4XYQmjSbNnHqW0iR4zRLoYzfdAkwjm7w7XZMLYbmYAHy9CQa5pkFCTzMJmnglSZ4EWMUouceMPBczN5X8DE=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "5c9355a894e8d59a59df633123636416"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1b1b1541598023e6"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5c9355a894e8d59a59df633123636416"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb4c1abaf5a3-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:34.131Z",
-        "time": 297,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 297
+          "wait": 289
         }
       },
       {
@@ -2781,7 +2160,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2806,26 +2185,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:34.000Z",
+              "expires": "2024-12-11T08:59:24.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "3646da19-3c04-4232-9407-314f1f9decd2"
+              "value": "c49f7f67-1900-436e-bcc7-4e9e9a2d38f6"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
+              "expires": "2023-12-11T09:29:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "p9KHfmtm9PcPWZnJaOmuVelm2dTDVmVOxwYSLjXlutY-1702277434-0-Ae8ISwZ8+G8V91n+iy16PnaxGrSZ4Z0+RkdWvk/hIgxUJauxupMxKa/G1MZjBDdl8it4JcTYlYh+deJX6h6Ei+0="
+              "value": "gWenXrhln63r8DR3oIw3gzDPf03QR_XyuRGfETraCb4-1702285164-1-AUaJA3o9avO5BXcsLGuwCJCl7jxR7Emp0+T4nCjCjgHM7ImzQUjMIowJfBaFyCUoNoJ0wyqRKOsQlPKcZ260Gxc="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
             },
             {
               "name": "content-type",
@@ -2849,7 +2228,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2866,12 +2245,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3646da19-3c04-4232-9407-314f1f9decd2; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=c49f7f67-1900-436e-bcc7-4e9e9a2d38f6; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=p9KHfmtm9PcPWZnJaOmuVelm2dTDVmVOxwYSLjXlutY-1702277434-0-Ae8ISwZ8+G8V91n+iy16PnaxGrSZ4Z0+RkdWvk/hIgxUJauxupMxKa/G1MZjBDdl8it4JcTYlYh+deJX6h6Ei+0=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=gWenXrhln63r8DR3oIw3gzDPf03QR_XyuRGfETraCb4-1702285164-1-AUaJA3o9avO5BXcsLGuwCJCl7jxR7Emp0+T4nCjCjgHM7ImzQUjMIowJfBaFyCUoNoJ0wyqRKOsQlPKcZ260Gxc=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2887,15 +2266,15 @@
             },
             {
               "name": "x-trace",
-              "value": "63405bdc03b5cc7640ba1e41aaa9ca0f"
+              "value": "4ec4d1b542dff4a6665dbfb98d6b3810"
             },
             {
               "name": "x-trace-span",
-              "value": "5ba00b5a90fa4895"
+              "value": "d74286f2de116108"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/63405bdc03b5cc7640ba1e41aaa9ca0f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4ec4d1b542dff4a6665dbfb98d6b3810"
             },
             {
               "name": "x-xss-protection",
@@ -2919,7 +2298,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb4c1de25c8b-NRT"
+              "value": "833c8807ae2e29a8-MEL"
             }
           ],
           "headersSize": 1236,
@@ -2928,8 +2307,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.122Z",
-        "time": 352,
+        "startedDateTime": "2023-12-11T08:59:24.504Z",
+        "time": 293,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2937,7 +2316,214 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 352
+          "wait": 293
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:24.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6e210750-5e6b-4096-97ae-82da3c0d2c59"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:25.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "wWeYGmBeVW2lumVC_vnCFmWr_ym5bmp8wr3_XIUkZl0-1702285165-0-ARC1T7QO4m3C6jvsQsT0vNrof3/on9xgwWulvzXtpv7UfKigDHcLfmUj0764Bh1WTD8Tb5mWFRQAK8I7jMVqCGs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:25 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "474"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6e210750-5e6b-4096-97ae-82da3c0d2c59; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=wWeYGmBeVW2lumVC_vnCFmWr_ym5bmp8wr3_XIUkZl0-1702285165-0-ARC1T7QO4m3C6jvsQsT0vNrof3/on9xgwWulvzXtpv7UfKigDHcLfmUj0764Bh1WTD8Tb5mWFRQAK8I7jMVqCGs=; path=/; expires=Mon, 11-Dec-23 09:29:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c088f001d424e5fc5b21ffbd05124cbd"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4fcad17cdf324ca0"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c088f001d424e5fc5b21ffbd05124cbd"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c8807adb81f5d-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:24.505Z",
+        "time": 587,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 587
         }
       },
       {
@@ -2988,7 +2574,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3013,26 +2599,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:34.000Z",
+              "expires": "2024-12-11T08:59:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1ed148e1-6724-4089-a10f-2ccc3f03d5da"
+              "value": "2a5780fa-29c7-4255-85ba-c14f89a17421"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
+              "expires": "2023-12-11T09:29:26.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "GWgmfUmBHH8LCAA3AN2M9QVZjrI6LL3a9cnOLTjoMDs-1702277434-0-AXcolrjMvjdc2ZeWHMhR+fVE+E7bxu+qblrpX5V5YIjK6qnlvk0YveYIQ82/dLaPHnsjoQpDFOqBhRBoq7N/dq4="
+              "value": "D8ke76M0JuluHPLXFgo0_SpUvYsPXfS5F9Sl4yuM.ZQ-1702285166-0-AZuR3fEfQs4xgLJnGLelzyyY2lzcaQfuagsSYzKIcaaBoNLlaqyqYTLpdpfgUfoHHGRRrYumuqvVkr/3d8c70ew="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
             },
             {
               "name": "content-type",
@@ -3056,7 +2642,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3073,12 +2659,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1ed148e1-6724-4089-a10f-2ccc3f03d5da; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=2a5780fa-29c7-4255-85ba-c14f89a17421; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=GWgmfUmBHH8LCAA3AN2M9QVZjrI6LL3a9cnOLTjoMDs-1702277434-0-AXcolrjMvjdc2ZeWHMhR+fVE+E7bxu+qblrpX5V5YIjK6qnlvk0YveYIQ82/dLaPHnsjoQpDFOqBhRBoq7N/dq4=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=D8ke76M0JuluHPLXFgo0_SpUvYsPXfS5F9Sl4yuM.ZQ-1702285166-0-AZuR3fEfQs4xgLJnGLelzyyY2lzcaQfuagsSYzKIcaaBoNLlaqyqYTLpdpfgUfoHHGRRrYumuqvVkr/3d8c70ew=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3094,15 +2680,15 @@
             },
             {
               "name": "x-trace",
-              "value": "780c89e9482497dbabc2cc87af70c8ae"
+              "value": "c23d771633a4219e462beaab8b69ea25"
             },
             {
               "name": "x-trace-span",
-              "value": "023987bba5582e04"
+              "value": "03f46c5fb9a2f84d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/780c89e9482497dbabc2cc87af70c8ae"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c23d771633a4219e462beaab8b69ea25"
             },
             {
               "name": "x-xss-protection",
@@ -3126,7 +2712,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb4c1f67afaf-NRT"
+              "value": "833c880f3bfc5aa0-MEL"
             }
           ],
           "headersSize": 1236,
@@ -3135,8 +2721,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.117Z",
-        "time": 365,
+        "startedDateTime": "2023-12-11T08:59:25.702Z",
+        "time": 303,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3144,7 +2730,421 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 365
+          "wait": 303
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:26.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "fc4df6a9-8cc3-4645-92e8-67d3160c8a98"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:26.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "52wu1Xch3cyqRGNSNq3kCFg45civ6RBAoxMKpK7ROyM-1702285166-0-ATQ++5aTyarbtHAlUv5qGPftm95pLuYEZEy96/CiRLqFSwRckfGOuum1Q6xaI/1qFDzmjFXHb9+obHbsL9Olgd8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "472"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=fc4df6a9-8cc3-4645-92e8-67d3160c8a98; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=52wu1Xch3cyqRGNSNq3kCFg45civ6RBAoxMKpK7ROyM-1702285166-0-ATQ++5aTyarbtHAlUv5qGPftm95pLuYEZEy96/CiRLqFSwRckfGOuum1Q6xaI/1qFDzmjFXHb9+obHbsL9Olgd8=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "beff7e70f1061ae2043df871535b50f4"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "aa67a835aafce6b4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/beff7e70f1061ae2043df871535b50f4"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c880f38f15a98-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:25.706Z",
+        "time": 306,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 306
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:26.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ae1bd774-b395-4c6c-99b3-1315003b8e92"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:26.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "IOLoSooewYynhcBK89nYfIoP2s3sZa6n0kdf4Sikn_Q-1702285166-0-Abuvlp3oDbfEM+6BW1SWv/Z3Zgpun54We0KQiwCZKu5sJ0L2Gyz70E5c/SSpyXxHZBFwzG+TKppM1xhvdQmH1UU="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "472"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ae1bd774-b395-4c6c-99b3-1315003b8e92; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=IOLoSooewYynhcBK89nYfIoP2s3sZa6n0kdf4Sikn_Q-1702285166-0-Abuvlp3oDbfEM+6BW1SWv/Z3Zgpun54We0KQiwCZKu5sJ0L2Gyz70E5c/SSpyXxHZBFwzG+TKppM1xhvdQmH1UU=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c4f862fd4c6ef49e65f911eb67b81a66"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "eda8409d57173c0a"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c4f862fd4c6ef49e65f911eb67b81a66"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c880f39d829c5-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:25.707Z",
+        "time": 307,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 307
         }
       },
       {
@@ -3195,7 +3195,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3212,34 +3212,34 @@
           "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 38,
+          "bodySize": 37,
           "content": {
             "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:34.000Z",
+              "expires": "2024-12-11T08:59:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c439675f-6b38-487c-b412-de619c083bf9"
+              "value": "2cde1153-690d-4b97-8734-9b95f2b8d4df"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:34.000Z",
+              "expires": "2023-12-11T09:29:26.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Q2KOA4vTN_xqPp.fn8UVKR3BRVwWsgRTp2XtA_Dgezg-1702277434-0-AYPUpV8eKVeEQVYv5J5TiKBjF6h6TcmAWBI7n9ifrILgMXkdciDheWcBptYQEv7B2lB5DhBbHXAOOEOHZXxp0ps="
+              "value": "KQgeXI9_PmUcF8S4auX.mSn9y1nJEytyXWcgBHZ1xiY-1702285166-0-AU70XEoiJH6hyU7r20BK90vWGGz+/qJDksDh+fWrRXDS7Tyy5rwcUme+JviPHdWlVNihtq/jsa1muYb0sSXwjYg="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
             },
             {
               "name": "content-type",
@@ -3247,7 +3247,7 @@
             },
             {
               "name": "content-length",
-              "value": "38"
+              "value": "37"
             },
             {
               "name": "connection",
@@ -3263,7 +3263,7 @@
             },
             {
               "name": "retry-after",
-              "value": "151"
+              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3280,12 +3280,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c439675f-6b38-487c-b412-de619c083bf9; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=2cde1153-690d-4b97-8734-9b95f2b8d4df; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=Q2KOA4vTN_xqPp.fn8UVKR3BRVwWsgRTp2XtA_Dgezg-1702277434-0-AYPUpV8eKVeEQVYv5J5TiKBjF6h6TcmAWBI7n9ifrILgMXkdciDheWcBptYQEv7B2lB5DhBbHXAOOEOHZXxp0ps=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=KQgeXI9_PmUcF8S4auX.mSn9y1nJEytyXWcgBHZ1xiY-1702285166-0-AU70XEoiJH6hyU7r20BK90vWGGz+/qJDksDh+fWrRXDS7Tyy5rwcUme+JviPHdWlVNihtq/jsa1muYb0sSXwjYg=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3301,15 +3301,15 @@
             },
             {
               "name": "x-trace",
-              "value": "dd3f978638017ee22deba22bc00cffb7"
+              "value": "58f8ed88012b522d5c7d303057877fa1"
             },
             {
               "name": "x-trace-span",
-              "value": "81531104f0c21afa"
+              "value": "d1d304b9db6123fd"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dd3f978638017ee22deba22bc00cffb7"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/58f8ed88012b522d5c7d303057877fa1"
             },
             {
               "name": "x-xss-protection",
@@ -3333,7 +3333,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb4c1c4e1d5b-NRT"
+              "value": "833c880f3b1e4ff9-MEL"
             }
           ],
           "headersSize": 1236,
@@ -3342,8 +3342,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.125Z",
-        "time": 446,
+        "startedDateTime": "2023-12-11T08:59:25.704Z",
+        "time": 591,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3351,7 +3351,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 446
+          "wait": 591
         }
       },
       {
@@ -3402,7 +3402,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3419,35 +3419,35 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 119,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 119,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:35.000Z",
+              "expires": "2024-12-11T08:59:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ea6584e6-6f1c-489d-92d4-94acf7bef3d4"
+              "value": "6c4451f9-b293-41b0-939f-80e7fb7834c7"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:35.000Z",
+              "expires": "2023-12-11T09:29:26.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "x0mI40RPCvgYFjgD_2A6fVTIIwujN1odvQu18ni.XYQ-1702277435-0-AavL5ZJ08VPEq6dEUxFfy7gXnkWEX0jFxRtynjK/oTBXvpC9GfcAN5UPgmAHg7UZNVqHN0Y+Ach+12DSTHLzbwM="
+              "value": "CTk3GQV1V0Kf__jlvAK5t2fCPYSYBvxcBGZfCm_Hg1U-1702285166-0-Aa8NdVhwae9PRtGb6ZJ43QLFwS6swo3ZKOLM02ubtDrJ9WE3JUzsJrpwCY10jMNpZ+lTsWFJ5DIhj9m8ZzLeEXA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
             },
             {
               "name": "content-type",
@@ -3471,7 +3471,7 @@
             },
             {
               "name": "retry-after",
-              "value": "150"
+              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3488,12 +3488,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ea6584e6-6f1c-489d-92d4-94acf7bef3d4; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=6c4451f9-b293-41b0-939f-80e7fb7834c7; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=x0mI40RPCvgYFjgD_2A6fVTIIwujN1odvQu18ni.XYQ-1702277435-0-AavL5ZJ08VPEq6dEUxFfy7gXnkWEX0jFxRtynjK/oTBXvpC9GfcAN5UPgmAHg7UZNVqHN0Y+Ach+12DSTHLzbwM=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=CTk3GQV1V0Kf__jlvAK5t2fCPYSYBvxcBGZfCm_Hg1U-1702285166-0-Aa8NdVhwae9PRtGb6ZJ43QLFwS6swo3ZKOLM02ubtDrJ9WE3JUzsJrpwCY10jMNpZ+lTsWFJ5DIhj9m8ZzLeEXA=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3509,15 +3509,15 @@
             },
             {
               "name": "x-trace",
-              "value": "becc2d5012eace858fdd0070067e7396"
+              "value": "fd3e9bc5fe9d6c24959be4ca20ba3849"
             },
             {
               "name": "x-trace-span",
-              "value": "1fa80be7e2fc27f1"
+              "value": "c846e639c3b065e4"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/becc2d5012eace858fdd0070067e7396"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fd3e9bc5fe9d6c24959be4ca20ba3849"
             },
             {
               "name": "x-xss-protection",
@@ -3541,7 +3541,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb514fe2af2a-NRT"
+              "value": "833c880f390a2996-MEL"
             },
             {
               "name": "content-encoding",
@@ -3554,8 +3554,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.958Z",
-        "time": 290,
+        "startedDateTime": "2023-12-11T08:59:25.700Z",
+        "time": 806,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3563,11 +3563,218 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 290
+          "wait": 806
         }
       },
       {
-        "_id": "3b85f96566a73d758acb8142a5f046ba",
+        "_id": "4a51e126edd6d383852063f79b16dd33",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1188,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1188"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"ba0d83eb-805a-44f3-99ef-3d66457162e4\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:26.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "970b4223-0b80-4637-994b-a8bdbc3ffb06"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:26.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "G041POfmIpb3kP39b1I4cydUHY4Xqt.dxXpRy4bXiwQ-1702285166-1-AaEY8DPdYRCzWkegEHPLK6Kw+65vF2GKUZSX8BZeMb5UUtC3W3ntlfGW1pEuxLtDU/f5kbnSnYJ+00L/1FFYpqE="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "472"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=970b4223-0b80-4637-994b-a8bdbc3ffb06; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=G041POfmIpb3kP39b1I4cydUHY4Xqt.dxXpRy4bXiwQ-1702285166-1-AaEY8DPdYRCzWkegEHPLK6Kw+65vF2GKUZSX8BZeMb5UUtC3W3ntlfGW1pEuxLtDU/f5kbnSnYJ+00L/1FFYpqE=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e5fe0a67b2aa952a1f78217b8b433f3d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5d35aefb1867af9c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e5fe0a67b2aa952a1f78217b8b433f3d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c880f2b663778-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:25.699Z",
+        "time": 891,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 891
+        }
+      },
+      {
+        "_id": "4c907eda316c4f31660acdc44dbb2eea",
         "_order": 0,
         "cache": {},
         "request": {
@@ -3614,13 +3821,13 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 323,
+          "headersSize": 340,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"097d3bae-9c1b-4ad7-910e-e5459e89df28\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"c257041d-6046-4228-877d-d6a7526ba885\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -3639,26 +3846,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:35.000Z",
+              "expires": "2024-12-11T08:59:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "70fe1817-b38b-46ac-83fb-72ad0a45c1ac"
+              "value": "95b3216b-5e26-4042-9665-2e307fbe93ac"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:35.000Z",
+              "expires": "2023-12-11T09:29:26.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "kq4FmQVLIOGdF92.6TBW7tNFqdCeG92mbvrYBKs9z4Y-1702277435-0-Ad2lpFSuxboBG0IS2szVD3E0VqbQX2Z0hUtjS/DUBznVcWcx98xZujR+85yyKwHd/O+Tg5peSEu0bKAcJOa9Ab8="
+              "value": "9D5nLP8y7zOZVbODtGuGnAeFkIW449iLHjyVMiyeWxk-1702285166-0-Aemt5qDqxkJP4SYqKlENHsh1q63RVtva+7gfncnzynAWKQodWvRNndpVm7mLvdfYHNjLYCv4L2NupTIcQYQfNcI="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
             },
             {
               "name": "content-type",
@@ -3682,7 +3889,7 @@
             },
             {
               "name": "retry-after",
-              "value": "150"
+              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3699,12 +3906,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=70fe1817-b38b-46ac-83fb-72ad0a45c1ac; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=95b3216b-5e26-4042-9665-2e307fbe93ac; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=kq4FmQVLIOGdF92.6TBW7tNFqdCeG92mbvrYBKs9z4Y-1702277435-0-Ad2lpFSuxboBG0IS2szVD3E0VqbQX2Z0hUtjS/DUBznVcWcx98xZujR+85yyKwHd/O+Tg5peSEu0bKAcJOa9Ab8=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=9D5nLP8y7zOZVbODtGuGnAeFkIW449iLHjyVMiyeWxk-1702285166-0-Aemt5qDqxkJP4SYqKlENHsh1q63RVtva+7gfncnzynAWKQodWvRNndpVm7mLvdfYHNjLYCv4L2NupTIcQYQfNcI=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3720,15 +3927,15 @@
             },
             {
               "name": "x-trace",
-              "value": "fdfe7fc5bc7aad888ce84e0410c296eb"
+              "value": "0a40c4d6259dfb7af6a1b50b6645b89a"
             },
             {
               "name": "x-trace-span",
-              "value": "a1b29d9cfae6113a"
+              "value": "7df761a14076a247"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fdfe7fc5bc7aad888ce84e0410c296eb"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0a40c4d6259dfb7af6a1b50b6645b89a"
             },
             {
               "name": "x-xss-protection",
@@ -3752,7 +3959,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb516cafe04f-NRT"
+              "value": "833c880f4c135a7f-MEL"
             }
           ],
           "headersSize": 1236,
@@ -3761,8 +3968,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.980Z",
-        "time": 291,
+        "startedDateTime": "2023-12-11T08:59:25.717Z",
+        "time": 1079,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3770,7 +3977,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 291
+          "wait": 1079
         }
       },
       {
@@ -3821,7 +4028,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3838,35 +4045,35 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 119,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 119,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:35.000Z",
+              "expires": "2024-12-11T08:59:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "58b2463e-6e26-4643-8d0c-9e1f79e9012d"
+              "value": "4734d2f1-867b-4f12-82e6-7bb385924ff6"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:35.000Z",
+              "expires": "2023-12-11T09:29:27.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "yBaj1cjMSOu4FjtJNs5oSmmua7Hkw3YTfvewhDvwK0g-1702277435-0-AS+AxK7EBevsmWEoehN/o2MmpduKUykAJXmKYwrM3X4nuTff37mqHTZI1Br+zcjaERElZ64TfBsekCh4iYJ4x6M="
+              "value": "oboETOnTjhJGabTWeDqqYWKKVPo0SAd3MKYs_NK8bq8-1702285167-0-AVa+70jbr4AFOiOAv4ziaZbKtrWEnSELJ/6LoNA14B/VlRKBNHqdDa8COEDIbjaGBBs1E1DdXL9Dew/CYmz6HuA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
             },
             {
               "name": "content-type",
@@ -3890,7 +4097,7 @@
             },
             {
               "name": "retry-after",
-              "value": "150"
+              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3907,12 +4114,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=58b2463e-6e26-4643-8d0c-9e1f79e9012d; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=4734d2f1-867b-4f12-82e6-7bb385924ff6; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=yBaj1cjMSOu4FjtJNs5oSmmua7Hkw3YTfvewhDvwK0g-1702277435-0-AS+AxK7EBevsmWEoehN/o2MmpduKUykAJXmKYwrM3X4nuTff37mqHTZI1Br+zcjaERElZ64TfBsekCh4iYJ4x6M=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=oboETOnTjhJGabTWeDqqYWKKVPo0SAd3MKYs_NK8bq8-1702285167-0-AVa+70jbr4AFOiOAv4ziaZbKtrWEnSELJ/6LoNA14B/VlRKBNHqdDa8COEDIbjaGBBs1E1DdXL9Dew/CYmz6HuA=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3928,15 +4135,15 @@
             },
             {
               "name": "x-trace",
-              "value": "1bc47e4fc345e0adc397853df5a47ad8"
+              "value": "daa5d9284a76a391c1f455bd83559292"
             },
             {
               "name": "x-trace-span",
-              "value": "756f3766cd22798b"
+              "value": "623171e2f8a74a88"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1bc47e4fc345e0adc397853df5a47ad8"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/daa5d9284a76a391c1f455bd83559292"
             },
             {
               "name": "x-xss-protection",
@@ -3960,7 +4167,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb516ed8afb2-NRT"
+              "value": "833c880f490b5a98-MEL"
             },
             {
               "name": "content-encoding",
@@ -3973,8 +4180,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:34.981Z",
-        "time": 304,
+        "startedDateTime": "2023-12-11T08:59:25.718Z",
+        "time": 1187,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3982,1042 +4189,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 304
-        }
-      },
-      {
-        "_id": "42f182961bcd677f1d11f6bda0580606",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1188,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1188"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 323,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"fd767883-d246-47fd-92e7-a61cb7c88f9a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:35.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ad9403bb-ad43-4ac6-becd-f16a3cf12467"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "tcWvbadiRoUS.U9mhSk7UZMtl2xXJRFi5WShIh04mwI-1702277435-0-AWqc0RVkhQ8uYgJvCNKIoT56VMOUtBUS5ph7JuWIojuNHq6aOQqAVMQrfsx0cN31sfBd7KPOTD4Y75PBOzOJXTA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "150"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ad9403bb-ad43-4ac6-becd-f16a3cf12467; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=tcWvbadiRoUS.U9mhSk7UZMtl2xXJRFi5WShIh04mwI-1702277435-0-AWqc0RVkhQ8uYgJvCNKIoT56VMOUtBUS5ph7JuWIojuNHq6aOQqAVMQrfsx0cN31sfBd7KPOTD4Y75PBOzOJXTA=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d72d3c2a201860e6544bf26bafc657e4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4bb0f89d235c61a8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d72d3c2a201860e6544bf26bafc657e4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb514d63e0a8-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:34.956Z",
-        "time": 629,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 629
-        }
-      },
-      {
-        "_id": "3bfde46a074296956deef9dbd207df0b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "89601edc-2844-4a2b-8129-05b14c26235d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "M3hK3ihGDQWeXyYUScgT762orOQr5i4YsD0QrePrElQ-1702277436-0-AQ/hipK7DxsJyPtQBB/D0TY8QUfsbtlMVQaXiwrI9RQP3lEDlShBs//Yk8qoHtfRzJQeCZ6rgh0Oni5Fbw0NZtY="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "149"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=89601edc-2844-4a2b-8129-05b14c26235d; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=M3hK3ihGDQWeXyYUScgT762orOQr5i4YsD0QrePrElQ-1702277436-0-AQ/hipK7DxsJyPtQBB/D0TY8QUfsbtlMVQaXiwrI9RQP3lEDlShBs//Yk8qoHtfRzJQeCZ6rgh0Oni5Fbw0NZtY=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "bd4d45c8b21c79ede9a645e62add61e6"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "a5daf245a9b2b82c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bd4d45c8b21c79ede9a645e62add61e6"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb573bde8a54-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:35.908Z",
-        "time": 241,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 241
-        }
-      },
-      {
-        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 190,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "190"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "95c3f6b6-96e3-4d43-8fe1-d1497e8e35f9"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "LcHvKOaHFBfVX3bLmMViWwv_Wf5kvCKnFo7mbnNitdI-1702277436-0-AfF9bpoQ3LouLyPStF6bvqY1/PCrS+/wEl1veyqhqkI/FAbQl+dgPZwUDl3SmbczXM1SQA++126b/9sG5YgqHiU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "149"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=95c3f6b6-96e3-4d43-8fe1-d1497e8e35f9; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=LcHvKOaHFBfVX3bLmMViWwv_Wf5kvCKnFo7mbnNitdI-1702277436-0-AfF9bpoQ3LouLyPStF6bvqY1/PCrS+/wEl1veyqhqkI/FAbQl+dgPZwUDl3SmbczXM1SQA++126b/9sG5YgqHiU=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "9de102e17036aedc3676b2cd046f33a0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "acf4f2466af5e79d"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9de102e17036aedc3676b2cd046f33a0"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb573e32687c-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:35.905Z",
-        "time": 255,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 255
-        }
-      },
-      {
-        "_id": "103c65b93dfa88c72eea86b3b023599e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1ea0691f-5b41-47c1-b559-83a5f4a7fa97"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "lgTcJhlXJ4zs2FkbTy_P9ON.6wgEspqc23uYAsz086Y-1702277436-0-AcaDzqaqyTJYU2fTihrTBr7wso2jWsnwMtv3+aWpVyA53bdty9IkZ2Sel3+1fYuikDnl5A4vb4iRNbseGyWmMoI="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "149"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1ea0691f-5b41-47c1-b559-83a5f4a7fa97; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=lgTcJhlXJ4zs2FkbTy_P9ON.6wgEspqc23uYAsz086Y-1702277436-0-AcaDzqaqyTJYU2fTihrTBr7wso2jWsnwMtv3+aWpVyA53bdty9IkZ2Sel3+1fYuikDnl5A4vb4iRNbseGyWmMoI=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "05999aef9612c8a6a5c9303df30d4de0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "9c85774b883d041c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/05999aef9612c8a6a5c9303df30d4de0"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb574fcf3bf9-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:35.907Z",
-        "time": 277,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 277
-        }
-      },
-      {
-        "_id": "ef779c1307829b0101c443d73f03b56c",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 323,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"097d3bae-9c1b-4ad7-910e-e5459e89df28\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "aa5557b2-d010-408b-9c91-9c21e8df143b"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "4ZbexE5vstzoH_Q0UcKiGyj44UIDCEgM8GeRlVj7qgQ-1702277436-0-AUHTD7tsPopMa+4xhUxjpD2SfF/t7mfSmsW1nv9x/bdC2YbRkKS+zL5tmXk2B8xFBqnUF69IIKnOELezLix6a9o="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "149"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=aa5557b2-d010-408b-9c91-9c21e8df143b; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=4ZbexE5vstzoH_Q0UcKiGyj44UIDCEgM8GeRlVj7qgQ-1702277436-0-AUHTD7tsPopMa+4xhUxjpD2SfF/t7mfSmsW1nv9x/bdC2YbRkKS+zL5tmXk2B8xFBqnUF69IIKnOELezLix6a9o=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c0251fa0affc1b57f627885472d5ee36"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "10b34a673cdf48ed"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c0251fa0affc1b57f627885472d5ee36"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb574815aff9-NRT"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:35.900Z",
-        "time": 298,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 298
+          "wait": 1187
         }
       },
       {
@@ -5068,7 +4240,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5093,26 +4265,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:36.000Z",
+              "expires": "2024-12-11T08:59:27.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "bf956356-e936-41e6-a26a-9d9fb97e393b"
+              "value": "5d7f1cb3-dd8a-46c2-900b-472c1f03dfb8"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
+              "expires": "2023-12-11T09:29:27.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "1qph1HJ4jMrpTz5YkD84ygF_oqIcYkgDIyOn43ff1yQ-1702277436-0-AYFcAOMWaeh3cIUfclrBNRTsRggA0mM1+jhWnAFvO+66p2AGzZ6U6R0pfSZzr0hSpaAkUKMNpVHxgzJDYb8xUDA="
+              "value": "09L.z_itL0wgZmb7mzgrcimVANsd2dcdsM082MzI6Xg-1702285167-1-AfLvjeNBN3xhl1QeaIj4VKFuvoPnph7lS2aUaPY7n2s/ntP+pGAcfxdqe4u0dLL3ZRTCiXhRHExcWGy2dTkpyqA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
             },
             {
               "name": "content-type",
@@ -5136,7 +4308,7 @@
             },
             {
               "name": "retry-after",
-              "value": "149"
+              "value": "471"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5153,12 +4325,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=bf956356-e936-41e6-a26a-9d9fb97e393b; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=5d7f1cb3-dd8a-46c2-900b-472c1f03dfb8; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=1qph1HJ4jMrpTz5YkD84ygF_oqIcYkgDIyOn43ff1yQ-1702277436-0-AYFcAOMWaeh3cIUfclrBNRTsRggA0mM1+jhWnAFvO+66p2AGzZ6U6R0pfSZzr0hSpaAkUKMNpVHxgzJDYb8xUDA=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=09L.z_itL0wgZmb7mzgrcimVANsd2dcdsM082MzI6Xg-1702285167-1-AfLvjeNBN3xhl1QeaIj4VKFuvoPnph7lS2aUaPY7n2s/ntP+pGAcfxdqe4u0dLL3ZRTCiXhRHExcWGy2dTkpyqA=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5174,15 +4346,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3540b173b66a0de8153c03c7f814a17a"
+              "value": "83db3d1891e98be99de99c4801b23384"
             },
             {
               "name": "x-trace-span",
-              "value": "022c1ec97d2f6230"
+              "value": "f02f4c543f72c11c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3540b173b66a0de8153c03c7f814a17a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83db3d1891e98be99de99c4801b23384"
             },
             {
               "name": "x-xss-protection",
@@ -5206,7 +4378,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb573c9af689-NRT"
+              "value": "833c88175b7a5a8b-MEL"
             }
           ],
           "headersSize": 1236,
@@ -5215,8 +4387,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:35.909Z",
-        "time": 293,
+        "startedDateTime": "2023-12-11T08:59:27.009Z",
+        "time": 298,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5224,7 +4396,628 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 293
+          "wait": 298
+        }
+      },
+      {
+        "_id": "103c65b93dfa88c72eea86b3b023599e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:27.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1f3da436-4513-4e0e-9cc5-e3d5e7bda0de"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:27.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "YFUlY7hyvfEnYJTIQ_tFyuSiHGwVkMAM6lzlKKpBPTI-1702285167-0-AYg5Hi5jmBu1gWZIyOEOua2bYJvy/TZUus4ZmPTuNl5pEBSdOajyq3LsLKnDQZCKjvjP5wvf7Y3l50eA2IZKJhY="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "471"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1f3da436-4513-4e0e-9cc5-e3d5e7bda0de; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=YFUlY7hyvfEnYJTIQ_tFyuSiHGwVkMAM6lzlKKpBPTI-1702285167-0-AYg5Hi5jmBu1gWZIyOEOua2bYJvy/TZUus4ZmPTuNl5pEBSdOajyq3LsLKnDQZCKjvjP5wvf7Y3l50eA2IZKJhY=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "dbe1c34ab47e7d5ae5ac008981de4617"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c65ad8f0b636f0b1"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dbe1c34ab47e7d5ae5ac008981de4617"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c88175e002b34-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:27.008Z",
+        "time": 305,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 305
+        }
+      },
+      {
+        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 190,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "190"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:27.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2b437522-528c-4cb2-bc9e-1ede48dae6f7"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:27.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "AO3jC2n4Gb8.5.4tO2OielsIly7vEEC49RW8sSmZ_qQ-1702285167-0-Af1lOhsXr/gfUComd3b3j33sE/B7xLRe7neDLkuJESwl/1JOqVCt+SeL9sXsByhKL/ggtXXaQZ7rBQJiW3vWNos="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "471"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2b437522-528c-4cb2-bc9e-1ede48dae6f7; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=AO3jC2n4Gb8.5.4tO2OielsIly7vEEC49RW8sSmZ_qQ-1702285167-0-Af1lOhsXr/gfUComd3b3j33sE/B7xLRe7neDLkuJESwl/1JOqVCt+SeL9sXsByhKL/ggtXXaQZ7rBQJiW3vWNos=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "bff333775d6132671453e30a14812c13"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "6d8bb765c98f04d3"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bff333775d6132671453e30a14812c13"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c88175c742b2e-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:27.006Z",
+        "time": 311,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 311
+        }
+      },
+      {
+        "_id": "3bfde46a074296956deef9dbd207df0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:27.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3e442cd3-b77b-4d16-beeb-d8739bb82215"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:27.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "j10uajO4nJH4gr11PBwzX4WEDVZECBHFz0emNIlGBoE-1702285167-0-ARCli55RCNkxDOzkEHs4NKMZpFmB2XxK38HS+WCzbwKm+8Zj7deaE0mavNJeQ5teq830dl9ubzFuNe46NCrigpo="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "471"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3e442cd3-b77b-4d16-beeb-d8739bb82215; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=j10uajO4nJH4gr11PBwzX4WEDVZECBHFz0emNIlGBoE-1702285167-0-ARCli55RCNkxDOzkEHs4NKMZpFmB2XxK38HS+WCzbwKm+8Zj7deaE0mavNJeQ5teq830dl9ubzFuNe46NCrigpo=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "39dfc7237fd625a418a2d657c386da25"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "27964431d800edee"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/39dfc7237fd625a418a2d657c386da25"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c8817587777e7-MEL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:27.008Z",
+        "time": 321,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 321
         }
       },
       {
@@ -5275,7 +5068,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5300,26 +5093,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:36.000Z",
+              "expires": "2024-12-11T08:59:27.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5ada5631-e34f-4f38-9a23-b5d4527cb6bf"
+              "value": "f9626d85-cc21-409c-803d-246e18f975d5"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
+              "expires": "2023-12-11T09:29:27.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "uALmy_q0WGZgsIAu7.Cwz.3vsQKnYsGyGS1pNu_Z_q0-1702277436-0-AfM1YKkmVQ5MwKIO3r/XJ1Nwfw1cw7w7Eki84X5xoNjbmeXGnMaa3tX61et0hZ3bVtpbGgAeIEQ6nQp5ub+N+d8="
+              "value": "BGAoUldJFNdzbdad_lNQG7WTZBWEQxbNEt7RtmSgNjI-1702285167-0-AUUub3JE7fDZP9yU2fzWRw0IvqzHEu2sQGOJkLgNJ3vZwChf0lvv/p/fW7VvHvIC8VJWmkNE30mk3h1+OeuwINQ="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
             },
             {
               "name": "content-type",
@@ -5343,7 +5136,7 @@
             },
             {
               "name": "retry-after",
-              "value": "149"
+              "value": "471"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5360,12 +5153,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5ada5631-e34f-4f38-9a23-b5d4527cb6bf; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=f9626d85-cc21-409c-803d-246e18f975d5; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=uALmy_q0WGZgsIAu7.Cwz.3vsQKnYsGyGS1pNu_Z_q0-1702277436-0-AfM1YKkmVQ5MwKIO3r/XJ1Nwfw1cw7w7Eki84X5xoNjbmeXGnMaa3tX61et0hZ3bVtpbGgAeIEQ6nQp5ub+N+d8=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=BGAoUldJFNdzbdad_lNQG7WTZBWEQxbNEt7RtmSgNjI-1702285167-0-AUUub3JE7fDZP9yU2fzWRw0IvqzHEu2sQGOJkLgNJ3vZwChf0lvv/p/fW7VvHvIC8VJWmkNE30mk3h1+OeuwINQ=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5381,15 +5174,15 @@
             },
             {
               "name": "x-trace",
-              "value": "ec6df75d2d22845d1b1d90650111e4c3"
+              "value": "0c66c3341098e4641a7bb5b2d23ecb90"
             },
             {
               "name": "x-trace-span",
-              "value": "e7849fa4be7b2249"
+              "value": "cac60f91d3e17bb3"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ec6df75d2d22845d1b1d90650111e4c3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0c66c3341098e4641a7bb5b2d23ecb90"
             },
             {
               "name": "x-xss-protection",
@@ -5413,7 +5206,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb573dd3685a-NRT"
+              "value": "833c88175a891f68-MEL"
             }
           ],
           "headersSize": 1236,
@@ -5422,8 +5215,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:35.906Z",
-        "time": 297,
+        "startedDateTime": "2023-12-11T08:59:27.007Z",
+        "time": 322,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5431,15 +5224,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 297
+          "wait": 322
         }
       },
       {
-        "_id": "7449140909c921a511332d4c1de94c1f",
+        "_id": "bab8949ac0f7ed5aa5fa607578da4a4f",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 182,
+          "bodySize": 1189,
           "cookies": [],
           "headers": [
             {
@@ -5465,7 +5258,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "182"
+              "value": "1189"
             },
             {
               "_fromType": "array",
@@ -5482,51 +5275,51 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 340,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"c257041d-6046-4228-877d-d6a7526ba885\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
-              "name": "EvaluateFeatureFlag",
+              "name": "LogEventMutation",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
         },
         "response": {
-          "bodySize": 37,
+          "bodySize": 26,
           "content": {
             "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:36.000Z",
+              "expires": "2024-12-11T08:59:27.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "75342e45-fd12-4316-a796-836dedd1597e"
+              "value": "b8df27a0-69c3-4dcb-b5de-c4571fcc6099"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:36.000Z",
+              "expires": "2023-12-11T09:29:27.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "SB4p8X7S3NTiwuvYdSANZLr.ZmxSWiJCCYaNw62MbB0-1702277436-0-AbHkTHv5QStp1P74/L+1dBwxBhTI3II+ss1aMhfvOooK7tsZhaTtulYLg3N0LyNw5NXmVtIioUhWC48u19KZVSM="
+              "value": "cvkRDlSWsEo55KDwc8I.2ZHxYyN1cVj1nFFj2XmMawA-1702285167-0-AUu3CXJl2uo/YBZXq3iSXR9FmarzHE0RIDW1Bs546J1InqhN3ZyOBWTtLjOgm6n7vhSCHywEBb9RQvKByLLOnHw="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
             },
             {
               "name": "content-type",
@@ -5534,7 +5327,7 @@
             },
             {
               "name": "content-length",
-              "value": "37"
+              "value": "26"
             },
             {
               "name": "connection",
@@ -5550,7 +5343,7 @@
             },
             {
               "name": "retry-after",
-              "value": "149"
+              "value": "471"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5567,12 +5360,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=75342e45-fd12-4316-a796-836dedd1597e; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=b8df27a0-69c3-4dcb-b5de-c4571fcc6099; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=SB4p8X7S3NTiwuvYdSANZLr.ZmxSWiJCCYaNw62MbB0-1702277436-0-AbHkTHv5QStp1P74/L+1dBwxBhTI3II+ss1aMhfvOooK7tsZhaTtulYLg3N0LyNw5NXmVtIioUhWC48u19KZVSM=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=cvkRDlSWsEo55KDwc8I.2ZHxYyN1cVj1nFFj2XmMawA-1702285167-0-AUu3CXJl2uo/YBZXq3iSXR9FmarzHE0RIDW1Bs546J1InqhN3ZyOBWTtLjOgm6n7vhSCHywEBb9RQvKByLLOnHw=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5588,15 +5381,15 @@
             },
             {
               "name": "x-trace",
-              "value": "bd3db4e999ae941bd46579ef4d8e17b8"
+              "value": "248d2a3f4d375cb6fd141b6e72e186a4"
             },
             {
               "name": "x-trace-span",
-              "value": "881f8b88b1762354"
+              "value": "2313150ce396144d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bd3db4e999ae941bd46579ef4d8e17b8"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/248d2a3f4d375cb6fd141b6e72e186a4"
             },
             {
               "name": "x-xss-protection",
@@ -5620,7 +5413,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb5a3b49decd-NRT"
+              "value": "833c881758bf2b36-MEL"
             }
           ],
           "headersSize": 1236,
@@ -5629,8 +5422,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:36.390Z",
-        "time": 227,
+        "startedDateTime": "2023-12-11T08:59:27.003Z",
+        "time": 330,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5638,209 +5431,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 227
-        }
-      },
-      {
-        "_id": "0d16a033a475b66e0dc0d6a4321be2a8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 297,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "297"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 319,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 98,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 98,
-            "text": "event: completion\ndata: {\"completion\":\" return a + b\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T06:50:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "74d18ffe-2547-4ed1-9f37-e2ae90e4a7b1"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Ph4CgpBYseErQH0SnjrpgEFTWgnJW7SX7XNQkowLsO8-1702277438-0-AdB4Nox604RkT3MHxRRrCEFBKDe4c3NwGBgPaJyky1RBNSgqytSh0I/zPBaTM0yEzo2kHbmD0aDQRzAVe54qyZA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:38 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "148"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=74d18ffe-2547-4ed1-9f37-e2ae90e4a7b1; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Ph4CgpBYseErQH0SnjrpgEFTWgnJW7SX7XNQkowLsO8-1702277438-0-AdB4Nox604RkT3MHxRRrCEFBKDe4c3NwGBgPaJyky1RBNSgqytSh0I/zPBaTM0yEzo2kHbmD0aDQRzAVe54qyZA=; path=/; expires=Mon, 11-Dec-23 07:20:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "2bc707dc4230fb06d8e643142c1d2139"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "82a626c4959aa312"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2bc707dc4230fb06d8e643142c1d2139"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833bcb5ba9db261e-NRT"
-            }
-          ],
-          "headersSize": 1239,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T06:50:36.628Z",
-        "time": 1368,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1368
+          "wait": 330
         }
       },
       {
@@ -5891,7 +5482,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5917,26 +5508,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:38.000Z",
+              "expires": "2024-12-11T08:59:28.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ec333477-4fe9-4d8f-978e-8d4a9cc514a2"
+              "value": "d1531eab-92f8-46b7-bf1e-600168fce4ee"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:38.000Z",
+              "expires": "2023-12-11T09:29:29.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HPVqbd.7mPVg8KyVEgYmq1rfj6JSWeLmAjHZJchNmRo-1702277438-0-AbcPK81CYUvBsBdcPtdhFm8sQW04mr1ODQiinThgtpSqkeb61ipYY8m8O4YoHEI5h1nBLIjgmJgKVL1DldRruFs="
+              "value": "nUzg_wKr.AMfO6pFsGiC1ooPcwwwiXW0AhUr8mD.DRw-1702285169-1-AYjwIv3B1zOfaSuM3MVpQle4zyLMrUiSItkvh3Er3vTgdFfeTLCslOWUsH678kV+gG5KvshbhuhnTQfmCjjJ2PU="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:38 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:29 GMT"
             },
             {
               "name": "content-type",
@@ -5960,7 +5551,7 @@
             },
             {
               "name": "retry-after",
-              "value": "147"
+              "value": "470"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5977,12 +5568,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ec333477-4fe9-4d8f-978e-8d4a9cc514a2; Expires=Wed, 11 Dec 2024 06:50:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=d1531eab-92f8-46b7-bf1e-600168fce4ee; Expires=Wed, 11 Dec 2024 08:59:28 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HPVqbd.7mPVg8KyVEgYmq1rfj6JSWeLmAjHZJchNmRo-1702277438-0-AbcPK81CYUvBsBdcPtdhFm8sQW04mr1ODQiinThgtpSqkeb61ipYY8m8O4YoHEI5h1nBLIjgmJgKVL1DldRruFs=; path=/; expires=Mon, 11-Dec-23 07:20:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=nUzg_wKr.AMfO6pFsGiC1ooPcwwwiXW0AhUr8mD.DRw-1702285169-1-AYjwIv3B1zOfaSuM3MVpQle4zyLMrUiSItkvh3Er3vTgdFfeTLCslOWUsH678kV+gG5KvshbhuhnTQfmCjjJ2PU=; path=/; expires=Mon, 11-Dec-23 09:29:29 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5998,15 +5589,15 @@
             },
             {
               "name": "x-trace",
-              "value": "9da363a6e1cd4f918831b36ea2419779"
+              "value": "47004e22982a5eb9d3228ab733ebb667"
             },
             {
               "name": "x-trace-span",
-              "value": "8df05a87615ca400"
+              "value": "7acbe197c84eddd0"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9da363a6e1cd4f918831b36ea2419779"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/47004e22982a5eb9d3228ab733ebb667"
             },
             {
               "name": "x-xss-protection",
@@ -6030,7 +5621,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb66fbb880fc-NRT"
+              "value": "833c881e1eaa29af-MEL"
             },
             {
               "name": "content-encoding",
@@ -6043,8 +5634,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:38.441Z",
-        "time": 264,
+        "startedDateTime": "2023-12-11T08:59:28.093Z",
+        "time": 1335,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6052,7 +5643,174 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 264
+          "wait": 1335
+        }
+      },
+      {
+        "_id": "e5443a606d1749be8736a7d667f0bdd9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 18591,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 169,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":47401}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/tim/.asdf/installs/nodejs/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/tim/.asdf/installs/nodejs/20.4.0/bin/node\"},{\"stringValue\":\"/Users/tim/Codez/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/tim/Codez/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"tim\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"d1d72ca9bcbb847e1f21b2e403ca1740\",\"spanId\":\"d7228895523917c0\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285164500000000\",\"endTimeUnixNano\":\"1702285164794067750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"426085903a41ac195106b65274ef2a3f\",\"spanId\":\"fe8441c474f7fd13\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285164501000000\",\"endTimeUnixNano\":\"1702285164800847583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"eedf6f8efa37f2458e6bf7357b32301e\",\"spanId\":\"1fb5744a3608bffa\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285164501000000\",\"endTimeUnixNano\":\"1702285164804285000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"898f756e087b00e0ee04b8dfd4953465\",\"spanId\":\"cf36d3b0f1df629c\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285164501000000\",\"endTimeUnixNano\":\"1702285164808482167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9a64eee6ff53f2cda1e9cb89a4777ff5\",\"spanId\":\"eaeef23f03982924\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285164502000000\",\"endTimeUnixNano\":\"1702285165006958750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"1b7cba37279488ce679d58b670a28e61\",\"spanId\":\"5b48ecfd5b8beae8\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285164501000000\",\"endTimeUnixNano\":\"1702285165095422250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"11460f48160ae65122c4c84b7812e099\",\"spanId\":\"9a80f33e2fac8422\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702285165007000000\",\"endTimeUnixNano\":\"1702285165694909917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"70f337627e9c9c1be32ea3daf1819ad8\",\"spanId\":\"c2190d2403d3aaff\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165698000000\",\"endTimeUnixNano\":\"1702285166003717042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0fcf1c18d2525e6dffb78e445a4ad6ef\",\"spanId\":\"e8f8671ceb508a01\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285165709000000\",\"endTimeUnixNano\":\"1702285166004571083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"df0b1fe24a4d05c8fe37aad653195bce\",\"spanId\":\"5f5e39da715d2bfb\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165697000000\",\"endTimeUnixNano\":\"1702285166007807500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6a6ada8607912fdf00b932da9766c520\",\"spanId\":\"ab3f329d826829b7\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285165709000000\",\"endTimeUnixNano\":\"1702285166011751916\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0f3e7486111933c7c2eed7b93c839bde\",\"spanId\":\"b1b1c087fdc80006\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1702285165710000000\",\"endTimeUnixNano\":\"1702285166013721333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"aaf80322a2d97f44fb665fe6fa3df747\",\"spanId\":\"91dffd06aa5f3b94\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165698000000\",\"endTimeUnixNano\":\"1702285166015631875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f3bf8eff0aa92c3a1754cfdcf2aa1bde\",\"spanId\":\"6808c6d2e414d0ec\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165698000000\",\"endTimeUnixNano\":\"1702285166016833083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8603dace4b810cfdbd25b4e14f552373\",\"spanId\":\"523dbb41b304c644\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165710000000\",\"endTimeUnixNano\":\"1702285166025943375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"83645cd110ad101465e911ec031da4ec\",\"spanId\":\"7256971799983821\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285165709000000\",\"endTimeUnixNano\":\"1702285166028644708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"944b8f0279ba1930b262d6bf9bf3f6a0\",\"spanId\":\"60bfe31a75c18563\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285165711000000\",\"endTimeUnixNano\":\"1702285166055687625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"103786d9cfd07179ee703663be31f33f\",\"spanId\":\"1fe14eb463493e6b\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165698000000\",\"endTimeUnixNano\":\"1702285166298709166\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7df5b65b6083ee2dc3c6ffbdd40176ee\",\"spanId\":\"5be25ce40ba5a397\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165711000000\",\"endTimeUnixNano\":\"1702285166301904375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9b86a77eb9db58b4466e1ec8d5f9a254\",\"spanId\":\"5ce452967840cbe1\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285166005000000\",\"endTimeUnixNano\":\"1702285166307925083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c53ca5ba3ce08cc7eb3d8a252ae73dfa\",\"spanId\":\"b80f725793bc61fc\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285166008000000\",\"endTimeUnixNano\":\"1702285166309530833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b2d88b35d5b0383f61d5040dd3818acf\",\"spanId\":\"50b0687378b858c1\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285165697000000\",\"endTimeUnixNano\":\"1702285166310149333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d09c06dd4e31839331f4555ec34b9979\",\"spanId\":\"e95672995707abc8\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285165710000000\",\"endTimeUnixNano\":\"1702285166314914917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8182ba5bc53ed6ca0c9afc90496d9101\",\"spanId\":\"8dde07d121ffec0b\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165697000000\",\"endTimeUnixNano\":\"1702285166394274917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a406976079c08458ccc7c622a98daa39\",\"spanId\":\"e5f1be91f1ea7a8e\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285165697000000\",\"endTimeUnixNano\":\"1702285166395652333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6ede47e92bd0ac2d21bbaec948e37685\",\"spanId\":\"c99b5fc453c12013\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285165696000000\",\"endTimeUnixNano\":\"1702285166508822209\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0a5cd54f6bf0cb6fda7d79775e9225de\",\"spanId\":\"7bf20642d63f7dab\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285165696000000\",\"endTimeUnixNano\":\"1702285166593538917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8a4bab230d59644b02c0fc84fb34340e\",\"spanId\":\"b947425da2c70d19\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285165709000000\",\"endTimeUnixNano\":\"1702285166693369958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0fcb7016952694d1aa826860f53f7195\",\"spanId\":\"f6d5de11f2771670\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285165710000000\",\"endTimeUnixNano\":\"1702285166798144250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6c3624fd21b1648249177409a4ce1598\",\"spanId\":\"1e2a4e830cf2cfcf\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285165711000000\",\"endTimeUnixNano\":\"1702285166907907416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9199e9493c6c91594d14f7c14f05a87c\",\"spanId\":\"342531eb013d8c3f\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702285166693000000\",\"endTimeUnixNano\":\"1702285166997130375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c6139605a54416fcdc14ad7e129e06d7\",\"spanId\":\"d99199191d3ca27a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167301403375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"457f327d098b1e3e660b5c5516869cf2\",\"spanId\":\"2829d3f1539a9f22\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167309083417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d9f02d71d3fa1bdc73889cf35f646bfe\",\"spanId\":\"85377ebbe4756ac0\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167000000000\",\"endTimeUnixNano\":\"1702285167312390875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d22db5a6cb509fae1d49e808ed77d276\",\"spanId\":\"cf0a6d7fce7b322f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167315517833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"23ca44c922224c1a2b3e8855dd595ba8\",\"spanId\":\"4bf7fa3f0cfba799\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167315838709\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"129ffccbc60eee10df2212173f17344c\",\"spanId\":\"abb6ad53dcda3070\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285166999000000\",\"endTimeUnixNano\":\"1702285167319269500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6ff2764e61cede7c59e888af3a7cc404\",\"spanId\":\"78ec64a8304eca2f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167000000000\",\"endTimeUnixNano\":\"1702285167320344167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a7b50d7a52090388da66745f2402eb58\",\"spanId\":\"2b506bcb31f0e610\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167326836291\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2ef3f6ad8b8f5aaabe5fdc36fee47596\",\"spanId\":\"882ca6fcf030a54a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167330831250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b075afcbd4d051ecdfd42b768ba3c701\",\"spanId\":\"c72c174992da3edf\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167000000000\",\"endTimeUnixNano\":\"1702285167330086709\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c6746877cf9b332f18873222a0db3eef\",\"spanId\":\"63b40d079e084985\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285166999000000\",\"endTimeUnixNano\":\"1702285167335310458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6fdea26cf2db78ebed981ee129f9e06d\",\"spanId\":\"b13e3c12e894bdf2\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285167000000000\",\"endTimeUnixNano\":\"1702285167400880917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9218b6fa7d0925115c989967d52e9de9\",\"spanId\":\"88d36ef167bcdc04\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167406730541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"91ac02d50ccbc365d9e41889010bc9a8\",\"spanId\":\"d494ce212ff3e1a5\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285167000000000\",\"endTimeUnixNano\":\"1702285167407039959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a4dcc4eb9d26a6943e218c0f5af687f3\",\"spanId\":\"a2a02ab973bbf3ea\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285167446229084\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"485993142876e0e1eb8a8f1757618f29\",\"spanId\":\"d2eb076c10ae8f31\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285167319000000\",\"endTimeUnixNano\":\"1702285167628679334\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8dcade81b3587b73ac844f24f9d36fcc\",\"spanId\":\"4a2b878787076c30\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285167001000000\",\"endTimeUnixNano\":\"1702285168048998625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"60dbcbb208740105e2e26b14500cfd75\",\"spanId\":\"53acf5deea3e6ddd\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285167401000000\",\"endTimeUnixNano\":\"1702285168050628916\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"80244f24a662fef2f2c0f5a99b9d939e\",\"spanId\":\"4d6be7ff5f722884\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285167634000000\",\"endTimeUnixNano\":\"1702285168091499125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8274865b9a047563ad5b81618b7578d0\",\"spanId\":\"062ceadea9b70668\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285168092000000\",\"endTimeUnixNano\":\"1702285169430797125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\"partialSuccess\":{}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T08:59:30.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "996d2b4c-3dcf-4568-9f41-43fd98587fc0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:29:30.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": ".1Ge88op_3seUbKacZp8LvydUkHDeUrg7UegsSIgBe0-1702285170-0-AaEBY3qgxDxMu0MmEn4yBe2kVEdXd9z0aUPXNlrwVH9T99Ud818JcgLdNhUJL/0OSzs8GIfl8SNGle6Arv5vlRc="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 08:59:30 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "468"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=996d2b4c-3dcf-4568-9f41-43fd98587fc0; Expires=Wed, 11 Dec 2024 08:59:30 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=.1Ge88op_3seUbKacZp8LvydUkHDeUrg7UegsSIgBe0-1702285170-0-AaEBY3qgxDxMu0MmEn4yBe2kVEdXd9z0aUPXNlrwVH9T99Ud818JcgLdNhUJL/0OSzs8GIfl8SNGle6Arv5vlRc=; path=/; expires=Mon, 11-Dec-23 09:29:30 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Authorization,Cookie,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "de8459aa7e507df25bf04622a93bdc36"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "543a31c6002ce4ed"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/de8459aa7e507df25bf04622a93bdc36"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c8828df222b36-MEL"
+            }
+          ],
+          "headersSize": 1121,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T08:59:29.801Z",
+        "time": 320,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 320
         }
       },
       {
@@ -6080,7 +5838,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 217,
+          "headersSize": 234,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -6100,26 +5858,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T06:50:38.000Z",
+              "expires": "2024-12-11T08:59:27.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e6810af8-52fc-430f-9298-c8aeb5accc75"
+              "value": "5f5511d4-a21d-4345-8b2b-bdd0cd2c342a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T07:20:40.000Z",
+              "expires": "2023-12-11T09:29:30.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "EcgOs1Qvp3gMDnwTl7vLzpQVWtyglw.INLZdC5N7vpE-1702277440-0-ATrhWLMiDq3zhplSo3aUoayxdWzFhUJEWLAUVYJz3D+FZzjl2GpuUqrZziZzn7g8nWDUT4f/IMUCtUzjWWDMBJ4="
+              "value": "U8y77ElYHQRwCVEuJTnmJl6N.5B3WQPc6ZsjRhZFx3E-1702285170-0-AVIZCerMfRcx+0OG3eMzOFGh+rd7M/G8ZSyL5mYtlyx04YoWwKL0iY0QT4uS0x5LLg8fEgOiPghPO5/l2syCkDk="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 06:50:40 GMT"
+              "value": "Mon, 11 Dec 2023 08:59:30 GMT"
             },
             {
               "name": "content-type",
@@ -6143,7 +5901,7 @@
             },
             {
               "name": "retry-after",
-              "value": "147"
+              "value": "471"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6160,12 +5918,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e6810af8-52fc-430f-9298-c8aeb5accc75; Expires=Wed, 11 Dec 2024 06:50:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=5f5511d4-a21d-4345-8b2b-bdd0cd2c342a; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=EcgOs1Qvp3gMDnwTl7vLzpQVWtyglw.INLZdC5N7vpE-1702277440-0-ATrhWLMiDq3zhplSo3aUoayxdWzFhUJEWLAUVYJz3D+FZzjl2GpuUqrZziZzn7g8nWDUT4f/IMUCtUzjWWDMBJ4=; path=/; expires=Mon, 11-Dec-23 07:20:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=U8y77ElYHQRwCVEuJTnmJl6N.5B3WQPc6ZsjRhZFx3E-1702285170-0-AVIZCerMfRcx+0OG3eMzOFGh+rd7M/G8ZSyL5mYtlyx04YoWwKL0iY0QT4uS0x5LLg8fEgOiPghPO5/l2syCkDk=; path=/; expires=Mon, 11-Dec-23 09:29:30 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6181,15 +5939,15 @@
             },
             {
               "name": "x-trace",
-              "value": "1220ae72d9660f48247590655cc6148f"
+              "value": "24c80ab945fbbd87ce92148c8653f3aa"
             },
             {
               "name": "x-trace-span",
-              "value": "12bd7eb62b74970e"
+              "value": "d395d7927de9851d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1220ae72d9660f48247590655cc6148f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/24c80ab945fbbd87ce92148c8653f3aa"
             },
             {
               "name": "x-xss-protection",
@@ -6213,7 +5971,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833bcb656eaa7341-NRT"
+              "value": "833c881b38841f6e-MEL"
             }
           ],
           "headersSize": 1239,
@@ -6222,8 +5980,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T06:50:38.191Z",
-        "time": 6302,
+        "startedDateTime": "2023-12-11T08:59:27.637Z",
+        "time": 7522,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6231,15 +5989,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 6302
+          "wait": 7522
         }
       },
       {
-        "_id": "e4d26bafcaa8e27807f08989dc2807f5",
+        "_id": "cba49d6912ec992c7dbbdfc957f3bffb",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 139,
+          "bodySize": 1186,
           "cookies": [],
           "headers": [
             {
@@ -6265,7 +6023,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "139"
+              "value": "1186"
             },
             {
               "_fromType": "array",
@@ -6282,76 +6040,63 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 334,
+          "headersSize": 340,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nquery CurrentUser {\\n    currentUser {\\n        id\\n        hasVerifiedEmail\\n        codyProEnabled\\n    }\\n}\",\"variables\":{}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"36d7be3e-b6d0-409c-b397-61370dc6151b\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
-              "name": "CurrentUser",
+              "name": "LogEventMutation",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
         },
         "response": {
-          "bodySize": 156,
+          "bodySize": 26,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 156,
-            "text": "[\"H4sIAAAAAAAAAyTIsQ5AMBAG4Hf5Z4PB1MRoJBZiPb1DpTQ5NUjTdxcxfl8CUySYBHuryhmHS/SjYxiMU+ftHspuH6p2rWsU2OgaRd3ihJuDnIeJeksBG/jpNTQnzV7435zzCwAA//8DAA4O7rVgAAAA\"]"
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:18.000Z",
+              "expires": "2024-12-11T08:57:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7ace5278-f60e-4e80-b4bf-7c9e4b5f00ae"
+              "value": "59fa0f91-00a7-43c4-bbdf-be63db9d077a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
+              "expires": "2023-12-11T09:27:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3nCIoVx7CE4f7wMxnw9EK07sScv.2FJgkQoomILZwjQ-1701947658-0-Aa04LCqImgdZPqPbynNTBUcVONqDMwoZzPVUYkQ6fh7MKGCeH4frwXUIacQpCVA8qYOsk3+UZSbXmkImQ/mWEfI="
+              "value": "cjxQQ6iFh0O2ndfmu4sBBh6GRCqBYLwcMcsX5HMXY_Y-1702285037-1-AfMyy0pZgO1HevKPCi7+IgNFCqybwBOODhUneQeIhLk9lOZMtBGOSFAQJ6Du+EX+cGxJcrb/aNntMqEbgtPJJ6A="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
+              "value": "Mon, 11 Dec 2023 08:57:17 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "26"
             },
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "203"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6368,12 +6113,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7ace5278-f60e-4e80-b4bf-7c9e4b5f00ae; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
+              "value": "sourcegraphDeviceId=59fa0f91-00a7-43c4-bbdf-be63db9d077a; Expires=Wed, 11 Dec 2024 08:57:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3nCIoVx7CE4f7wMxnw9EK07sScv.2FJgkQoomILZwjQ-1701947658-0-Aa04LCqImgdZPqPbynNTBUcVONqDMwoZzPVUYkQ6fh7MKGCeH4frwXUIacQpCVA8qYOsk3+UZSbXmkImQ/mWEfI=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=cjxQQ6iFh0O2ndfmu4sBBh6GRCqBYLwcMcsX5HMXY_Y-1702285037-1-AfMyy0pZgO1HevKPCi7+IgNFCqybwBOODhUneQeIhLk9lOZMtBGOSFAQJ6Du+EX+cGxJcrb/aNntMqEbgtPJJ6A=; path=/; expires=Mon, 11-Dec-23 09:27:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6389,15 +6134,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e1e0549fed926596a4d250c876c8214a"
+              "value": "217d6b49343f61664ccdd4520872c758"
             },
             {
               "name": "x-trace-span",
-              "value": "c873259cb40c7c9e"
+              "value": "62baf00d3d5a648d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e1e0549fed926596a4d250c876c8214a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/217d6b49343f61664ccdd4520872c758"
             },
             {
               "name": "x-xss-protection",
@@ -6421,21 +6166,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c581dfc77c256-VIE"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
+              "value": "833c84eb8a742edc-MEL"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:17.887Z",
-        "time": 230,
+        "startedDateTime": "2023-12-11T08:57:17.117Z",
+        "time": 435,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6443,15 +6184,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 230
+          "wait": 435
         }
       },
       {
-        "_id": "f8cee7bab5ae8cff9390a1f3098e2cf1",
+        "_id": "8119134a179ec1e334b97a7ffe329ba9",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 444,
+          "bodySize": 1189,
           "cookies": [],
           "headers": [
             {
@@ -6477,7 +6218,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "444"
+              "value": "1189"
             },
             {
               "_fromType": "array",
@@ -6494,60 +6235,59 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 344,
+          "headersSize": 340,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.extension\",\"action\":\"installed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.0\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"36d7be3e-b6d0-409c-b397-61370dc6151b\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
-              "name": "RecordTelemetryEvents",
+              "name": "LogEventMutation",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
         },
         "response": {
-          "bodySize": 119,
+          "bodySize": 26,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 119,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:17.000Z",
+              "expires": "2024-12-11T08:57:18.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ba0ccc81-52ef-4b6f-8ec5-900d52c0c31b"
+              "value": "9d22afb4-658a-44d0-b3eb-ff1e9e675551"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
+              "expires": "2023-12-11T09:27:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "WRNLowzRjBdURyR94ar.SitGM2Btb_Aqu1ssaZ1uH9w-1701947658-0-AUwDILZUbnW6XEnuuOoTZozLpUds5WxwWfVsaX/qW72LvA2slUYS3iGF+NOvHFJt5PyQ5n2sz9xoD3eSdrcbaa8="
+              "value": "FUM2v2SzWUAy4T0K89yVv0myWSEoDp2bnsakdKhOizM-1702285038-0-AVuc1SueRQ/szm78Ysjfh04XlMiCMTNADTkZFvIufVSvjf75Y+k/f+ViHS+L+ib243r99PlZSVAuyhZhGITl6HM="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
+              "value": "Mon, 11 Dec 2023 08:57:18 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "26"
             },
             {
               "name": "connection",
@@ -6563,7 +6303,7 @@
             },
             {
               "name": "retry-after",
-              "value": "203"
+              "value": "600"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6580,12 +6320,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ba0ccc81-52ef-4b6f-8ec5-900d52c0c31b; Expires=Sat, 07 Dec 2024 11:14:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=9d22afb4-658a-44d0-b3eb-ff1e9e675551; Expires=Wed, 11 Dec 2024 08:57:18 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=WRNLowzRjBdURyR94ar.SitGM2Btb_Aqu1ssaZ1uH9w-1701947658-0-AUwDILZUbnW6XEnuuOoTZozLpUds5WxwWfVsaX/qW72LvA2slUYS3iGF+NOvHFJt5PyQ5n2sz9xoD3eSdrcbaa8=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=FUM2v2SzWUAy4T0K89yVv0myWSEoDp2bnsakdKhOizM-1702285038-0-AVuc1SueRQ/szm78Ysjfh04XlMiCMTNADTkZFvIufVSvjf75Y+k/f+ViHS+L+ib243r99PlZSVAuyhZhGITl6HM=; path=/; expires=Mon, 11-Dec-23 09:27:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6601,15 +6341,15 @@
             },
             {
               "name": "x-trace",
-              "value": "504c4c25737181d3575b0d53e3d80b6b"
+              "value": "c54c8a51b58dbc5432231a547b773a5b"
             },
             {
               "name": "x-trace-span",
-              "value": "da7f24deb56dbda2"
+              "value": "2f6c5a6d3598d0ee"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/504c4c25737181d3575b0d53e3d80b6b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c54c8a51b58dbc5432231a547b773a5b"
             },
             {
               "name": "x-xss-protection",
@@ -6633,21 +6373,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c581dec5d5c2b-VIE"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
+              "value": "833c84ef7c5d299d-MEL"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:17.868Z",
-        "time": 276,
+        "startedDateTime": "2023-12-11T08:57:17.756Z",
+        "time": 317,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6655,11 +6391,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 276
+          "wait": 317
         }
       },
       {
-        "_id": "382d1d2bc146ae8b54ef8bd1ec219d96",
+        "_id": "96e6bf75eeaaf185a4a3453faab7d983",
         "_order": 0,
         "cache": {},
         "request": {
@@ -6712,7 +6448,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"af36cd4e-0351-4ac3-ad80-72bf862eca42\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.0\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.0\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"94f0104c-690b-4462-97c8-15f73664fc8a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -6731,26 +6467,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:20.000Z",
+              "expires": "2024-12-11T08:57:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d9922431-4a8c-410c-ad3c-cd0936ba29a8"
+              "value": "b437930e-b30d-43b6-80ce-7606623558c6"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
+              "expires": "2023-12-11T09:27:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "56V28CKQd105nz3BqL5xttt22otCOuGZRh5t0pyR.kw-1701947660-0-AePqke+KcdXgPBedGojGWEcCzx+Ov46Qfu56MstQOM/qOl35/BhCMwZAITqaLKqSA8jXThtiLuVqSoxZtwpHPL0="
+              "value": "1LRm0Pwf68Mw6A44nMPlk7swvvAtR5pJovIs59zBwzk-1702285038-0-AVUisdWrVqN+jxCNTc3bcCVZZDOxw5I5efsvp0y2bD0QoP7NjRdNHTWNn5mOslWOo1yZiYP7W9p9+qgmQ//0JkQ="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
+              "value": "Mon, 11 Dec 2023 08:57:18 GMT"
             },
             {
               "name": "content-type",
@@ -6765,18 +6501,6 @@
               "value": "close"
             },
             {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "201"
-            },
-            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -6791,12 +6515,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d9922431-4a8c-410c-ad3c-cd0936ba29a8; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
+              "value": "sourcegraphDeviceId=b437930e-b30d-43b6-80ce-7606623558c6; Expires=Wed, 11 Dec 2024 08:57:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=56V28CKQd105nz3BqL5xttt22otCOuGZRh5t0pyR.kw-1701947660-0-AePqke+KcdXgPBedGojGWEcCzx+Ov46Qfu56MstQOM/qOl35/BhCMwZAITqaLKqSA8jXThtiLuVqSoxZtwpHPL0=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=1LRm0Pwf68Mw6A44nMPlk7swvvAtR5pJovIs59zBwzk-1702285038-0-AVUisdWrVqN+jxCNTc3bcCVZZDOxw5I5efsvp0y2bD0QoP7NjRdNHTWNn5mOslWOo1yZiYP7W9p9+qgmQ//0JkQ=; path=/; expires=Mon, 11-Dec-23 09:27:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6812,15 +6536,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b14270e4e5d0a80852ec09e18e801bcb"
+              "value": "4971e27abfdc2616b542ccdeb234fe2f"
             },
             {
               "name": "x-trace-span",
-              "value": "f147617f52fd9bdf"
+              "value": "0cd098caecd2e9cb"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b14270e4e5d0a80852ec09e18e801bcb"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4971e27abfdc2616b542ccdeb234fe2f"
             },
             {
               "name": "x-xss-protection",
@@ -6844,17 +6568,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c582a8f003250-VIE"
+              "value": "833c84eb6b7e2ed2-MEL"
             }
           ],
-          "headersSize": 1236,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:19.885Z",
-        "time": 228,
+        "startedDateTime": "2023-12-11T08:57:17.091Z",
+        "time": 1205,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6862,853 +6586,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 228
+          "wait": 1205
         }
       },
       {
-        "_id": "47197cbc40f472e4f63ed08aebe47e93",
+        "_id": "3f294870e301deec3c7dfc1c87ff459b",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1185,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1185"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"17b97274-60c6-49c2-a23b-e810be55d6db\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.0\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.0\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "8805e3a4-7469-405b-b58f-314adebcdfec"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "H7pBmrgTR2mAgs313PGEM8UCzpLCg_uKYBcvooAh7Bo-1701947660-0-AemPUAl1/V3oAz6Z60lvYhMhakzCHWHhY7zbVUTphTAsG7Yfwr041gcz1IRagiQvL/yijSG0yHlzzp+dxbcnFbU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "201"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8805e3a4-7469-405b-b58f-314adebcdfec; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=H7pBmrgTR2mAgs313PGEM8UCzpLCg_uKYBcvooAh7Bo-1701947660-0-AemPUAl1/V3oAz6Z60lvYhMhakzCHWHhY7zbVUTphTAsG7Yfwr041gcz1IRagiQvL/yijSG0yHlzzp+dxbcnFbU=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "52776a6a380919d60901f232247008ba"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "913bf7b09453d346"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/52776a6a380919d60901f232247008ba"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582a9e70c316-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:19.900Z",
-        "time": 226,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 226
-        }
-      },
-      {
-        "_id": "0b01ed88850df0661081a31fd51d8528",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 439,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "439"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.0\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7a00d13e-da47-450e-aa2e-a79a7e520fbb"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "x4ZwGFbiUzdsNvBznhSe9dUPDRSQJzfvHYb16Aq.lPA-1701947660-0-AVt0nKh3VWpk6f/pHTq0QM6MJZIMd0DmIE+zTbxqdBbIFnA90RpBnqDdgFM1p71gxXoHflIXFBisXGJt+anr2UY="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "201"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7a00d13e-da47-450e-aa2e-a79a7e520fbb; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=x4ZwGFbiUzdsNvBznhSe9dUPDRSQJzfvHYb16Aq.lPA-1701947660-0-AVt0nKh3VWpk6f/pHTq0QM6MJZIMd0DmIE+zTbxqdBbIFnA90RpBnqDdgFM1p71gxXoHflIXFBisXGJt+anr2UY=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f8497e24bf8203ab5644250b6cdf4203"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "9385b6cfc89273d2"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f8497e24bf8203ab5644250b6cdf4203"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582a9a91c24f-VIE"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:19.886Z",
-        "time": 246,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 246
-        }
-      },
-      {
-        "_id": "6cdbbb44dd35cfbb07e77492e4392f7d",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 436,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "436"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.0\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 119,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 119,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "0da37129-aea2-41e7-b3eb-359d21be5354"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "jWr6OyvRRriLGNMxyLS63_MN4KiQ0c9Gc8Kz.ZQqy40-1701947660-0-AUFEDH2udmzaRby5obu6ngOOiISzv4Ej3v6bhnCL+FymuHAwOoEIlwUkrWLb9Td6CHTOibHYAWywuHalJlWbbE4="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "201"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0da37129-aea2-41e7-b3eb-359d21be5354; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=jWr6OyvRRriLGNMxyLS63_MN4KiQ0c9Gc8Kz.ZQqy40-1701947660-0-AUFEDH2udmzaRby5obu6ngOOiISzv4Ej3v6bhnCL+FymuHAwOoEIlwUkrWLb9Td6CHTOibHYAWywuHalJlWbbE4=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "40b2296ce100779493a2ace0a09ecbdc"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "eba8b8cb0f5c746d"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/40b2296ce100779493a2ace0a09ecbdc"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582c6c5d325c-VIE"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:20.192Z",
-        "time": 209,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 209
-        }
-      },
-      {
-        "_id": "fe0cd1fdd530f7ad4eb3f53598120c86",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1188,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1188"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"6a082d94-a050-48d9-bc8b-0d9d0204414f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.0\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.0\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2a095624-9f65-4f2a-8639-fb4acbd1f1cc"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "5.94DFaDgh4DToovkmg08D8aM4Io7xGZKhE0QKa0b94-1701947660-0-AVxruT4hJ/smUsBqsosdp2ysWEZCNeVYnMW3pS9epGrN27PiL+3o2SYyM11Q5IDp0t2+GTQS6DAygp7NeF1LjGc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "200"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2a095624-9f65-4f2a-8639-fb4acbd1f1cc; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=5.94DFaDgh4DToovkmg08D8aM4Io7xGZKhE0QKa0b94-1701947660-0-AVxruT4hJ/smUsBqsosdp2ysWEZCNeVYnMW3pS9epGrN27PiL+3o2SYyM11Q5IDp0t2+GTQS6DAygp7NeF1LjGc=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "074cbcb7278e47ecffa9efc6650c7212"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "775f876f3bc2dccf"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/074cbcb7278e47ecffa9efc6650c7212"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582e5e965a99-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:20.487Z",
-        "time": 334,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 334
-        }
-      },
-      {
-        "_id": "4eab0c42ef5e5fa592fd11d87422298c",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 16345,
+          "bodySize": 18251,
           "cookies": [],
           "headers": [
             {
@@ -7730,7 +6616,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.0\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":84476}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/philipp/.asdf/installs/nodejs/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/philipp/.asdf/installs/nodejs/20.4.0/bin/node\"},{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"philipp\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"5582246acf037ac90d9d232e972162ab\",\"spanId\":\"9efdf4d6fe16ef3c\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947658442000000\",\"endTimeUnixNano\":\"1701947658639638583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"465aeca424ab182f7225e621de303d11\",\"spanId\":\"611eb5f77539cf06\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947658443000000\",\"endTimeUnixNano\":\"1701947658643332041\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3400ffc73de22cb3c3d6479491f36adf\",\"spanId\":\"87f8825750494413\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947658444000000\",\"endTimeUnixNano\":\"1701947658733415333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5db8dfadaa9536590b055ff8feb866be\",\"spanId\":\"50a4c98edb93c990\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947658441000000\",\"endTimeUnixNano\":\"1701947658734814666\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7db0ba54cbfd01cb4bee87fba0dde241\",\"spanId\":\"047618ac53c0b58c\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1701947658444000000\",\"endTimeUnixNano\":\"1701947658739233833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e518471673f1a9a7586f859d5629ecfb\",\"spanId\":\"2b64ad80456f439d\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1701947658444000000\",\"endTimeUnixNano\":\"1701947658886488042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cc0435dc995520563054c0ca6ff35f8d\",\"spanId\":\"5c7872a47e1444e8\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1701947658887000000\",\"endTimeUnixNano\":\"1701947659879348542\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"22e60d1f489cf511bc4bffacc7625867\",\"spanId\":\"4fa027e3e2d2039c\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947659891000000\",\"endTimeUnixNano\":\"1701947660082865583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"46cbaf17212be335ad6b0195d5037cb2\",\"spanId\":\"3053acdffd497d45\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1701947659880000000\",\"endTimeUnixNano\":\"1701947660096107583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"df0ec26874ea6179fcf316aecf57c88e\",\"spanId\":\"fc142316174047de\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947659888000000\",\"endTimeUnixNano\":\"1701947660097905167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7671c5d46a2ff5830a0aec2cce36a75c\",\"spanId\":\"41b81a1dddee8b5a\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1701947659889000000\",\"endTimeUnixNano\":\"1701947660101156500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"18b2c4fdc119bd239d30a4893fd032c7\",\"spanId\":\"2e56ee8748049791\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1701947659881000000\",\"endTimeUnixNano\":\"1701947660116418834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cb11468245cccfdff207b6f95e534dd3\",\"spanId\":\"eb77b65e6162c288\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1701947659889000000\",\"endTimeUnixNano\":\"1701947660116242292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"25c5b046cb575c033b0b53ab9675c0cc\",\"spanId\":\"e9d4168bef1c3eb1\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1701947659890000000\",\"endTimeUnixNano\":\"1701947660129367250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"150549b062fc03e1e7e88920749327e3\",\"spanId\":\"4a7d39d1870199e5\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1701947659881000000\",\"endTimeUnixNano\":\"1701947660134793625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"999414f921ac6f767e64898c313572dd\",\"spanId\":\"e62dd5ab0361f254\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1701947659889000000\",\"endTimeUnixNano\":\"1701947660182724042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"dbb842fa69072020dd1c8adf632173ae\",\"spanId\":\"040efd52a2f3cc61\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947659890000000\",\"endTimeUnixNano\":\"1701947660191244875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cf1e091ecd5aa88766e480c935ac073c\",\"spanId\":\"0197d89641ed0e1a\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947659893000000\",\"endTimeUnixNano\":\"1701947660211273000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"280df1c0cba713a97bf10930a2e7b625\",\"spanId\":\"ff03e358370289fb\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947659893000000\",\"endTimeUnixNano\":\"1701947660224568541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"edf1331c8eb5e577f4fd892fa24047b0\",\"spanId\":\"bb5c66c4d8835582\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947660083000000\",\"endTimeUnixNano\":\"1701947660266705125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"77d4bea16ba86c7607a63b084d28b504\",\"spanId\":\"003790f6275ff5c0\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947659892000000\",\"endTimeUnixNano\":\"1701947660282687875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"45b2b84e12fcf528737902480409bacb\",\"spanId\":\"a1eecc65c37f182c\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947659882000000\",\"endTimeUnixNano\":\"1701947660293544167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4c902d6acbe7870b6c41e7d60c41e357\",\"spanId\":\"fb68d83f02962a9e\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1701947660191000000\",\"endTimeUnixNano\":\"1701947660403605625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4c56497de8c9a56a52504fedb6d22c18\",\"spanId\":\"e37cef6b119b96a1\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1701947660183000000\",\"endTimeUnixNano\":\"1701947660479552416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e1802db7f044066f40d03ca221f1cd22\",\"spanId\":\"1c63265526785a4c\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947660482000000\",\"endTimeUnixNano\":\"1701947660698540833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"89a6ac6d59032fd89ce31298f6aa9466\",\"spanId\":\"83b14a183c826c3b\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947660485000000\",\"endTimeUnixNano\":\"1701947660701428208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6c186b4a5a92fab90065a26d8d7b2faf\",\"spanId\":\"c35b7673aef3e576\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660482000000\",\"endTimeUnixNano\":\"1701947660714590667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a4b3ce774f5244b02c46db8fd689b96b\",\"spanId\":\"2cf1a5b2b3d886ca\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660482000000\",\"endTimeUnixNano\":\"1701947660718089792\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f2a44dca337693603ae6bdf6b291a176\",\"spanId\":\"66511b1c71b1543d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660484000000\",\"endTimeUnixNano\":\"1701947660803036416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"1fbe1d7c2e29dd711e64a45f45292aea\",\"spanId\":\"288fb2ba891d6b51\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660483000000\",\"endTimeUnixNano\":\"1701947660813595458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9515ef953d54bd1cacc9340937772d4d\",\"spanId\":\"799407e926598fa5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660483000000\",\"endTimeUnixNano\":\"1701947660815543375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"058d2da2464f3a1de17ac7450913e35c\",\"spanId\":\"99e071854d6d6923\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660483000000\",\"endTimeUnixNano\":\"1701947660820676959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"942f74fd6a7f541a2a8241a91c7c68b9\",\"spanId\":\"19e21378f34129ad\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1701947660481000000\",\"endTimeUnixNano\":\"1701947660823629125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3c7f0aa4b953f9a60fed5515fa5c1c99\",\"spanId\":\"383d4eb2560bd89f\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947660482000000\",\"endTimeUnixNano\":\"1701947660886031167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"befc12e6bae015e62d794e52a2a73a6a\",\"spanId\":\"3ad4561af735f7b9\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947660484000000\",\"endTimeUnixNano\":\"1701947660888286458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cecf5be753ef93ae26d709771129d2c8\",\"spanId\":\"771201fe4a4c451f\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1701947660484000000\",\"endTimeUnixNano\":\"1701947660890975125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0c0c9b2079f86f2d99d159d83c7537b8\",\"spanId\":\"7f13b63ee30a3f20\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1701947660480000000\",\"endTimeUnixNano\":\"1701947660911662333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"34758ce46bf647a57cdbf846094fa03c\",\"spanId\":\"cb0d4aa18d63bae2\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947660483000000\",\"endTimeUnixNano\":\"1701947661003354166\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3340ef66749683194b41a019c89017ee\",\"spanId\":\"4b42a2bfcb101ea4\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947660886000000\",\"endTimeUnixNano\":\"1701947661164679916\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"05d1e608b8c76d84c69588f7d2168958\",\"spanId\":\"7efd2a297f6553ee\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1701947660698000000\",\"endTimeUnixNano\":\"1701947661232564833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"cac8851642354415\",\"parentSpanId\":\"8f4423d60e869f6a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1701947661166000000\",\"endTimeUnixNano\":\"1701947661447174750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"08a05f00b410e3fd\",\"parentSpanId\":\"8f4423d60e869f6a\",\"name\":\"autocomplete.debounce\",\"kind\":1,\"startTimeUnixNano\":\"1701947661449000000\",\"endTimeUnixNano\":\"1701947661449049125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"08871317f3e69882\",\"parentSpanId\":\"391a1b0bba79866e\",\"name\":\"autocomplete.retrieve.jaccard-similarity\",\"kind\":1,\"startTimeUnixNano\":\"1701947661449000000\",\"endTimeUnixNano\":\"1701947661449432083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"391a1b0bba79866e\",\"parentSpanId\":\"8f4423d60e869f6a\",\"name\":\"autocomplete.retrieve\",\"kind\":1,\"startTimeUnixNano\":\"1701947661449000000\",\"endTimeUnixNano\":\"1701947661449748875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
+            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":45637}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/tim/.asdf/installs/nodejs/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/tim/.asdf/installs/nodejs/20.4.0/bin/node\"},{\"stringValue\":\"/Users/tim/Codez/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/tim/Codez/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"tim\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"9271ed63c92efe886316a070aca3f80d\",\"spanId\":\"3cfbb5a61f7c13b5\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285036104000000\",\"endTimeUnixNano\":\"1702285036404652666\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"09f68f4f68439389a38a3f84842a3e9f\",\"spanId\":\"0b7672aaa51d19d7\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285036103000000\",\"endTimeUnixNano\":\"1702285036408973834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"90b8a760629c411b1bf059d345f44679\",\"spanId\":\"5f1cf4097fa0a059\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285036101000000\",\"endTimeUnixNano\":\"1702285036424256250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"18554baefa5f490b9587c2ef5f84a260\",\"spanId\":\"a8c5aeaa67f5e164\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285036104000000\",\"endTimeUnixNano\":\"1702285036447275459\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2df6f544f94265b216ff2b84f920f82d\",\"spanId\":\"82790b4b0dbdce17\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285036103000000\",\"endTimeUnixNano\":\"1702285036775410250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9e5bf0d4a1ab9e768090397e7d62f4b8\",\"spanId\":\"f0f40e7e04c2c2b1\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285036104000000\",\"endTimeUnixNano\":\"1702285036777430167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f30b1800c7b69a823c2e4811fdb7a20c\",\"spanId\":\"868e189975a70159\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702285036778000000\",\"endTimeUnixNano\":\"1702285037084346041\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8574a5eccd92d798e33e6157a8433d0d\",\"spanId\":\"f7cc0e6884bd3d32\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285037106000000\",\"endTimeUnixNano\":\"1702285037396936292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f7a9dacbea2c26817811fac94d7e67b\",\"spanId\":\"5c9ceaadf5aba2da\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037089000000\",\"endTimeUnixNano\":\"1702285037402502791\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4c7ae2fc765c6895ad3fe52ef3ac6251\",\"spanId\":\"42f7496570e7d0eb\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285037087000000\",\"endTimeUnixNano\":\"1702285037404428166\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c89b816657f4913e8f10f62090019691\",\"spanId\":\"7bc58dd2003a0d1f\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285037105000000\",\"endTimeUnixNano\":\"1702285037420202042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"06d97bf34437ca4dabd5b9d27828692f\",\"spanId\":\"9b00e2f06423629f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037088000000\",\"endTimeUnixNano\":\"1702285037424051334\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7a61b6cc64cac06129c42a6eea290f4e\",\"spanId\":\"327897812e49e92a\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285037106000000\",\"endTimeUnixNano\":\"1702285037425065209\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cd0347167f6f4028ce4e2af8c4382eea\",\"spanId\":\"e0140f93a60e4340\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037089000000\",\"endTimeUnixNano\":\"1702285037425719583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ded50c0dd81fbbe166f1f2c0f4677495\",\"spanId\":\"2e68dd5af60e6a99\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037090000000\",\"endTimeUnixNano\":\"1702285037440065750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3735b73ca44220e17b98188789149d23\",\"spanId\":\"4af46eabe3a85072\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285037105000000\",\"endTimeUnixNano\":\"1702285037449562292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"fb58eb9f5cf87109da7566fb3e064571\",\"spanId\":\"17b372b22352c4b5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037108000000\",\"endTimeUnixNano\":\"1702285037466959958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7cd9c8eaea1f2a5a12f8dd08aa0e40a5\",\"spanId\":\"b228e6d6bb8baca1\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1702285037107000000\",\"endTimeUnixNano\":\"1702285037467094167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"90cdb3ef1897c1581065c730a8c9b540\",\"spanId\":\"432c86102449d39e\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285037106000000\",\"endTimeUnixNano\":\"1702285037475325625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"aee49876a7d103d2b80c5d621c583407\",\"spanId\":\"75c8c99ae0538c7f\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285037107000000\",\"endTimeUnixNano\":\"1702285037554251541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"15480783561fdc89ba94dbf3815a18db\",\"spanId\":\"d32ac86e07a5c5d5\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285037397000000\",\"endTimeUnixNano\":\"1702285037691495208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"52d2dadcbe0255c053aad77eb0d058ba\",\"spanId\":\"3008d6dd0ca1e79e\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037088000000\",\"endTimeUnixNano\":\"1702285037697026708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7d5bd49246f20cf6cf8309e8e62146de\",\"spanId\":\"74b12dad40c489f8\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037089000000\",\"endTimeUnixNano\":\"1702285037704911125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"54b8ae4ee23241ad8075246d596c5276\",\"spanId\":\"13815d56602637b6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037107000000\",\"endTimeUnixNano\":\"1702285037704995167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"53d8ddfb7bda7dbf6a206284c8588bb3\",\"spanId\":\"59f4f714f79483ac\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037089000000\",\"endTimeUnixNano\":\"1702285037708668875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b83e14824e08768a20f69fad6e6b6601\",\"spanId\":\"4a5507ccb3381e9f\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285037108000000\",\"endTimeUnixNano\":\"1702285037713656584\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"91f640add7d8c620337c0aea1d7303f3\",\"spanId\":\"64f3eebe93438aed\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702285037450000000\",\"endTimeUnixNano\":\"1702285037749576125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"72c07be77936d6db07846e18ca412d69\",\"spanId\":\"e711b679663a205a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038057840625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e733dc32e806f78d7d4f80e4c91ef8b8\",\"spanId\":\"37a26a33c9b191c6\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285037751000000\",\"endTimeUnixNano\":\"1702285038061109333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"aaf05423be1dce42bc842750573136ab\",\"spanId\":\"8ed4dce035ee24dc\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037752000000\",\"endTimeUnixNano\":\"1702285038063991667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"75e72903d5c193f35516d3eada1f82b5\",\"spanId\":\"ad90c128598e14b7\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038072529417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f5805ff10d5897b25744015f3239eed0\",\"spanId\":\"2c9b17ad21817f81\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038074422000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"400f74f01c8224c2e6f92574aa3b0ca0\",\"spanId\":\"05cec5633dd78de2\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285037751000000\",\"endTimeUnixNano\":\"1702285038074598833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"eba6f0cb5eb15349b41aa202e9991806\",\"spanId\":\"9fa7df9d119d813e\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038077489834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7d1c0610e0cfefae3aa6ad4e55da651f\",\"spanId\":\"3f8862e64ab111be\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285037752000000\",\"endTimeUnixNano\":\"1702285038087975500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e81a08a1bb091e3337f606c9cdf2ac82\",\"spanId\":\"f216847f4a8baee5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038089203292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"30356505ece845453cc5f7c0726b0b44\",\"spanId\":\"cc9e8f227e16f6b6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038089818292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"aa7f9d1e5e2bef77b7ee548747f8335c\",\"spanId\":\"6ab67b3a4fb1656c\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285037087000000\",\"endTimeUnixNano\":\"1702285038100386958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4ae79be145f2c2a82baf2849d5378976\",\"spanId\":\"e10dcd1c5b5ba7df\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285037752000000\",\"endTimeUnixNano\":\"1702285038112028417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"956a1d440a62c0b55b69858863124864\",\"spanId\":\"f2e66178c5875c8a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038149361042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0446a936c4ede587d3d8d4263b6eac58\",\"spanId\":\"9c23d8bb0316f8c5\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285037086000000\",\"endTimeUnixNano\":\"1702285038299642250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3c18d46e0808d34a77f36a87ac41a1a7\",\"spanId\":\"9a43a62a916067a2\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037753000000\",\"endTimeUnixNano\":\"1702285038299298708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"55e76bc347c8a4d21aa17611b6aa81d7\",\"spanId\":\"cf73c8d67b1ba750\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285037108000000\",\"endTimeUnixNano\":\"1702285038301010209\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ca8b4353f3cd778ab2a94f172ef63cdf\",\"spanId\":\"9f59057dfc19853c\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285038061000000\",\"endTimeUnixNano\":\"1702285038360244500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e17f51bf0d450d9fea78bc0cf956c63c\",\"spanId\":\"1d56cba22395b53c\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285038367000000\",\"endTimeUnixNano\":\"1702285038665766042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"413350778767e36b4032190c110985ac\",\"spanId\":\"090c77d773c00b77\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037752000000\",\"endTimeUnixNano\":\"1702285038894320708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d8b07ef0d1409ee923a23854c1115867\",\"spanId\":\"ddc1a66c7d1f1fef\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037752000000\",\"endTimeUnixNano\":\"1702285038900821375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4348c1f82348ea82dcda1179fd4f4405\",\"spanId\":\"9e6b4ff62113131a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285037754000000\",\"endTimeUnixNano\":\"1702285038903042792\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e1f2815b11566e77eae9c634bf1bce89\",\"spanId\":\"875d1f28cb4b616a\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285038666000000\",\"endTimeUnixNano\":\"1702285038985270625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"36b308af3e1159276cc3f6c8a0fdc1e4\",\"spanId\":\"fa0702cc9b5b3a9f\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285038088000000\",\"endTimeUnixNano\":\"1702285039592674125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
           },
           "queryString": [],
           "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
@@ -7744,26 +6630,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:23.000Z",
+              "expires": "2024-12-11T08:57:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "b2bdd460-4e83-49ee-b16a-717e1b4a9cd4"
+              "value": "ae07d397-2d80-4533-b7d6-0761091e6771"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:23.000Z",
+              "expires": "2023-12-11T09:27:21.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "1kJUl6tZz6xmGNS3ZGF1z.DKsTo5g6GmHzShB4Zg.dY-1701947663-0-AVj2bJakCUkKKtmrf08ZqZc3Q16e9AUFXcb0uwPOY18eSWmLIBU9x4Bfc2ugpIZ8tooYgX/a1iKQIjKvy3PMZuA="
+              "value": "V.i0UtQJ0dWJ0ztZVOOJ3ZOjetOf8WyqNsUsq87RJdg-1702285041-0-AY4dGs2U6HaHPiqkDpI5y1ixz6yHJ5cA4qqeeaqoFcQtX30FpkaBeiKaAWl6c5KKmFi0qtm6akDej5MgLAgESgM="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:23 GMT"
+              "value": "Mon, 11 Dec 2023 08:57:21 GMT"
             },
             {
               "name": "content-type",
@@ -7787,7 +6673,7 @@
             },
             {
               "name": "retry-after",
-              "value": "197"
+              "value": "597"
             },
             {
               "name": "cache-control",
@@ -7796,12 +6682,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b2bdd460-4e83-49ee-b16a-717e1b4a9cd4; Expires=Sat, 07 Dec 2024 11:14:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=ae07d397-2d80-4533-b7d6-0761091e6771; Expires=Wed, 11 Dec 2024 08:57:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=1kJUl6tZz6xmGNS3ZGF1z.DKsTo5g6GmHzShB4Zg.dY-1701947663-0-AVj2bJakCUkKKtmrf08ZqZc3Q16e9AUFXcb0uwPOY18eSWmLIBU9x4Bfc2ugpIZ8tooYgX/a1iKQIjKvy3PMZuA=; path=/; expires=Thu, 07-Dec-23 11:44:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=V.i0UtQJ0dWJ0ztZVOOJ3ZOjetOf8WyqNsUsq87RJdg-1702285041-0-AY4dGs2U6HaHPiqkDpI5y1ixz6yHJ5cA4qqeeaqoFcQtX30FpkaBeiKaAWl6c5KKmFi0qtm6akDej5MgLAgESgM=; path=/; expires=Mon, 11-Dec-23 09:27:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7817,15 +6703,15 @@
             },
             {
               "name": "x-trace",
-              "value": "cb52d9f96d47c55bb2cdf19f166f3162"
+              "value": "1582517d48f25ca24d49a1739fab85fa"
             },
             {
               "name": "x-trace-span",
-              "value": "ab38d2a9176a86c3"
+              "value": "369a534c02fdd278"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cb52d9f96d47c55bb2cdf19f166f3162"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1582517d48f25ca24d49a1739fab85fa"
             },
             {
               "name": "x-xss-protection",
@@ -7849,7 +6735,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c584208e5c29b-VIE"
+              "value": "833c850679bf2efa-MEL"
             }
           ],
           "headersSize": 1121,
@@ -7858,8 +6744,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:23.648Z",
-        "time": 189,
+        "startedDateTime": "2023-12-11T08:57:21.413Z",
+        "time": 310,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7867,1334 +6753,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 189
-        }
-      },
-      {
-        "_id": "579e52553a9fb832a9408564e196d7e4",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 3030,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 169,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.0\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":84476}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/philipp/.asdf/installs/nodejs/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/philipp/.asdf/installs/nodejs/20.4.0/bin/node\"},{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"philipp\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"f565f81c6df93ed6\",\"parentSpanId\":\"8f4423d60e869f6a\",\"name\":\"autocomplete.generate\",\"kind\":1,\"startTimeUnixNano\":\"1701947661450000000\",\"endTimeUnixNano\":\"1701947663662023833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"5a0f59852a23b63b\",\"parentSpanId\":\"8f4423d60e869f6a\",\"name\":\"autocomplete.post-process\",\"kind\":1,\"startTimeUnixNano\":\"1701947663662000000\",\"endTimeUnixNano\":\"1701947663662172833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02692307433c3a9fc3aa2905822dbe05\",\"spanId\":\"8f4423d60e869f6a\",\"name\":\"autocomplete.provideInlineCompletionItems\",\"kind\":1,\"startTimeUnixNano\":\"1701947661166000000\",\"endTimeUnixNano\":\"1701947663663382167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"89b32585815a92064b6af287d33e8e32\",\"spanId\":\"40d290610bf440c2\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1701947663664000000\",\"endTimeUnixNano\":\"1701947663856719291\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8fc186810d6df8dc51202da7b8ce55c9\",\"spanId\":\"23af4177ec96e438\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1701947663857000000\",\"endTimeUnixNano\":\"1701947664075314583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
-        },
-        "response": {
-          "bodySize": 21,
-          "content": {
-            "mimeType": "application/json",
-            "size": 21,
-            "text": "{\"partialSuccess\":{}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:28.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e6ebf524-e3fd-4894-83ab-1ddf7367e591"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:29.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ezDb1Za2o4Xupb6.EBaoU9BNARdpZt4pXE5Myxp2EWo-1701947669-0-AeffMvJsnKAWBWcwUD80Rm/oTrkU+TcAI1nXi1OlVMmnxSGK5CRyCRWdn61VgBvVx2N9R2suxN7o6Il4MGX0XZE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:29 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "21"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "192"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e6ebf524-e3fd-4894-83ab-1ddf7367e591; Expires=Sat, 07 Dec 2024 11:14:28 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ezDb1Za2o4Xupb6.EBaoU9BNARdpZt4pXE5Myxp2EWo-1701947669-0-AeffMvJsnKAWBWcwUD80Rm/oTrkU+TcAI1nXi1OlVMmnxSGK5CRyCRWdn61VgBvVx2N9R2suxN7o6Il4MGX0XZE=; path=/; expires=Thu, 07-Dec-23 11:44:29 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Authorization,Cookie,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "9e7b56f20df6f93c731263b8984b1505"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d8daa3d655e512a8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9e7b56f20df6f93c731263b8984b1505"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c58625ff6c29b-VIE"
-            }
-          ],
-          "headersSize": 1121,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:28.843Z",
-        "time": 163,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 163
-        }
-      },
-      {
-        "_id": "03c26228549f19324c6c7aa44f045c3a",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 309,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "309"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 319,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topP\":0.95,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 98,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 98,
-            "text": "event: completion\ndata: {\"completion\":\" return a + b\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-29T08:13:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "78e970dc-8f0a-4ccb-ba92-dc40532777f7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-29T08:43:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OpVgFYPQjhPVs5N7WftM3IUy2u3_kvYbEcJk8fSuxww-1701245607-0-ARqyGzGuNtDPAVS7gdl1AgWrM73Gr5Hu8F29izG1xsE+rZLOaWXWxVkykWqfBOOigFBVqrXg+j3qVHqgFffiUA8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 29 Nov 2023 08:13:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=78e970dc-8f0a-4ccb-ba92-dc40532777f7; Expires=Fri, 29 Nov 2024 08:13:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=OpVgFYPQjhPVs5N7WftM3IUy2u3_kvYbEcJk8fSuxww-1701245607-0-ARqyGzGuNtDPAVS7gdl1AgWrM73Gr5Hu8F29izG1xsE+rZLOaWXWxVkykWqfBOOigFBVqrXg+j3qVHqgFffiUA8=; path=/; expires=Wed, 29-Nov-23 08:43:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6f341d4a077d480b42c6411fd79d7b19"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c78c21cdffe2c510"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6f341d4a077d480b42c6411fd79d7b19"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82d96434f833e029-NRT"
-            }
-          ],
-          "headersSize": 1132,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-29T08:13:27.065Z",
-        "time": 461,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 461
-        }
-      },
-      {
-        "_id": "840d8c3bd41061b30f0f01f81092c2ed",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 258,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-network-cache\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a70413a7-5fb3-4ff1-8901-3fdb18bdbe3e"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "1R7XUVltVh4MRLVYYER_Xe9VcxJ9icvZCbWej1vT_TE-1701000051-0-AdXLEiygZj+4ZrQJPLxjAvRIWtYWdKCPt+6bxJtCKO915Pds2dMFG0gnGgIwYxc0riDqBqaaLydtbnehnyzmHIU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a70413a7-5fb3-4ff1-8901-3fdb18bdbe3e; Expires=Tue, 26 Nov 2024 12:00:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=1R7XUVltVh4MRLVYYER_Xe9VcxJ9icvZCbWej1vT_TE-1701000051-0-AdXLEiygZj+4ZrQJPLxjAvRIWtYWdKCPt+6bxJtCKO915Pds2dMFG0gnGgIwYxc0riDqBqaaLydtbnehnyzmHIU=; path=/; expires=Sun, 26-Nov-23 12:30:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8889c3e974dfbddc216f5d7d9ae966fd"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1f01eafc6b236244"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8889c3e974dfbddc216f5d7d9ae966fd"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f9342e7d6404-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:46.124Z",
-        "time": 183,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 183
-        }
-      },
-      {
-        "_id": "e2380bdedcae954b3525f101b5775070",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 184,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "184"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-anthropic-cyan\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:52.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "87183500-6d90-4bfb-b18b-3b5ad7459bd7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "3GRtpKE2AtGLFHhvUxTOsrLzaubQXhBgihkApOjjai8-1701000053-0-AeHTqpAqgwnA7yU3mqA5p8v4+sT2PWhUEW7Pnu/t8Oekf3YKfMhZL19cu5g5zQ25+wcQAZF7OCE7QgN69310LZc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=87183500-6d90-4bfb-b18b-3b5ad7459bd7; Expires=Tue, 26 Nov 2024 12:00:52 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=3GRtpKE2AtGLFHhvUxTOsrLzaubQXhBgihkApOjjai8-1701000053-0-AeHTqpAqgwnA7yU3mqA5p8v4+sT2PWhUEW7Pnu/t8Oekf3YKfMhZL19cu5g5zQ25+wcQAZF7OCE7QgN69310LZc=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "9934d42887a2255a1c921c493399187a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "dccaab3093b5e3e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9934d42887a2255a1c921c493399187a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93a8d94dd50-LHR"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.141Z",
-        "time": 198,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 198
-        }
-      },
-      {
-        "_id": "c9361d90a26c84c77ab2fc65f3686661",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 322,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "322"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 319,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>/path/to/foo/file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topP\":0.95,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 172,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 172,
-            "text": "event: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:53.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "76ae0157-585a-4b6a-915b-94045b1f7b19"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:54.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "BhZF_9vXX3jAbtMLF5EHF7V88nSxbU1EpHSi.1eye_c-1701000054-0-AUtpUI52BY7uq5aC3p+LfXvlsQ/9KvGd1SNeSoEj8sjHbUDT6P5mBSN1AAdX6tIpeGDUV31FEbzx6S6dKAJyCfQ="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:54 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=76ae0157-585a-4b6a-915b-94045b1f7b19; Expires=Tue, 26 Nov 2024 12:00:53 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=BhZF_9vXX3jAbtMLF5EHF7V88nSxbU1EpHSi.1eye_c-1701000054-0-AUtpUI52BY7uq5aC3p+LfXvlsQ/9KvGd1SNeSoEj8sjHbUDT6P5mBSN1AAdX6tIpeGDUV31FEbzx6S6dKAJyCfQ=; path=/; expires=Sun, 26-Nov-23 12:30:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "1b665c7172ede11933de380aa6d86a8d"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d99cd8dc423d1dba"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1b665c7172ede11933de380aa6d86a8d"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f9405f486319-LHR"
-            }
-          ],
-          "headersSize": 1132,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:48.069Z",
-        "time": 504,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 504
-        }
-      },
-      {
-        "_id": "77be8b54ac7b249d2e0c2b6e481b82a4",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 115,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "115"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 317,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentUser {\\n    currentUser {\\n        id\\n        hasVerifiedEmail\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentUser",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
-        },
-        "response": {
-          "bodySize": 132,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 132,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJxM1OUrJTCIvxykrPyq/xcIk2VdJQyEovDUosy0zJTU1xzEzNzlKxKikpTa2trAQAAAP//AwA3Lh8/RgAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-24T13:17:22.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "8995ce6b-0237-4051-9135-860de7d8dd66"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-24T13:47:22.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": ".36CcL_RAPPNkGMHBDSwyHtr39ep5JmTpnosj5fufEo-1700831842-0-AR+szMDwczQFgzf0/F4AKtSDQWn9CubwWHe6L6Bq90nvQ0f2/LtC6VNVqpk9rKDH0DnR/Lwtmfpc/ISYAQLbb/c="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 24 Nov 2023 13:17:22 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8995ce6b-0237-4051-9135-860de7d8dd66; Expires=Sun, 24 Nov 2024 13:17:22 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=.36CcL_RAPPNkGMHBDSwyHtr39ep5JmTpnosj5fufEo-1700831842-0-AR+szMDwczQFgzf0/F4AKtSDQWn9CubwWHe6L6Bq90nvQ0f2/LtC6VNVqpk9rKDH0DnR/Lwtmfpc/ISYAQLbb/c=; path=/; expires=Fri, 24-Nov-23 13:47:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ead5838e129e44ea9bfeb80e91e1a3a3"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "240d3c31c43311af"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ead5838e129e44ea9bfeb80e91e1a3a3"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82b1ee848eb556c4-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-24T13:17:21.969Z",
-        "time": 218,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 218
-        }
-      },
-      {
-        "_id": "7a9709ed2ea97cdf006435d35cf7f3fd",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 186,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "186"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-language-latency\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-24T13:17:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "36edadb1-d689-497f-936e-cca5ddb9bca4"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-24T13:47:23.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xMRQ8x.ZHNEyIcjrUPbVi5H9.bneyqMasQFK31Qd_K4-1700831843-0-AffE52bhX8TsiHa/loQv3fuxJ8T8BejNwm1KdW+wTSFNOlUpuAOQcXv85gPtbvHl7OkSb9gDR1l5dWtgLXooM28="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 24 Nov 2023 13:17:23 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=36edadb1-d689-497f-936e-cca5ddb9bca4; Expires=Sun, 24 Nov 2024 13:17:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=xMRQ8x.ZHNEyIcjrUPbVi5H9.bneyqMasQFK31Qd_K4-1700831843-0-AffE52bhX8TsiHa/loQv3fuxJ8T8BejNwm1KdW+wTSFNOlUpuAOQcXv85gPtbvHl7OkSb9gDR1l5dWtgLXooM28=; path=/; expires=Fri, 24-Nov-23 13:47:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6a0057989e8c0d05de41f397a9a77a86"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "729bdc63a30f1b56"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6a0057989e8c0d05de41f397a9a77a86"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82b1ee8efcb8b4ee-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-24T13:17:23.639Z",
-        "time": 221,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 221
+          "wait": 310
         }
       }
     ],

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -55,7 +55,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 341,
+          "headersSize": 324,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -72,35 +72,35 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteProductVersion"
         },
         "response": {
-          "bodySize": 139,
+          "bodySize": 136,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 139,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxmbGxvFGBkbGuoZGugbm8aZ6RrpmFkkGBgYmlqaGhpZKtbU=\",\"tQAAAAD//wMAfxOIaEkAAAA=\"]"
+            "size": 136,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxuYmFvFGBkbGuoZGugYW8aZ6RroGacYppoaGFoYpqYlKtbW1AAAAAP//AwDACBkySQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:16.000Z",
+              "expires": "2024-12-11T06:50:33.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "cd2f992d-82a4-46e4-86d3-274be92fedd3"
+              "value": "8d485024-2599-4bd2-b14f-fa18c58788f2"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:16.000Z",
+              "expires": "2023-12-11T07:20:33.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "bDN6k1qO5Nu5tp7mW3yJjJXv5.oI6d.lqTtjLaSEEHQ-1701947656-0-AYyPuQ4hBB29wDPv7LJaNzHKYBp5pxYhrgLtfWFNsJz2fTvTz05JEd6hV4vL7PceXAy3/dUoKYCibp150zinGxc="
+              "value": "dT.M9QJ8V0zgMKf4BIGpezv0E0igyB3kAayBzgHwrQw-1702277433-0-AYBV/vxngW2UiSD79vIVP4gDr09giXqyDy71z+Xg5JNAEPpU0zEeUm+o9uq6xODE3vzgthA/F3ajzWUnmauR488="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:16 GMT"
+              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
             },
             {
               "name": "content-type",
@@ -124,7 +124,7 @@
             },
             {
               "name": "retry-after",
-              "value": "205"
+              "value": "152"
             },
             {
               "name": "access-control-allow-credentials",
@@ -141,12 +141,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cd2f992d-82a4-46e4-86d3-274be92fedd3; Expires=Sat, 07 Dec 2024 11:14:16 GMT; Secure"
+              "value": "sourcegraphDeviceId=8d485024-2599-4bd2-b14f-fa18c58788f2; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=bDN6k1qO5Nu5tp7mW3yJjJXv5.oI6d.lqTtjLaSEEHQ-1701947656-0-AYyPuQ4hBB29wDPv7LJaNzHKYBp5pxYhrgLtfWFNsJz2fTvTz05JEd6hV4vL7PceXAy3/dUoKYCibp150zinGxc=; path=/; expires=Thu, 07-Dec-23 11:44:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=dT.M9QJ8V0zgMKf4BIGpezv0E0igyB3kAayBzgHwrQw-1702277433-0-AYBV/vxngW2UiSD79vIVP4gDr09giXqyDy71z+Xg5JNAEPpU0zEeUm+o9uq6xODE3vzgthA/F3ajzWUnmauR488=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -162,15 +162,15 @@
             },
             {
               "name": "x-trace",
-              "value": "0028436fb395c26f09e09fe03013e321"
+              "value": "9010588174884c4371a52ad13fe5e218"
             },
             {
               "name": "x-trace-span",
-              "value": "f5ae7dd0d0f0c785"
+              "value": "45e36fd9f89d139f"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0028436fb395c26f09e09fe03013e321"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9010588174884c4371a52ad13fe5e218"
             },
             {
               "name": "x-xss-protection",
@@ -194,7 +194,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c58120f4f5ab3-VIE"
+              "value": "833bcb442a69f65d-NRT"
             },
             {
               "name": "content-encoding",
@@ -207,8 +207,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:15.956Z",
-        "time": 964,
+        "startedDateTime": "2023-12-11T06:50:32.846Z",
+        "time": 252,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -216,7 +216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 964
+          "wait": 252
         }
       },
       {
@@ -267,7 +267,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 341,
+          "headersSize": 324,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -284,35 +284,35 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
         },
         "response": {
-          "bodySize": 212,
+          "bodySize": 222,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+            "size": 222,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lw=\",\"JKetpnU5wSuJLuVnZyqzxkHf0ANHH7DjRnVqCS07NR26KzljTYMGUby3FsV3wZERa9gEmbj1HNQiBvicfQEAAP//\",\"AwBhzrhaoAAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:17.000Z",
+              "expires": "2024-12-11T06:50:33.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ab13a2f6-b044-447b-be24-3d8dae292539"
+              "value": "44b32adc-6eca-44ad-93a8-f659a2f612c0"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:17.000Z",
+              "expires": "2023-12-11T07:20:33.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "aeSspl4RrD6K548IMO0Oa0x3VNGBHE3EvRIIyg8k7YE-1701947657-0-AVCMelmRmE2RtLgE54wrDY9wgGqqPuGdYPXC1yFYOAVY7bLWcEFQKFPZ1/TElWugVir+IZbek7J75t4WXl5f8Y4="
+              "value": "r9G6RDXxk6cPNHu5y.SHJvdgaxf1ITJOg7up7XMCr2k-1702277433-0-AeqH1UHbxtBgNgTyGqUIBIz1U5ohzxcWUAzb0GHIOPRkU3iN05VNoUhaVAE3FwlQkVN3ijicxdgH1R2DHK2F8+w="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:17 GMT"
+              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
             },
             {
               "name": "content-type",
@@ -336,7 +336,7 @@
             },
             {
               "name": "retry-after",
-              "value": "204"
+              "value": "152"
             },
             {
               "name": "access-control-allow-credentials",
@@ -353,12 +353,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ab13a2f6-b044-447b-be24-3d8dae292539; Expires=Sat, 07 Dec 2024 11:14:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=44b32adc-6eca-44ad-93a8-f659a2f612c0; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=aeSspl4RrD6K548IMO0Oa0x3VNGBHE3EvRIIyg8k7YE-1701947657-0-AVCMelmRmE2RtLgE54wrDY9wgGqqPuGdYPXC1yFYOAVY7bLWcEFQKFPZ1/TElWugVir+IZbek7J75t4WXl5f8Y4=; path=/; expires=Thu, 07-Dec-23 11:44:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=r9G6RDXxk6cPNHu5y.SHJvdgaxf1ITJOg7up7XMCr2k-1702277433-0-AeqH1UHbxtBgNgTyGqUIBIz1U5ohzxcWUAzb0GHIOPRkU3iN05VNoUhaVAE3FwlQkVN3ijicxdgH1R2DHK2F8+w=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -374,15 +374,15 @@
             },
             {
               "name": "x-trace",
-              "value": "16312d4d250381c3495d27408a494c1a"
+              "value": "ebf66b46363231c83128baa13cb67d10"
             },
             {
               "name": "x-trace-span",
-              "value": "fa44b7760778b035"
+              "value": "cf756c9ecf1492c5"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/16312d4d250381c3495d27408a494c1a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ebf66b46363231c83128baa13cb67d10"
             },
             {
               "name": "x-xss-protection",
@@ -406,7 +406,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c581aa8d8c245-VIE"
+              "value": "833bcb472c7aafab-NRT"
             },
             {
               "name": "content-encoding",
@@ -419,8 +419,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:17.343Z",
-        "time": 207,
+        "startedDateTime": "2023-12-11T06:50:33.348Z",
+        "time": 226,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -428,219 +428,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 207
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 131,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 131,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP8=\",\"/wMAHxQFwEUAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:17.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1c80a7f9-1772-487f-a1ce-8a1d8beea33d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:17.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "za2tq4kYaGpmfq1_hSGOxKN4tBhz0DrXekeiF_lIXOY-1701947657-0-AaMp9NguhfGorjh3MM+O4eG2pYm9Di8uDFwlA5RdKeRpWAaTjFJ6EvB5GOhv5px4ar/tc9Zr5SuQWnXqKoIV1kw="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:17 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "204"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1c80a7f9-1772-487f-a1ce-8a1d8beea33d; Expires=Sat, 07 Dec 2024 11:14:17 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=za2tq4kYaGpmfq1_hSGOxKN4tBhz0DrXekeiF_lIXOY-1701947657-0-AaMp9NguhfGorjh3MM+O4eG2pYm9Di8uDFwlA5RdKeRpWAaTjFJ6EvB5GOhv5px4ar/tc9Zr5SuQWnXqKoIV1kw=; path=/; expires=Thu, 07-Dec-23 11:44:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "0f3a0ece5ca7a37455b11bd846c34aa3"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "69e258ec90e0da64"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0f3a0ece5ca7a37455b11bd846c34aa3"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c581a9b56c28c-VIE"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:17.348Z",
-        "time": 230,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 230
+          "wait": 226
         }
       },
       {
@@ -691,7 +479,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 354,
+          "headersSize": 337,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -717,26 +505,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-07T11:14:17.000Z",
+              "expires": "2024-12-11T06:50:33.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5b68c28b-e6f4-4759-b8aa-34fe27f600fd"
+              "value": "5e2e81db-a356-4b2d-8f7b-675e1f58de82"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:17.000Z",
+              "expires": "2023-12-11T07:20:33.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "i4afo1MgaEBFPvwc.t40euFmxivsRTLoNQIQDzHpvcI-1701947657-0-AVy4Q1isC6Ko3ctvZjtRE6vAI1ohAn0qnk+FL/kLmGlqVPicrayv646mszS1Y+ZFG96m9jBMN6DaIAJfxpQ3ZgI="
+              "value": "8lBCm7ws914gJndDvUIjznIu.oaRo5ZPzOjCAL5arLw-1702277433-0-AfPzyrOEo8ohGOEsQFv2kzDnCxRX7iy9jr2XVoYqn2esujkFZZoPbFk2Yi1Ook8O+9r5lCA59TZnnOdXuaGkhzA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:17 GMT"
+              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
             },
             {
               "name": "content-type",
@@ -760,7 +548,7 @@
             },
             {
               "name": "retry-after",
-              "value": "204"
+              "value": "152"
             },
             {
               "name": "access-control-allow-credentials",
@@ -777,12 +565,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5b68c28b-e6f4-4759-b8aa-34fe27f600fd; Expires=Sat, 07 Dec 2024 11:14:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=5e2e81db-a356-4b2d-8f7b-675e1f58de82; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=i4afo1MgaEBFPvwc.t40euFmxivsRTLoNQIQDzHpvcI-1701947657-0-AVy4Q1isC6Ko3ctvZjtRE6vAI1ohAn0qnk+FL/kLmGlqVPicrayv646mszS1Y+ZFG96m9jBMN6DaIAJfxpQ3ZgI=; path=/; expires=Thu, 07-Dec-23 11:44:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=8lBCm7ws914gJndDvUIjznIu.oaRo5ZPzOjCAL5arLw-1702277433-0-AfPzyrOEo8ohGOEsQFv2kzDnCxRX7iy9jr2XVoYqn2esujkFZZoPbFk2Yi1Ook8O+9r5lCA59TZnnOdXuaGkhzA=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -798,15 +586,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f3e727c981b12f079a23fa076544a130"
+              "value": "99cce8e34f938820d32cb83fcc66036c"
             },
             {
               "name": "x-trace-span",
-              "value": "ad785daf51eae78e"
+              "value": "9bf0de4dacf359b7"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f3e727c981b12f079a23fa076544a130"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/99cce8e34f938820d32cb83fcc66036c"
             },
             {
               "name": "x-xss-protection",
@@ -830,7 +618,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "831c581a9a79c31f-VIE"
+              "value": "833bcb472a06afbe-NRT"
             },
             {
               "name": "content-encoding",
@@ -843,8 +631,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-07T11:14:17.347Z",
-        "time": 533,
+        "startedDateTime": "2023-12-11T06:50:33.354Z",
+        "time": 231,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -852,7 +640,5598 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 533
+          "wait": 231
+        }
+      },
+      {
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 155,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "155"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 337,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 128,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 128,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "4130c925-ebb0-489f-a6a8-24995ddd4c2c"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "x5frC_SNYUvG6Whzk96EvzjezBEvX_s45fVSjuhT3V0-1702277433-0-ASyP+T8FeRJFDO/axGDnmmSVZQU3Lawn7kFF7zL9xFlt7PbpOEq/JsTrjGQ3TjUsW7S8pkdx+UKnB8eVNdbolZk="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "152"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4130c925-ebb0-489f-a6a8-24995ddd4c2c; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=x5frC_SNYUvG6Whzk96EvzjezBEvX_s45fVSjuhT3V0-1702277433-0-ASyP+T8FeRJFDO/axGDnmmSVZQU3Lawn7kFF7zL9xFlt7PbpOEq/JsTrjGQ3TjUsW7S8pkdx+UKnB8eVNdbolZk=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "6cd41fb7864e8e5a83404c6cc4f66f40"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0bbb0f881d6ed8c3"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6cd41fb7864e8e5a83404c6cc4f66f40"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4728326875-NRT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:33.355Z",
+        "time": 231,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 231
+        }
+      },
+      {
+        "_id": "bc9d710017cb613b863131822d75d5c7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 233,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "233"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 317,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentUser {\\n    currentUser {\\n        id\\n        hasVerifiedEmail\\n        displayName\\n        avatarURL\\n        codyProEnabled\\n        primaryEmail {\\n            email\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentUser",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
+        },
+        "response": {
+          "bodySize": 302,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 302,
+            "text": "[\"H4sIAAAAAAAAAyyOy07DMBREfwXNOkooohtLEaDSHRSESMX21r5tjPyIru2KKMq/oxB2M2cxZyYYygQ1QRcRDrlLLEu1BgrHr4PT33Hz9tk=\",\"/bw+tS0q9JSOLPZs2ew9WQeVpXAFY9PgaDyQZyg8R2+D1Te7GAOPqEBXyiTdxwsU+pyHpJpmZam+2NyXU0ksOobMIdc6+qY02+3m7vbh2t6jgo5mfJe4D3RybKDO5BJXGMR6kvH/yQReA8zqr/Wf//Gy4GUV8zzPvwAAAP//\",\"AwDJyTrR9AAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "49dcee37-4728-401a-adfd-e03c0af88671"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "8oEWw3v5nm07ajlTY7EJxk08za0nRDjYkrLMCdKxI0M-1702277433-0-ActY6sutPoyH8gBBAw9kgUbxwd0a6ONbw9qAKuvFf844gsUifC+V3BHFBnb/u7hkObwcfb3T5hpff1cQeT9vp0U="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=49dcee37-4728-401a-adfd-e03c0af88671; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=8oEWw3v5nm07ajlTY7EJxk08za0nRDjYkrLMCdKxI0M-1702277433-0-ActY6sutPoyH8gBBAw9kgUbxwd0a6ONbw9qAKuvFf844gsUifC+V3BHFBnb/u7hkObwcfb3T5hpff1cQeT9vp0U=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3dc138ac81bae39c8193fb6b36adafd7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "9247e2da8386ce20"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3dc138ac81bae39c8193fb6b36adafd7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb48ada6afab-NRT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:33.591Z",
+        "time": 225,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 225
+        }
+      },
+      {
+        "_id": "648b7bd2fc47e7d1c610409c95476db3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 444,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "444"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.extension\",\"action\":\"installed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "9ffbf61d-7628-4fcf-910d-7e8377a50d30"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "v_UAVxHFsmeiBtm._IYeb1oMp4UYuIcNJ0zeDhbF7N8-1702277433-0-AVYeW90Ru68pJr19MM9b/v5KggvJ80MOOx3RiclsZNGQ0BUs8jfxaQ6rpBZb7sdG4ausOkj7dNzYqSsAc5Nbx3E="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=9ffbf61d-7628-4fcf-910d-7e8377a50d30; Expires=Wed, 11 Dec 2024 06:50:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=v_UAVxHFsmeiBtm._IYeb1oMp4UYuIcNJ0zeDhbF7N8-1702277433-0-AVYeW90Ru68pJr19MM9b/v5KggvJ80MOOx3RiclsZNGQ0BUs8jfxaQ6rpBZb7sdG4ausOkj7dNzYqSsAc5Nbx3E=; path=/; expires=Mon, 11-Dec-23 07:20:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "b059060d2673d7f5f11409c7c7119c96"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5c8d8f9a700af2e4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b059060d2673d7f5f11409c7c7119c96"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb48aa115ead-NRT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:33.583Z",
+        "time": 256,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 256
+        }
+      },
+      {
+        "_id": "457ee78ea180e105401d1713fa553a05",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 171,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "171"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "52457695-6930-4737-955d-24b57402c62c"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XOMpwgryEXV7I4V53vpt37nhrYiPDVHuNC_uTP_fapo-1702277434-0-Aey9YtNQ2LbKaAYgwh0GL37qCKh8Yb4mfnuAFDNcDBvdw0lCTbCBFcQvZlB4bqIQfdgeeF3jMqE34+F7e/1Xdso="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=52457695-6930-4737-955d-24b57402c62c; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=XOMpwgryEXV7I4V53vpt37nhrYiPDVHuNC_uTP_fapo-1702277434-0-Aey9YtNQ2LbKaAYgwh0GL37qCKh8Yb4mfnuAFDNcDBvdw0lCTbCBFcQvZlB4bqIQfdgeeF3jMqE34+F7e/1Xdso=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "6de366e001620b44c77a326ad0118592"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "1fc6496523929b71"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6de366e001620b44c77a326ad0118592"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4a3be9dfdd-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:33.836Z",
+        "time": 266,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 266
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 318,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 735,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 735,
+            "text": "[\"H4sIAAAAAAAA/4xVUXLrOAy7i7/LC+QAvcTOftASYnMiSy5JJfF2evcdJZn3Jq9Pcb8FQ4AI0J9DZOfh8DngzKmyI76DvSreE082HP75HA==\",\"Mi8YDkMocaMLRgoz+/A2NDyGw5GT4evtF2xMZaSVJ5BdxMNMrGAjm4t6qG79Lw2sYaZ5G1Xib5hrfULJlOtKVvWMjZB5TIh90pvqVUuX7wbg6iWUZU1wUMSRa3IyZw0lQh+SyErVgEl5nfsX8khnMfGi5KUqXcRnysUxlnKyvq27eeV8kjx1YZOuoXtYVuQmeEfh46pQsiM7jWyIlDhPFOEILiXvvOfTc914rk7jcaJFrrvDaBHilLou7iMlcwUvkieaxGlM7XDnEywjImmp3oc+zGdc6ITtUvSF3Ae2XDLUZln3SCPGOvXpHAkLXDfCdS3qryPZWkZLCSdy2Iu+KTsoySJuhGsAIiIdW/pg/hSl/VH2kv8yjvRfwWnHzPMtW+ZFAi01uSTJLUK3Iyn5xXpoOVM2v6OFs5Nt2flKs0xzkmn+gd0WPpOIkbWrmEOAGXk5IRtJDqlGkGRzzgEkEdnlKOgzfPfsyuFn6hBvu0MRZEV/X3y/ojW4tr2b2JHDtuNPWmOOkpo29Pvyl/GJ3dqmCFtIraDlSKviLKUaKT4q7NWa/6gSTreI+X1DtrBy9bk9a2h/IKoGfW39T/p/v77+DwAA//8RG8BUywYAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6ad6fca0-0dde-46c9-a9ac-de00bacf2fb2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Uxfa3l9lHGPey1Xz1dJJIX3DykiqwEkFDprz2ob012g-1702277434-0-AU4p9601mi314lLd7h0wzNgyQsMqrSuNLPDH4t1BdgPN/JBhRa0Ci6wbp+qfhKzeLlkKux9OcTbbPESA6jRJXmE="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6ad6fca0-0dde-46c9-a9ac-de00bacf2fb2; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Uxfa3l9lHGPey1Xz1dJJIX3DykiqwEkFDprz2ob012g-1702277434-0-AU4p9601mi314lLd7h0wzNgyQsMqrSuNLPDH4t1BdgPN/JBhRa0Ci6wbp+qfhKzeLlkKux9OcTbbPESA6jRJXmE=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "54272d4302ccefaf061bd0201c0e5d71"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "f60af9e9d38f96e9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/54272d4302ccefaf061bd0201c0e5d71"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4a39c9f619-NRT"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:33.831Z",
+        "time": 304,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 304
+        }
+      },
+      {
+        "_id": "68618dc68610496fb5623c6778ea6c25",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 177,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "177"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2a828fe1-37ce-48d6-ae17-99088587b27c"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "X4HjnDgYgimPccDuwWZ9f9XmRkK9PDc3Iv3wfFdM4XY-1702277434-0-AbOpDSk4WshA2iE+zZ7XhKeTrV5AcOPJ7ziV74a/rXQWmUwDYp/cokVS4/3dlOLV3b7FTnVQ3eU1oFqEY+vuPR4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2a828fe1-37ce-48d6-ae17-99088587b27c; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=X4HjnDgYgimPccDuwWZ9f9XmRkK9PDc3Iv3wfFdM4XY-1702277434-0-AbOpDSk4WshA2iE+zZ7XhKeTrV5AcOPJ7ziV74a/rXQWmUwDYp/cokVS4/3dlOLV3b7FTnVQ3eU1oFqEY+vuPR4=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c07e421b10503f87fdc23975e7bc6f28"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "6d769ded3ba895b8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c07e421b10503f87fdc23975e7bc6f28"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4a3989f629-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:33.833Z",
+        "time": 340,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 340
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2cc306b7-727b-4777-a533-40c99580a91d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "PFdCQrXr2jPw3pJAwgIRn7VxpsU08NG.ikm19OG_KwU-1702277434-0-AQKTeVAunCxDzyL67ght5FjpVicFHnAqVo9lwu2cmj1Fc4+Nx4OZxUBSjPza/zGtKi1kS8bDXP3UL6I00QyvAT0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2cc306b7-727b-4777-a533-40c99580a91d; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=PFdCQrXr2jPw3pJAwgIRn7VxpsU08NG.ikm19OG_KwU-1702277434-0-AQKTeVAunCxDzyL67ght5FjpVicFHnAqVo9lwu2cmj1Fc4+Nx4OZxUBSjPza/zGtKi1kS8bDXP3UL6I00QyvAT0=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "434e925963e81a329cb43df3adcea77e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "d98fbb63327a3ace"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/434e925963e81a329cb43df3adcea77e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c19998a27-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.120Z",
+        "time": 258,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 258
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "4a34ca04-f685-4fd4-8d87-54ff7151c1c5"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "OTfiKqBn.mPdaxh8ec8tiQHtBOR704EVn_WN5dGA__g-1702277434-0-AZagjBvUZgYuo+P3Ye9N4KRm4IjvG29j1ettN7Q5bzZ2lHuI1QGyLvIbJX/YvjXuw+A//uwlI/kkKvkGQwf4Y0A="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4a34ca04-f685-4fd4-8d87-54ff7151c1c5; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=OTfiKqBn.mPdaxh8ec8tiQHtBOR704EVn_WN5dGA__g-1702277434-0-AZagjBvUZgYuo+P3Ye9N4KRm4IjvG29j1ettN7Q5bzZ2lHuI1QGyLvIbJX/YvjXuw+A//uwlI/kkKvkGQwf4Y0A=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "aa2c817b73b79f8d4de8dcf2779a721a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0339ccb84c379dca"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/aa2c817b73b79f8d4de8dcf2779a721a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c1abc0ad8-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.127Z",
+        "time": 259,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 259
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "62ef6fb8-ae43-4968-8611-a70fcdd6cc28"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "3.9yJCGZdleMN8D27VMfF618nU32sAGsjKlF9SXH6Vs-1702277434-1-ATRC/ffB8RLkgQEdRTtfr22HchkldF6TE2D6DnIQet7rv+z5Wfsg0hqXnNz+AH+0syibJw0W+hN48iy9FvU3C64="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=62ef6fb8-ae43-4968-8611-a70fcdd6cc28; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=3.9yJCGZdleMN8D27VMfF618nU32sAGsjKlF9SXH6Vs-1702277434-1-ATRC/ffB8RLkgQEdRTtfr22HchkldF6TE2D6DnIQet7rv+z5Wfsg0hqXnNz+AH+0syibJw0W+hN48iy9FvU3C64=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "692561189ed9e62a77e4c68f68607a32"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "d21334e7d3dcef9a"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/692561189ed9e62a77e4c68f68607a32"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c18ef80b4-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.129Z",
+        "time": 270,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 270
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "9b605e72-62a1-4b17-859c-87e85b280920"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "QK6Jop9faFGHqLSzECfk30jmAhlO3DVy.yBwjlz3xmM-1702277434-0-AVHo4XYQmjSbNnHqW0iR4zRLoYzfdAkwjm7w7XZMLYbmYAHy9CQa5pkFCTzMJmnglSZ4EWMUouceMPBczN5X8DE="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=9b605e72-62a1-4b17-859c-87e85b280920; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=QK6Jop9faFGHqLSzECfk30jmAhlO3DVy.yBwjlz3xmM-1702277434-0-AVHo4XYQmjSbNnHqW0iR4zRLoYzfdAkwjm7w7XZMLYbmYAHy9CQa5pkFCTzMJmnglSZ4EWMUouceMPBczN5X8DE=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "5c9355a894e8d59a59df633123636416"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "1b1b1541598023e6"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5c9355a894e8d59a59df633123636416"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c1abaf5a3-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.131Z",
+        "time": 297,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 297
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3646da19-3c04-4232-9407-314f1f9decd2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "p9KHfmtm9PcPWZnJaOmuVelm2dTDVmVOxwYSLjXlutY-1702277434-0-Ae8ISwZ8+G8V91n+iy16PnaxGrSZ4Z0+RkdWvk/hIgxUJauxupMxKa/G1MZjBDdl8it4JcTYlYh+deJX6h6Ei+0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3646da19-3c04-4232-9407-314f1f9decd2; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=p9KHfmtm9PcPWZnJaOmuVelm2dTDVmVOxwYSLjXlutY-1702277434-0-Ae8ISwZ8+G8V91n+iy16PnaxGrSZ4Z0+RkdWvk/hIgxUJauxupMxKa/G1MZjBDdl8it4JcTYlYh+deJX6h6Ei+0=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "63405bdc03b5cc7640ba1e41aaa9ca0f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5ba00b5a90fa4895"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/63405bdc03b5cc7640ba1e41aaa9ca0f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c1de25c8b-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.122Z",
+        "time": 352,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 352
+        }
+      },
+      {
+        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 160,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "160"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1ed148e1-6724-4089-a10f-2ccc3f03d5da"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "GWgmfUmBHH8LCAA3AN2M9QVZjrI6LL3a9cnOLTjoMDs-1702277434-0-AXcolrjMvjdc2ZeWHMhR+fVE+E7bxu+qblrpX5V5YIjK6qnlvk0YveYIQ82/dLaPHnsjoQpDFOqBhRBoq7N/dq4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1ed148e1-6724-4089-a10f-2ccc3f03d5da; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=GWgmfUmBHH8LCAA3AN2M9QVZjrI6LL3a9cnOLTjoMDs-1702277434-0-AXcolrjMvjdc2ZeWHMhR+fVE+E7bxu+qblrpX5V5YIjK6qnlvk0YveYIQ82/dLaPHnsjoQpDFOqBhRBoq7N/dq4=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "780c89e9482497dbabc2cc87af70c8ae"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "023987bba5582e04"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/780c89e9482497dbabc2cc87af70c8ae"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c1f67afaf-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.117Z",
+        "time": 365,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 365
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "c439675f-6b38-487c-b412-de619c083bf9"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Q2KOA4vTN_xqPp.fn8UVKR3BRVwWsgRTp2XtA_Dgezg-1702277434-0-AYPUpV8eKVeEQVYv5J5TiKBjF6h6TcmAWBI7n9ifrILgMXkdciDheWcBptYQEv7B2lB5DhBbHXAOOEOHZXxp0ps="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "151"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=c439675f-6b38-487c-b412-de619c083bf9; Expires=Wed, 11 Dec 2024 06:50:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Q2KOA4vTN_xqPp.fn8UVKR3BRVwWsgRTp2XtA_Dgezg-1702277434-0-AYPUpV8eKVeEQVYv5J5TiKBjF6h6TcmAWBI7n9ifrILgMXkdciDheWcBptYQEv7B2lB5DhBbHXAOOEOHZXxp0ps=; path=/; expires=Mon, 11-Dec-23 07:20:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "dd3f978638017ee22deba22bc00cffb7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "81531104f0c21afa"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dd3f978638017ee22deba22bc00cffb7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb4c1c4e1d5b-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.125Z",
+        "time": 446,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 446
+        }
+      },
+      {
+        "_id": "78b16a1b0ad38fb4611e80c039f06be3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 439,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "439"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 119,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:35.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ea6584e6-6f1c-489d-92d4-94acf7bef3d4"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:35.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "x0mI40RPCvgYFjgD_2A6fVTIIwujN1odvQu18ni.XYQ-1702277435-0-AavL5ZJ08VPEq6dEUxFfy7gXnkWEX0jFxRtynjK/oTBXvpC9GfcAN5UPgmAHg7UZNVqHN0Y+Ach+12DSTHLzbwM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "150"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ea6584e6-6f1c-489d-92d4-94acf7bef3d4; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=x0mI40RPCvgYFjgD_2A6fVTIIwujN1odvQu18ni.XYQ-1702277435-0-AavL5ZJ08VPEq6dEUxFfy7gXnkWEX0jFxRtynjK/oTBXvpC9GfcAN5UPgmAHg7UZNVqHN0Y+Ach+12DSTHLzbwM=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "becc2d5012eace858fdd0070067e7396"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "1fa80be7e2fc27f1"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/becc2d5012eace858fdd0070067e7396"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb514fe2af2a-NRT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.958Z",
+        "time": 290,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 290
+        }
+      },
+      {
+        "_id": "3b85f96566a73d758acb8142a5f046ba",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1186,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1186"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"097d3bae-9c1b-4ad7-910e-e5459e89df28\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:35.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "70fe1817-b38b-46ac-83fb-72ad0a45c1ac"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:35.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "kq4FmQVLIOGdF92.6TBW7tNFqdCeG92mbvrYBKs9z4Y-1702277435-0-Ad2lpFSuxboBG0IS2szVD3E0VqbQX2Z0hUtjS/DUBznVcWcx98xZujR+85yyKwHd/O+Tg5peSEu0bKAcJOa9Ab8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "150"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=70fe1817-b38b-46ac-83fb-72ad0a45c1ac; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=kq4FmQVLIOGdF92.6TBW7tNFqdCeG92mbvrYBKs9z4Y-1702277435-0-Ad2lpFSuxboBG0IS2szVD3E0VqbQX2Z0hUtjS/DUBznVcWcx98xZujR+85yyKwHd/O+Tg5peSEu0bKAcJOa9Ab8=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "fdfe7fc5bc7aad888ce84e0410c296eb"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a1b29d9cfae6113a"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fdfe7fc5bc7aad888ce84e0410c296eb"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb516cafe04f-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.980Z",
+        "time": 291,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 291
+        }
+      },
+      {
+        "_id": "c6fff7961bbfc269c8c577f2e1929038",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 436,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "436"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 119,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:35.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "58b2463e-6e26-4643-8d0c-9e1f79e9012d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:35.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "yBaj1cjMSOu4FjtJNs5oSmmua7Hkw3YTfvewhDvwK0g-1702277435-0-AS+AxK7EBevsmWEoehN/o2MmpduKUykAJXmKYwrM3X4nuTff37mqHTZI1Br+zcjaERElZ64TfBsekCh4iYJ4x6M="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "150"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=58b2463e-6e26-4643-8d0c-9e1f79e9012d; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=yBaj1cjMSOu4FjtJNs5oSmmua7Hkw3YTfvewhDvwK0g-1702277435-0-AS+AxK7EBevsmWEoehN/o2MmpduKUykAJXmKYwrM3X4nuTff37mqHTZI1Br+zcjaERElZ64TfBsekCh4iYJ4x6M=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1bc47e4fc345e0adc397853df5a47ad8"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "756f3766cd22798b"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1bc47e4fc345e0adc397853df5a47ad8"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb516ed8afb2-NRT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.981Z",
+        "time": 304,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 304
+        }
+      },
+      {
+        "_id": "42f182961bcd677f1d11f6bda0580606",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1188,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1188"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"fd767883-d246-47fd-92e7-a61cb7c88f9a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:35.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ad9403bb-ad43-4ac6-becd-f16a3cf12467"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:35.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "tcWvbadiRoUS.U9mhSk7UZMtl2xXJRFi5WShIh04mwI-1702277435-0-AWqc0RVkhQ8uYgJvCNKIoT56VMOUtBUS5ph7JuWIojuNHq6aOQqAVMQrfsx0cN31sfBd7KPOTD4Y75PBOzOJXTA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "150"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ad9403bb-ad43-4ac6-becd-f16a3cf12467; Expires=Wed, 11 Dec 2024 06:50:35 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=tcWvbadiRoUS.U9mhSk7UZMtl2xXJRFi5WShIh04mwI-1702277435-0-AWqc0RVkhQ8uYgJvCNKIoT56VMOUtBUS5ph7JuWIojuNHq6aOQqAVMQrfsx0cN31sfBd7KPOTD4Y75PBOzOJXTA=; path=/; expires=Mon, 11-Dec-23 07:20:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d72d3c2a201860e6544bf26bafc657e4"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4bb0f89d235c61a8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d72d3c2a201860e6544bf26bafc657e4"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb514d63e0a8-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:34.956Z",
+        "time": 629,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 629
+        }
+      },
+      {
+        "_id": "3bfde46a074296956deef9dbd207df0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "89601edc-2844-4a2b-8129-05b14c26235d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "M3hK3ihGDQWeXyYUScgT762orOQr5i4YsD0QrePrElQ-1702277436-0-AQ/hipK7DxsJyPtQBB/D0TY8QUfsbtlMVQaXiwrI9RQP3lEDlShBs//Yk8qoHtfRzJQeCZ6rgh0Oni5Fbw0NZtY="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=89601edc-2844-4a2b-8129-05b14c26235d; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=M3hK3ihGDQWeXyYUScgT762orOQr5i4YsD0QrePrElQ-1702277436-0-AQ/hipK7DxsJyPtQBB/D0TY8QUfsbtlMVQaXiwrI9RQP3lEDlShBs//Yk8qoHtfRzJQeCZ6rgh0Oni5Fbw0NZtY=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "bd4d45c8b21c79ede9a645e62add61e6"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a5daf245a9b2b82c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bd4d45c8b21c79ede9a645e62add61e6"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb573bde8a54-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:35.908Z",
+        "time": 241,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 241
+        }
+      },
+      {
+        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 190,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "190"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "95c3f6b6-96e3-4d43-8fe1-d1497e8e35f9"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "LcHvKOaHFBfVX3bLmMViWwv_Wf5kvCKnFo7mbnNitdI-1702277436-0-AfF9bpoQ3LouLyPStF6bvqY1/PCrS+/wEl1veyqhqkI/FAbQl+dgPZwUDl3SmbczXM1SQA++126b/9sG5YgqHiU="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=95c3f6b6-96e3-4d43-8fe1-d1497e8e35f9; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=LcHvKOaHFBfVX3bLmMViWwv_Wf5kvCKnFo7mbnNitdI-1702277436-0-AfF9bpoQ3LouLyPStF6bvqY1/PCrS+/wEl1veyqhqkI/FAbQl+dgPZwUDl3SmbczXM1SQA++126b/9sG5YgqHiU=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "9de102e17036aedc3676b2cd046f33a0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "acf4f2466af5e79d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9de102e17036aedc3676b2cd046f33a0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb573e32687c-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:35.905Z",
+        "time": 255,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 255
+        }
+      },
+      {
+        "_id": "103c65b93dfa88c72eea86b3b023599e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1ea0691f-5b41-47c1-b559-83a5f4a7fa97"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "lgTcJhlXJ4zs2FkbTy_P9ON.6wgEspqc23uYAsz086Y-1702277436-0-AcaDzqaqyTJYU2fTihrTBr7wso2jWsnwMtv3+aWpVyA53bdty9IkZ2Sel3+1fYuikDnl5A4vb4iRNbseGyWmMoI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1ea0691f-5b41-47c1-b559-83a5f4a7fa97; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=lgTcJhlXJ4zs2FkbTy_P9ON.6wgEspqc23uYAsz086Y-1702277436-0-AcaDzqaqyTJYU2fTihrTBr7wso2jWsnwMtv3+aWpVyA53bdty9IkZ2Sel3+1fYuikDnl5A4vb4iRNbseGyWmMoI=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "05999aef9612c8a6a5c9303df30d4de0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "9c85774b883d041c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/05999aef9612c8a6a5c9303df30d4de0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb574fcf3bf9-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:35.907Z",
+        "time": 277,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 277
+        }
+      },
+      {
+        "_id": "ef779c1307829b0101c443d73f03b56c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"097d3bae-9c1b-4ad7-910e-e5459e89df28\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "aa5557b2-d010-408b-9c91-9c21e8df143b"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "4ZbexE5vstzoH_Q0UcKiGyj44UIDCEgM8GeRlVj7qgQ-1702277436-0-AUHTD7tsPopMa+4xhUxjpD2SfF/t7mfSmsW1nv9x/bdC2YbRkKS+zL5tmXk2B8xFBqnUF69IIKnOELezLix6a9o="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=aa5557b2-d010-408b-9c91-9c21e8df143b; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=4ZbexE5vstzoH_Q0UcKiGyj44UIDCEgM8GeRlVj7qgQ-1702277436-0-AUHTD7tsPopMa+4xhUxjpD2SfF/t7mfSmsW1nv9x/bdC2YbRkKS+zL5tmXk2B8xFBqnUF69IIKnOELezLix6a9o=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c0251fa0affc1b57f627885472d5ee36"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "10b34a673cdf48ed"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c0251fa0affc1b57f627885472d5ee36"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb574815aff9-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:35.900Z",
+        "time": 298,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 298
+        }
+      },
+      {
+        "_id": "ac7fc975d31f02e814346a770195c756",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 192,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "192"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "bf956356-e936-41e6-a26a-9d9fb97e393b"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "1qph1HJ4jMrpTz5YkD84ygF_oqIcYkgDIyOn43ff1yQ-1702277436-0-AYFcAOMWaeh3cIUfclrBNRTsRggA0mM1+jhWnAFvO+66p2AGzZ6U6R0pfSZzr0hSpaAkUKMNpVHxgzJDYb8xUDA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=bf956356-e936-41e6-a26a-9d9fb97e393b; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=1qph1HJ4jMrpTz5YkD84ygF_oqIcYkgDIyOn43ff1yQ-1702277436-0-AYFcAOMWaeh3cIUfclrBNRTsRggA0mM1+jhWnAFvO+66p2AGzZ6U6R0pfSZzr0hSpaAkUKMNpVHxgzJDYb8xUDA=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3540b173b66a0de8153c03c7f814a17a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "022c1ec97d2f6230"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3540b173b66a0de8153c03c7f814a17a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb573c9af689-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:35.909Z",
+        "time": 293,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 293
+        }
+      },
+      {
+        "_id": "4cb0e95333a7b013a23cbf416464bd74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "5ada5631-e34f-4f38-9a23-b5d4527cb6bf"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "uALmy_q0WGZgsIAu7.Cwz.3vsQKnYsGyGS1pNu_Z_q0-1702277436-0-AfM1YKkmVQ5MwKIO3r/XJ1Nwfw1cw7w7Eki84X5xoNjbmeXGnMaa3tX61et0hZ3bVtpbGgAeIEQ6nQp5ub+N+d8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=5ada5631-e34f-4f38-9a23-b5d4527cb6bf; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=uALmy_q0WGZgsIAu7.Cwz.3vsQKnYsGyGS1pNu_Z_q0-1702277436-0-AfM1YKkmVQ5MwKIO3r/XJ1Nwfw1cw7w7Eki84X5xoNjbmeXGnMaa3tX61et0hZ3bVtpbGgAeIEQ6nQp5ub+N+d8=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "ec6df75d2d22845d1b1d90650111e4c3"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e7849fa4be7b2249"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ec6df75d2d22845d1b1d90650111e4c3"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb573dd3685a-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:35.906Z",
+        "time": 297,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 297
+        }
+      },
+      {
+        "_id": "7449140909c921a511332d4c1de94c1f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 182,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "75342e45-fd12-4316-a796-836dedd1597e"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "SB4p8X7S3NTiwuvYdSANZLr.ZmxSWiJCCYaNw62MbB0-1702277436-0-AbHkTHv5QStp1P74/L+1dBwxBhTI3II+ss1aMhfvOooK7tsZhaTtulYLg3N0LyNw5NXmVtIioUhWC48u19KZVSM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "149"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=75342e45-fd12-4316-a796-836dedd1597e; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=SB4p8X7S3NTiwuvYdSANZLr.ZmxSWiJCCYaNw62MbB0-1702277436-0-AbHkTHv5QStp1P74/L+1dBwxBhTI3II+ss1aMhfvOooK7tsZhaTtulYLg3N0LyNw5NXmVtIioUhWC48u19KZVSM=; path=/; expires=Mon, 11-Dec-23 07:20:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "bd3db4e999ae941bd46579ef4d8e17b8"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "881f8b88b1762354"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bd3db4e999ae941bd46579ef4d8e17b8"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb5a3b49decd-NRT"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:36.390Z",
+        "time": 227,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 227
+        }
+      },
+      {
+        "_id": "0d16a033a475b66e0dc0d6a4321be2a8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 297,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "297"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 319,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/code"
+        },
+        "response": {
+          "bodySize": 98,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 98,
+            "text": "event: completion\ndata: {\"completion\":\" return a + b\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "74d18ffe-2547-4ed1-9f37-e2ae90e4a7b1"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:38.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Ph4CgpBYseErQH0SnjrpgEFTWgnJW7SX7XNQkowLsO8-1702277438-0-AdB4Nox604RkT3MHxRRrCEFBKDe4c3NwGBgPaJyky1RBNSgqytSh0I/zPBaTM0yEzo2kHbmD0aDQRzAVe54qyZA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "148"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=74d18ffe-2547-4ed1-9f37-e2ae90e4a7b1; Expires=Wed, 11 Dec 2024 06:50:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Ph4CgpBYseErQH0SnjrpgEFTWgnJW7SX7XNQkowLsO8-1702277438-0-AdB4Nox604RkT3MHxRRrCEFBKDe4c3NwGBgPaJyky1RBNSgqytSh0I/zPBaTM0yEzo2kHbmD0aDQRzAVe54qyZA=; path=/; expires=Mon, 11-Dec-23 07:20:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "2bc707dc4230fb06d8e643142c1d2139"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "82a626c4959aa312"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2bc707dc4230fb06d8e643142c1d2139"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb5ba9db261e-NRT"
+            }
+          ],
+          "headersSize": 1239,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:36.628Z",
+        "time": 1368,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1368
+        }
+      },
+      {
+        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 333,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "333"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:38.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ec333477-4fe9-4d8f-978e-8d4a9cc514a2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:38.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "HPVqbd.7mPVg8KyVEgYmq1rfj6JSWeLmAjHZJchNmRo-1702277438-0-AbcPK81CYUvBsBdcPtdhFm8sQW04mr1ODQiinThgtpSqkeb61ipYY8m8O4YoHEI5h1nBLIjgmJgKVL1DldRruFs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:38 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "147"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ec333477-4fe9-4d8f-978e-8d4a9cc514a2; Expires=Wed, 11 Dec 2024 06:50:38 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=HPVqbd.7mPVg8KyVEgYmq1rfj6JSWeLmAjHZJchNmRo-1702277438-0-AbcPK81CYUvBsBdcPtdhFm8sQW04mr1ODQiinThgtpSqkeb61ipYY8m8O4YoHEI5h1nBLIjgmJgKVL1DldRruFs=; path=/; expires=Mon, 11-Dec-23 07:20:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "9da363a6e1cd4f918831b36ea2419779"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "8df05a87615ca400"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9da363a6e1cd4f918831b36ea2419779"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb66fbb880fc-NRT"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:38.441Z",
+        "time": 264,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 264
+        }
+      },
+      {
+        "_id": "34fa3baab68c77b4e329fd24907b91f7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1300,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 217,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/stream"
+        },
+        "response": {
+          "bodySize": 44267,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 44267,
+            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum`.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum`.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T06:50:38.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "e6810af8-52fc-430f-9298-c8aeb5accc75"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T07:20:40.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "EcgOs1Qvp3gMDnwTl7vLzpQVWtyglw.INLZdC5N7vpE-1702277440-0-ATrhWLMiDq3zhplSo3aUoayxdWzFhUJEWLAUVYJz3D+FZzjl2GpuUqrZziZzn7g8nWDUT4f/IMUCtUzjWWDMBJ4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 06:50:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "147"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=e6810af8-52fc-430f-9298-c8aeb5accc75; Expires=Wed, 11 Dec 2024 06:50:38 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=EcgOs1Qvp3gMDnwTl7vLzpQVWtyglw.INLZdC5N7vpE-1702277440-0-ATrhWLMiDq3zhplSo3aUoayxdWzFhUJEWLAUVYJz3D+FZzjl2GpuUqrZziZzn7g8nWDUT4f/IMUCtUzjWWDMBJ4=; path=/; expires=Mon, 11-Dec-23 07:20:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1220ae72d9660f48247590655cc6148f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "12bd7eb62b74970e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1220ae72d9660f48247590655cc6148f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833bcb656eaa7341-NRT"
+            }
+          ],
+          "headersSize": 1239,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T06:50:38.191Z",
+        "time": 6302,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6302
         }
       },
       {
@@ -1277,1253 +6656,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 276
-        }
-      },
-      {
-        "_id": "68618dc68610496fb5623c6778ea6c25",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 177,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "177"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "234733e7-1cdf-4b17-a53d-41f8cdb85b4a"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xe003kegFQxukDGhnw.OxyC1xQHxN5aV1223TAKcqLA-1701947658-0-ATgSdMi6xE8mHxxEZ0oGdq773ff8cgzXL12ch9h6AEOKrIjwYfdTSNt6drwSOFC2j+VFyY3ls402gCJXnM3ORRs="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "203"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=234733e7-1cdf-4b17-a53d-41f8cdb85b4a; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=xe003kegFQxukDGhnw.OxyC1xQHxN5aV1223TAKcqLA-1701947658-0-ATgSdMi6xE8mHxxEZ0oGdq773ff8cgzXL12ch9h6AEOKrIjwYfdTSNt6drwSOFC2j+VFyY3ls402gCJXnM3ORRs=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "1ea2cddef626582b7c4b6879abf0afba"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "fe40e79214633356"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1ea2cddef626582b7c4b6879abf0afba"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c581f8fe63251-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:18.134Z",
-        "time": 232,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 232
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 335,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 787,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 787,
-            "text": "[\"H4sIAAAAAAAA/6RVW3LbMAy8i76DC/gAuUSnHxC5ljCmSAUAbauZ3L1DxZM2aSW70288uNgFlq9dZOfu8NrhzKmyIz6DvSqeEw/WHb69dg==\",\"mSd0h+6lSjiROauTl6p0LEpcfUR2Ca2SqkGte+paK3SHIyfD29NHB46TZOLMaXEJRoHDCIpi3CfE7bpB5/Ar6lp/D4YSl+3SFqULegoj+3aagTWMFEp2ZKeeDZES54EiHMGl5O3iPpWeZh5AdhEPI7GCjWws6qH6DiEf6EwietbdIQnXGSoTsnPazERuZBKmHpG0VMdm6qwl1uBktbegMrcpjRQcoWTQswQQh1Bq3qFuhcbVSyjTnOB4Z/Hq1B8HmuS6p+wNrbmCJ8kDDeLUpxbcQt2WgX4UnHyfrUYronhRUgSZYTv52ZXNaR1BODvZkp2vNMowJhlGlzzc3Z5yyVAbZd586JaonE+fGj4kzH8oEnHkmnw93lCavOPSq8R7QCXP1dsiX2gU86L3Lu3Tq64c9sb8C84l8ySBpppckmTQLdQI2H5a2UFJJnEjXAMQEVd3cti+co9TRVaqBgzK8/hP/d7dre3gElJb8XKkWXGWUtuxvVTYnkXclHhMr4i+3pu23QWnbQPhEGAmDfNRUlMR28e4dmzWSlMJp5XvexgzLnTCcim64wtr31nLNsqezmLrda9/0UV8pFwcfSmn7Uv/+gO9+882r3/q2T6F2rw+sSOH5REebZn6kvaZdCRMcF1tvuhXGr+/vf0MAAD//98jL9mrBwAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "56cbda65-1b3e-4441-becf-c5c7575f6bf4"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "bCvBUP8O3cC5bwkutUxCtRYnbgTie1DK7lgWIsB96Qg-1701947658-0-ASzD/cxkyR0EeH/N03OiQjgOJmGuNtCSRyGQIF/LoCncUplC4h1tdZz1GCTmMzujMiZXLhRYjOrU0mEjMW7rAug="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "203"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=56cbda65-1b3e-4441-becf-c5c7575f6bf4; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=bCvBUP8O3cC5bwkutUxCtRYnbgTie1DK7lgWIsB96Qg-1701947658-0-ASzD/cxkyR0EeH/N03OiQjgOJmGuNtCSRyGQIF/LoCncUplC4h1tdZz1GCTmMzujMiZXLhRYjOrU0mEjMW7rAug=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f824b02b8bc0900bcbfcd0d986bfd3d0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "01a1e967e11ffcb8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f824b02b8bc0900bcbfcd0d986bfd3d0"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c581f8a49c232-VIE"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:18.136Z",
-        "time": 233,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 233
-        }
-      },
-      {
-        "_id": "457ee78ea180e105401d1713fa553a05",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 171,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "171"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "75b4930e-44d5-489c-a5b5-f5485567d5f8"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "XdQ4Mcp_.DnvGNfeC0vgp4KnSpyy877Moor2e6buSDE-1701947658-0-Aa1/1yT7sTB94BHnaMvuS6h/CKGCgTodOJlUDgoS7S32/jSkm0EyVUaAJv5zoho5kBPEJDsd/n67tl0wzNEnaJE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "203"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=75b4930e-44d5-489c-a5b5-f5485567d5f8; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=XdQ4Mcp_.DnvGNfeC0vgp4KnSpyy877Moor2e6buSDE-1701947658-0-Aa1/1yT7sTB94BHnaMvuS6h/CKGCgTodOJlUDgoS7S32/jSkm0EyVUaAJv5zoho5kBPEJDsd/n67tl0wzNEnaJE=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "5d526cad33456a0fd7183870e99493ac"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "235cdb5fa0a38849"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5d526cad33456a0fd7183870e99493ac"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c581f8ec85a9f-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:18.138Z",
-        "time": 295,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 295
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "27e2c402-5c9e-458a-a296-62654634c994"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Pvxsq_D4ckUZgCzcaJ4nKUNSFWceGaavszsyZwdo6do-1701947658-0-AZIBL4F1sfhhfVKgkr4hsx6+f+Fdf/9SvBhp8ER+KO6BGDyE0qO5oxdzEduvhrTBCY6B0HmNPt40ysq02/phmkg="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "202"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=27e2c402-5c9e-458a-a296-62654634c994; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Pvxsq_D4ckUZgCzcaJ4nKUNSFWceGaavszsyZwdo6do-1701947658-0-AZIBL4F1sfhhfVKgkr4hsx6+f+Fdf/9SvBhp8ER+KO6BGDyE0qO5oxdzEduvhrTBCY6B0HmNPt40ysq02/phmkg=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b1b943744a0a3bcfbedf74fe8e938438"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "a2d75e1e26f0a7c9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b1b943744a0a3bcfbedf74fe8e938438"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c58218873c256-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:18.448Z",
-        "time": 189,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 189
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "5e2f440f-6258-4d0b-9490-6946ae6e71f9"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "fA_rXtsQusFonIVTL7iXaHpy5WAm.C2eSjPw3xOnFBo-1701947658-0-AR37yEs1y0PB8JUvai8+lJF+5zLcwPSVLOlrBKXKH/569Sjh8siLCkgPzqxpSaCZzLBDr0SYb2OgRcdmjlre2lc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "202"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5e2f440f-6258-4d0b-9490-6946ae6e71f9; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=fA_rXtsQusFonIVTL7iXaHpy5WAm.C2eSjPw3xOnFBo-1701947658-0-AR37yEs1y0PB8JUvai8+lJF+5zLcwPSVLOlrBKXKH/569Sjh8siLCkgPzqxpSaCZzLBDr0SYb2OgRcdmjlre2lc=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c3771c6f44e8fdd69ef2a4ea31ed6f07"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "668940df11528a4a"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c3771c6f44e8fdd69ef2a4ea31ed6f07"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582189b73266-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:18.449Z",
-        "time": 192,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 192
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c6b954c9-6b0c-4da4-9bc9-ea14afce02ba"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "muDhChBP5snY9Z7F3Fpd0k4MeYOKyaSwr76jD3oeX84-1701947658-0-ATqLUTKK2cwbI01+WG/rWQcdxFmvcT2CaLE+WkwRZ6gwOXs7tjmdJJibwuMJx8dNdKAoDsYVV1gbswLZPixGSNM="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "202"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c6b954c9-6b0c-4da4-9bc9-ea14afce02ba; Expires=Sat, 07 Dec 2024 11:14:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=muDhChBP5snY9Z7F3Fpd0k4MeYOKyaSwr76jD3oeX84-1701947658-0-ATqLUTKK2cwbI01+WG/rWQcdxFmvcT2CaLE+WkwRZ6gwOXs7tjmdJJibwuMJx8dNdKAoDsYVV1gbswLZPixGSNM=; path=/; expires=Thu, 07-Dec-23 11:44:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b2d81eae58f85cd2b3257f49080ca596"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "03b7835155123752"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b2d81eae58f85cd2b3257f49080ca596"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582189d65a84-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:18.446Z",
-        "time": 285,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 285
         }
       },
       {
@@ -3365,627 +7497,6 @@
         }
       },
       {
-        "_id": "4cb0e95333a7b013a23cbf416464bd74",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "014b54b9-e26e-498e-ad34-263c69828710"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "rXBeROrgF8OsO2mhg7yZ22JgrxdwDwCkqS2pO4lXcF0-1701947660-0-AZRjzxmSnX+zxvsDW3wwdU+WbW4SXxQ5jyCzM/YkhKmBh4NBBQhtwDg4Cqr70EQzzVOYxh/4KjxyAIISOPFfiQw="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "200"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=014b54b9-e26e-498e-ad34-263c69828710; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=rXBeROrgF8OsO2mhg7yZ22JgrxdwDwCkqS2pO4lXcF0-1701947660-0-AZRjzxmSnX+zxvsDW3wwdU+WbW4SXxQ5jyCzM/YkhKmBh4NBBQhtwDg4Cqr70EQzzVOYxh/4KjxyAIISOPFfiQw=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c305809de3c2ee61d3b1acbea7cca0af"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "58038c18943d4e34"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c305809de3c2ee61d3b1acbea7cca0af"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582e5952c2cd-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:20.492Z",
-        "time": 220,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 220
-        }
-      },
-      {
-        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 190,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "190"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d0d901f7-97bf-423e-a3ed-16a1f18832de"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "kkhLPbSdx3AUJM9IUUhZO0KgytLotDHqiMB8MiW.YG4-1701947660-0-Ac0LspmIDepz4joOEpB84dPw8/so9TKOK4Ktr9+rIWcZ5dR3LWQjMySpcTRJSVeKFB6AQQSvgJouqHZX65MKiLs="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "200"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d0d901f7-97bf-423e-a3ed-16a1f18832de; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=kkhLPbSdx3AUJM9IUUhZO0KgytLotDHqiMB8MiW.YG4-1701947660-0-Ac0LspmIDepz4joOEpB84dPw8/so9TKOK4Ktr9+rIWcZ5dR3LWQjMySpcTRJSVeKFB6AQQSvgJouqHZX65MKiLs=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "bca6c98ec5d1dca31ecf493e427fbcc1"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7a3656efd5fd1550"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bca6c98ec5d1dca31ecf493e427fbcc1"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582e5c5ac311-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:20.491Z",
-        "time": 224,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 224
-        }
-      },
-      {
-        "_id": "3bfde46a074296956deef9dbd207df0b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6133df9e-e7ba-41ef-b0eb-343d064e6c1f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "IXEeFo2Eiok0MTWU8_s0WJZNbFuFvRUbR45rJKuhMOI-1701947660-0-AUlDA7HirLpPPFY+N/sMzof8FaMrteismbAVuZ6lyMYYg4fybmFnRcYK2MgaZLCbV7XsK1U4S7YYtX1rEfRQcjc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "200"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6133df9e-e7ba-41ef-b0eb-343d064e6c1f; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=IXEeFo2Eiok0MTWU8_s0WJZNbFuFvRUbR45rJKuhMOI-1701947660-0-AUlDA7HirLpPPFY+N/sMzof8FaMrteismbAVuZ6lyMYYg4fybmFnRcYK2MgaZLCbV7XsK1U4S7YYtX1rEfRQcjc=; path=/; expires=Thu, 07-Dec-23 11:44:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c3db4625852f76eb7f18bf9a51da720a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1a4d55728c287b43"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c3db4625852f76eb7f18bf9a51da720a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582e5ce65ac1-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:20.493Z",
-        "time": 320,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 320
-        }
-      },
-      {
         "_id": "fe0cd1fdd530f7ad4eb3f53598120c86",
         "_order": 0,
         "cache": {},
@@ -4193,637 +7704,6 @@
         }
       },
       {
-        "_id": "ac7fc975d31f02e814346a770195c756",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 192,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "192"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2d812e70-3fcf-462f-995e-ec528595ed94"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:21.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "jcQ5oGu5dGeDsPlFM3Wp0KBu1jz2yKStCU6zx7Tjwos-1701947661-0-Act2F0E1+xEbxaacePFThYKCZJjX7OLHle2bW0pDY3C2KDEAe+plwjmWwWO4SOdw5XQ/PrDzKN19tS7Gv65y1DM="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:21 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "200"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2d812e70-3fcf-462f-995e-ec528595ed94; Expires=Sat, 07 Dec 2024 11:14:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=jcQ5oGu5dGeDsPlFM3Wp0KBu1jz2yKStCU6zx7Tjwos-1701947661-0-Act2F0E1+xEbxaacePFThYKCZJjX7OLHle2bW0pDY3C2KDEAe+plwjmWwWO4SOdw5XQ/PrDzKN19tS7Gv65y1DM=; path=/; expires=Thu, 07-Dec-23 11:44:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "a9b0fbc4f0567ff14ee6bb9fca3aafc5"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ff4806a45f54954c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a9b0fbc4f0567ff14ee6bb9fca3aafc5"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c582e5aef5af7-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:20.494Z",
-        "time": 507,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 507
-        }
-      },
-      {
-        "_id": "7449140909c921a511332d4c1de94c1f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 182,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "traceparent",
-              "value": "00-02692307433c3a9fc3aa2905822dbe05-8f4423d60e869f6a-01"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "182"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 412,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:21.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c5dbd6b0-5cef-4ee9-8e0b-6db57141058d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:21.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "DNamvVCD9_MIj8ilMwH4SBAOVzxqjZPKVM5Gte6Cxjs-1701947661-0-AYL7zL4wmTTeHgI+/2VGol0FGi6FFcq03aR5Xuvu7UNE4x+Zp6JZk6/0pIv//2Q42QTTS1LAX/qXbZKqPFaixTA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:21 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "200"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c5dbd6b0-5cef-4ee9-8e0b-6db57141058d; Expires=Sat, 07 Dec 2024 11:14:21 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=DNamvVCD9_MIj8ilMwH4SBAOVzxqjZPKVM5Gte6Cxjs-1701947661-0-AYL7zL4wmTTeHgI+/2VGol0FGi6FFcq03aR5Xuvu7UNE4x+Zp6JZk6/0pIv//2Q42QTTS1LAX/qXbZKqPFaixTA=; path=/; expires=Thu, 07-Dec-23 11:44:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "02692307433c3a9fc3aa2905822dbe05"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c5a7e85d566658ac"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/02692307433c3a9fc3aa2905822dbe05"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c58328cdf5a8a-VIE"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:21.169Z",
-        "time": 276,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 276
-        }
-      },
-      {
-        "_id": "0d16a033a475b66e0dc0d6a4321be2a8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 297,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "traceparent",
-              "value": "00-02692307433c3a9fc3aa2905822dbe05-f565f81c6df93ed6-01"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-sourcegraph-should-trace",
-              "value": "1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "297"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 437,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 172,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 172,
-            "text": "event: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:21.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "04f46a8a-1085-494e-8f23-9a794c167d24"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:22.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "YwNYqdWfcrUDHoXa7ocoqtHO41Fvw5meFCMXtuj0mAU-1701947662-0-AecLH2lwyWQ4NtD3TomfxZjMdFvtwSd12xvz6o7BZFHJmneW95OErDOtCV+SfwmrKwTND2ik5ESoAbyegVviN+M="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:22 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "199"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=04f46a8a-1085-494e-8f23-9a794c167d24; Expires=Sat, 07 Dec 2024 11:14:21 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=YwNYqdWfcrUDHoXa7ocoqtHO41Fvw5meFCMXtuj0mAU-1701947662-0-AecLH2lwyWQ4NtD3TomfxZjMdFvtwSd12xvz6o7BZFHJmneW95OErDOtCV+SfwmrKwTND2ik5ESoAbyegVviN+M=; path=/; expires=Thu, 07-Dec-23 11:44:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "02692307433c3a9fc3aa2905822dbe05"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "559b0b0a3cff5958"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/02692307433c3a9fc3aa2905822dbe05"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c58344d6a5a38-VIE"
-            }
-          ],
-          "headersSize": 1239,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:21.453Z",
-        "time": 891,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 891
-        }
-      },
-      {
         "_id": "4eab0c42ef5e5fa592fd11d87422298c",
         "_order": 0,
         "cache": {},
@@ -4991,218 +7871,6 @@
         }
       },
       {
-        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 333,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "333"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "38704e19-3570-4610-a579-00ed69bfc180"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:24.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9EBOLB03WzyfZ_AqbQpYggzTY3qTBmYU12w..AdCQw0-1701947664-0-AWI/v/NylsfXFtShNwTXWyeYX0L+URV8kRFUnvg62lXlx9XLhXi8oQgb3HVxwbpzVbEho/tjZQuVL+bSJXYYg1s="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:24 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "197"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=38704e19-3570-4610-a579-00ed69bfc180; Expires=Sat, 07 Dec 2024 11:14:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=9EBOLB03WzyfZ_AqbQpYggzTY3qTBmYU12w..AdCQw0-1701947664-0-AWI/v/NylsfXFtShNwTXWyeYX0L+URV8kRFUnvg62lXlx9XLhXi8oQgb3HVxwbpzVbEho/tjZQuVL+bSJXYYg1s=; path=/; expires=Thu, 07-Dec-23 11:44:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "cbb754e93c0c9c1ee79e5904e4e54f39"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d8e190154852e020"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cbb754e93c0c9c1ee79e5904e4e54f39"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c58434d56c2f0-VIE"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:23.858Z",
-        "time": 215,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 215
-        }
-      },
-      {
         "_id": "579e52553a9fb832a9408564e196d7e4",
         "_order": 0,
         "cache": {},
@@ -5367,575 +8035,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 163
-        }
-      },
-      {
-        "_id": "34fa3baab68c77b4e329fd24907b91f7",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1300,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 234,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/stream"
-        },
-        "response": {
-          "bodySize": 44258,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 44258,
-            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation for implementing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation for implementing `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation for implementing `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation for implementing `sum`.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code sample or explanation for implementing `sum`.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-07T11:14:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1bd95576-50ca-4aaa-b096-c4cfaf560b83"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-07T11:44:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "tcjiqwepVBTtnbKIfGI4yBC9.SHc3nCbg3uHGGMPFnM-1701947665-0-ARD6+60kbOn7PBwjibLLSqe6p5pO4Su3JhsNjVxKu4ASd61lPgDtijhnc3Wsd/h9eLsfYSQIvMWiDQXNGheZOCM="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Thu, 07 Dec 2023 11:14:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "197"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1bd95576-50ca-4aaa-b096-c4cfaf560b83; Expires=Sat, 07 Dec 2024 11:14:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=tcjiqwepVBTtnbKIfGI4yBC9.SHc3nCbg3uHGGMPFnM-1701947665-0-ARD6+60kbOn7PBwjibLLSqe6p5pO4Su3JhsNjVxKu4ASd61lPgDtijhnc3Wsd/h9eLsfYSQIvMWiDQXNGheZOCM=; path=/; expires=Thu, 07-Dec-23 11:44:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6aed6ccbe4dd7224cdcd13543046b9f5"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f521b6caf97416c6"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6aed6ccbe4dd7224cdcd13543046b9f5"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "831c58422a005a77-VIE"
-            }
-          ],
-          "headersSize": 1239,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-07T11:14:23.668Z",
-        "time": 5946,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 5946
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-29T08:13:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b25db8d3-9dfb-4f64-acb2-31758b3f383d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-29T08:43:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "kIpoVPd7ikfZhciD32ao3au4V5m6EwXMCFm7q3WMNDk-1701245605-0-ARisz8/3gW05ZQK7kc7NxGC4AXQlXq+fpDWh9oJweOUXYgFC0/xUR1ShbfhdNdPG5MIWus1B2LxdBPNKq7lhfFE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 29 Nov 2023 08:13:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b25db8d3-9dfb-4f64-acb2-31758b3f383d; Expires=Fri, 29 Nov 2024 08:13:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=kIpoVPd7ikfZhciD32ao3au4V5m6EwXMCFm7q3WMNDk-1701245605-0-ARisz8/3gW05ZQK7kc7NxGC4AXQlXq+fpDWh9oJweOUXYgFC0/xUR1ShbfhdNdPG5MIWus1B2LxdBPNKq7lhfFE=; path=/; expires=Wed, 29-Nov-23 08:43:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "15735a908312dffb40f0efa9e6ae3870"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "576ad05051e9a308"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/15735a908312dffb40f0efa9e6ae3870"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82d9642a1f805c01-NRT"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-29T08:13:25.312Z",
-        "time": 251,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 251
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-29T08:13:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2c659aab-15d5-4ed8-a75b-087d9853ab27"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-29T08:43:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "t88LBRxoo53BQUtqFTTXNT_LZltw.STCTF_YmkdtVdw-1701245605-0-AXGQOsA0PxuHfNSpiFkJzJUnWnAnU5k+54VjlT934ty/PJs+deO+hFgxIDhycCmV376pR/zLGthbqN61NCkatls="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 29 Nov 2023 08:13:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2c659aab-15d5-4ed8-a75b-087d9853ab27; Expires=Fri, 29 Nov 2024 08:13:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=t88LBRxoo53BQUtqFTTXNT_LZltw.STCTF_YmkdtVdw-1701245605-0-AXGQOsA0PxuHfNSpiFkJzJUnWnAnU5k+54VjlT934ty/PJs+deO+hFgxIDhycCmV376pR/zLGthbqN61NCkatls=; path=/; expires=Wed, 29-Nov-23 08:43:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "20abd2a77ebb78292dff60a30d13997c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4540f5b9af67f3d0"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/20abd2a77ebb78292dff60a30d13997c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82d9642a1a371d87-NRT"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-29T08:13:25.315Z",
-        "time": 270,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 270
         }
       },
       {
@@ -6129,196 +8228,6 @@
         }
       },
       {
-        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 160,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "160"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 258,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-28T15:16:51.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c21f90de-e2d2-4582-8c38-419910ab1420"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-28T15:46:51.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "94D54SleD3jSkmhYF2WynA72kCwvTcXMVouPefSJTgw-1701184611-0-AeoZDJ/sHorg+NQOoJIVnS0T/7Jy/rf/bcs8kwS+1byYnv58YqdlGrrHhiIt0NufBiJJTsiVM9/GmEqKFnZsvx0="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 28 Nov 2023 15:16:51 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c21f90de-e2d2-4582-8c38-419910ab1420; Expires=Thu, 28 Nov 2024 15:16:51 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=94D54SleD3jSkmhYF2WynA72kCwvTcXMVouPefSJTgw-1701184611-0-AeoZDJ/sHorg+NQOoJIVnS0T/7Jy/rf/bcs8kwS+1byYnv58YqdlGrrHhiIt0NufBiJJTsiVM9/GmEqKFnZsvx0=; path=/; expires=Tue, 28-Nov-23 15:46:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "79b30663957aad6d18661860d5dfa399"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "72f95cd70edabdc3"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/79b30663957aad6d18661860d5dfa399"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82d3930c0935b50c-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-28T15:16:51.092Z",
-        "time": 219,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 219
-        }
-      },
-      {
         "_id": "840d8c3bd41061b30f0f01f81092c2ed",
         "_order": 0,
         "cache": {},
@@ -6506,201 +8415,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 183
-        }
-      },
-      {
-        "_id": "103c65b93dfa88c72eea86b3b023599e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-11-26T12:00:52.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a9b890c8-a24f-40ef-ba95-852ec831fae6"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-11-26T12:30:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xroFAGTmkWbqO4Xei4m6Ens8DMsjiC2tFRzF5KKRvEM-1701000053-0-AROo9y2lriFXfynNeObeR0ChuNvObnYTKMobpxQX6uVMZ3Ge60TqlZCMEXhygOA5UZBFRl7Lz6GCzh4t8dj5dgQ="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Sun, 26 Nov 2023 12:00:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a9b890c8-a24f-40ef-ba95-852ec831fae6; Expires=Tue, 26 Nov 2024 12:00:52 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=xroFAGTmkWbqO4Xei4m6Ens8DMsjiC2tFRzF5KKRvEM-1701000053-0-AROo9y2lriFXfynNeObeR0ChuNvObnYTKMobpxQX6uVMZ3Ge60TqlZCMEXhygOA5UZBFRl7Lz6GCzh4t8dj5dgQ=; path=/; expires=Sun, 26-Nov-23 12:30:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f1ffb7b92002af398ca678ec46547b0f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1cc9eec3f20f28a5"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f1ffb7b92002af398ca678ec46547b0f"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "82c1f93a7b846ab2-MAN"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-11-26T12:00:47.138Z",
-        "time": 200,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 200
         }
       },
       {

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -72,35 +72,35 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteProductVersion"
         },
         "response": {
-          "bodySize": 146,
+          "bodySize": 136,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 146,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxuYmFvFGBkbGuoZGugYW8aZ6RroGacYppoaGFoYpqYlKtbU=\",\"tQAAAAD//w==\",\"AwDACBkySQAAAA==\"]"
+            "size": 136,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxuYmFvFGBkbGuoZGugYW8aZ6RroGacYppoaGFoYpqYlKtbW1AAAAAP//AwDACBkySQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:22.000Z",
+              "expires": "2024-12-11T09:09:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ee1d2b05-eb94-4a1a-b3c1-9b8e3578ed6f"
+              "value": "3fd2b54e-bcdc-404a-ada7-d04dc014f1a8"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:22.000Z",
+              "expires": "2023-12-11T09:39:41.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "86VfBgdg2Lo3kxHwMKM4bFJFnXxIGioXEVSFOWFVekE-1702285162-0-AVl8YOCAtNfbqtJOKHeSKd+I301xzjiEVwiyG78UhrNLFzUtMnISAV63I4lpiJD/W3Xr0vckzJKSjLl6yhCjr20="
+              "value": "5zb8ODGqJi474i6USS9dKkTAZUlKTIYGX2Dc.XQNNYM-1702285781-0-AWTVgnk6mD/cxemvsXDSm/eIuKTv1KR+vIWdnJK5JxqCM9gmcA8K/CgVWJUnRroDw1sXMzqBHcKEELnG9rvsow0="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:22 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:41 GMT"
             },
             {
               "name": "content-type",
@@ -113,18 +113,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "476"
             },
             {
               "name": "access-control-allow-credentials",
@@ -141,12 +129,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ee1d2b05-eb94-4a1a-b3c1-9b8e3578ed6f; Expires=Wed, 11 Dec 2024 08:59:22 GMT; Secure"
+              "value": "sourcegraphDeviceId=3fd2b54e-bcdc-404a-ada7-d04dc014f1a8; Expires=Wed, 11 Dec 2024 09:09:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=86VfBgdg2Lo3kxHwMKM4bFJFnXxIGioXEVSFOWFVekE-1702285162-0-AVl8YOCAtNfbqtJOKHeSKd+I301xzjiEVwiyG78UhrNLFzUtMnISAV63I4lpiJD/W3Xr0vckzJKSjLl6yhCjr20=; path=/; expires=Mon, 11-Dec-23 09:29:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=5zb8ODGqJi474i6USS9dKkTAZUlKTIYGX2Dc.XQNNYM-1702285781-0-AWTVgnk6mD/cxemvsXDSm/eIuKTv1KR+vIWdnJK5JxqCM9gmcA8K/CgVWJUnRroDw1sXMzqBHcKEELnG9rvsow0=; path=/; expires=Mon, 11-Dec-23 09:39:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -162,15 +150,15 @@
             },
             {
               "name": "x-trace",
-              "value": "01a73b55d1537870f61857c8358e7e2a"
+              "value": "1e5898d4431e2c29170ed79585b229d7"
             },
             {
               "name": "x-trace-span",
-              "value": "8bb9df81a8186865"
+              "value": "f6938fd5a2ca42be"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/01a73b55d1537870f61857c8358e7e2a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1e5898d4431e2c29170ed79585b229d7"
             },
             {
               "name": "x-xss-protection",
@@ -194,21 +182,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c87f87e194ffd-MEL"
+              "value": "833c97132c3a5a55-MEL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:22.056Z",
-        "time": 315,
+        "startedDateTime": "2023-12-11T09:09:40.811Z",
+        "time": 410,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -216,219 +204,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 315
-        }
-      },
-      {
-        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 164,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "164"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 341,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "SiteIdentification",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "96146077-728f-482b-aada-5fb1844a86ba"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:23.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "dLxQ0A.FNDy326eUqXB3zcBjVtvh_51zxP5SHnjW8Uk-1702285163-0-Ac37SxnJzwgR25Kr7iyX8o7o2ASN2LMNetpOb7Z3qmBeYvdYQOZm+KwNDaDRZVuy306wzAJnhgRoJf+kn9hmcZM="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:23 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "475"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=96146077-728f-482b-aada-5fb1844a86ba; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=dLxQ0A.FNDy326eUqXB3zcBjVtvh_51zxP5SHnjW8Uk-1702285163-0-Ac37SxnJzwgR25Kr7iyX8o7o2ASN2LMNetpOb7Z3qmBeYvdYQOZm+KwNDaDRZVuy306wzAJnhgRoJf+kn9hmcZM=; path=/; expires=Mon, 11-Dec-23 09:29:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c36812171614f0118261b74172ee63e8"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "351deba02a0d3023"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c36812171614f0118261b74172ee63e8"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c87fd2b8b1f6e-MEL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:22.821Z",
-        "time": 292,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 292
+          "wait": 410
         }
       },
       {
@@ -505,26 +281,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:23.000Z",
+              "expires": "2024-12-11T09:09:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e14b07ae-2118-4903-b544-a653f4670a1b"
+              "value": "0c01229f-8be5-4205-bf3d-78afb2bbf910"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:23.000Z",
+              "expires": "2023-12-11T09:39:41.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "eok8nhisOwypyNxZUuBi3evOAURv6KbD7uMqXRA_jEY-1702285163-0-Ae1lQ3bz0uHmzKyVXB2QNj62zQzkFlohkiUq3NnOd97t0QWntKDwb7FJsEIB7NiQ4SmfaPPx0QCLznSX1XfKWQs="
+              "value": "A3ekNq8DR1svmYgP2voDL.ygOS4yaaOCPInznB4Dwjs-1702285781-0-Ac3ZCgsYSjdf3EIWMcEjQrS0bhlUElGawJHc0B9UbyKO83Ch8DCJNWpAJXoj5r8llHV4+A2CO6KajjR6ISyJiW8="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:23 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:41 GMT"
             },
             {
               "name": "content-type",
@@ -537,18 +313,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -565,12 +329,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e14b07ae-2118-4903-b544-a653f4670a1b; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=0c01229f-8be5-4205-bf3d-78afb2bbf910; Expires=Wed, 11 Dec 2024 09:09:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=eok8nhisOwypyNxZUuBi3evOAURv6KbD7uMqXRA_jEY-1702285163-0-Ae1lQ3bz0uHmzKyVXB2QNj62zQzkFlohkiUq3NnOd97t0QWntKDwb7FJsEIB7NiQ4SmfaPPx0QCLznSX1XfKWQs=; path=/; expires=Mon, 11-Dec-23 09:29:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=A3ekNq8DR1svmYgP2voDL.ygOS4yaaOCPInznB4Dwjs-1702285781-0-Ac3ZCgsYSjdf3EIWMcEjQrS0bhlUElGawJHc0B9UbyKO83Ch8DCJNWpAJXoj5r8llHV4+A2CO6KajjR6ISyJiW8=; path=/; expires=Mon, 11-Dec-23 09:39:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -586,15 +350,15 @@
             },
             {
               "name": "x-trace",
-              "value": "998e9aa87e92606776073236e837b50d"
+              "value": "d966d4da76503436ecc8e5532be362f6"
             },
             {
               "name": "x-trace-span",
-              "value": "e7b70f14f2886058"
+              "value": "1ce1effbc228fae1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/998e9aa87e92606776073236e837b50d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d966d4da76503436ecc8e5532be362f6"
             },
             {
               "name": "x-xss-protection",
@@ -618,21 +382,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c87fd3daa299f-MEL"
+              "value": "833c97178bbe77e2-MEL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:22.826Z",
-        "time": 288,
+        "startedDateTime": "2023-12-11T09:09:41.534Z",
+        "time": 286,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -640,7 +404,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 288
+          "wait": 286
         }
       },
       {
@@ -717,26 +481,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:23.000Z",
+              "expires": "2024-12-11T09:09:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "bb3700b5-833b-4e65-aed6-f52e2fd05666"
+              "value": "13256e67-113e-4505-85ab-58f7d9a1a533"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:23.000Z",
+              "expires": "2023-12-11T09:39:41.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8w1ED0jce0bZ618aDpWXFt7N_asMrsRk2EBY2Dtvl4c-1702285163-1-AZdmQ5tkIvlaxBGPE0tqhy9yo1ApaBn8Wn7aE0bqTuVawHRmjELtPecnx4Uq2mfUzbNFuXG+UP/Tc0AACNpJmxk="
+              "value": "xJ4Bczj3SYTWP.4EulzVQgdbx3ZBs45_bOqKbZp3xaI-1702285781-1-ATAgNXTRA3uFI8bYVWyfCIQkWSJ5u8yihvdUPDohaJbglCqCv9V3LtbsK1lhENywIOHOC2vnYVD1Zm2i/MPvmOI="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:23 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:41 GMT"
             },
             {
               "name": "content-type",
@@ -749,18 +513,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -777,12 +529,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=bb3700b5-833b-4e65-aed6-f52e2fd05666; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=13256e67-113e-4505-85ab-58f7d9a1a533; Expires=Wed, 11 Dec 2024 09:09:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=8w1ED0jce0bZ618aDpWXFt7N_asMrsRk2EBY2Dtvl4c-1702285163-1-AZdmQ5tkIvlaxBGPE0tqhy9yo1ApaBn8Wn7aE0bqTuVawHRmjELtPecnx4Uq2mfUzbNFuXG+UP/Tc0AACNpJmxk=; path=/; expires=Mon, 11-Dec-23 09:29:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=xJ4Bczj3SYTWP.4EulzVQgdbx3ZBs45_bOqKbZp3xaI-1702285781-1-ATAgNXTRA3uFI8bYVWyfCIQkWSJ5u8yihvdUPDohaJbglCqCv9V3LtbsK1lhENywIOHOC2vnYVD1Zm2i/MPvmOI=; path=/; expires=Mon, 11-Dec-23 09:39:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -798,15 +550,15 @@
             },
             {
               "name": "x-trace",
-              "value": "07e876ad565f40ed4fcbc3e975ef6d90"
+              "value": "987a214dabe0b70aa6adc24c912b31a3"
             },
             {
               "name": "x-trace-span",
-              "value": "5674a9e71daace65"
+              "value": "5b109cca4509a6ca"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/07e876ad565f40ed4fcbc3e975ef6d90"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/987a214dabe0b70aa6adc24c912b31a3"
             },
             {
               "name": "x-xss-protection",
@@ -830,21 +582,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c87fd3dbe5ac8-MEL"
+              "value": "833c97178d3a5a8b-MEL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:22.825Z",
-        "time": 296,
+        "startedDateTime": "2023-12-11T09:09:41.532Z",
+        "time": 291,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -852,15 +604,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 296
+          "wait": 291
         }
       },
       {
-        "_id": "bc9d710017cb613b863131822d75d5c7",
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 233,
+          "bodySize": 164,
           "cookies": [],
           "headers": [
             {
@@ -886,7 +638,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "233"
+              "value": "164"
             },
             {
               "_fromType": "array",
@@ -903,52 +655,52 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 334,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nquery CurrentUser {\\n    currentUser {\\n        id\\n        hasVerifiedEmail\\n        displayName\\n        avatarURL\\n        codyProEnabled\\n        primaryEmail {\\n            email\\n        }\\n    }\\n}\",\"variables\":{}}"
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
           },
           "queryString": [
             {
-              "name": "CurrentUser",
+              "name": "SiteIdentification",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
         },
         "response": {
-          "bodySize": 276,
+          "bodySize": 212,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 276,
-            "text": "[\"H4sIAAAAAAAAAzSOPWvDQBBE/0qYWliYJM2BiBt3RgnBNmnXd2vrzH2IvT0HIfTfg3Hczbxi3sxwpAQzw1YRTnooLPfqHQyOP32w17z+3Nup/+06NBioHFn82bPbRvIBRqVyA+fLGGjqKTIM9j6+7KqlggZ0IyU5fO9gMKiOxbTtg5XVxetQT7Ww2JyUk65sjm1t1++vH7fuDQ1sdtOX5G2iU2D3tI3iI8n0/2AGPwJ0ozmHSEl9vE9hWZblDwAA//8DAD3SxSPkAAAA\"]"
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:23.000Z",
+              "expires": "2024-12-11T09:09:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "62322717-0b76-4221-a1bf-4bb5af5a6c98"
+              "value": "611c06b2-31f4-485b-8817-1dd21f128753"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
+              "expires": "2023-12-11T09:39:41.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "xz6n_waHOlbEx2kD3c9mMWdX1uXAilRiphF5NBmZ5z0-1702285164-0-AcZ6XKz5cShXemUR7tXlw2HRS74E71PSg5UeVaXhQ0weRpB0xRga5uf3fMgm/BIjULYsKXY0Y2P3kkG42fL4FpQ="
+              "value": "bu12Exp68z.kUwJ8mFOYad2znLhShsqS5.FurQMeL84-1702285781-0-AVnPACZBOPL3CKFI3Vfb23fXOlUk230XzpS9QQYj+zDsBH/N6ryPyms4f8tbBceKsCEj9W0NGbn4GQOFltqFv3Y="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:41 GMT"
             },
             {
               "name": "content-type",
@@ -961,18 +713,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -989,12 +729,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=62322717-0b76-4221-a1bf-4bb5af5a6c98; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=611c06b2-31f4-485b-8817-1dd21f128753; Expires=Wed, 11 Dec 2024 09:09:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=xz6n_waHOlbEx2kD3c9mMWdX1uXAilRiphF5NBmZ5z0-1702285164-0-AcZ6XKz5cShXemUR7tXlw2HRS74E71PSg5UeVaXhQ0weRpB0xRga5uf3fMgm/BIjULYsKXY0Y2P3kkG42fL4FpQ=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=bu12Exp68z.kUwJ8mFOYad2znLhShsqS5.FurQMeL84-1702285781-0-AVnPACZBOPL3CKFI3Vfb23fXOlUk230XzpS9QQYj+zDsBH/N6ryPyms4f8tbBceKsCEj9W0NGbn4GQOFltqFv3Y=; path=/; expires=Mon, 11-Dec-23 09:39:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1010,15 +750,15 @@
             },
             {
               "name": "x-trace",
-              "value": "14fda9914859b0b794bd09d1cd6962c3"
+              "value": "1c8aaba15d3c56b9907c8d1eaea8d777"
             },
             {
               "name": "x-trace-span",
-              "value": "5ae8ed2976d95ce5"
+              "value": "0c35772e03a3c2aa"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/14fda9914859b0b794bd09d1cd6962c3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1c8aaba15d3c56b9907c8d1eaea8d777"
             },
             {
               "name": "x-xss-protection",
@@ -1042,21 +782,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c8801afe72b31-MEL"
+              "value": "833c97178df23779-MEL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:23.546Z",
-        "time": 304,
+        "startedDateTime": "2023-12-11T09:09:41.527Z",
+        "time": 299,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1064,7 +804,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 304
+          "wait": 299
         }
       },
       {
@@ -1141,26 +881,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:23.000Z",
+              "expires": "2024-12-11T09:09:42.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "058d5eac-7716-4845-9375-f61d3d2e226c"
+              "value": "f1f4744c-51c6-48d2-9222-551e5edcd5a0"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
+              "expires": "2023-12-11T09:39:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "JJtolQT7iSyg3yk4QpoxIOJ.UmrLjH3mK_foMEEASbI-1702285164-0-AVW8tKVHkYHoOPC2FQg9tEgekzwkQuR4cNgDZ57J4rdZDXR7nHfpWwdxwcSu4mfp3FWJZqjILwbOwa4AVD5tKkI="
+              "value": "B9MzuuLJ5KMGInjqryP4_kYYQcpZ5mMmo1j6XqV98.g-1702285782-0-AWeYRo7caQWZawE7jLdq6kwCQGN3dexxgkpu0IAYZYcsP1BrPPBOayEbv7RgVjgr1XisKCrKxbXXqjS2o6tArig="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
             },
             {
               "name": "content-type",
@@ -1173,18 +913,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "475"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1201,12 +929,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=058d5eac-7716-4845-9375-f61d3d2e226c; Expires=Wed, 11 Dec 2024 08:59:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=f1f4744c-51c6-48d2-9222-551e5edcd5a0; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=JJtolQT7iSyg3yk4QpoxIOJ.UmrLjH3mK_foMEEASbI-1702285164-0-AVW8tKVHkYHoOPC2FQg9tEgekzwkQuR4cNgDZ57J4rdZDXR7nHfpWwdxwcSu4mfp3FWJZqjILwbOwa4AVD5tKkI=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=B9MzuuLJ5KMGInjqryP4_kYYQcpZ5mMmo1j6XqV98.g-1702285782-0-AWeYRo7caQWZawE7jLdq6kwCQGN3dexxgkpu0IAYZYcsP1BrPPBOayEbv7RgVjgr1XisKCrKxbXXqjS2o6tArig=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1222,15 +950,15 @@
             },
             {
               "name": "x-trace",
-              "value": "84871854a125323bd780ab86ff3a429b"
+              "value": "647d64cf541b49a1978eabe594bda35f"
             },
             {
               "name": "x-trace-span",
-              "value": "c1db2f52e175ebfe"
+              "value": "e56e89730322a6c1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/84871854a125323bd780ab86ff3a429b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/647d64cf541b49a1978eabe594bda35f"
             },
             {
               "name": "x-xss-protection",
@@ -1254,21 +982,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c8801ad612b30-MEL"
+              "value": "833c97194ca32ef4-MEL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:23.548Z",
-        "time": 321,
+        "startedDateTime": "2023-12-11T09:09:41.816Z",
+        "time": 305,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1276,7 +1004,207 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 321
+          "wait": 305
+        }
+      },
+      {
+        "_id": "bc9d710017cb613b863131822d75d5c7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 233,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "233"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 334,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentUser {\\n    currentUser {\\n        id\\n        hasVerifiedEmail\\n        displayName\\n        avatarURL\\n        codyProEnabled\\n        primaryEmail {\\n            email\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentUser",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
+        },
+        "response": {
+          "bodySize": 283,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 283,
+            "text": "[\"H4sIAAAAAAAAAzSOPWvDQBBE/0qYWliYJM2BiBt3RgnBNmnXd2vrzH2IvT0HIfTfg3Hczbxi3sxwpAQzw1YRTnooLPfqHQyOP32w17z+3Nup/+06NBioHFn82bPbRvIBRqVyA+fLGGjqKTIM9j6+7KqlggZ0IyU5fO9gMKiOxbTtg5XVxetQT7Ww2JyUk65sjm1t1++vH7fuDQ1sdtOX5G2iU2D3tI3iI8n0/2AGPwJ0ozmHSEl9vE9hWQ==\",\"luUPAAD//wMAPdLFI+QAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:42.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "18970c3a-43d1-43d3-b04c-ef282eb04cef"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "V10jKbVYyqASAmU4LMvJpLK9eV.kw0sRDWD70b0lHwk-1702285782-0-AdbWBCCeoh2TEWVgJqhQbsdP+qX+X1bJueEPHS2dJPm+xAfnwRwgKnR8wqEQqtjDUPe/nFmJUToqJTqumBGoEFc="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=18970c3a-43d1-43d3-b04c-ef282eb04cef; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=V10jKbVYyqASAmU4LMvJpLK9eV.kw0sRDWD70b0lHwk-1702285782-0-AdbWBCCeoh2TEWVgJqhQbsdP+qX+X1bJueEPHS2dJPm+xAfnwRwgKnR8wqEQqtjDUPe/nFmJUToqJTqumBGoEFc=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "7be9125870d977ebc76b12c6f31233d3"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "93bc88ce68b3bfb9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7be9125870d977ebc76b12c6f31233d3"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c971959e229bf-MEL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:41.834Z",
+        "time": 307,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 307
         }
       },
       {
@@ -1352,26 +1280,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:24.000Z",
+              "expires": "2024-12-11T09:09:42.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "b546b5a9-1d21-4232-8618-76dd93cae311"
+              "value": "bd2b21be-75c5-40cb-b8ba-983ed4bc710a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
+              "expires": "2023-12-11T09:39:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "vfqjViaYlggjJbWLcmuN0dLNlxux35GyLpCOUv1ZfXw-1702285164-0-AVCUnYFQ9N9mQa+zTo2Kxbw+GV/zmY5w9qwPw0Yhj2StXWu/brmGfCx/KjZxHm1BirluTUrfu4PEtNszvji/1Ls="
+              "value": "jD9lGwvdEzPw0F2NFVkhKdzPvdxJt13YT37nVl56_jE-1702285782-0-AShlYp9AGGeW6MdqhEeNZHv9GFRiml+JOevpWNmlkmle0D+t79BJMwscYtbP7p6dZwgE56IrjiALdChM4sAe5Ac="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
             },
             {
               "name": "content-type",
@@ -1384,18 +1312,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1412,12 +1328,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b546b5a9-1d21-4232-8618-76dd93cae311; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=bd2b21be-75c5-40cb-b8ba-983ed4bc710a; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=vfqjViaYlggjJbWLcmuN0dLNlxux35GyLpCOUv1ZfXw-1702285164-0-AVCUnYFQ9N9mQa+zTo2Kxbw+GV/zmY5w9qwPw0Yhj2StXWu/brmGfCx/KjZxHm1BirluTUrfu4PEtNszvji/1Ls=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=jD9lGwvdEzPw0F2NFVkhKdzPvdxJt13YT37nVl56_jE-1702285782-0-AShlYp9AGGeW6MdqhEeNZHv9GFRiml+JOevpWNmlkmle0D+t79BJMwscYtbP7p6dZwgE56IrjiALdChM4sAe5Ac=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1433,15 +1349,15 @@
             },
             {
               "name": "x-trace",
-              "value": "8a00151cdf548252403e09f2ff26a99e"
+              "value": "084190fdd28dc7cdfa37ab1af171a290"
             },
             {
               "name": "x-trace-span",
-              "value": "7ab5d5316fc236c2"
+              "value": "cab056a59c3e8bd8"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a00151cdf548252403e09f2ff26a99e"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/084190fdd28dc7cdfa37ab1af171a290"
             },
             {
               "name": "x-xss-protection",
@@ -1465,17 +1381,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c8803a8ff2b34-MEL"
+              "value": "833c971b6eda2ef4-MEL"
             }
           ],
-          "headersSize": 1236,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:23.859Z",
-        "time": 295,
+        "startedDateTime": "2023-12-11T09:09:42.153Z",
+        "time": 291,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1483,7 +1399,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 295
+          "wait": 291
         }
       },
       {
@@ -1551,35 +1467,35 @@
           "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
         },
         "response": {
-          "bodySize": 715,
+          "bodySize": 723,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 715,
-            "text": "[\"H4sIAAAAAA==\",\"AAD/lJRRbvM4DITv4ufyAjlAL7HYB5qa2ERkySWpJEbRuy/sFPvjL2CneTOgoUyOvuFnlzi4O312uHJuHEjv4GiG98yDd6d/PrvCE7pT52CTkeqtwHzUuXvr1hJ0p7CGr7f/hVLTQjf05JrQsx0LuUWVOs0ZAcpchsbD+hEosuyWDjbL7uF3p1JLoAT17Ejb1ZQQkNBa/tSeOftxU2kpPKnQ1HJo1gL6PtJafP8iFoE7Rb2gOGmR3BJIiwcXAWlCCT0r9v0xXi3RScMJdwESEp2rUcBDy7D/728HjMvlL91Po3QobSZvdsVCKNxnpP1bAxkTwhbCfa4Wxw8rIwdNVS5bu7vaj6ZyIQ+2oKjNtgG5xbjaIyuQ1Bx2YPT6zsYej2dRLkG+lOA7jTqMWYfxV2Yl9O1Atc2E+wzTCSU4P8NvXHrTtKt6uE0eBp60DDRoUJ/Xw6fBQtKoRgbRGb6rn62mJkHeehfTeQOWDJxg5LCrCohFaivxSiC2YN2D+vNAk96xP+Ra+1LUcOaWY8NB6trmw0Xy2kwwGM/js8TpautZMygM+2b2ufY0r7vGbxoyEhvYycdqIS0OefvZdhjLYc4eRBTc6ILlVu0gZL835YW9mtQ32gyySF5pq2eaDVetbSXio8GfjjxbfRG11xhbyV6Xxi9knH/G79+vr/8CAAD//2YV22fMBgAA\"]"
+            "size": 723,
+            "text": "[\"H4sIAAAAAAAA/5RVS1LkMAy9S9boAn0ALjE1C8V+SVTt2EGSuztFcfcpB2oGGNKBdZ7k95GU5y6yc3d67nDhVNkRH8FeFY+JR+tOv567zDO6U4fMfQKZK3iWPNIoTn1qHx+6Vozu5Frx8vC3JJS40hU9IYoXJUWQBXYHn13ZnEKZlyScnWzNzjeaZJySjJNLHv+VD5zsfb2BNUyknM8fcJ+eeYOVa4baJMsusE+lp4VHkF3Fw0SsYCOb\",\"inqobvtMNuVcvWxK4CBXDvdILVpiDU5Wewsqi0vJRga9SABxCKVm33/w63IFR+j3u/xPO4ptsSvCGlKLvQy0KC5Sauv/VGH3jDAZc13Iql6w0usMxQMCYWKnuYQzOcyPYmxDg+zUsyFS4jxShCM0B36idOtzc+qHkWa5vWf59cPT2qvso77wcs08S6C5JpckGfT2qWW1T1XZQUlmcSPcAhARaSi6uXN3HzYKi5bjBW2W/2gsMHBNTuasobQZO3DjzbOIvh4RbnxMInrW3XajLuFYFae0C3IkzHBdCbel6P6YfV88WakaMCov075GDgFm0pZqkNQOA/Yv6CuYvJyRjSSHVCNIsjnnAJKI7DII9p1q9PfJPFUJ502Ik5eq21xx9an1De13QNWg9xb8NdiMK52xXosebfcHK9u61nZgEztyWO+ngNsClRnZ+XOwv19e/gQAAP//Vv8nPMwGAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:24.000Z",
+              "expires": "2024-12-11T09:09:42.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1cf536bf-d79f-43ae-a424-cd5b2f699936"
+              "value": "6b569c31-6690-41fa-a1b2-c533714245dd"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
+              "expires": "2023-12-11T09:39:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3cm0C0ZfJYMEOizLwFrGaNqKumenW0Xq6Vrq7oFYP2g-1702285164-0-AcKM08aA0dFOPItGR1SbpGnGm/FD3bnEVzPbHMtQkhkosYmDNKsPczV4O6wriwuQFTGk1RbMXhap9KKC/o0YT2w="
+              "value": "Ul1F1qb7X4GONQ58RnXkVo6kAoSXMmx7T4hpGkHERkY-1702285782-1-AeC8ubpIGi5//Uf/msR1IjrVKaWGYsY7Ky3R3bu1VDlw953gy9T12fdNRzLv4fwCugsBKLlnbsjPwtwsFEFohQk="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
             },
             {
               "name": "content-type",
@@ -1592,18 +1508,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1624,12 +1528,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1cf536bf-d79f-43ae-a424-cd5b2f699936; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=6b569c31-6690-41fa-a1b2-c533714245dd; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3cm0C0ZfJYMEOizLwFrGaNqKumenW0Xq6Vrq7oFYP2g-1702285164-0-AcKM08aA0dFOPItGR1SbpGnGm/FD3bnEVzPbHMtQkhkosYmDNKsPczV4O6wriwuQFTGk1RbMXhap9KKC/o0YT2w=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=Ul1F1qb7X4GONQ58RnXkVo6kAoSXMmx7T4hpGkHERkY-1702285782-1-AeC8ubpIGi5//Uf/msR1IjrVKaWGYsY7Ky3R3bu1VDlw953gy9T12fdNRzLv4fwCugsBKLlnbsjPwtwsFEFohQk=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1645,15 +1549,15 @@
             },
             {
               "name": "x-trace",
-              "value": "162c8d984da26894a35692e3ba197cf1"
+              "value": "19501f36266c65a11c5688c1230c7e4c"
             },
             {
               "name": "x-trace-span",
-              "value": "b36e1b309ba62136"
+              "value": "d2b6c6c3d7f75341"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/162c8d984da26894a35692e3ba197cf1"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/19501f36266c65a11c5688c1230c7e4c"
             },
             {
               "name": "x-xss-protection",
@@ -1677,16 +1581,16 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c880399a45aa8-MEL"
+              "value": "833c971b5ee329a6-MEL"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:23.858Z",
+        "startedDateTime": "2023-12-11T09:09:42.149Z",
         "time": 303,
         "timings": {
           "blocked": -1,
@@ -1771,26 +1675,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:24.000Z",
+              "expires": "2024-12-11T09:09:42.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "98d95c76-a514-4b1e-a482-f68946b50429"
+              "value": "8b695574-7dc7-41ad-be85-3b0415cefcdb"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
+              "expires": "2023-12-11T09:39:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ssDRDPnQ3bnJ4Nso6wYISPE7sYB6DQtoRcaUkTonrtc-1702285164-1-AV+fJbT3SIwTHA4QAbrFzKDqmFluTfEwFQqheWoof+yNfLa+ktZGyYS5xMe0vkOgYinZLdgJRA2D1e2jwOXx9zo="
+              "value": "ruIGK_pTxkgUGoq6qsQUDPaHrcoB8K6Be131p6MNsyo-1702285782-0-AaZ22tfH1+jLXI/2Nh6n67F7B5nvUop6t9UtMiOglAbB2oipqrOiHlyPLma/Wy6+4pdjewl165nDdCW7kmLYE2I="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
             },
             {
               "name": "content-type",
@@ -1803,18 +1707,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1831,12 +1723,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=98d95c76-a514-4b1e-a482-f68946b50429; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=8b695574-7dc7-41ad-be85-3b0415cefcdb; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=ssDRDPnQ3bnJ4Nso6wYISPE7sYB6DQtoRcaUkTonrtc-1702285164-1-AV+fJbT3SIwTHA4QAbrFzKDqmFluTfEwFQqheWoof+yNfLa+ktZGyYS5xMe0vkOgYinZLdgJRA2D1e2jwOXx9zo=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ruIGK_pTxkgUGoq6qsQUDPaHrcoB8K6Be131p6MNsyo-1702285782-0-AaZ22tfH1+jLXI/2Nh6n67F7B5nvUop6t9UtMiOglAbB2oipqrOiHlyPLma/Wy6+4pdjewl165nDdCW7kmLYE2I=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1852,15 +1744,15 @@
             },
             {
               "name": "x-trace",
-              "value": "1fb4e7c93cfe1f6a9f0971ec1471bfc7"
+              "value": "d63a1ca662371948536352500da80cc4"
             },
             {
               "name": "x-trace-span",
-              "value": "7d03bcb2e1002932"
+              "value": "b97daa868f0fe525"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1fb4e7c93cfe1f6a9f0971ec1471bfc7"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d63a1ca662371948536352500da80cc4"
             },
             {
               "name": "x-xss-protection",
@@ -1884,17 +1776,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c8803ad7929a3-MEL"
+              "value": "833c971b6fc41f6e-MEL"
             }
           ],
-          "headersSize": 1236,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:23.861Z",
-        "time": 633,
+        "startedDateTime": "2023-12-11T09:09:42.156Z",
+        "time": 299,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1902,421 +1794,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 633
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:24.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "fdf7f9d1-6e1d-478e-9e5f-f58f0da944ea"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "d0kZP0csEMYQLJEb6sqoKurOeU6oGBmeIf4PSOnk0ZE-1702285164-0-AVagRR6gdYhN68cisfOJDdnJr8T8cBQRPtSbwlXlV9bhJXyj62bUDEbeWEW5fLZmEVUbZqq+AbaTKzHw4JEhoMo="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "474"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fdf7f9d1-6e1d-478e-9e5f-f58f0da944ea; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=d0kZP0csEMYQLJEb6sqoKurOeU6oGBmeIf4PSOnk0ZE-1702285164-0-AVagRR6gdYhN68cisfOJDdnJr8T8cBQRPtSbwlXlV9bhJXyj62bUDEbeWEW5fLZmEVUbZqq+AbaTKzHw4JEhoMo=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8ccba42b21af24ae72843ded3eafa449"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "772d96c30c217bd9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8ccba42b21af24ae72843ded3eafa449"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c8807aa8929b9-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:24.503Z",
-        "time": 289,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 289
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:24.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c49f7f67-1900-436e-bcc7-4e9e9a2d38f6"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:24.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gWenXrhln63r8DR3oIw3gzDPf03QR_XyuRGfETraCb4-1702285164-1-AUaJA3o9avO5BXcsLGuwCJCl7jxR7Emp0+T4nCjCjgHM7ImzQUjMIowJfBaFyCUoNoJ0wyqRKOsQlPKcZ260Gxc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:24 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "474"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c49f7f67-1900-436e-bcc7-4e9e9a2d38f6; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=gWenXrhln63r8DR3oIw3gzDPf03QR_XyuRGfETraCb4-1702285164-1-AUaJA3o9avO5BXcsLGuwCJCl7jxR7Emp0+T4nCjCjgHM7ImzQUjMIowJfBaFyCUoNoJ0wyqRKOsQlPKcZ260Gxc=; path=/; expires=Mon, 11-Dec-23 09:29:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4ec4d1b542dff4a6665dbfb98d6b3810"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d74286f2de116108"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4ec4d1b542dff4a6665dbfb98d6b3810"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c8807ae2e29a8-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:24.504Z",
-        "time": 293,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 293
+          "wait": 299
         }
       },
       {
@@ -2392,26 +1870,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:24.000Z",
+              "expires": "2024-12-11T09:09:42.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6e210750-5e6b-4096-97ae-82da3c0d2c59"
+              "value": "c40f0b99-d780-4fb4-96a2-7964d12d80d6"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:25.000Z",
+              "expires": "2023-12-11T09:39:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "wWeYGmBeVW2lumVC_vnCFmWr_ym5bmp8wr3_XIUkZl0-1702285165-0-ARC1T7QO4m3C6jvsQsT0vNrof3/on9xgwWulvzXtpv7UfKigDHcLfmUj0764Bh1WTD8Tb5mWFRQAK8I7jMVqCGs="
+              "value": "wI1XmvimHlW5n0WL7.xn89L2DkeDimDWpoX8DaWqe7Q-1702285782-0-AQeDvw4r4XzubdhiWLgnw6bMISNX6plt4ySV02AjAPOSWWGUtnJT9eX7m7s0lFZrZlWeRE7nMgksccn2vlRN2uU="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:25 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
             },
             {
               "name": "content-type",
@@ -2424,18 +1902,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "474"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2452,12 +1918,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6e210750-5e6b-4096-97ae-82da3c0d2c59; Expires=Wed, 11 Dec 2024 08:59:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=c40f0b99-d780-4fb4-96a2-7964d12d80d6; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=wWeYGmBeVW2lumVC_vnCFmWr_ym5bmp8wr3_XIUkZl0-1702285165-0-ARC1T7QO4m3C6jvsQsT0vNrof3/on9xgwWulvzXtpv7UfKigDHcLfmUj0764Bh1WTD8Tb5mWFRQAK8I7jMVqCGs=; path=/; expires=Mon, 11-Dec-23 09:29:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=wI1XmvimHlW5n0WL7.xn89L2DkeDimDWpoX8DaWqe7Q-1702285782-0-AQeDvw4r4XzubdhiWLgnw6bMISNX6plt4ySV02AjAPOSWWGUtnJT9eX7m7s0lFZrZlWeRE7nMgksccn2vlRN2uU=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2473,15 +1939,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c088f001d424e5fc5b21ffbd05124cbd"
+              "value": "7cd6003ada6549554a15490cdec0b074"
             },
             {
               "name": "x-trace-span",
-              "value": "4fcad17cdf324ca0"
+              "value": "9cac840384507002"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c088f001d424e5fc5b21ffbd05124cbd"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7cd6003ada6549554a15490cdec0b074"
             },
             {
               "name": "x-xss-protection",
@@ -2505,17 +1971,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c8807adb81f5d-MEL"
+              "value": "833c971d5bf11f68-MEL"
             }
           ],
-          "headersSize": 1236,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:24.505Z",
-        "time": 587,
+        "startedDateTime": "2023-12-11T09:09:42.467Z",
+        "time": 288,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2523,7 +1989,397 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 587
+          "wait": 288
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:42.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6e797749-06a6-42d3-aa9a-20e9f474dcef"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "wG8V3PCy7gQNv.eu9iIVlsDRTXHYIkHu10KGS096.aQ-1702285782-0-AYbrazPE+AMA8X+D0Hpct1T/dGysSExeUS8AuAXYkfB5QzD35Ku1F89W5QArRfUkcqTms8dcoZQN8fR+LUFtxI0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6e797749-06a6-42d3-aa9a-20e9f474dcef; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=wG8V3PCy7gQNv.eu9iIVlsDRTXHYIkHu10KGS096.aQ-1702285782-0-AYbrazPE+AMA8X+D0Hpct1T/dGysSExeUS8AuAXYkfB5QzD35Ku1F89W5QArRfUkcqTms8dcoZQN8fR+LUFtxI0=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "90c782c80ec0bcddb00c089cf4c12868"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "cee5ce553e1a5de3"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/90c782c80ec0bcddb00c089cf4c12868"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c971d5c852ed2-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:42.466Z",
+        "time": 308,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 308
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:42.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "10cd477e-994e-4f39-9d6e-baab9e2d0dbe"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "KKao.g_nl11J22_Z7lFfTqEU0tM_I4pT6TapE98zUAQ-1702285782-0-AfC74SaoHCJRzmWvwF5cGjgN2hdn/j6Tc7mUrAqw4spwrpqo0T1sd++IW5z0YPdjG6X7WaKENs38bY+XpEwn4e4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=10cd477e-994e-4f39-9d6e-baab9e2d0dbe; Expires=Wed, 11 Dec 2024 09:09:42 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=KKao.g_nl11J22_Z7lFfTqEU0tM_I4pT6TapE98zUAQ-1702285782-0-AfC74SaoHCJRzmWvwF5cGjgN2hdn/j6Tc7mUrAqw4spwrpqo0T1sd++IW5z0YPdjG6X7WaKENs38bY+XpEwn4e4=; path=/; expires=Mon, 11-Dec-23 09:39:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "87b99f35d495e520be644a0db25c4515"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "cad5843f899cad76"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/87b99f35d495e520be644a0db25c4515"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c971d49685ab4-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:42.464Z",
+        "time": 325,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 325
         }
       },
       {
@@ -2599,26 +2455,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:26.000Z",
+              "expires": "2024-12-11T09:09:43.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2a5780fa-29c7-4255-85ba-c14f89a17421"
+              "value": "ee680aab-649d-48f9-86c7-bf37be5710c2"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:26.000Z",
+              "expires": "2023-12-11T09:39:43.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "D8ke76M0JuluHPLXFgo0_SpUvYsPXfS5F9Sl4yuM.ZQ-1702285166-0-AZuR3fEfQs4xgLJnGLelzyyY2lzcaQfuagsSYzKIcaaBoNLlaqyqYTLpdpfgUfoHHGRRrYumuqvVkr/3d8c70ew="
+              "value": "zYvlidc5VOmUwdruXHnC5R0y3Z8rZsOOtlXINzJyI4c-1702285783-0-AaU6vFRZhDkHDAZwWvqh17Iudou4glDFfbIKCwxuU5avb1fU/YafmzNp3JYaqBMo0+9pEuxiVDCCx5X2M0oASAY="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
             },
             {
               "name": "content-type",
@@ -2633,18 +2489,6 @@
               "value": "close"
             },
             {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "472"
-            },
-            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -2659,12 +2503,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2a5780fa-29c7-4255-85ba-c14f89a17421; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
+              "value": "sourcegraphDeviceId=ee680aab-649d-48f9-86c7-bf37be5710c2; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=D8ke76M0JuluHPLXFgo0_SpUvYsPXfS5F9Sl4yuM.ZQ-1702285166-0-AZuR3fEfQs4xgLJnGLelzyyY2lzcaQfuagsSYzKIcaaBoNLlaqyqYTLpdpfgUfoHHGRRrYumuqvVkr/3d8c70ew=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=zYvlidc5VOmUwdruXHnC5R0y3Z8rZsOOtlXINzJyI4c-1702285783-0-AaU6vFRZhDkHDAZwWvqh17Iudou4glDFfbIKCwxuU5avb1fU/YafmzNp3JYaqBMo0+9pEuxiVDCCx5X2M0oASAY=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2680,15 +2524,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c23d771633a4219e462beaab8b69ea25"
+              "value": "ba7ad36d2f5f416b1ef65dd95b62d0da"
             },
             {
               "name": "x-trace-span",
-              "value": "03f46c5fb9a2f84d"
+              "value": "053f31686035d3e4"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c23d771633a4219e462beaab8b69ea25"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ba7ad36d2f5f416b1ef65dd95b62d0da"
             },
             {
               "name": "x-xss-protection",
@@ -2712,17 +2556,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c880f3bfc5aa0-MEL"
+              "value": "833c9721bd8a5ab4-MEL"
             }
           ],
-          "headersSize": 1236,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:25.702Z",
-        "time": 303,
+        "startedDateTime": "2023-12-11T09:09:43.158Z",
+        "time": 297,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2730,421 +2574,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 303
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:26.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "fc4df6a9-8cc3-4645-92e8-67d3160c8a98"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:26.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "52wu1Xch3cyqRGNSNq3kCFg45civ6RBAoxMKpK7ROyM-1702285166-0-ATQ++5aTyarbtHAlUv5qGPftm95pLuYEZEy96/CiRLqFSwRckfGOuum1Q6xaI/1qFDzmjFXHb9+obHbsL9Olgd8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "472"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fc4df6a9-8cc3-4645-92e8-67d3160c8a98; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=52wu1Xch3cyqRGNSNq3kCFg45civ6RBAoxMKpK7ROyM-1702285166-0-ATQ++5aTyarbtHAlUv5qGPftm95pLuYEZEy96/CiRLqFSwRckfGOuum1Q6xaI/1qFDzmjFXHb9+obHbsL9Olgd8=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "beff7e70f1061ae2043df871535b50f4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "aa67a835aafce6b4"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/beff7e70f1061ae2043df871535b50f4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c880f38f15a98-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:25.706Z",
-        "time": 306,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 306
-        }
-      },
-      {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:26.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ae1bd774-b395-4c6c-99b3-1315003b8e92"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:26.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "IOLoSooewYynhcBK89nYfIoP2s3sZa6n0kdf4Sikn_Q-1702285166-0-Abuvlp3oDbfEM+6BW1SWv/Z3Zgpun54We0KQiwCZKu5sJ0L2Gyz70E5c/SSpyXxHZBFwzG+TKppM1xhvdQmH1UU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "472"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ae1bd774-b395-4c6c-99b3-1315003b8e92; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=IOLoSooewYynhcBK89nYfIoP2s3sZa6n0kdf4Sikn_Q-1702285166-0-Abuvlp3oDbfEM+6BW1SWv/Z3Zgpun54We0KQiwCZKu5sJ0L2Gyz70E5c/SSpyXxHZBFwzG+TKppM1xhvdQmH1UU=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c4f862fd4c6ef49e65f911eb67b81a66"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "eda8409d57173c0a"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c4f862fd4c6ef49e65f911eb67b81a66"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c880f39d829c5-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:25.707Z",
-        "time": 307,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 307
+          "wait": 297
         }
       },
       {
@@ -3220,26 +2650,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:26.000Z",
+              "expires": "2024-12-11T09:09:43.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2cde1153-690d-4b97-8734-9b95f2b8d4df"
+              "value": "6ab9963c-a195-4aff-ad49-5b6196cd482a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:26.000Z",
+              "expires": "2023-12-11T09:39:43.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "KQgeXI9_PmUcF8S4auX.mSn9y1nJEytyXWcgBHZ1xiY-1702285166-0-AU70XEoiJH6hyU7r20BK90vWGGz+/qJDksDh+fWrRXDS7Tyy5rwcUme+JviPHdWlVNihtq/jsa1muYb0sSXwjYg="
+              "value": "DAd65Psn6SGZa9OVU2VhJVw5C8jJHjNY8NELnyCeLHc-1702285783-0-AbQkX//FqZA6lWj7nbHWuIR66KZiIAedIf1JkBbvgqJODQBjDg6bQTXBfAPLnK04dZFqV+WL14YQwLgtGBcLpw0="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
             },
             {
               "name": "content-type",
@@ -3252,18 +2682,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3280,12 +2698,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2cde1153-690d-4b97-8734-9b95f2b8d4df; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
+              "value": "sourcegraphDeviceId=6ab9963c-a195-4aff-ad49-5b6196cd482a; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=KQgeXI9_PmUcF8S4auX.mSn9y1nJEytyXWcgBHZ1xiY-1702285166-0-AU70XEoiJH6hyU7r20BK90vWGGz+/qJDksDh+fWrRXDS7Tyy5rwcUme+JviPHdWlVNihtq/jsa1muYb0sSXwjYg=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=DAd65Psn6SGZa9OVU2VhJVw5C8jJHjNY8NELnyCeLHc-1702285783-0-AbQkX//FqZA6lWj7nbHWuIR66KZiIAedIf1JkBbvgqJODQBjDg6bQTXBfAPLnK04dZFqV+WL14YQwLgtGBcLpw0=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3301,15 +2719,15 @@
             },
             {
               "name": "x-trace",
-              "value": "58f8ed88012b522d5c7d303057877fa1"
+              "value": "409e4bb43c8c2cab18080d790a5f26cf"
             },
             {
               "name": "x-trace-span",
-              "value": "d1d304b9db6123fd"
+              "value": "6467f23067a8abb1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/58f8ed88012b522d5c7d303057877fa1"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/409e4bb43c8c2cab18080d790a5f26cf"
             },
             {
               "name": "x-xss-protection",
@@ -3333,17 +2751,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c880f3b1e4ff9-MEL"
+              "value": "833c9721bfce2b34-MEL"
             }
           ],
-          "headersSize": 1236,
+          "headersSize": 1129,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:25.704Z",
-        "time": 591,
+        "startedDateTime": "2023-12-11T09:09:43.162Z",
+        "time": 313,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3351,7 +2769,397 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 591
+          "wait": 313
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:43.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "d151b16d-6362-4ab5-8fc7-36e61d288300"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "EHBCy7ygZ8rvtKEqoaKCS_wBmtutkoWkjqMU.zSJ_Ik-1702285783-0-AZjQgGUTyMDtJ4d/DYwmXZxZxdPJqr4i0+9BxW+XhKzvhLUYMXgqaxCNR+CwPQtEDm7C7l9gXAzQ6uCWbb7UlLs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=d151b16d-6362-4ab5-8fc7-36e61d288300; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=EHBCy7ygZ8rvtKEqoaKCS_wBmtutkoWkjqMU.zSJ_Ik-1702285783-0-AZjQgGUTyMDtJ4d/DYwmXZxZxdPJqr4i0+9BxW+XhKzvhLUYMXgqaxCNR+CwPQtEDm7C7l9gXAzQ6uCWbb7UlLs=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "6e82c4a3dbaeed0e9ef849fd73fee738"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a97504d09d07aeae"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6e82c4a3dbaeed0e9ef849fd73fee738"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9721b9fb17cb-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.164Z",
+        "time": 317,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 317
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:43.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "351209f5-88f1-4460-9db1-4c694a8fef7f"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "eXaEZyu6iSRnrvzA5atBOR2mjX5EyTdfYI70Nx2pC5I-1702285783-0-AXNQbk1ApAGysqzarQ0BeEjUzCsXkk1jK6tZ8AuuJFdrPapLiCCsGPQo0NloK435y3QXkWCUR7YEvPH1odkcoNo="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=351209f5-88f1-4460-9db1-4c694a8fef7f; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=eXaEZyu6iSRnrvzA5atBOR2mjX5EyTdfYI70Nx2pC5I-1702285783-0-AXNQbk1ApAGysqzarQ0BeEjUzCsXkk1jK6tZ8AuuJFdrPapLiCCsGPQo0NloK435y3QXkWCUR7YEvPH1odkcoNo=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "32217b2644445ae5af0fcb56bed81034"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "41c3d3eba359f58d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/32217b2644445ae5af0fcb56bed81034"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9721cb5c5ab0-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.165Z",
+        "time": 316,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 316
         }
       },
       {
@@ -3428,26 +3236,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T08:59:26.000Z",
+              "expires": "2024-12-11T09:09:43.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6c4451f9-b293-41b0-939f-80e7fb7834c7"
+              "value": "dd8ee501-5869-4eb6-afe6-d7b3687e82d7"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:26.000Z",
+              "expires": "2023-12-11T09:39:43.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "CTk3GQV1V0Kf__jlvAK5t2fCPYSYBvxcBGZfCm_Hg1U-1702285166-0-Aa8NdVhwae9PRtGb6ZJ43QLFwS6swo3ZKOLM02ubtDrJ9WE3JUzsJrpwCY10jMNpZ+lTsWFJ5DIhj9m8ZzLeEXA="
+              "value": "G4WNihJ4a8M8dnw1zTo96YoawnWJciMTTPI5yrLReKU-1702285783-1-AXR+FllzqoPWFZNJWvq7MxAq8baP/6CR7XuzpioQobWOVPXOzpzPLr4kdV+n3Ad+jjDDjWkLRcGkHX1jnwRsThU="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:26 GMT"
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
             },
             {
               "name": "content-type",
@@ -3460,18 +3268,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "472"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3488,12 +3284,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6c4451f9-b293-41b0-939f-80e7fb7834c7; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
+              "value": "sourcegraphDeviceId=dd8ee501-5869-4eb6-afe6-d7b3687e82d7; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=CTk3GQV1V0Kf__jlvAK5t2fCPYSYBvxcBGZfCm_Hg1U-1702285166-0-Aa8NdVhwae9PRtGb6ZJ43QLFwS6swo3ZKOLM02ubtDrJ9WE3JUzsJrpwCY10jMNpZ+lTsWFJ5DIhj9m8ZzLeEXA=; path=/; expires=Mon, 11-Dec-23 09:29:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=G4WNihJ4a8M8dnw1zTo96YoawnWJciMTTPI5yrLReKU-1702285783-1-AXR+FllzqoPWFZNJWvq7MxAq8baP/6CR7XuzpioQobWOVPXOzpzPLr4kdV+n3Ad+jjDDjWkLRcGkHX1jnwRsThU=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3509,15 +3305,15 @@
             },
             {
               "name": "x-trace",
-              "value": "fd3e9bc5fe9d6c24959be4ca20ba3849"
+              "value": "fbf693a4f2600c243b33e4ff626b0a94"
             },
             {
               "name": "x-trace-span",
-              "value": "c846e639c3b065e4"
+              "value": "06ac4a3cac722454"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fd3e9bc5fe9d6c24959be4ca20ba3849"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fbf693a4f2600c243b33e4ff626b0a94"
             },
             {
               "name": "x-xss-protection",
@@ -3541,21 +3337,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833c880f390a2996-MEL"
+              "value": "833c9721be745ac8-MEL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1268,
+          "headersSize": 1161,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T08:59:25.700Z",
-        "time": 806,
+        "startedDateTime": "2023-12-11T09:09:43.155Z",
+        "time": 327,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3563,7 +3359,2689 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 806
+          "wait": 327
+        }
+      },
+      {
+        "_id": "2e848451056cc77b9b943972023118ad",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1188,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1188"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"274c9191-caf1-47b1-b227-58d90fcdfc80\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:43.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3dfb70f7-b991-442b-92c0-25af7b988bcd"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "9.rLJCHUF4VFaIkMLEQm6f683Exg1IQugY9wi_SWqmU-1702285783-0-AYkroFbk8KLabOqGQ1XX1YRO7CBAYAPYNbIOas0ANQywyQVCFc6REFs2aWpbjs7YlkH8DAUKVxCj7Vj/OxpninI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3dfb70f7-b991-442b-92c0-25af7b988bcd; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=9.rLJCHUF4VFaIkMLEQm6f683Exg1IQugY9wi_SWqmU-1702285783-0-AYkroFbk8KLabOqGQ1XX1YRO7CBAYAPYNbIOas0ANQywyQVCFc6REFs2aWpbjs7YlkH8DAUKVxCj7Vj/OxpninI=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "f5fd81f97607bcfc7b75dd938e89f7a0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "8b33d21cbff1fe25"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f5fd81f97607bcfc7b75dd938e89f7a0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9721bdce2b2e-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.153Z",
+        "time": 331,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 331
+        }
+      },
+      {
+        "_id": "5537aa39a8f93f5f44f27da0e625c9ef",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1186,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1186"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"f1513d66-c877-449e-9769-18eb5c73d0b0\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:43.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "df0af406-c070-478a-9456-d0bb084b6840"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "jemv9ZNrfGeG6QzZ3TKbDKPayyBnHh7ukE6d8KAsSGU-1702285783-0-AelvRipcTsGfJkl84sb72L7HJFIfAiCKUe0I5gRWX5cuc12vYZSmKIq1c7NAfGRASTktyyv9NZcBqOjW+Sw4ZLw="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=df0af406-c070-478a-9456-d0bb084b6840; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=jemv9ZNrfGeG6QzZ3TKbDKPayyBnHh7ukE6d8KAsSGU-1702285783-0-AelvRipcTsGfJkl84sb72L7HJFIfAiCKUe0I5gRWX5cuc12vYZSmKIq1c7NAfGRASTktyyv9NZcBqOjW+Sw4ZLw=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e23c519483430ba363de62b20dca1a01"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "dd5ba61370fac987"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e23c519483430ba363de62b20dca1a01"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9721dd6617cd-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.178Z",
+        "time": 348,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 348
+        }
+      },
+      {
+        "_id": "c6fff7961bbfc269c8c577f2e1929038",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 436,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "436"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:43.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "b31db45c-8128-4f48-8a11-7c61b697d512"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "YsaLaHH2UAyI.Q.Nr5QCz12Py5.Igl81ISfuIUmCBWE-1702285783-0-AVEUQW2PVCw82EP3EKta022jiFSf5ouFZnXL19YmlOEWVub8ND60kBu1GwjfmwaR0WWDN23TA+Bzt8O0r3eJTvo="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=b31db45c-8128-4f48-8a11-7c61b697d512; Expires=Wed, 11 Dec 2024 09:09:43 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=YsaLaHH2UAyI.Q.Nr5QCz12Py5.Igl81ISfuIUmCBWE-1702285783-0-AVEUQW2PVCw82EP3EKta022jiFSf5ouFZnXL19YmlOEWVub8ND60kBu1GwjfmwaR0WWDN23TA+Bzt8O0r3eJTvo=; path=/; expires=Mon, 11-Dec-23 09:39:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "ffcc18a5cfb7e33fb6d4030888e50c9d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "fb8004e071a4ce28"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ffcc18a5cfb7e33fb6d4030888e50c9d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9721da6177dc-MEL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.179Z",
+        "time": 501,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 501
+        }
+      },
+      {
+        "_id": "4cb0e95333a7b013a23cbf416464bd74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "8af52dda-2ed9-4a20-9581-1e5f82931a89"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "FWDUkSF0Sero2YeQvodTXRAms03oEEfhJ4rjooIbdVY-1702285784-0-AYc5lrHyeDZG2Erj3ufsfEe6f634DfIBrtli3cxEvhBAZBrn+BQbVFS74Y5HujfRWmZgu+1FnqPUspJnQe3Hd/Q="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=8af52dda-2ed9-4a20-9581-1e5f82931a89; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=FWDUkSF0Sero2YeQvodTXRAms03oEEfhJ4rjooIbdVY-1702285784-0-AYc5lrHyeDZG2Erj3ufsfEe6f634DfIBrtli3cxEvhBAZBrn+BQbVFS74Y5HujfRWmZgu+1FnqPUspJnQe3Hd/Q=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "2ab582392b036837505a7b6bea7eae11"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "64162ef8459f0252"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2ab582392b036837505a7b6bea7eae11"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c97263a0e5abc-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.879Z",
+        "time": 301,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 301
+        }
+      },
+      {
+        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 190,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "190"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "40af0267-71b3-48bb-b613-7655c580f61a"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "TwjWguDf47Rfj5dlzpIcdDONAvIFANYDQwpgpYTv_jI-1702285784-0-AWDj95KWRIYzaeeIRhTDC9LjX0v4tsbA0fdp2l0PvPsYDKIsI+ARkos44MJ44n1OjxbeYq1n+DWZ0NaSA0ig6vw="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=40af0267-71b3-48bb-b613-7655c580f61a; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=TwjWguDf47Rfj5dlzpIcdDONAvIFANYDQwpgpYTv_jI-1702285784-0-AWDj95KWRIYzaeeIRhTDC9LjX0v4tsbA0fdp2l0PvPsYDKIsI+ARkos44MJ44n1OjxbeYq1n+DWZ0NaSA0ig6vw=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3389dea67fb09dc5ae225342be0a1320"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "d10bc48f608493ce"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3389dea67fb09dc5ae225342be0a1320"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c97263d972e6e-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.878Z",
+        "time": 304,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 304
+        }
+      },
+      {
+        "_id": "ac7fc975d31f02e814346a770195c756",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 192,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "192"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "847caaae-5f4c-4d20-94a3-29cf1b4dcd0b"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "uJ9m0A9y5PzOMil4AxfTlud2jIav7g1zxElpc3dd1g8-1702285784-1-AWKtyBjWTxrP5oVaEBaNHj2n3KwSAkelk2lIvR9x2lKP/adHdUfCGqDqWa761z3NxE/ou0OVS2U6KQOChQ+N1g0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=847caaae-5f4c-4d20-94a3-29cf1b4dcd0b; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=uJ9m0A9y5PzOMil4AxfTlud2jIav7g1zxElpc3dd1g8-1702285784-1-AWKtyBjWTxrP5oVaEBaNHj2n3KwSAkelk2lIvR9x2lKP/adHdUfCGqDqWa761z3NxE/ou0OVS2U6KQOChQ+N1g0=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "95cab5760393f72f8e1bde6b1e5582a2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "755cffd9f5206497"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/95cab5760393f72f8e1bde6b1e5582a2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c97263c8f3777-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.881Z",
+        "time": 303,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 303
+        }
+      },
+      {
+        "_id": "3bfde46a074296956deef9dbd207df0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1ac6e5b7-c801-4207-b135-45d318daede1"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "CyBz0b3kNO65R74GBwweDfn2xx3YrrxY8tzIvx8.bAQ-1702285784-1-AdchgqBLjIPT0jsWBg/Pes+Muhlx67XcZQxfKuGaTRqZ0NFn+zdYx69D1Hukg7vcYDci1O0ztnjd/TaAa87bv2E="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1ac6e5b7-c801-4207-b135-45d318daede1; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=CyBz0b3kNO65R74GBwweDfn2xx3YrrxY8tzIvx8.bAQ-1702285784-1-AdchgqBLjIPT0jsWBg/Pes+Muhlx67XcZQxfKuGaTRqZ0NFn+zdYx69D1Hukg7vcYDci1O0ztnjd/TaAa87bv2E=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4cb34921ffb98ddd3cdc69bce35a9834"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "abb6a114748eab0f"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4cb34921ffb98ddd3cdc69bce35a9834"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c97263bc85ac8-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.880Z",
+        "time": 308,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 308
+        }
+      },
+      {
+        "_id": "8ce04cab0665c317a6df547eaff03a02",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"f1513d66-c877-449e-9769-18eb5c73d0b0\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ebb5b5ab-1f7c-45ab-910c-bd0b3ffe9ee9"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "JZN34PJJ0BuM_3v90PBEbmYQ3EiZdU2ccSl0Ua28nYM-1702285784-0-AejqAXxp9Pw4+ripXbCEqqI4Qu5HAgkThBbbN8rMUmamqpwRXKSYRyNTHGq9SDbxlOlwGIM/gtW9B/fi0cAMWk8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ebb5b5ab-1f7c-45ab-910c-bd0b3ffe9ee9; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=JZN34PJJ0BuM_3v90PBEbmYQ3EiZdU2ccSl0Ua28nYM-1702285784-0-AejqAXxp9Pw4+ripXbCEqqI4Qu5HAgkThBbbN8rMUmamqpwRXKSYRyNTHGq9SDbxlOlwGIM/gtW9B/fi0cAMWk8=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "56494f0c71063e11ff2b759212c1264d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "ce11fb38c05ec149"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/56494f0c71063e11ff2b759212c1264d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c97263ca91f5d-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.874Z",
+        "time": 323,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 323
+        }
+      },
+      {
+        "_id": "103c65b93dfa88c72eea86b3b023599e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "21c20a80-ff6d-4e9f-a9fe-bbce971ef96c"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "kj.IYIu9.73jeQEidNFCVVp6KwPvqBL86nh5SvY9.ZY-1702285784-1-AeBqmnIkbFF57uUgghPSDfe6WKGIk7AFchrtqtxfICeteQJ0vnNlndN3OuYx0KLmOflZRk1FPuezYdSzXJQXmI8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=21c20a80-ff6d-4e9f-a9fe-bbce971ef96c; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=kj.IYIu9.73jeQEidNFCVVp6KwPvqBL86nh5SvY9.ZY-1702285784-1-AeBqmnIkbFF57uUgghPSDfe6WKGIk7AFchrtqtxfICeteQJ0vnNlndN3OuYx0KLmOflZRk1FPuezYdSzXJQXmI8=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "ffe21d3c9df0f8fc3fbbc79d231f898b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "80e615fbd0129f39"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ffe21d3c9df0f8fc3fbbc79d231f898b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c97263c5129a6-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:43.880Z",
+        "time": 423,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 423
+        }
+      },
+      {
+        "_id": "7449140909c921a511332d4c1de94c1f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 182,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "traceparent",
+              "value": "00-76f2047ffea3ead6ad95ae4b1dd40a9d-aa4992abe363799f-01"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 412,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "83312ae3-7917-4442-8e19-b5bee0a12ffb"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "9Eg0ScBD9bWWcenbV2H27khyKiiBUBuyMHHotKgFQIg-1702285784-0-AXq6u7sKt1otCk1bmmw8o2H1jTALEKCFqa6J2HusZE4OPwFpUdjhB5l0aOLN+wnBs3Jd/cncmEoWUHK/As8Z9Ts="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=83312ae3-7917-4442-8e19-b5bee0a12ffb; Expires=Wed, 11 Dec 2024 09:09:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=9Eg0ScBD9bWWcenbV2H27khyKiiBUBuyMHHotKgFQIg-1702285784-0-AXq6u7sKt1otCk1bmmw8o2H1jTALEKCFqa6J2HusZE4OPwFpUdjhB5l0aOLN+wnBs3Jd/cncmEoWUHK/As8Z9Ts=; path=/; expires=Mon, 11-Dec-23 09:39:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "76f2047ffea3ead6ad95ae4b1dd40a9d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "7ed877a177a8bae4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/76f2047ffea3ead6ad95ae4b1dd40a9d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9729cbaf1f62-MEL"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:44.465Z",
+        "time": 285,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 285
+        }
+      },
+      {
+        "_id": "0d16a033a475b66e0dc0d6a4321be2a8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 297,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "traceparent",
+              "value": "00-76f2047ffea3ead6ad95ae4b1dd40a9d-04a49e77d35f8d80-01"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "x-sourcegraph-should-trace",
+              "value": "1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "297"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 437,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/code"
+        },
+        "response": {
+          "bodySize": 172,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 172,
+            "text": "event: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:45.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "b2e4f693-c317-47e4-bd35-a5c7163c2c00"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:45.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "3Dc9x21DQVY.WE5MZ.eT5CAjkJyTIAYA4FBivl0zTkk-1702285785-0-AZUklUQ8Adh4YXcVTn8t3v5VNK+16l3EhgWmnHZvFV+yAsVRUGuvdRNifpHkzVMIQU/qVQ8Kibn+TQEbB/Ky0zo="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:45 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=b2e4f693-c317-47e4-bd35-a5c7163c2c00; Expires=Wed, 11 Dec 2024 09:09:45 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=3Dc9x21DQVY.WE5MZ.eT5CAjkJyTIAYA4FBivl0zTkk-1702285785-0-AZUklUQ8Adh4YXcVTn8t3v5VNK+16l3EhgWmnHZvFV+yAsVRUGuvdRNifpHkzVMIQU/qVQ8Kibn+TQEbB/Ky0zo=; path=/; expires=Mon, 11-Dec-23 09:39:45 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "76f2047ffea3ead6ad95ae4b1dd40a9d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "414e7c65cb23d4bc"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/76f2047ffea3ead6ad95ae4b1dd40a9d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c972baea31f61-MEL"
+            }
+          ],
+          "headersSize": 1132,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:44.761Z",
+        "time": 660,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 660
+        }
+      },
+      {
+        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 333,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "333"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:45.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "f15575cc-29ca-4e05-aef7-c560befacba6"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:46.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "HcusQz_DafEMnFuHRvxkuDMuh5vXC8r2Wf9Zk54waEY-1702285786-0-AUzSeSf9qQ6G/lPo5Cm1XTBhau/D4yxYRCpqM3U8bmqWGJy9N6feMpdRP+tJ3aRtW8T9Qym6A99CWk0IJ3pwrV0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:46 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=f15575cc-29ca-4e05-aef7-c560befacba6; Expires=Wed, 11 Dec 2024 09:09:45 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=HcusQz_DafEMnFuHRvxkuDMuh5vXC8r2Wf9Zk54waEY-1702285786-0-AUzSeSf9qQ6G/lPo5Cm1XTBhau/D4yxYRCpqM3U8bmqWGJy9N6feMpdRP+tJ3aRtW8T9Qym6A99CWk0IJ3pwrV0=; path=/; expires=Mon, 11-Dec-23 09:39:46 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e0836cfa50e6be0dac0200fb72746396"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3759f82d1b1aa5b2"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e0836cfa50e6be0dac0200fb72746396"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c9731987e29ba-MEL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:45.711Z",
+        "time": 734,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 734
+        }
+      },
+      {
+        "_id": "1e3347ed0f7bcaf253d3200070fdf5e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 21512,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 169,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":49748}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/tim/.asdf/installs/nodejs/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/tim/.asdf/installs/nodejs/20.4.0/bin/node\"},{\"stringValue\":\"/Users/tim/Codez/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/tim/Codez/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"tim\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"078c8209647786376df0021c9580a738\",\"spanId\":\"7b5289f47821d760\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285782463000000\",\"endTimeUnixNano\":\"1702285782757480167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"34d3b6302c32f80c8ca2a1280f08075f\",\"spanId\":\"322456f31eecf198\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285782462000000\",\"endTimeUnixNano\":\"1702285782757930000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"71514e1a5c5bc8c420a2801b650f8433\",\"spanId\":\"330d93964f5681d3\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285782463000000\",\"endTimeUnixNano\":\"1702285782760563500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"04f79003b2729e19ab04a63be0c8bbf3\",\"spanId\":\"bf173e75ba44d55c\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285782462000000\",\"endTimeUnixNano\":\"1702285782777239125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"887160d1313f1cdf2ea6552fab41ef69\",\"spanId\":\"3671bca9d68e08f4\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285782461000000\",\"endTimeUnixNano\":\"1702285782791677625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b872ade7e002bb54326b18d4b320f4c2\",\"spanId\":\"b9d86274f276a289\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285782463000000\",\"endTimeUnixNano\":\"1702285782853321292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0cc2df1da857dfb36734b187f8c9d26f\",\"spanId\":\"ff158d757d48f1ce\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702285782853000000\",\"endTimeUnixNano\":\"1702285783145909875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"01e25e92307c7a633dec72180129be19\",\"spanId\":\"48a8130a00757be5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783151000000\",\"endTimeUnixNano\":\"1702285783457754667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"1a4a230a3910e89891775164b2658434\",\"spanId\":\"f01a87a46f6c4346\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783150000000\",\"endTimeUnixNano\":\"1702285783459209375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"eabe82bc8ea9aa568dc5a3d3cf9e7f99\",\"spanId\":\"fb931e264f1bc4d2\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783151000000\",\"endTimeUnixNano\":\"1702285783465586959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"46d179c88e6ca54f354071fbddda44cd\",\"spanId\":\"cde4c3e26f1a8947\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783151000000\",\"endTimeUnixNano\":\"1702285783477850542\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0d009bc5f221959cc4e2567796f8d340\",\"spanId\":\"dee1d43e3163d829\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285783168000000\",\"endTimeUnixNano\":\"1702285783478385875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0d6febece6d64db33ac847a2fb64124e\",\"spanId\":\"c95c9c993267975d\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285783167000000\",\"endTimeUnixNano\":\"1702285783480238000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c388cb22733c035bd06ae1fd55878674\",\"spanId\":\"4fbca3751d2fccab\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702285783167000000\",\"endTimeUnixNano\":\"1702285783482035666\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0bedc9d528c08c290e02565a2067120d\",\"spanId\":\"d691a92937df4c5d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783151000000\",\"endTimeUnixNano\":\"1702285783483049583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e61122a9d4c32c3f90fd6344885e7f98\",\"spanId\":\"9fe2b3632d38f125\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783152000000\",\"endTimeUnixNano\":\"1702285783483931417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9ee40cb70a09e8d546ecd3a4244328d1\",\"spanId\":\"3b5bbf06fe27c289\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285783149000000\",\"endTimeUnixNano\":\"1702285783486130000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8e29e173ca639d2bb2f633edccde4f68\",\"spanId\":\"e65ce4f3d1980d9e\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285783148000000\",\"endTimeUnixNano\":\"1702285783486054959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"dbc71fee9ca1174e2caebed7c2dabee5\",\"spanId\":\"ccae66f6e033bd5f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783170000000\",\"endTimeUnixNano\":\"1702285783500505041\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"95d56438eb75b613606be23d94c61e3f\",\"spanId\":\"fee72a6f7733b1a8\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1702285783169000000\",\"endTimeUnixNano\":\"1702285783514946208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6f3e3b44cae8be9034e8d3228367bafa\",\"spanId\":\"20a589d2ed8c5d66\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285783170000000\",\"endTimeUnixNano\":\"1702285783518071584\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ecf9e0597ba7c07e1cc72d17270eb080\",\"spanId\":\"682e5939a858f8a9\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285783169000000\",\"endTimeUnixNano\":\"1702285783528723583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"035e1740c78a8834f251826d076e8e65\",\"spanId\":\"7dbd52cadee60256\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285783167000000\",\"endTimeUnixNano\":\"1702285783573518333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5f411ea893bad05977c5f976ba0638bc\",\"spanId\":\"eb64eb90e0281f72\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783150000000\",\"endTimeUnixNano\":\"1702285783579471042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"bfd06fb8cd5ecd4e098af6f6ff265a77\",\"spanId\":\"b6565dc8d58e93ea\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285783168000000\",\"endTimeUnixNano\":\"1702285783589886667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"207a6c9d5aaad3431e18c4c93c334af1\",\"spanId\":\"b5812daedb6e1695\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285783149000000\",\"endTimeUnixNano\":\"1702285783611215292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"db7e06b7902d401c949185bf5dca3eb2\",\"spanId\":\"c5f28866454150ff\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783168000000\",\"endTimeUnixNano\":\"1702285783660626917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"02a1e7fcc92f4217b7cb92f87e667401\",\"spanId\":\"3caaa00ec04fd3b7\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285783170000000\",\"endTimeUnixNano\":\"1702285783682808167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9911f348f4f301276f1654059ead920a\",\"spanId\":\"c35db45afe4ea3ff\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783459000000\",\"endTimeUnixNano\":\"1702285783750557458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cc459784d33fbcb3aebb2b638e8d83e6\",\"spanId\":\"39d02b9081ae3a4d\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285783478000000\",\"endTimeUnixNano\":\"1702285783757501208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"774899cf624a5fd3605fb6eac9975b97\",\"spanId\":\"6c728298fcbb363c\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702285783573000000\",\"endTimeUnixNano\":\"1702285783865560916\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"98b29156370d5149dcceb0e67b345f21\",\"spanId\":\"38b77f320b5eedd6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783871000000\",\"endTimeUnixNano\":\"1702285784170454833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0072eac96e2892ad0ac784c97b72363f\",\"spanId\":\"5c21f1eb389bc95a\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285783867000000\",\"endTimeUnixNano\":\"1702285784170190500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"381543511d2ab039103fbc6a0ac0d00f\",\"spanId\":\"a9574f1539d7f414\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783870000000\",\"endTimeUnixNano\":\"1702285784177817416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e46f0ca8fed8778bb96061479aecd7ba\",\"spanId\":\"6f56fa2cdf2650a1\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783870000000\",\"endTimeUnixNano\":\"1702285784181006291\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"eacd8527d7ddb008a85a112a020e1efb\",\"spanId\":\"40078d75394e1685\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783870000000\",\"endTimeUnixNano\":\"1702285784182104917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4dd748ab95f37e98c13760323bada8de\",\"spanId\":\"8c6d8a8d941c2ed3\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783869000000\",\"endTimeUnixNano\":\"1702285784182666458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b6f8881e9b501fa399d7bf68e0ed21c4\",\"spanId\":\"45960813fc3b10ce\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783870000000\",\"endTimeUnixNano\":\"1702285784186388417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b885ccf785e0f7f4910d3558bfc45556\",\"spanId\":\"0416c395c70bd08b\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783870000000\",\"endTimeUnixNano\":\"1702285784190627084\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e0d10b12c14ab8dea56c9909a2556f8c\",\"spanId\":\"277efa7b4ebb8ac6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783871000000\",\"endTimeUnixNano\":\"1702285784191171084\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5e56c123c9117767d0575a8e09c3ca21\",\"spanId\":\"eb0b510324e873c7\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285783869000000\",\"endTimeUnixNano\":\"1702285784191190083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4315929eb166a5dcbb26809271de04f7\",\"spanId\":\"101503f31c39329d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783869000000\",\"endTimeUnixNano\":\"1702285784194530208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"455207082082346c468d20462c674e94\",\"spanId\":\"92dc19c653bf9b74\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702285783868000000\",\"endTimeUnixNano\":\"1702285784199205958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a1e98c47e89597ed794e8e60d8d01a92\",\"spanId\":\"3d9611e9bfb0a041\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783871000000\",\"endTimeUnixNano\":\"1702285784202988708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a61d2adfb9474cf0ab7e736842c944a1\",\"spanId\":\"aef2d0ee670ecb80\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702285783869000000\",\"endTimeUnixNano\":\"1702285784209062375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6c6c2a1f423986556bac468ba2908716\",\"spanId\":\"672212c004d2fd83\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783871000000\",\"endTimeUnixNano\":\"1702285784268165917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8136da29976af9354801dabc86bee4b3\",\"spanId\":\"19505d668ceb4f2f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285783870000000\",\"endTimeUnixNano\":\"1702285784304218292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0071ea1c58b79f765cb556086348b8ce\",\"spanId\":\"eda4d294e3de48ea\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285784171000000\",\"endTimeUnixNano\":\"1702285784461958000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9b6342a1bf96bf3f797f12bb868fa680\",\"spanId\":\"70d5929ebb59e151\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285784191000000\",\"endTimeUnixNano\":\"1702285784490621417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"fb2462963babbdba\",\"parentSpanId\":\"aa4992abe363799f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702285784463000000\",\"endTimeUnixNano\":\"1702285784753382958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"489da91046bee06b\",\"parentSpanId\":\"aa4992abe363799f\",\"name\":\"autocomplete.debounce\",\"kind\":1,\"startTimeUnixNano\":\"1702285784754000000\",\"endTimeUnixNano\":\"1702285784754071167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"289e81cf17e7baa3\",\"parentSpanId\":\"59a06806a9706bbb\",\"name\":\"autocomplete.retrieve.jaccard-similarity\",\"kind\":1,\"startTimeUnixNano\":\"1702285784755000000\",\"endTimeUnixNano\":\"1702285784755575208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"a1e406a26ee44ccc\",\"parentSpanId\":\"59a06806a9706bbb\",\"name\":\"autocomplete.retrieve.bfg\",\"kind\":1,\"startTimeUnixNano\":\"1702285784755000000\",\"endTimeUnixNano\":\"1702285784755961875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"59a06806a9706bbb\",\"parentSpanId\":\"aa4992abe363799f\",\"name\":\"autocomplete.retrieve\",\"kind\":1,\"startTimeUnixNano\":\"1702285784755000000\",\"endTimeUnixNano\":\"1702285784756370167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"04a49e77d35f8d80\",\"parentSpanId\":\"aa4992abe363799f\",\"name\":\"autocomplete.generate\",\"kind\":1,\"startTimeUnixNano\":\"1702285784756000000\",\"endTimeUnixNano\":\"1702285785425171334\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"e6dd1c627a5caa9f\",\"parentSpanId\":\"aa4992abe363799f\",\"name\":\"autocomplete.post-process\",\"kind\":1,\"startTimeUnixNano\":\"1702285785426000000\",\"endTimeUnixNano\":\"1702285785426122958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"76f2047ffea3ead6ad95ae4b1dd40a9d\",\"spanId\":\"aa4992abe363799f\",\"name\":\"autocomplete.provideInlineCompletionItems\",\"kind\":1,\"startTimeUnixNano\":\"1702285784462000000\",\"endTimeUnixNano\":\"1702285785426180750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"98fb6a2fa9c0888a30f0d603cfe5ecad\",\"spanId\":\"fb06c0cf74129bea\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702285785427000000\",\"endTimeUnixNano\":\"1702285785709641458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"45ecd47a85a651758346f0861b02143b\",\"spanId\":\"0250effa7a8f8f6e\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702285785710000000\",\"endTimeUnixNano\":\"1702285786447949541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\"partialSuccess\":{}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:48.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3a4ab7b6-09e1-40b7-bc53-70305d8aa562"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:48.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "qFVDC06y1Pmr48C4LMKH1Oai6kgyAN7q0_prVhTbhvs-1702285788-0-AeNV/g1fIlcu+vWii+nrC5jlMFxbr4oDflix9q2FLzXRsVzwkYTc7HyxwbH+ej+38SRuU2AXdLQBDg0PXsZ1i7M="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:48 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3a4ab7b6-09e1-40b7-bc53-70305d8aa562; Expires=Wed, 11 Dec 2024 09:09:48 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=qFVDC06y1Pmr48C4LMKH1Oai6kgyAN7q0_prVhTbhvs-1702285788-0-AeNV/g1fIlcu+vWii+nrC5jlMFxbr4oDflix9q2FLzXRsVzwkYTc7HyxwbH+ej+38SRuU2AXdLQBDg0PXsZ1i7M=; path=/; expires=Mon, 11-Dec-23 09:39:48 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Authorization,Cookie,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "7421d600e039d31e8b535ee96a985eec"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "2a123cbcd6045bf6"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7421d600e039d31e8b535ee96a985eec"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c973e8c772996-MEL"
+            }
+          ],
+          "headersSize": 1014,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:47.765Z",
+        "time": 419,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 419
+        }
+      },
+      {
+        "_id": "34fa3baab68c77b4e329fd24907b91f7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1300,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 234,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/stream"
+        },
+        "response": {
+          "bodySize": 44267,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 44267,
+            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum`.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum`.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-11T09:09:45.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "dc375177-1fa7-4b7f-9be5-7e80899a5d38"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-11T09:39:47.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ZYVshyfodYW4CxaPf1jY835PJD2xvvEsQ8HENusN0Bc-1702285787-0-AZZDCJzSe1fv4qj4tHLUm0fDxH5FezD9DeZ0zOpDHrn6HQ0Eu3CfarTNyOkZEhK/Xo/WIBR/tKcHH52bPXtfDf0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Mon, 11 Dec 2023 09:09:47 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=dc375177-1fa7-4b7f-9be5-7e80899a5d38; Expires=Wed, 11 Dec 2024 09:09:45 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ZYVshyfodYW4CxaPf1jY835PJD2xvvEsQ8HENusN0Bc-1702285787-0-AZZDCJzSe1fv4qj4tHLUm0fDxH5FezD9DeZ0zOpDHrn6HQ0Eu3CfarTNyOkZEhK/Xo/WIBR/tKcHH52bPXtfDf0=; path=/; expires=Mon, 11-Dec-23 09:39:47 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c9eb3b74cdf5693f35ccbdc28feac175"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5cc666ec4e531b1d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c9eb3b74cdf5693f35ccbdc28feac175"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "833c972fdd232eac-MEL"
+            }
+          ],
+          "headersSize": 1132,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-11T09:09:45.430Z",
+        "time": 6515,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6515
         }
       },
       {
@@ -3981,1253 +6459,6 @@
         }
       },
       {
-        "_id": "c6fff7961bbfc269c8c577f2e1929038",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 436,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "436"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:26.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "4734d2f1-867b-4f12-82e6-7bb385924ff6"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "oboETOnTjhJGabTWeDqqYWKKVPo0SAd3MKYs_NK8bq8-1702285167-0-AVa+70jbr4AFOiOAv4ziaZbKtrWEnSELJ/6LoNA14B/VlRKBNHqdDa8COEDIbjaGBBs1E1DdXL9Dew/CYmz6HuA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "472"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4734d2f1-867b-4f12-82e6-7bb385924ff6; Expires=Wed, 11 Dec 2024 08:59:26 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=oboETOnTjhJGabTWeDqqYWKKVPo0SAd3MKYs_NK8bq8-1702285167-0-AVa+70jbr4AFOiOAv4ziaZbKtrWEnSELJ/6LoNA14B/VlRKBNHqdDa8COEDIbjaGBBs1E1DdXL9Dew/CYmz6HuA=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "daa5d9284a76a391c1f455bd83559292"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "623171e2f8a74a88"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/daa5d9284a76a391c1f455bd83559292"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c880f490b5a98-MEL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:25.718Z",
-        "time": 1187,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1187
-        }
-      },
-      {
-        "_id": "ac7fc975d31f02e814346a770195c756",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 192,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "192"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "5d7f1cb3-dd8a-46c2-900b-472c1f03dfb8"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "09L.z_itL0wgZmb7mzgrcimVANsd2dcdsM082MzI6Xg-1702285167-1-AfLvjeNBN3xhl1QeaIj4VKFuvoPnph7lS2aUaPY7n2s/ntP+pGAcfxdqe4u0dLL3ZRTCiXhRHExcWGy2dTkpyqA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "471"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5d7f1cb3-dd8a-46c2-900b-472c1f03dfb8; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=09L.z_itL0wgZmb7mzgrcimVANsd2dcdsM082MzI6Xg-1702285167-1-AfLvjeNBN3xhl1QeaIj4VKFuvoPnph7lS2aUaPY7n2s/ntP+pGAcfxdqe4u0dLL3ZRTCiXhRHExcWGy2dTkpyqA=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "83db3d1891e98be99de99c4801b23384"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f02f4c543f72c11c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83db3d1891e98be99de99c4801b23384"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c88175b7a5a8b-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:27.009Z",
-        "time": 298,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 298
-        }
-      },
-      {
-        "_id": "103c65b93dfa88c72eea86b3b023599e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1f3da436-4513-4e0e-9cc5-e3d5e7bda0de"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "YFUlY7hyvfEnYJTIQ_tFyuSiHGwVkMAM6lzlKKpBPTI-1702285167-0-AYg5Hi5jmBu1gWZIyOEOua2bYJvy/TZUus4ZmPTuNl5pEBSdOajyq3LsLKnDQZCKjvjP5wvf7Y3l50eA2IZKJhY="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "471"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1f3da436-4513-4e0e-9cc5-e3d5e7bda0de; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=YFUlY7hyvfEnYJTIQ_tFyuSiHGwVkMAM6lzlKKpBPTI-1702285167-0-AYg5Hi5jmBu1gWZIyOEOua2bYJvy/TZUus4ZmPTuNl5pEBSdOajyq3LsLKnDQZCKjvjP5wvf7Y3l50eA2IZKJhY=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "dbe1c34ab47e7d5ae5ac008981de4617"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c65ad8f0b636f0b1"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dbe1c34ab47e7d5ae5ac008981de4617"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c88175e002b34-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:27.008Z",
-        "time": 305,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 305
-        }
-      },
-      {
-        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 190,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "190"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2b437522-528c-4cb2-bc9e-1ede48dae6f7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "AO3jC2n4Gb8.5.4tO2OielsIly7vEEC49RW8sSmZ_qQ-1702285167-0-Af1lOhsXr/gfUComd3b3j33sE/B7xLRe7neDLkuJESwl/1JOqVCt+SeL9sXsByhKL/ggtXXaQZ7rBQJiW3vWNos="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "471"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2b437522-528c-4cb2-bc9e-1ede48dae6f7; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=AO3jC2n4Gb8.5.4tO2OielsIly7vEEC49RW8sSmZ_qQ-1702285167-0-Af1lOhsXr/gfUComd3b3j33sE/B7xLRe7neDLkuJESwl/1JOqVCt+SeL9sXsByhKL/ggtXXaQZ7rBQJiW3vWNos=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "bff333775d6132671453e30a14812c13"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "6d8bb765c98f04d3"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bff333775d6132671453e30a14812c13"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c88175c742b2e-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:27.006Z",
-        "time": 311,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 311
-        }
-      },
-      {
-        "_id": "3bfde46a074296956deef9dbd207df0b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "3e442cd3-b77b-4d16-beeb-d8739bb82215"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "j10uajO4nJH4gr11PBwzX4WEDVZECBHFz0emNIlGBoE-1702285167-0-ARCli55RCNkxDOzkEHs4NKMZpFmB2XxK38HS+WCzbwKm+8Zj7deaE0mavNJeQ5teq830dl9ubzFuNe46NCrigpo="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "471"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3e442cd3-b77b-4d16-beeb-d8739bb82215; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=j10uajO4nJH4gr11PBwzX4WEDVZECBHFz0emNIlGBoE-1702285167-0-ARCli55RCNkxDOzkEHs4NKMZpFmB2XxK38HS+WCzbwKm+8Zj7deaE0mavNJeQ5teq830dl9ubzFuNe46NCrigpo=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "39dfc7237fd625a418a2d657c386da25"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "27964431d800edee"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/39dfc7237fd625a418a2d657c386da25"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c8817587777e7-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:27.008Z",
-        "time": 321,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 321
-        }
-      },
-      {
-        "_id": "4cb0e95333a7b013a23cbf416464bd74",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "f9626d85-cc21-409c-803d-246e18f975d5"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "BGAoUldJFNdzbdad_lNQG7WTZBWEQxbNEt7RtmSgNjI-1702285167-0-AUUub3JE7fDZP9yU2fzWRw0IvqzHEu2sQGOJkLgNJ3vZwChf0lvv/p/fW7VvHvIC8VJWmkNE30mk3h1+OeuwINQ="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "471"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f9626d85-cc21-409c-803d-246e18f975d5; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=BGAoUldJFNdzbdad_lNQG7WTZBWEQxbNEt7RtmSgNjI-1702285167-0-AUUub3JE7fDZP9yU2fzWRw0IvqzHEu2sQGOJkLgNJ3vZwChf0lvv/p/fW7VvHvIC8VJWmkNE30mk3h1+OeuwINQ=; path=/; expires=Mon, 11-Dec-23 09:29:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "0c66c3341098e4641a7bb5b2d23ecb90"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "cac60f91d3e17bb3"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0c66c3341098e4641a7bb5b2d23ecb90"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c88175a891f68-MEL"
-            }
-          ],
-          "headersSize": 1236,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:27.007Z",
-        "time": 322,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 322
-        }
-      },
-      {
         "_id": "bab8949ac0f7ed5aa5fa607578da4a4f",
         "_order": 0,
         "cache": {},
@@ -5435,218 +6666,6 @@
         }
       },
       {
-        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 333,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "333"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:28.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d1531eab-92f8-46b7-bf1e-600168fce4ee"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:29.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "nUzg_wKr.AMfO6pFsGiC1ooPcwwwiXW0AhUr8mD.DRw-1702285169-1-AYjwIv3B1zOfaSuM3MVpQle4zyLMrUiSItkvh3Er3vTgdFfeTLCslOWUsH678kV+gG5KvshbhuhnTQfmCjjJ2PU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:29 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "470"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d1531eab-92f8-46b7-bf1e-600168fce4ee; Expires=Wed, 11 Dec 2024 08:59:28 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=nUzg_wKr.AMfO6pFsGiC1ooPcwwwiXW0AhUr8mD.DRw-1702285169-1-AYjwIv3B1zOfaSuM3MVpQle4zyLMrUiSItkvh3Er3vTgdFfeTLCslOWUsH678kV+gG5KvshbhuhnTQfmCjjJ2PU=; path=/; expires=Mon, 11-Dec-23 09:29:29 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "47004e22982a5eb9d3228ab733ebb667"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7acbe197c84eddd0"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/47004e22982a5eb9d3228ab733ebb667"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c881e1eaa29af-MEL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1268,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:28.093Z",
-        "time": 1335,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1335
-        }
-      },
-      {
         "_id": "e5443a606d1749be8736a7d667f0bdd9",
         "_order": 0,
         "cache": {},
@@ -5811,185 +6830,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 320
-        }
-      },
-      {
-        "_id": "34fa3baab68c77b4e329fd24907b91f7",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1300,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 234,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/stream"
-        },
-        "response": {
-          "bodySize": 44267,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 44267,
-            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum`.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without any context about the programming language, project, or problem you are working on, I do not have enough information to provide a specific implementation of a `sum` function. If you can provide more details about the task and goals, I would be happy to try assisting further. As an AI assistant, I aim to avoid making assumptions or providing misleading information when the context is unclear. Please let me know if there are any details you can add that would help me understand the problem space, so I can try to offer a relevant code snippet or explanation for implementing `sum`.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T08:59:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "5f5511d4-a21d-4345-8b2b-bdd0cd2c342a"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T09:29:30.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "U8y77ElYHQRwCVEuJTnmJl6N.5B3WQPc6ZsjRhZFx3E-1702285170-0-AVIZCerMfRcx+0OG3eMzOFGh+rd7M/G8ZSyL5mYtlyx04YoWwKL0iY0QT4uS0x5LLg8fEgOiPghPO5/l2syCkDk="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 08:59:30 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "471"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5f5511d4-a21d-4345-8b2b-bdd0cd2c342a; Expires=Wed, 11 Dec 2024 08:59:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=U8y77ElYHQRwCVEuJTnmJl6N.5B3WQPc6ZsjRhZFx3E-1702285170-0-AVIZCerMfRcx+0OG3eMzOFGh+rd7M/G8ZSyL5mYtlyx04YoWwKL0iY0QT4uS0x5LLg8fEgOiPghPO5/l2syCkDk=; path=/; expires=Mon, 11-Dec-23 09:29:30 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "24c80ab945fbbd87ce92148c8653f3aa"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d395d7927de9851d"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/24c80ab945fbbd87ce92148c8653f3aa"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833c881b38841f6e-MEL"
-            }
-          ],
-          "headersSize": 1239,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T08:59:27.637Z",
-        "time": 7522,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 7522
         }
       },
       {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -400,7 +400,7 @@ export class Agent extends MessageHandler {
             if (!client) {
                 throw new Error('Cody client not initialized')
             }
-            const res = await client.graphqlClient.getCurrentUserIdAndVerifiedEmailAndCodyPro()
+            const res = await client.graphqlClient.getCurrentUserCodyProEnabled()
             if (res instanceof Error) {
                 throw res
             }

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -60,7 +60,7 @@ interface CurrentUserIdResponse {
     currentUser: { id: string } | null
 }
 
-interface CurrentUserInfoDotComResponse {
+interface DotComCurrentUserInfoResponse {
     currentUser: {
         id: string
         hasVerifiedEmail: boolean
@@ -376,7 +376,7 @@ export class SourcegraphGraphQLAPIClient {
           }
         | Error
     > {
-        return this.fetchSourcegraphAPI<APIResponse<CurrentUserInfoDotComResponse>>(
+        return this.fetchSourcegraphAPI<APIResponse<DotComCurrentUserInfoResponse>>(
             DOT_COM_CURRENT_USER_INFO_QUERY,
             {}
         ).then(response =>

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -16,7 +16,7 @@ import {
     CURRENT_SITE_VERSION_QUERY,
     CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
     CURRENT_USER_ID_QUERY,
-    CURRENT_USER_INFO_DOT_COM_QUERY,
+    DOT_COM_CURRENT_USER_INFO_QUERY,
     ENTERPRISE_CURRENT_USER_INFO_QUERY,
     EVALUATE_FEATURE_FLAG_QUERY,
     GET_CODY_CONTEXT_QUERY,
@@ -363,7 +363,7 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getCurrentUserInfoDotCom(): Promise<
+    public async getDotComCurrentUserInfo(): Promise<
         | {
               id: string
               hasVerifiedEmail: boolean
@@ -377,7 +377,7 @@ export class SourcegraphGraphQLAPIClient {
         | Error
     > {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserInfoDotComResponse>>(
-            CURRENT_USER_INFO_DOT_COM_QUERY,
+            DOT_COM_CURRENT_USER_INFO_QUERY,
             {}
         ).then(response =>
             extractDataOrError(response, data =>
@@ -389,12 +389,7 @@ export class SourcegraphGraphQLAPIClient {
     }
 
     public async getCurrentUserIdAndVerifiedEmailAndCodyPro(): Promise<
-        | {
-              id: string
-              hasVerifiedEmail: boolean
-              codyProEnabled: boolean
-          }
-        | Error
+        { id: string; hasVerifiedEmail: boolean; codyProEnabled: boolean } | Error
     > {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdHasVerifiedEmailHasCodyProResponse>>(
             CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -14,8 +14,9 @@ import {
     CURRENT_SITE_HAS_CODY_ENABLED_QUERY,
     CURRENT_SITE_IDENTIFICATION,
     CURRENT_SITE_VERSION_QUERY,
-    CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
     CURRENT_USER_ID_QUERY,
+    CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
+    ENTERPRISE_CURRENT_USER_INFO_QUERY,
     EVALUATE_FEATURE_FLAG_QUERY,
     GET_CODY_CONTEXT_QUERY,
     GET_FEATURE_FLAGS_QUERY,
@@ -58,8 +59,28 @@ interface CurrentUserIdResponse {
     currentUser: { id: string } | null
 }
 
+interface EnterpriseCurrentUserInfoResponse {
+    currentUser: {
+        id: string
+        displayName: string
+        avatarURL: string
+        primaryEmail: {
+            email: string
+        }
+    } | null
+}
+
 interface CurrentUserIdHasVerifiedEmailHasCodyProResponse {
-    currentUser: { id: string; hasVerifiedEmail: boolean; codyProEnabled: boolean } | null
+    currentUser: {
+        id: string
+        hasVerifiedEmail: boolean
+        displayName: string
+        avatarURL: string
+        codyProEnabled: boolean
+        primaryEmail: {
+            email: string
+        }
+    } | null
 }
 
 interface CodyLLMSiteConfigurationResponse {
@@ -312,11 +333,42 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
+    public async getEnterpriseCurrentUserInfo(): Promise<
+        | {
+              id: string
+              displayName: string
+              avatarURL: string
+              primaryEmail: {
+                  email: string
+              }
+          }
+        | Error
+    > {
+        return this.fetchSourcegraphAPI<APIResponse<EnterpriseCurrentUserInfoResponse>>(
+            ENTERPRISE_CURRENT_USER_INFO_QUERY,
+            {}
+        ).then(response =>
+            extractDataOrError(response, data =>
+                data.currentUser ? { ...data.currentUser } : new Error('current user not found')
+            )
+        )
+    }
+
     public async getCurrentUserIdAndVerifiedEmailAndCodyPro(): Promise<
-        { id: string; hasVerifiedEmail: boolean; codyProEnabled: boolean } | Error
+        | {
+              id: string
+              hasVerifiedEmail: boolean
+              displayName: string
+              avatarURL: string
+              codyProEnabled: boolean
+              primaryEmail: {
+                  email: string
+              }
+          }
+        | Error
     > {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdHasVerifiedEmailHasCodyProResponse>>(
-            CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
+            CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
             {}
         ).then(response =>
             extractDataOrError(response, data =>

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -14,8 +14,8 @@ import {
     CURRENT_SITE_HAS_CODY_ENABLED_QUERY,
     CURRENT_SITE_IDENTIFICATION,
     CURRENT_SITE_VERSION_QUERY,
+    CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
     CURRENT_USER_ID_QUERY,
-    CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
     CURRENT_USER_INFO_DOT_COM_QUERY,
     ENTERPRISE_CURRENT_USER_INFO_QUERY,
     EVALUATE_FEATURE_FLAG_QUERY,
@@ -371,8 +371,8 @@ export class SourcegraphGraphQLAPIClient {
               displayName: string
               avatarURL: string
               primaryEmail: {
-                email: string
-            }
+                  email: string
+              }
           }
         | Error
     > {
@@ -397,7 +397,7 @@ export class SourcegraphGraphQLAPIClient {
         | Error
     > {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdHasVerifiedEmailHasCodyProResponse>>(
-            CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
+            CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
             {}
         ).then(response =>
             extractDataOrError(response, data =>

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -340,17 +340,13 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getCurrentUserCodyProEnabled(): Promise<
-        { codyProEnabled: boolean } | Error
-    > {
+    public async getCurrentUserCodyProEnabled(): Promise<{ codyProEnabled: boolean } | Error> {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserCodyProEnabledResponse>>(
             CURRENT_USER_CODY_PRO_ENABLED_QUERY,
             {}
         ).then(response =>
             extractDataOrError(response, data =>
-                data.currentUser
-                    ? { ...data.currentUser }
-                    : new Error('current user not found')
+                data.currentUser ? { ...data.currentUser } : new Error('current user not found')
             )
         )
     }
@@ -394,9 +390,7 @@ export class SourcegraphGraphQLAPIClient {
             {}
         ).then(response =>
             extractDataOrError(response, data =>
-                data.currentUser
-                    ? { ...data.currentUser }
-                    : new Error('current user not found')
+                data.currentUser ? { ...data.currentUser } : new Error('current user not found')
             )
         )
     }

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -14,7 +14,7 @@ import {
     CURRENT_SITE_HAS_CODY_ENABLED_QUERY,
     CURRENT_SITE_IDENTIFICATION,
     CURRENT_SITE_VERSION_QUERY,
-    CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
+    CURRENT_USER_CODY_PRO_ENABLED_QUERY,
     CURRENT_USER_ID_QUERY,
     DOT_COM_CURRENT_USER_INFO_QUERY,
     ENTERPRISE_CURRENT_USER_INFO_QUERY,
@@ -84,10 +84,8 @@ interface EnterpriseCurrentUserInfoResponse {
     } | null
 }
 
-interface CurrentUserIdHasVerifiedEmailHasCodyProResponse {
+interface CurrentUserCodyProEnabledResponse {
     currentUser: {
-        id: string
-        hasVerifiedEmail: boolean
         codyProEnabled: boolean
     } | null
 }
@@ -342,6 +340,21 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
+    public async getCurrentUserCodyProEnabled(): Promise<
+        { codyProEnabled: boolean } | Error
+    > {
+        return this.fetchSourcegraphAPI<APIResponse<CurrentUserCodyProEnabledResponse>>(
+            CURRENT_USER_CODY_PRO_ENABLED_QUERY,
+            {}
+        ).then(response =>
+            extractDataOrError(response, data =>
+                data.currentUser
+                    ? { ...data.currentUser }
+                    : new Error('current user not found')
+            )
+        )
+    }
+
     public async getEnterpriseCurrentUserInfo(): Promise<
         | {
               id: string
@@ -383,22 +396,7 @@ export class SourcegraphGraphQLAPIClient {
             extractDataOrError(response, data =>
                 data.currentUser
                     ? { ...data.currentUser }
-                    : new Error('current user not found with verified email and cody pro')
-            )
-        )
-    }
-
-    public async getCurrentUserIdAndVerifiedEmailAndCodyPro(): Promise<
-        { id: string; hasVerifiedEmail: boolean; codyProEnabled: boolean } | Error
-    > {
-        return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdHasVerifiedEmailHasCodyProResponse>>(
-            CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
-            {}
-        ).then(response =>
-            extractDataOrError(response, data =>
-                data.currentUser
-                    ? { ...data.currentUser }
-                    : new Error('current user not found with verified email and cody pro')
+                    : new Error('current user not found')
             )
         )
     }

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -16,6 +16,7 @@ import {
     CURRENT_SITE_VERSION_QUERY,
     CURRENT_USER_ID_QUERY,
     CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY,
+    CURRENT_USER_INFO_DOT_COM_QUERY,
     ENTERPRISE_CURRENT_USER_INFO_QUERY,
     EVALUATE_FEATURE_FLAG_QUERY,
     GET_CODY_CONTEXT_QUERY,
@@ -59,6 +60,19 @@ interface CurrentUserIdResponse {
     currentUser: { id: string } | null
 }
 
+interface CurrentUserInfoDotComResponse {
+    currentUser: {
+        id: string
+        hasVerifiedEmail: boolean
+        displayName: string
+        avatarURL: string
+        codyProEnabled: boolean
+        primaryEmail: {
+            email: string
+        }
+    } | null
+}
+
 interface EnterpriseCurrentUserInfoResponse {
     currentUser: {
         id: string
@@ -74,12 +88,7 @@ interface CurrentUserIdHasVerifiedEmailHasCodyProResponse {
     currentUser: {
         id: string
         hasVerifiedEmail: boolean
-        displayName: string
-        avatarURL: string
         codyProEnabled: boolean
-        primaryEmail: {
-            email: string
-        }
     } | null
 }
 
@@ -354,16 +363,36 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
+    public async getCurrentUserInfoDotCom(): Promise<
+        | {
+              id: string
+              hasVerifiedEmail: boolean
+              codyProEnabled: boolean
+              displayName: string
+              avatarURL: string
+              primaryEmail: {
+                email: string
+            }
+          }
+        | Error
+    > {
+        return this.fetchSourcegraphAPI<APIResponse<CurrentUserInfoDotComResponse>>(
+            CURRENT_USER_INFO_DOT_COM_QUERY,
+            {}
+        ).then(response =>
+            extractDataOrError(response, data =>
+                data.currentUser
+                    ? { ...data.currentUser }
+                    : new Error('current user not found with verified email and cody pro')
+            )
+        )
+    }
+
     public async getCurrentUserIdAndVerifiedEmailAndCodyPro(): Promise<
         | {
               id: string
               hasVerifiedEmail: boolean
-              displayName: string
-              avatarURL: string
               codyProEnabled: boolean
-              primaryEmail: {
-                  email: string
-              }
           }
         | Error
     > {

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -5,6 +5,18 @@ query CurrentUser {
     }
 }`
 
+export const ENTERPRISE_CURRENT_USER_INFO_QUERY = `
+query CurrentUser {
+    currentUser {
+        id
+        displayName
+        avatarURL
+        primaryEmail {
+            email
+        }
+    }
+}`
+
 export const CURRENT_SITE_VERSION_QUERY = `
 query SiteProductVersion {
     site {
@@ -28,12 +40,17 @@ query SiteGraphQLFields {
     }
 }`
 
-export const CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY = `
+export const CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY = `
 query CurrentUser {
     currentUser {
         id
         hasVerifiedEmail
+        displayName
+        avatarURL
         codyProEnabled
+        primaryEmail {
+            email
+        }
     }
 }`
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -5,6 +5,13 @@ query CurrentUser {
     }
 }`
 
+export const CURRENT_USER_CODY_PRO_ENABLED_QUERY = `
+query CurrentUser {
+    currentUser {
+        codyProEnabled
+    }
+}`
+
 export const DOT_COM_CURRENT_USER_INFO_QUERY = `
 query CurrentUser {
     currentUser {
@@ -51,15 +58,6 @@ query SiteGraphQLFields {
         fields {
             name
         }
-    }
-}`
-
-export const CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY = `
-query CurrentUser {
-    currentUser {
-        id
-        hasVerifiedEmail
-        codyProEnabled
     }
 }`
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -54,7 +54,7 @@ query SiteGraphQLFields {
     }
 }`
 
-export const CURRENT_USER_INFO_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY = `
+export const CURRENT_USER_ID_AND_VERIFIED_EMAIL_AND_CODY_PRO_QUERY = `
 query CurrentUser {
     currentUser {
         id

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -5,6 +5,20 @@ query CurrentUser {
     }
 }`
 
+export const CURRENT_USER_INFO_DOT_COM_QUERY = `
+query CurrentUser {
+    currentUser {
+        id
+        hasVerifiedEmail
+        displayName
+        avatarURL
+        codyProEnabled
+        primaryEmail {
+            email
+        }
+    }
+}`
+
 export const ENTERPRISE_CURRENT_USER_INFO_QUERY = `
 query CurrentUser {
     currentUser {
@@ -45,12 +59,7 @@ query CurrentUser {
     currentUser {
         id
         hasVerifiedEmail
-        displayName
-        avatarURL
         codyProEnabled
-        primaryEmail {
-            email
-        }
     }
 }`
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -5,7 +5,7 @@ query CurrentUser {
     }
 }`
 
-export const CURRENT_USER_INFO_DOT_COM_QUERY = `
+export const DOT_COM_CURRENT_USER_INFO_QUERY = `
 query CurrentUser {
     currentUser {
         id

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Replace "Sign Out" with an account dialog. [pull/2233](https://github.com/sourcegraph/cody/pull/2233)
+
 ## [0.18.2]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -250,7 +250,7 @@
     "commands": [
       {
         "command": "cody.welcome",
-        "title": "Help & Getting Started",
+        "title": "Getting Started Guide",
         "category": "Cody",
         "group": "Cody",
         "icon": "$(book)"
@@ -666,19 +666,9 @@
           "group": "navigation@3"
         },
         {
-          "command": "cody.feedback",
-          "when": "view == cody.support.tree.view",
-          "group": "7_cody@0"
-        },
-        {
           "command": "cody.welcome",
           "when": "view == cody.support.tree.view",
           "group": "7_cody@0"
-        },
-        {
-          "command": "cody.auth.signin",
-          "when": "view == cody.support.tree.view && cody.activated",
-          "group": "9_cody@0"
         },
         {
           "command": "cody.search.index-update",

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -146,6 +146,9 @@ export interface AuthStatus {
     siteVersion: string
     configOverwrites?: CodyLLMSiteConfiguration
     showNetworkError?: boolean
+    primaryEmail: string
+    displayName: string
+    avatarURL: string
     /**
      * Whether the users account can be upgraded.
      *
@@ -167,6 +170,9 @@ export const defaultAuthStatus = {
     siteHasCodyEnabled: false,
     siteVersion: '',
     userCanUpgrade: false,
+    primaryEmail: '',
+    displayName: '',
+    avatarURL: '',
 }
 
 export const unauthenticatedStatus = {
@@ -179,6 +185,9 @@ export const unauthenticatedStatus = {
     siteHasCodyEnabled: false,
     siteVersion: '',
     userCanUpgrade: false,
+    primaryEmail: '',
+    displayName: '',
+    avatarURL: '',
 }
 
 export const networkErrorAuthStatus = {
@@ -191,6 +200,9 @@ export const networkErrorAuthStatus = {
     siteHasCodyEnabled: false,
     siteVersion: '',
     userCanUpgrade: false,
+    primaryEmail: '',
+    displayName: '',
+    avatarURL: '',
 }
 
 /** The local environment of the editor. */

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -46,7 +46,7 @@ describe('validateAuthStatus', () => {
             endpoint,
             avatarURL,
             primaryEmail,
-            displayName
+            displayName,
         }
         expect(
             newAuthStatus(
@@ -74,7 +74,7 @@ describe('validateAuthStatus', () => {
             endpoint,
             avatarURL,
             primaryEmail,
-            displayName
+            displayName,
         }
         expect(
             newAuthStatus(
@@ -102,7 +102,7 @@ describe('validateAuthStatus', () => {
             endpoint,
             avatarURL,
             primaryEmail,
-            displayName
+            displayName,
         }
         expect(
             newAuthStatus(
@@ -146,7 +146,7 @@ describe('validateAuthStatus', () => {
             endpoint,
             avatarURL,
             primaryEmail,
-            displayName
+            displayName,
         }
         expect(
             newAuthStatus(

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -12,9 +12,9 @@ describe('validateAuthStatus', () => {
     const validUser = true
     const endpoint = ''
     const userCanUpgrade = false
-    const primaryEmail = 'email@domain.com'
-    const displayName = 'Hello There'
-    const avatarURL = 'https://example.com/avatar.png'
+    const primaryEmail = 'me@domain.test'
+    const displayName = 'Test Name'
+    const avatarURL = 'https://domain.test/avatar.png'
     // DOTCOM AND APP USERS
     test('returns auth state for invalid user on dotcom or app instance', () => {
         const expected = { ...unauthenticatedStatus, endpoint }

--- a/vscode/src/chat/utils.test.ts
+++ b/vscode/src/chat/utils.test.ts
@@ -10,13 +10,27 @@ describe('validateAuthStatus', () => {
     const verifiedEmail = true
     const codyEnabled = true
     const validUser = true
-    const endpoint = 'https://example.com'
+    const endpoint = ''
     const userCanUpgrade = false
+    const primaryEmail = 'email@domain.com'
+    const displayName = 'Hello There'
+    const avatarURL = 'https://example.com/avatar.png'
     // DOTCOM AND APP USERS
     test('returns auth state for invalid user on dotcom or app instance', () => {
         const expected = { ...unauthenticatedStatus, endpoint }
         expect(
-            newAuthStatus(endpoint, isDotComOrApp, !validUser, !verifiedEmail, codyEnabled, userCanUpgrade, siteVersion)
+            newAuthStatus(
+                endpoint,
+                isDotComOrApp,
+                !validUser,
+                !verifiedEmail,
+                codyEnabled,
+                userCanUpgrade,
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
+            )
         ).toEqual(expected)
     })
 
@@ -30,9 +44,23 @@ describe('validateAuthStatus', () => {
             siteHasCodyEnabled: true,
             isLoggedIn: true,
             endpoint,
+            avatarURL,
+            primaryEmail,
+            displayName
         }
         expect(
-            newAuthStatus(endpoint, isDotComOrApp, validUser, verifiedEmail, codyEnabled, userCanUpgrade, siteVersion)
+            newAuthStatus(
+                endpoint,
+                isDotComOrApp,
+                validUser,
+                verifiedEmail,
+                codyEnabled,
+                userCanUpgrade,
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
+            )
         ).toEqual(expected)
     })
 
@@ -44,9 +72,23 @@ describe('validateAuthStatus', () => {
             requiresVerifiedEmail: true,
             siteHasCodyEnabled: true,
             endpoint,
+            avatarURL,
+            primaryEmail,
+            displayName
         }
         expect(
-            newAuthStatus(endpoint, isDotComOrApp, validUser, !verifiedEmail, codyEnabled, userCanUpgrade, siteVersion)
+            newAuthStatus(
+                endpoint,
+                isDotComOrApp,
+                validUser,
+                !verifiedEmail,
+                codyEnabled,
+                userCanUpgrade,
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
+            )
         ).toEqual(expected)
     })
 
@@ -58,16 +100,41 @@ describe('validateAuthStatus', () => {
             siteHasCodyEnabled: true,
             isLoggedIn: true,
             endpoint,
+            avatarURL,
+            primaryEmail,
+            displayName
         }
         expect(
-            newAuthStatus(endpoint, !isDotComOrApp, validUser, verifiedEmail, codyEnabled, userCanUpgrade, siteVersion)
+            newAuthStatus(
+                endpoint,
+                !isDotComOrApp,
+                validUser,
+                verifiedEmail,
+                codyEnabled,
+                userCanUpgrade,
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
+            )
         ).toEqual(expected)
     })
 
     test('returns auth status for invalid user on enterprise instance with Cody enabled', () => {
         const expected = { ...unauthenticatedStatus, endpoint }
         expect(
-            newAuthStatus(endpoint, !isDotComOrApp, !validUser, verifiedEmail, codyEnabled, userCanUpgrade, siteVersion)
+            newAuthStatus(
+                endpoint,
+                !isDotComOrApp,
+                !validUser,
+                verifiedEmail,
+                codyEnabled,
+                userCanUpgrade,
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
+            )
         ).toEqual(expected)
     })
 
@@ -77,6 +144,9 @@ describe('validateAuthStatus', () => {
             authenticated: true,
             siteHasCodyEnabled: false,
             endpoint,
+            avatarURL,
+            primaryEmail,
+            displayName
         }
         expect(
             newAuthStatus(
@@ -86,7 +156,10 @@ describe('validateAuthStatus', () => {
                 !verifiedEmail,
                 !codyEnabled,
                 userCanUpgrade,
-                siteVersion
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
             )
         ).toEqual(expected)
     })
@@ -101,7 +174,10 @@ describe('validateAuthStatus', () => {
                 verifiedEmail,
                 !codyEnabled,
                 userCanUpgrade,
-                siteVersion
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
             )
         ).toEqual(expected)
     })

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -2,12 +2,14 @@ import { AuthStatus, defaultAuthStatus, unauthenticatedStatus } from './protocol
 
 /**
  * Checks a user's authentication status.
- *
  * @param isDotComOrApp Whether the user is on an insider build instance or enterprise instance.
  * @param userId The user's ID.
  * @param isEmailVerified Whether the user has verified their email. Default to true for non-enterprise instances.
  * @param isCodyEnabled Whether Cody is enabled on the Sourcegraph instance. Default to true for non-enterprise instances.
  * @param version The Sourcegraph instance version.
+ * @param avatarURL The user's avatar URL.
+ * @param primaryEmail The user's primary email.
+ * @param displayName The user's display name.
  * @returns The user's authentication status. It's for frontend to display when instance is on unsupported version if siteHasCodyEnabled is false
  */
 export function newAuthStatus(
@@ -18,6 +20,9 @@ export function newAuthStatus(
     isCodyEnabled: boolean,
     userCanUpgrade: boolean,
     version: string,
+    avatarURL: string,
+    primaryEmail: string,
+    displayName: string,
     configOverwrites?: AuthStatus['configOverwrites']
 ): AuthStatus {
     if (!user) {
@@ -32,6 +37,9 @@ export function newAuthStatus(
     authStatus.siteHasCodyEnabled = isCodyEnabled
     authStatus.userCanUpgrade = userCanUpgrade
     authStatus.siteVersion = version
+    authStatus.avatarURL = avatarURL
+    authStatus.primaryEmail = primaryEmail
+    authStatus.displayName = displayName
     if (configOverwrites) {
         authStatus.configOverwrites = configOverwrites
     }
@@ -43,7 +51,6 @@ export function newAuthStatus(
 
 /**
  * Counts the number of lines and characters in code blocks in a given string.
- *
  * @param text - The string to search for code blocks.
  * @returns An object with the total lineCount and charCount of code in code blocks,
  * or null if no code blocks are found.

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -7,9 +7,9 @@ import { AuthStatus, defaultAuthStatus, unauthenticatedStatus } from './protocol
  * @param isEmailVerified Whether the user has verified their email. Default to true for non-enterprise instances.
  * @param isCodyEnabled Whether Cody is enabled on the Sourcegraph instance. Default to true for non-enterprise instances.
  * @param version The Sourcegraph instance version.
- * @param avatarURL The user's avatar URL.
- * @param primaryEmail The user's primary email.
- * @param displayName The user's display name.
+ * @param avatarURL The user's avatar URL, or '' if not set.
+ * @param primaryEmail The user's primary email, or '' if not set.
+ * @param displayName The user's display name, or '' if not set.
  * @returns The user's authentication status. It's for frontend to display when instance is on unsupported version if siteHasCodyEnabled is false
  */
 export function newAuthStatus(

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -491,7 +491,7 @@ const register = async (
     vscode.window.onDidChangeWindowState(async ws => {
         const endpoint = authProvider.getAuthStatus().endpoint
         if (ws.focused && endpoint && isDotCom(endpoint)) {
-            const res = await graphqlClient.getCurrentUserIdAndVerifiedEmailAndCodyPro()
+            const res = await graphqlClient.getCurrentUserInfoDotCom()
             if (res instanceof Error) {
                 console.error(res)
                 return

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -491,7 +491,7 @@ const register = async (
     vscode.window.onDidChangeWindowState(async ws => {
         const endpoint = authProvider.getAuthStatus().endpoint
         if (ws.focused && endpoint && isDotCom(endpoint)) {
-            const res = await graphqlClient.getCurrentUserInfoDotCom()
+            const res = await graphqlClient.getDotComCurrentUserInfo()
             if (res instanceof Error) {
                 console.error(res)
                 return

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -314,6 +314,7 @@ const register = async (
         // Auth
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
+        vscode.commands.registerCommand('cody.auth.account', () => authProvider.accountMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
         // Commands
         vscode.commands.registerCommand('cody.chat.restart', async () => {
@@ -500,6 +501,9 @@ const register = async (
 
             authStatus.hasVerifiedEmail = res.hasVerifiedEmail
             authStatus.userCanUpgrade = !res.codyProEnabled
+            authStatus.primaryEmail = res.primaryEmail.email
+            authStatus.displayName = res.displayName
+            authStatus.avatarURL = res.avatarURL
 
             void chatManager.syncAuthStatus(authStatus)
         }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -248,7 +248,7 @@ export class AuthProvider {
             )
         }
 
-        const userInfo = await this.client.getCurrentUserInfoDotCom()
+        const userInfo = await this.client.getDotComCurrentUserInfo()
         const isCodyEnabled = true
 
         // check first if it's a network error

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -101,6 +101,9 @@ export class AuthProvider {
                 let authStatus = await this.auth(selectedEndpoint, token || null)
                 if (!authStatus?.isLoggedIn) {
                     const newToken = await showAccessTokenInputBox(item.uri)
+                    if (!newToken) {
+                        return
+                    }
                     authStatus = await this.auth(selectedEndpoint, newToken || null)
                 }
                 await showAuthResultMessage(selectedEndpoint, authStatus?.authStatus)

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -435,7 +435,7 @@ function formatURL(uri: string): string | null {
 async function showAuthResultMessage(endpoint: string, authStatus: AuthStatus | undefined): Promise<void> {
     if (authStatus?.isLoggedIn) {
         const authority = vscode.Uri.parse(endpoint).authority
-        await vscode.window.showInformationMessage(`Signed in to ${authority}`)
+        await vscode.window.showInformationMessage(`Signed in to ${authority || endpoint}`)
     } else {
         await showAuthFailureMessage(endpoint)
     }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -161,7 +161,11 @@ export class AuthProvider {
         }
 
         const option = await vscode.window.showInformationMessage(
-            `Signed in as ${this.authStatus.displayName ? `${this.authStatus.displayName} (${this.authStatus.primaryEmail})` : this.authStatus.primaryEmail}`,
+            `Signed in as ${
+                this.authStatus.displayName
+                    ? `${this.authStatus.displayName} (${this.authStatus.primaryEmail})`
+                    : this.authStatus.primaryEmail
+            }`,
             {
                 modal: true,
                 detail: `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Pro' : 'Cody Free'}`,

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -248,7 +248,7 @@ export class AuthProvider {
             )
         }
 
-        const userInfo = await this.client.getCurrentUserIdAndVerifiedEmailAndCodyPro()
+        const userInfo = await this.client.getCurrentUserInfoDotCom()
         const isCodyEnabled = true
 
         // check first if it's a network error

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -168,7 +168,7 @@ export class AuthProvider {
             }`,
             {
                 modal: true,
-                detail: `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Pro' : 'Cody Free'}`,
+                detail: `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}`,
             },
             'Manage Account',
             'Switch Account...',

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -158,7 +158,7 @@ export class AuthProvider {
         }
 
         const option = await vscode.window.showInformationMessage(
-            `${this.authStatus.displayName}\n${this.authStatus.primaryEmail}`,
+            `Signed in as ${this.authStatus.displayName ? `${this.authStatus.displayName} (${this.authStatus.primaryEmail})` : this.authStatus.primaryEmail}`,
             {
                 modal: true,
                 detail: `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Pro' : 'Cody Free'}`,

--- a/vscode/src/services/TreeViewProvider.test.ts
+++ b/vscode/src/services/TreeViewProvider.test.ts
@@ -18,9 +18,9 @@ describe('TreeViewProvider', () => {
     const verifiedEmail = true
     const codyEnabled = true
     const validUser = true
-    const primaryEmail = 'email@domain.com'
-    const displayName = 'Hello There'
-    const avatarURL = 'https://example.com/avatar.png'
+    const primaryEmail = 'me@domain.test'
+    const displayName = 'Test Name'
+    const avatarURL = 'https://domain.test/avatar.png'
 
     let tree: TreeViewProvider
 

--- a/vscode/src/services/TreeViewProvider.test.ts
+++ b/vscode/src/services/TreeViewProvider.test.ts
@@ -18,6 +18,9 @@ describe('TreeViewProvider', () => {
     const verifiedEmail = true
     const codyEnabled = true
     const validUser = true
+    const primaryEmail = 'email@domain.com'
+    const displayName = 'Hello There'
+    const avatarURL = 'https://example.com/avatar.png'
 
     let tree: TreeViewProvider
 
@@ -53,7 +56,10 @@ describe('TreeViewProvider', () => {
                 verifiedEmail,
                 codyEnabled,
                 upgradeAvailable,
-                siteVersion
+                siteVersion,
+                avatarURL,
+                primaryEmail,
+                displayName
             )
         )
         return nextUpdate

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -112,9 +112,9 @@ const supportItems: CodySidebarTreeItem[] = [
         command: { command: 'vscode.open', args: [DISCORD_URL.href] },
     },
     {
-        title: 'Sign Out',
-        icon: 'log-out',
-        command: { command: 'cody.auth.signout' },
+        title: 'Account',
+        icon: 'account',
+        command: { command: 'cody.auth.account' },
     },
 ]
 

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -176,9 +176,9 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
                                 displayName: 'Person',
                                 avatarURL: '',
                                 primaryEmail: {
-                                    email: 'person@company.comp'
-                                }
-                            }
+                                    email: 'person@company.comp',
+                                },
+                            },
                         },
                     })
                 )

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -168,7 +168,18 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
             case 'CurrentUser':
                 res.send(
                     JSON.stringify({
-                        data: { currentUser: { id: 'u', hasVerifiedEmail: true, codyProEnabled: false } },
+                        data: {
+                            currentUser: {
+                                id: 'u',
+                                hasVerifiedEmail: true,
+                                codyProEnabled: false,
+                                displayName: 'Person',
+                                avatarURL: '',
+                                primaryEmail: {
+                                    email: 'person@company.comp'
+                                }
+                            }
+                        },
                     })
                 )
                 break


### PR DESCRIPTION
Replaces the "Sign Out" option with a new Account dialog that gives you visibility of what user you're signed in as, which server, and what plan.

| State | Screenshot |
| - | - |
| Cody Pro FF Not Enabled | <img width="1253" alt="Screenshot 2023-12-11 at 8 39 59 pm" src="https://github.com/sourcegraph/cody/assets/153/32b32e8d-34f8-40a2-af1f-7e97b7ef9c4f"> |
| Cody Pro FF Enabled | <img width="1253" alt="Screenshot 2023-12-11 at 8 40 22 pm" src="https://github.com/sourcegraph/cody/assets/153/2cff6715-48cb-4e39-a820-dac198f3cf76"> |
| Enterprise Instance | <img width="1253" alt="Screenshot 2023-12-11 at 8 41 16 pm" src="https://github.com/sourcegraph/cody/assets/153/bb0f1d59-25a9-4d66-af17-d122e4314d19"> |

Notes:

- Display name is often missing in Enterprise accounts, so we just use the email

Fixes #1520

## Test plan

- Signed into DotCom
  - Clicked account, switch, sign out, etc
  - Changed plan, return, clicked account, verified plan has changed
  - Turn off CodyPro feature flag, clicked account, verify no manage or plan
- Signed in to S2 (Enterprise), clicked account, switch, sign out, etc