### PR TITLE
Fix pre-release version numbers not being correctly detected

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Fix pre-release version numbers not being correctly detected. [pull/2240](https://github.com/sourcegraph/cody/pull/2240)
+
 ### Changed
 
 ## [0.18.2]

--- a/vscode/src/release.test.ts
+++ b/vscode/src/release.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { majorMinorVersion, releaseNotesURL, releaseType } from './release'
+
+describe('majorMinorVersion', () => {
+    it('returns the first two components', () => {
+        expect(majorMinorVersion('0.2.1')).toEqual('0.2')
+        expect(majorMinorVersion('4.2.1')).toEqual('4.2')
+        expect(majorMinorVersion('4.3.1689391131')).toEqual('4.3')
+    })
+})
+
+describe('releaseType', () => {
+    it('returns stable if no dash', () => {
+        expect(releaseType('4.2.1')).toEqual('stable')
+    })
+    it('returns insiders if it is an odd minor version', () => {
+        expect(releaseType('4.3.1689391131')).toEqual('insiders')
+    })
+})
+
+describe('releaseNotesURL', () => {
+    it('returns GitHub release notes for stable builds', () => {
+        expect(releaseNotesURL('4.2.1')).toEqual('https://github.com/sourcegraph/cody/releases/tag/vscode-v4.2.1')
+    })
+    it('returns changelog for insiders builds', () => {
+        expect(releaseNotesURL('4.3.1689391131')).toEqual(
+            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
+        )
+    })
+})

--- a/vscode/src/release.ts
+++ b/vscode/src/release.ts
@@ -1,0 +1,15 @@
+export type ReleaseType = 'stable' | 'insiders'
+
+export const majorVersion = (version: string): string => version.split('.')[0]
+
+export const minorVersion = (version: string): string => version.split('.')[1]
+
+export const majorMinorVersion = (version: string): string => [majorVersion(version), minorVersion(version)].join('.')
+
+export const releaseType = (version: string): ReleaseType =>
+    Number(minorVersion(version)) % 2 === 1 ? 'insiders' : 'stable'
+
+export const releaseNotesURL = (version: string): string =>
+    releaseType(version) === 'stable'
+        ? `https://github.com/sourcegraph/cody/releases/tag/vscode-v${version}`
+        : 'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'

--- a/vscode/src/services/OpenTelemetryService.node.ts
+++ b/vscode/src/services/OpenTelemetryService.node.ts
@@ -7,7 +7,7 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
-import { extensionVersion } from './telemetry'
+import { version } from '../version'
 
 export class OpenTelemetryService {
     private sdk: NodeSDK | undefined
@@ -42,7 +42,7 @@ export class OpenTelemetryService {
         this.sdk = new NodeSDK({
             resource: new Resource({
                 [SemanticResourceAttributes.SERVICE_NAME]: 'cody-client',
-                [SemanticResourceAttributes.SERVICE_VERSION]: extensionVersion,
+                [SemanticResourceAttributes.SERVICE_VERSION]: version,
             }),
             instrumentations: [new HttpInstrumentation()],
             traceExporter: new OTLPTraceExporter({

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -10,7 +10,7 @@ import {
     NetworkError,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
-import { extensionVersion } from '../telemetry'
+import { version } from '../../version'
 
 export * from '@sentry/core'
 export const SENTRY_DSN = 'https://f565373301c9c7ef18448a1c60dfde8d@o19358.ingest.sentry.io/4505743319564288'
@@ -39,7 +39,7 @@ export abstract class SentryService {
 
             const options: SentryOptions = {
                 dsn: SENTRY_DSN,
-                release: extensionVersion,
+                release: version,
                 environment: this.config.isRunningInsideAgent
                     ? 'agent'
                     : typeof process === 'undefined'

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -7,7 +7,7 @@ import { EventLogger, ExtensionDetails } from '@sourcegraph/cody-shared/src/tele
 import { getConfiguration } from '../configuration'
 import { logDebug } from '../log'
 import { getOSArch } from '../os'
-import { version as extensionVersion } from '../version'
+import { version } from '../version'
 
 import { localStorage } from './LocalStorageProvider'
 
@@ -22,10 +22,7 @@ export const getExtensionDetails = (config: Pick<Configuration, 'agentIDE'>): Ex
     ideExtensionType: 'Cody',
     platform: platform ?? 'browser',
     arch,
-    // Prefer the runtime package json over the version that is inlined during build times. This
-    // way we will be able to include pre-release builds that are published with a different version
-    // identifier.
-    version: extensionVersion,
+    version,
 })
 
 /**

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -4,10 +4,10 @@ import { Configuration, ConfigurationWithAccessToken } from '@sourcegraph/cody-s
 import { TelemetryEventProperties, TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import { EventLogger, ExtensionDetails } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
 
-import { version as extensionVersion } from '../version'
 import { getConfiguration } from '../configuration'
 import { logDebug } from '../log'
 import { getOSArch } from '../os'
+import { version as extensionVersion } from '../version'
 
 import { localStorage } from './LocalStorageProvider'
 

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -4,7 +4,7 @@ import { Configuration, ConfigurationWithAccessToken } from '@sourcegraph/cody-s
 import { TelemetryEventProperties, TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import { EventLogger, ExtensionDetails } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
 
-import { version as packageVersion } from '../../package.json'
+import { version as extensionVersion } from '../version'
 import { getConfiguration } from '../configuration'
 import { logDebug } from '../log'
 import { getOSArch } from '../os'
@@ -17,8 +17,6 @@ let globalAnonymousUserID: string
 
 const { platform, arch } = getOSArch()
 
-export const extensionVersion =
-    vscode.extensions.getExtension('sourcegraph.cody-ai')?.packageJSON?.version ?? packageVersion
 export const getExtensionDetails = (config: Pick<Configuration, 'agentIDE'>): ExtensionDetails => ({
     ide: config.agentIDE ?? 'VSCode',
     ideExtensionType: 'Cody',

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -2,7 +2,8 @@ import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/Featur
 
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
-import { releaseNotesURL, releaseType, version } from '../version'
+import { releaseNotesURL, releaseType } from '../release'
+import { version } from '../version'
 
 import { localStorage } from './LocalStorageProvider'
 

--- a/vscode/src/version.test.ts
+++ b/vscode/src/version.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it } from 'vitest'
-
-import { version as packageVersion } from '../package.json'
+import { describe, expect, it, vi } from 'vitest'
 
 import { majorMinorVersion, releaseNotesURL, releaseType, version } from './version'
 
+vi.mock('vscode', () => ({
+    extensions: {
+        getExtension: vi.fn().mockReturnValue({ packageJSON: { version: '1.2.3' } })
+    }
+}))
+
 describe('version', () => {
-    it('returns the version from JSON', () => {
-        expect(version).toEqual(packageVersion)
+    it('returns the version from the extension manifest', () => {
+        expect(version).toEqual('1.2.3')
     })
 })
 

--- a/vscode/src/version.test.ts
+++ b/vscode/src/version.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { majorMinorVersion, releaseNotesURL, releaseType, version } from './version'
+import { version } from './version'
 
 vi.mock('vscode', () => ({
     extensions: {
@@ -9,35 +9,7 @@ vi.mock('vscode', () => ({
 }))
 
 describe('version', () => {
-    it('returns the version from the extension manifest', () => {
+    it('returns the version from the runtime extension info', () => {
         expect(version).toEqual('1.2.3')
-    })
-})
-
-describe('majorMinorVersion', () => {
-    it('returns the first two components', () => {
-        expect(majorMinorVersion('0.2.1')).toEqual('0.2')
-        expect(majorMinorVersion('4.2.1')).toEqual('4.2')
-        expect(majorMinorVersion('4.3.1689391131')).toEqual('4.3')
-    })
-})
-
-describe('releaseType', () => {
-    it('returns stable if no dash', () => {
-        expect(releaseType('4.2.1')).toEqual('stable')
-    })
-    it('returns insiders if it is an odd minor version', () => {
-        expect(releaseType('4.3.1689391131')).toEqual('insiders')
-    })
-})
-
-describe('releaseNotesURL', () => {
-    it('returns GitHub release notes for stable builds', () => {
-        expect(releaseNotesURL('4.2.1')).toEqual('https://github.com/sourcegraph/cody/releases/tag/vscode-v4.2.1')
-    })
-    it('returns changelog for insiders builds', () => {
-        expect(releaseNotesURL('4.3.1689391131')).toEqual(
-            'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'
-        )
     })
 })

--- a/vscode/src/version.test.ts
+++ b/vscode/src/version.test.ts
@@ -4,8 +4,8 @@ import { majorMinorVersion, releaseNotesURL, releaseType, version } from './vers
 
 vi.mock('vscode', () => ({
     extensions: {
-        getExtension: vi.fn().mockReturnValue({ packageJSON: { version: '1.2.3' } })
-    }
+        getExtension: vi.fn().mockReturnValue({ packageJSON: { version: '1.2.3' } }),
+    },
 }))
 
 describe('version', () => {

--- a/vscode/src/version.ts
+++ b/vscode/src/version.ts
@@ -1,8 +1,17 @@
+import * as vscode from 'vscode'
+
 import { version as packageVersion } from '../package.json'
 
 export type ReleaseType = 'stable' | 'insiders'
 
-export const version = packageVersion
+// For insiders builds, packageVersion above will be wrong. This is because
+// `pnpm build` bakes the version in to the source _before_ the the pre-release
+// build modifies the package.json. So instead of packageVersion which may not
+// match the version in package.json, we prefer the value given by
+// vscode.extensions.getExtension.
+export const version =
+    (vscode.extensions.getExtension('sourcegraph.cody-ai')?.packageJSON as { version: string })?.version ??
+    packageVersion
 
 export const majorVersion = (version: string): string => version.split('.')[0]
 

--- a/vscode/src/version.ts
+++ b/vscode/src/version.ts
@@ -2,27 +2,9 @@ import * as vscode from 'vscode'
 
 import { version as packageVersion } from '../package.json'
 
-export type ReleaseType = 'stable' | 'insiders'
-
-// For insiders builds, packageVersion above will be wrong. This is because
-// `pnpm build` bakes the version in to the source _before_ the the pre-release
-// build modifies the package.json. So instead of packageVersion which may not
-// match the version in package.json, we prefer the value given by
-// vscode.extensions.getExtension.
+// The runtime version (available from the host extension) will represent
+// pre-release numbers properly, otherwise fall back to the stable/static one
+// inlined at build time
 export const version =
     (vscode.extensions.getExtension('sourcegraph.cody-ai')?.packageJSON as { version: string })?.version ??
     packageVersion
-
-export const majorVersion = (version: string): string => version.split('.')[0]
-
-export const minorVersion = (version: string): string => version.split('.')[1]
-
-export const majorMinorVersion = (version: string): string => [majorVersion(version), minorVersion(version)].join('.')
-
-export const releaseType = (version: string): ReleaseType =>
-    Number(minorVersion(version)) % 2 === 1 ? 'insiders' : 'stable'
-
-export const releaseNotesURL = (version: string): string =>
-    releaseType(version) === 'stable'
-        ? `https://github.com/sourcegraph/cody/releases/tag/vscode-v${version}`
-        : 'https://github.com/sourcegraph/cody/blob/main/vscode/CHANGELOG.md'

--- a/vscode/webviews/Notices/VersionUpdatedNotice.tsx
+++ b/vscode/webviews/Notices/VersionUpdatedNotice.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
-import { majorMinorVersion, releaseNotesURL, version } from '../../src/version'
+import { version as packageVersion } from '../../package.json'
+import { majorMinorVersion, releaseNotesURL } from '../../src/release'
 
 import { Notice } from './Notice'
 
@@ -39,7 +40,7 @@ interface VersionUpdateNoticeProps {
 }
 
 export const VersionUpdatedNotice: React.FunctionComponent<VersionUpdateNoticeProps> = ({ probablyNewInstall }) => {
-    const [showNotice, setDismissed] = useShowNotice(majorMinorVersion(version), probablyNewInstall)
+    const [showNotice, setDismissed] = useShowNotice(majorMinorVersion(packageVersion), probablyNewInstall)
 
     if (!showNotice) {
         return undefined
@@ -48,8 +49,8 @@ export const VersionUpdatedNotice: React.FunctionComponent<VersionUpdateNoticePr
     return (
         <Notice
             icon={<Icon />}
-            title={`Cody updated to v${majorMinorVersion(version)}`}
-            linkHref={releaseNotesURL(version)}
+            title={`Cody updated to v${majorMinorVersion(packageVersion)}`}
+            linkHref={releaseNotesURL(packageVersion)}
             linkText="See what’s new →"
             linkTarget="_blank"
             onDismiss={setDismissed}


### PR DESCRIPTION
Follow on from #2210, this fixes pre-release version not being shown correctly in the sidebar. This was because the version value is baked at build time, before pre-release bumps the package.json.

This updates the version detection to use the vscode extensions API (borrowed & moved from Telemetry, which was already doing this correctly).

The update notice in the web UI still uses the static version, as it always has. We can update that to handle pre-release/insider builds better in the future.

## Test plan

- Ran the extension with different versions, verified nav change
- Modified compiled source and reloaded the extension, verified nav change