### PR TITLE
Only search relative paths when @-mentioning files in chat

### DIFF
--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -71,7 +71,8 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
     await expect(chatInput).toHaveValue(withPlatformSlashes('Explain @lib/batches/env/var.go '))
     await chatInput.type('and @vgo', { delay: 50 }) // without this delay the following Enter submits the form instead of selecting
-    await chatInput.press('ArrowDown') // second item
+    await chatInput.press('ArrowDown') // second item (visualize.go)
+    await chatInput.press('ArrowDown') // third item (.vscode/settings.json)
     await chatInput.press('ArrowDown') // wraps back to first item
     await chatInput.press('ArrowDown') // second item again
     await chatInput.press('Enter')

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -30,6 +30,9 @@ test('@-file empty state', async ({ page, sidebar }) => {
 
     // We should only match the relative visible path, not parts of the full path outside of the workspace.
     // Eg. searching for "source" should not find all files if the project is inside `C:\Source`.
+    // TODO(dantup): After https://github.com/sourcegraph/cody/pull/2235 lands, add workspacedirectory to the test
+    //   and assert that it contains `fixtures` to ensure this check isn't passing because the fixture folder no
+    //   longer matches.
     await chatInput.fill('@fixtures') // fixture is in the test project folder name, but in the relative paths.
     await expect(chatPanelFrame.getByRole('heading', { name: 'No matching files found' })).toBeVisible()
 

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -24,6 +24,15 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await chatInput.fill('@definitelydoesntexist')
     await expect(chatPanelFrame.getByRole('heading', { name: 'No matching files found' })).toBeVisible()
 
+    // Clear the input so the next test doesn't detect the same text already visible from the previous
+    // check (otherwise the test can pass even without the filter working).
+    await chatInput.clear()
+
+    // We should only match the relative visible path, not parts of the full path outside of the workspace.
+    // Eg. searching for "source" should not find all files if the project is inside `C:\Source`.
+    await chatInput.fill('@fixtures') // fixture is in the test project folder name, but in the relative paths.
+    await expect(chatPanelFrame.getByRole('heading', { name: 'No matching files found' })).toBeVisible()
+
     // Includes dotfiles after just "."
     await chatInput.fill('@.')
     await expect(chatPanelFrame.getByRole('button', { name: '.mydotfile' })).toBeVisible()


### PR DESCRIPTION
[This depends on a function added in https://github.com/sourcegraph/cody/pull/2215 so this will fail bots until that lands and I rebase/merge]

Fixes https://github.com/sourcegraph/cody/issues/2208

## Test plan

- Run `pnpm test:e2e at-file` to run the updated test, or
- Open chat, and mention a file using `@` but type part of the file path outside of the folder opened in VS Code (eg. if you have `C:\Source\cody\ open, type `source`)
- Ensure that the results don't list every file because `source` exists in their full fspaths
