### PR TITLE
VSCode: Local Embeddings should pick up initial access token

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Fix pre-release version numbers not being correctly detected. [pull/2240](https://github.com/sourcegraph/cody/pull/2240)
+- Embeddings appear in the enhanced context selector when the user is already signed in and loads/reloads VSCode. [pull/2247](https://github.com/sourcegraph/cody/pull/2247)
+- Embeddings status in the enhanced context selector has accurate messages when working in workspaces that aren't git repositories, or in git repositories which don't have remotes. [pull/2235](https://github.com/sourcegraph/cody/pull/2235)
 
 ### Changed
 

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -6,6 +6,7 @@ import {
     ContextStatusProvider,
     LocalEmbeddingsProvider,
 } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
+import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { LocalEmbeddingsFetcher } from '@sourcegraph/cody-shared/src/local-context'
 import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import { EmbeddingsSearchResult } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
@@ -23,7 +24,7 @@ export function createLocalEmbeddingsController(
     return new LocalEmbeddingsController(context, config)
 }
 
-export interface LocalEmbeddingsConfig {
+export type LocalEmbeddingsConfig = Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken'> & {
     testingLocalEmbeddingsModel: string | undefined
     testingLocalEmbeddingsEndpoint: string | undefined
     testingLocalEmbeddingsIndexLibraryPath: string | undefined
@@ -88,6 +89,10 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
     ) {
         logDebug('LocalEmbeddingsController', 'constructor')
         this.disposables.push(this.changeEmitter, this.statusEmitter)
+
+        // Pick up the initial access token, and whether the account is dotcom.
+        this.accessToken = config.accessToken || undefined
+        this.endpointIsDotcom = isDotCom(config.serverEndpoint)
 
         this.model = config.testingLocalEmbeddingsModel || 'openai/text-embedding-ada-002'
         this.endpoint = config.testingLocalEmbeddingsEndpoint || 'https://cody-gateway.sourcegraph.com/v1/embeddings'


### PR DESCRIPTION
Fixes #2245. Local Embeddings was not using the initial access token, when available.

https://github.com/sourcegraph/cody/assets/55120/833c1783-5384-45e4-94c4-bb93fbb8f471

## Test plan

Manual test:

1. Open a workspace, start a chat
2. Open the enhanced context selector and check that there's some local embeddings status
3. Cmd-Shift-P, Reload the window
4. Open the enhanced context selector; local embeddings status should appear
