### PR TITLE
VSCode: Fix local embeddings status for non-git workspaces, git repos w/out remotes

### DIFF
--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -38,7 +38,7 @@ interface RemoteEmbeddingsProvider {
 export interface LocalEmbeddingsProvider {
     kind: 'embeddings'
     type: 'local'
-    state: 'indeterminate' | 'unconsented' | 'indexing' | 'ready'
+    state: 'indeterminate' | 'no-match' | 'unconsented' | 'indexing' | 'ready'
 }
 
 interface SearchProvider {

--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -39,6 +39,7 @@ export interface LocalEmbeddingsProvider {
     kind: 'embeddings'
     type: 'local'
     state: 'indeterminate' | 'no-match' | 'unconsented' | 'indexing' | 'ready'
+    errorReason?: 'not-a-git-repo' | 'git-repo-has-no-remote'
 }
 
 interface SearchProvider {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -44,6 +44,10 @@ export interface Configuration {
     isRunningInsideAgent?: boolean
     agentIDE?: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
     autocompleteTimeouts: AutocompleteTimeouts
+
+    testingLocalEmbeddingsModel: string | undefined
+    testingLocalEmbeddingsEndpoint: string | undefined
+    testingLocalEmbeddingsIndexLibraryPath: string | undefined
 }
 
 export interface AutocompleteTimeouts {

--- a/lib/shared/src/sourcegraph-api/environments.ts
+++ b/lib/shared/src/sourcegraph-api/environments.ts
@@ -1,4 +1,4 @@
-export const DOTCOM_URL = new URL('https://sourcegraph.com')
+export const DOTCOM_URL = new URL(process.env.TESTING_DOTCOM_URL || 'https://sourcegraph.com')
 export const INTERNAL_S2_URL = new URL('https://sourcegraph.sourcegraph.com/')
 export const LOCAL_APP_URL = new URL('http://localhost:3080')
 

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -42,6 +42,9 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocompleteExperimentalSyntacticPostProcessing: false,
     autocompleteExperimentalGraphContext: null,
     autocompleteTimeouts: {},
+    testingLocalEmbeddingsEndpoint: undefined,
+    testingLocalEmbeddingsIndexLibraryPath: undefined,
+    testingLocalEmbeddingsModel: undefined,
 }
 
 const getVSCodeSettings = (config: Partial<Configuration> = {}): Configuration => ({

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -132,6 +132,16 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
             multiline: getHiddenSetting<number | undefined>('autocomplete.advanced.timeout.multiline', undefined),
             singleline: getHiddenSetting<number | undefined>('autocomplete.advanced.timeout.singleline', undefined),
         },
+
+        testingLocalEmbeddingsModel: isTesting
+            ? getHiddenSetting<string | undefined>('testing.localEmbeddings.model', undefined)
+            : undefined,
+        testingLocalEmbeddingsEndpoint: isTesting
+            ? getHiddenSetting<string | undefined>('testing.localEmbeddings.endpoint', undefined)
+            : undefined,
+        testingLocalEmbeddingsIndexLibraryPath: isTesting
+            ? getHiddenSetting<string | undefined>('testing.localEmbeddings.indexLibraryPath', undefined)
+            : undefined,
     }
 }
 

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -10,7 +10,7 @@ import { BfgRetriever } from './completions/context/retrievers/bfg/bfg-retriever
 import { onActivationDevelopmentHelpers } from './dev/helpers'
 import { ExtensionApi } from './extension-api'
 import type { FilenameContextFetcher } from './local-context/filename-context-fetcher'
-import type { LocalEmbeddingsController } from './local-context/local-embeddings'
+import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { LocalKeywordContextFetcher } from './local-context/local-keyword-context-fetcher'
 import type { SymfRunner } from './local-context/symf'
 import { start } from './main'
@@ -26,7 +26,7 @@ type Constructor<T extends new (...args: any) => any> = T extends new (...args: 
 export interface PlatformContext {
     getRgPath?: typeof getRgPath
     createCommandsController?: Constructor<typeof CommandsController>
-    createLocalEmbeddingsController?: () => LocalEmbeddingsController
+    createLocalEmbeddingsController?: (config: LocalEmbeddingsConfig) => LocalEmbeddingsController
     createLocalKeywordContextFetcher?: Constructor<typeof LocalKeywordContextFetcher>
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
     return activateCommon(context, {
         getRgPath,
         createCommandsController: (...args) => new CommandsController(...args),
-        createLocalEmbeddingsController: () => createLocalEmbeddingsController(context),
+        createLocalEmbeddingsController: config => createLocalEmbeddingsController(context, config),
         createLocalKeywordContextFetcher: (...args) => new LocalKeywordContextFetcher(...args),
         createFilenameContextFetcher: (...args) => new FilenameContextFetcher(...args),
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -13,7 +13,7 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { CodeCompletionsClient, createClient as createCodeCompletionsClint } from './completions/client'
 import { PlatformContext } from './extension.common'
-import { LocalEmbeddingsController } from './local-context/local-embeddings'
+import { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import { logDebug, logger } from './log'
 
 interface ExternalServices {
@@ -37,7 +37,8 @@ type ExternalServicesConfiguration = Pick<
     | 'accessToken'
     | 'debugEnable'
     | 'experimentalLocalSymbols'
->
+> &
+    LocalEmbeddingsConfig
 
 export async function configureExternalServices(
     initialConfig: ExternalServicesConfiguration,
@@ -72,7 +73,7 @@ export async function configureExternalServices(
             ? new SourcegraphEmbeddingsSearchClient(graphqlClient, initialConfig.codebase || repoId, repoId)
             : null
 
-    const localEmbeddings = platform.createLocalEmbeddingsController?.()
+    const localEmbeddings = platform.createLocalEmbeddingsController?.(initialConfig)
 
     const chatClient = new ChatClient(completionsClient)
     const codebaseContext = new CodebaseContext(

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.2.11713'
+const defaultBfgVersion = '5.2.11763'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -159,10 +159,12 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                     const percent = Math.floor((100 * obj.Progress.numItems) / obj.Progress.totalItems)
                     this.statusBar.text = `$(loading~spin) Cody Embeddings (${percent.toFixed(0)}%)`
                     this.statusBar.backgroundColor = undefined
+                    this.statusBar.tooltip = obj.Progress.currentPath
                     this.statusBar.show()
                 } else if ('Error' in obj) {
                     this.statusBar.text = '$(warning) Cody Embeddings'
                     this.statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
+                    this.statusBar.tooltip = obj.Error
                     this.statusBar.show()
                 }
             } else if (obj === 'Done') {
@@ -196,7 +198,14 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
         logDebug('LocalEmbeddingsController', 'spawnAndBindService', 'service started, initializing')
         const paths = getIndexLibraryPaths()
         // Tests may override the index library path
+        logDebug('LocalEmbeddingsController', 'spawnAndBindService', 'index library paths', JSON.stringify(paths))
         if (this.indexLibraryPath) {
+            logDebug(
+                'LocalEmbeddingsController',
+                'spawnAndBindService',
+                'overriding index library path',
+                this.indexLibraryPath
+            )
             paths.indexPath = this.indexLibraryPath
         }
         const initResult = await service.request('embeddings/initialize', {

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -147,7 +147,6 @@ export class AuthProvider {
         const endpoint = config.serverEndpoint
         const token = config.accessToken
         if (!token || !endpoint) {
-            logDebug('AuthProvider', 'no auth status')
             return { ...defaultAuthStatus, endpoint }
         }
         // Cache the config and the GraphQL client
@@ -160,7 +159,7 @@ export class AuthProvider {
             this.client.isCodyEnabled(),
             this.client.getCodyLLMConfiguration(),
         ])
-        logDebug('AuthProvider', 'isError codyLLMConfiguration', isError(codyLLMConfiguration), codyLLMConfiguration)
+
         const configOverwrites = isError(codyLLMConfiguration) ? undefined : codyLLMConfiguration
 
         const isDotCom = this.client.isDotCom()
@@ -187,14 +186,11 @@ export class AuthProvider {
             )
         }
 
-        logDebug('AuthProvider', 'getCurrentUserIdAndVerifiedEmailAndCodyPro')
         const userInfo = await this.client.getCurrentUserIdAndVerifiedEmailAndCodyPro()
-        logDebug('AuthProvider', 'getCurrentUserIdAndVerifiedEmailAndCodyPro done', userInfo)
         const isCodyEnabled = true
 
         // check first if it's a network error
         if (isError(userInfo)) {
-            logDebug('AuthProvider:makeAuthStatus', 'userInfo error', userInfo)
             if (isNetworkError(userInfo)) {
                 return { ...networkErrorAuthStatus, endpoint }
             }
@@ -235,13 +231,7 @@ export class AuthProvider {
             accessToken: token,
             customHeaders: customHeaders || this.config.customHeaders,
         }
-        let authStatus
-        try {
-            authStatus = await this.makeAuthStatus(config)
-        } catch (error) {
-            logDebug('AuthProvider:auth', 'error makeAuthStatus', error)
-            throw error
-        }
+        const authStatus = await this.makeAuthStatus(config)
         const isLoggedIn = isAuthed(authStatus)
         authStatus.isLoggedIn = isLoggedIn
         await this.storeAuthInfo(endpoint, token)

--- a/vscode/test/e2e/chat.test.ts
+++ b/vscode/test/e2e/chat.test.ts
@@ -44,7 +44,7 @@ test('shows standard rate limit message for non-dotCom users', async ({ page, si
     await expect(chatFrame.getByRole('button', { name: 'Learn More' })).toBeVisible()
 })
 
-async function prepareChat(page: Page, sidebar: Frame): Promise<[FrameLocator, Locator]> {
+export async function prepareChat(page: Page, sidebar: Frame): Promise<[FrameLocator, Locator]> {
     await sidebarSignin(page, sidebar)
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
     // Chat webview iframe is the second and last frame (search is the first)

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -55,8 +55,6 @@ export const test = base
             const extensionsDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))
             const videoDirectory = path.join(vscodeRoot, '..', 'playwright', escapeToPath(testInfo.title))
 
-            console.log(`Workspace directory: ${workspaceDirectory}`)
-
             await buildWorkSpaceSettings(workspaceDirectory, extraWorkspaceSettings)
 
             sendTestInfo(testInfo.title, testInfo.testId, uuid.v4())

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -218,7 +218,7 @@ export async function assertEvents(loggedEvents: string[], expectedEvents: strin
 // directory when done.
 export async function withTempDir<T>(f: (dir: string) => Promise<T>): Promise<T> {
     // Create the temporary directory
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cody-vsce'))
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'cody-vsce'))
     try {
         return await f(dir)
     } finally {

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -218,7 +218,7 @@ export async function assertEvents(loggedEvents: string[], expectedEvents: strin
 // directory when done.
 export async function withTempDir<T>(f: (dir: string) => Promise<T>): Promise<T> {
     // Create the temporary directory
-    const dir = await fs.mkdtemp(await fs.realpath(os.tmpdir() + path.sep))
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cody-vsce'))
     try {
         return await f(dir)
     } finally {

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -171,6 +171,9 @@ export async function buildWorkSpaceSettings(
     workspaceDirectory: string,
     extraSettings: WorkspaceSettings
 ): Promise<void> {
+    console.log(
+        `Building workspace settings for ${workspaceDirectory} with extra settings ${JSON.stringify(extraSettings)}`
+    )
     const settings = {
         'cody.serverEndpoint': 'http://localhost:49300',
         'cody.commandCodeLenses': true,
@@ -180,7 +183,9 @@ export async function buildWorkSpaceSettings(
     // create a temporary directory with settings.json and add to the workspaceDirectory
     const workspaceSettingsPath = path.join(workspaceDirectory, '.vscode', 'settings.json')
     const workspaceSettingsDirectory = path.join(workspaceDirectory, '.vscode')
-    mkdir(workspaceSettingsDirectory, { recursive: true }, () => {})
+    await new Promise((resolve, reject) => {
+        mkdir(workspaceSettingsDirectory, { recursive: true }, err => (err ? reject(err) : resolve(undefined)))
+    })
     await new Promise<void>((resolve, reject) => {
         writeFile(workspaceSettingsPath, JSON.stringify(settings), error => {
             if (error) {

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -1,53 +1,13 @@
-import * as child_process from 'child_process'
 import { promises as fs } from 'fs'
-import * as os from 'os'
 import * as path from 'path'
 
-import { expect, FrameLocator, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
 
 import { SERVER_URL } from '../fixtures/mock-server'
 
 import { sidebarSignin } from './common'
 import * as helpers from './helpers'
-
-async function withTempDir<T>(f: (dir: string) => Promise<T>): Promise<T> {
-    // Create the temporary directory
-    const dir = await fs.mkdtemp(await fs.realpath(os.tmpdir() + path.sep))
-    try {
-        return await f(dir)
-    } finally {
-        // Remove the temporary directory
-        await fs.rm(dir, { recursive: true, force: true })
-    }
-}
-
-function spawn(...args: Parameters<typeof child_process.spawn>): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const child = child_process.spawn(...args)
-        child.once('close', (code, signal) => {
-            if (code || signal) {
-                reject(new Error(`child exited with code ${code}/signal ${signal}`))
-            } else {
-                resolve()
-            }
-        })
-    })
-}
-
-async function openFile(page: Page, filename: string): Promise<void> {
-    // Open a file from the file picker
-    await page.keyboard.down('Control')
-    await page.keyboard.down('Shift')
-    await page.keyboard.press('P')
-    await page.keyboard.up('Shift')
-    await page.keyboard.up('Control')
-    await page.keyboard.type(`${filename}\n`)
-}
-
-async function newChat(page: Page): Promise<FrameLocator> {
-    await page.getByRole('button', { name: 'New Chat' }).click()
-    return page.frameLocator('iframe.webview').last().frameLocator('iframe')
-}
+import { newChat, openFile, spawn, withTempDir } from './helpers'
 
 // Reconfigured test for local embeddings:
 // - treats http://localhost:49000 as dotcom

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -1,0 +1,103 @@
+import * as child_process from 'child_process'
+import { promises as fs } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { expect } from '@playwright/test'
+
+import { SERVER_URL } from '../fixtures/mock-server'
+
+import { sidebarSignin } from './common'
+import * as helpers from './helpers'
+
+async function withTempDir<T>(f: (dir: string) => Promise<T>): Promise<T> {
+    // Create the temporary directory
+    const dir = await fs.mkdtemp(await fs.realpath(os.tmpdir() + path.sep))
+    try {
+        return await f(dir)
+    } finally {
+        // Remove the temporary directory
+        await fs.rm(dir, { recursive: true, force: true })
+    }
+}
+
+function spawn(...args: Parameters<typeof child_process.spawn>): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = child_process.spawn(...args)
+        child.once('close', (code, signal) => {
+            if (code || signal) {
+                reject(new Error(`child exited with code ${code}/signal ${signal}`))
+            } else {
+                resolve()
+            }
+        })
+    })
+}
+
+// Reconfigured test for local embeddings:
+// - treats http://localhost:49000 as dotcom
+// - uses a temporary workspace that's a git repository
+// - uses a temporary directory for local embeddings indexes
+// - uses the stub/stub embeddings model
+const test = helpers.test
+    .extend<helpers.DotcomUrlOverride>({
+        dotcomUrl: SERVER_URL,
+    })
+    .extend<helpers.WorkspaceDirectory>({
+        // Playwright needs empty pattern to specify "no dependencies".
+        // eslint-disable-next-line no-empty-pattern
+        workspaceDirectory: async ({}, use) => {
+            await withTempDir(async dir => {
+                // Initialize a git repository there
+                await spawn('git', ['init'], { cwd: dir })
+                await spawn('git', ['config', 'user.name', 'Test User'], { cwd: dir })
+                await spawn('git', ['config', 'user.email', 'test@example.host'], { cwd: dir })
+
+                // Commit some content to the git repository.
+                await Promise.all([
+                    fs.writeFile(path.join(dir, 'README.md'), 'Prints an classic greeting'),
+                    fs.writeFile(path.join(dir, 'main.c'), '#include <stdio.h> main() { printf("Hello, world.\\n"); }'),
+                ])
+                await spawn('git', ['add', 'README.md', 'main.c'], { cwd: dir })
+                await spawn('git', ['commit', '-m', 'Initial commit'], { cwd: dir })
+
+                await use(dir)
+            })
+        },
+    })
+    .extend<helpers.ExtraWorkspaceSettings>({
+        // Playwright needs empty pattern to specify "no dependencies".
+        // eslint-disable-next-line no-empty-pattern
+        extraWorkspaceSettings: async ({}, use) => {
+            await withTempDir(async dir =>
+                use({
+                    'cody.testing.localEmbeddingsModel': 'stub/stub',
+                    'cody.testing.localEmbeddingsIndexLibraryPath': dir,
+                })
+            )
+        },
+    })
+
+// test('should create and tear down a git repository', async ({}) => {})
+
+test('should create and search a local embeddings index', async ({ page, sidebar }) => {
+    // Open a file from the file picker
+    await page.keyboard.down('Control')
+    await page.keyboard.down('Shift')
+    await page.keyboard.press('P')
+    await page.keyboard.up('Shift')
+    await page.keyboard.up('Control')
+    await page.keyboard.type('main.c\n')
+
+    await sidebarSignin(page, sidebar)
+    await page.getByRole('button', { name: 'New Chat' }).click()
+
+    // Find the chat frame
+    const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+    const enhancedContextButton = chatFrame.getByTitle('Configure Enhanced Context')
+    await enhancedContextButton.click()
+
+    const enableEmbeddingsButton = chatFrame.getByText('Enable Embeddings')
+    await expect(enableEmbeddingsButton).toBeVisible({ timeout: 60000 })
+    await enableEmbeddingsButton.click()
+})

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -66,7 +66,7 @@ test.extend<helpers.WorkspaceDirectory>({
             await use(dir)
         })
     },
-})('non-git repositories should not advertise embeddings', async ({ page, sidebar }) => {
+})('non-git repositories should explain lack of embeddings', async ({ page, sidebar }) => {
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
@@ -75,17 +75,19 @@ test.extend<helpers.WorkspaceDirectory>({
 
     // Embeddings is visible at first as cody-engine starts...
     await expect(chatFrame.getByText('Embeddings')).toBeVisible()
-    // ...and disappears when the engine works out this is not a git repo.
-    await expect(chatFrame.getByText('Embeddings')).not.toBeVisible()
+    // ...and displays this message when the engine works out this is not a git repo.
+    await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible()
+    await expect(chatFrame.getByText('Folder is not a Git repository.')).toBeVisible()
 })
 
-test('git repositories without a remote should show the "no match" state', async ({ page, sidebar }) => {
+test('git repositories without a remote should explain the issue', async ({ page, sidebar }) => {
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
     const enhancedContextButton = chatFrame.getByTitle('Configure Enhanced Context')
     await enhancedContextButton.click()
     await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible()
+    await expect(chatFrame.getByText('Git repository is missing a remote origin.')).toBeVisible()
 })
 
 test.extend<helpers.WorkspaceDirectory>({

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -209,7 +209,6 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
                 break
             }
             default:
-                console.log(`mock-server not handling request: ${req.url}`)
                 res.sendStatus(400)
                 break
         }

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -164,12 +164,29 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
         }
 
         const operation = new URL(req.url, 'https://example.com').search.replace(/^\?/, '')
+        console.log(operation)
         switch (operation) {
             case 'CurrentUser':
-                res.send(JSON.stringify({ data: { currentUser: 'u' } }))
+                res.send(
+                    JSON.stringify({
+                        data: { currentUser: { id: 'u', hasVerifiedEmail: true, codyProEnabled: false } },
+                    })
+                )
                 break
             case 'IsContextRequiredForChatQuery':
                 res.send(JSON.stringify({ data: { isContextRequiredForChatQuery: false } }))
+                break
+            case 'SiteIdentification':
+                res.send(
+                    JSON.stringify({
+                        data: {
+                            site: {
+                                siteID: 'test-site-id',
+                                productSubscription: { license: { hashedKey: 'mmm,hashedkey' } },
+                            },
+                        },
+                    })
+                )
                 break
             case 'SiteProductVersion':
                 res.send(JSON.stringify({ data: { site: { productVersion: 'dev' } } }))
@@ -184,13 +201,16 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
                 res.send(
                     JSON.stringify({
                         data: {
-                            site: { codyLLMConfiguration: { chatModel: 'test-chat-default-model' } },
+                            site: {
+                                codyLLMConfiguration: { chatModel: 'test-chat-default-model', provider: 'sourcegraph' },
+                            },
                         },
                     })
                 )
                 break
             }
             default:
+                console.log(`not handling request, ${req.url}: ${JSON.stringify(req.headers)}`)
                 res.sendStatus(400)
                 break
         }

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -21,7 +21,7 @@ interface MockRequest {
 const SERVER_PORT = 49300
 
 export const SERVER_URL = 'http://localhost:49300'
-export const VALID_TOKEN = 'abcdefgh1234'
+export const VALID_TOKEN = 'sgp_1234567890123456789012345678901234567890'
 
 const responses = {
     chat: 'hello from the assistant',

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -164,7 +164,6 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
         }
 
         const operation = new URL(req.url, 'https://example.com').search.replace(/^\?/, '')
-        console.log(operation)
         switch (operation) {
             case 'CurrentUser':
                 res.send(
@@ -210,7 +209,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
                 break
             }
             default:
-                console.log(`not handling request, ${req.url}: ${JSON.stringify(req.headers)}`)
+                console.log(`mock-server not handling request: ${req.url}`)
                 res.sendStatus(400)
                 break
         }

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -129,14 +129,28 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
         case 'unconsented':
             return <EmbeddingsConsentComponent provider={provider} />
         case 'no-match':
-            return provider.kind === 'embeddings' && provider.type === 'remote' ? (
-                <p className={styles.providerExplanatoryText}>
-                    {/* No repository matching {provider.remoteName} on <a href="about:blank#TODO">{provider.origin}</a> */}
-                    No repository matching {provider.remoteName} on {provider.origin}
-                </p>
-            ) : (
-                <></>
-            )
+            if (provider.kind === 'embeddings') {
+                if (provider.type === 'remote') {
+                    return (
+                        <p className={styles.providerExplanatoryText}>
+                            No repository matching {provider.remoteName} on {provider.origin}
+                        </p>
+                    )
+                }
+                // Error messages for local embeddings missing.
+                switch (provider.errorReason) {
+                    case 'not-a-git-repo':
+                        return <p className={styles.providerExplanatoryText}>Folder is not a Git repository.</p>
+                    case 'git-repo-has-no-remote':
+                        return (
+                            <p className={styles.providerExplanatoryText}>Git repository is missing a remote origin.</p>
+                        )
+                    default:
+                        return <></>
+                }
+            } else {
+                return <></>
+            }
         default:
             return ''
     }

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -114,6 +114,7 @@ const EmbeddingsConsentComponent: React.FunctionComponent<{ provider: LocalEmbed
 function contextProviderState(provider: ContextProvider): React.ReactNode {
     switch (provider.state) {
         case 'indeterminate':
+            return <></>
         case 'ready':
             if (provider.kind === 'embeddings' && provider.type === 'remote') {
                 return (
@@ -128,11 +129,13 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
         case 'unconsented':
             return <EmbeddingsConsentComponent provider={provider} />
         case 'no-match':
-            return (
+            return provider.kind === 'embeddings' && provider.type === 'remote' ? (
                 <p className={styles.providerExplanatoryText}>
                     {/* No repository matching {provider.remoteName} on <a href="about:blank#TODO">{provider.origin}</a> */}
                     No repository matching {provider.remoteName} on {provider.origin}
                 </p>
+            ) : (
+                <p className={styles.providerExplanatoryText}>Hello, world</p>
             )
         default:
             return ''

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -135,7 +135,7 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
                     No repository matching {provider.remoteName} on {provider.origin}
                 </p>
             ) : (
-                <p className={styles.providerExplanatoryText}>Hello, world</p>
+                <></>
             )
         default:
             return ''


### PR DESCRIPTION
- When opening a non-git repo, instead of the enhanced context selector showing a non-functional "enable embeddings" button, do not show local embeddings status.
- When opening a git repo without a remote, instead of showing a spinner indefinitely and "Indexed", show the circle-slash. Fixes #2217.
- During embeddings index generation, show the current file being indexed in the status bar item tooltip.
- If embeddings index generation fails, show the error message in a tooltip on the status bar. (Test coverage and improvements planned in a follow-up change.)

Adds e2e tests for the major cases above.

Also improves the e2e test framework:
- Fixes a race condition creating the workspace `.vscode` directory, and writing `.vscode/settings.json`. This sometimes meant the tests were running without the correct settings.
- Adds Playwright extensions so tests can configure an isolated working directory, extra VSCode settings, and treat the test server endpoint as "dotcom".
- Expands the mock server so that the consumer login path works.
- Adds testing hooks to local embeddings to use a mock server, embeddings model, and isolated index library path.
- Deletes obsolete helper for submitting sidebar chat messages.

## Test plan

This integration test covers the scenarios of opening no git repo, a git repo without a remote, and a git repo *with* a remote and then generating embeddings for the repo and querying them:

```
pnpm test:e2e -- local-embeddings.test.ts
```
