### PR TITLE
Chat: Update chat icon and transcript gradient

### DIFF
--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -21,7 +21,7 @@
 }
 
 .assistant-row:before {
-    background-image: linear-gradient(to bottom, #b200f8, #ff5543, #00cbec);
+    background-image: linear-gradient(to bottom, #00cbec, #b200f8, #ff5543);
 }
 
 .row:hover > .header-container {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Replace "Sign Out" with an account dialog. [pull/2233](https://github.com/sourcegraph/cody/pull/2233)
+- Chat: Update chat icon and transcript gradient. [pull/2254](https://github.com/sourcegraph/cody/pull/2254)
 
 ## [0.18.2]
 

--- a/vscode/resources/active-chat-icon.svg
+++ b/vscode/resources/active-chat-icon.svg
@@ -1,0 +1,15 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+	<defs>
+		<clipPath id="dicsussion-icon">
+			<path fill-rule="evenodd" clip-rule="evenodd"
+				d="M4 11.29l1-1v1.42l-1.15 1.14L3 12.5V10H1.5L1 9.5v-8l.5-.5h12l.5.5V6h-1V2H2v7h1.5l.5.5v1.79zM10.29 13l1.86 1.85.85-.35V13h1.5l.5-.5v-5l-.5-.5h-8l-.5.5v5l.5.5h3.79zm.21-1H7V8h7v4h-1.5l-.5.5v.79l-1.15-1.14-.35-.15z" fill="black" />
+		</clipPath>
+		<linearGradient id="gradient" gradientTransform="rotate(45)">
+            <!-- A bit more subdued than the usual colors -->
+			<stop offset="0.2" stop-color="#60d5e7" />
+			<stop offset="0.7" stop-color="#cd8bfa" />
+			<stop offset="1" stop-color="#f4897d" />
+		</linearGradient>
+	</defs>
+	<rect cx="0" cy="0" height="16" width="16" clip-path="url(#dicsussion-icon)" fill="url(#gradient)" />
+</svg>

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -428,7 +428,7 @@ export class ChatPanelProvider extends MessageProvider {
      */
     private async registerWebviewPanel(panel: vscode.WebviewPanel): Promise<vscode.WebviewPanel> {
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
-        panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'resources', 'cody.png')
+        panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'resources', 'active-chat-icon.svg')
 
         panel.webview.options = {
             enableScripts: true,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -235,7 +235,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         }
 
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
-        panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'resources', 'cody.png')
+        panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'resources', 'active-chat-icon.svg')
 
         // Reset the webview options to ensure localResourceRoots is up-to-date
         panel.webview.options = {


### PR DESCRIPTION
Updates the chat editor icon:

| Theme | Preview |
| - | - |
| Before | <img width="429" alt="Screenshot 2023-12-11 at 10 57 55 pm" src="https://github.com/sourcegraph/cody/assets/153/02432ce1-62c5-4587-8457-6d3fa6c9ad69"> |
| After (Dark) | <img width="429" alt="Screenshot 2023-12-11 at 10 42 56 pm" src="https://github.com/sourcegraph/cody/assets/153/9f1cd108-5b63-49db-96de-ea55116dbf6f"> |
| After (Light) | <img width="429" alt="Screenshot 2023-12-11 at 10 43 12 pm" src="https://github.com/sourcegraph/cody/assets/153/c3c503c2-fa71-4311-8ff4-05c71715f34d"> |

## Test plan

- Start a new chat
- Observe icon
- Change color themes
- Observe icon