### PR TITLE
Chat: Add support for cody.chat.preInstruction in the new preamble

### DIFF
--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -1,10 +1,10 @@
 import { Message } from '../sourcegraph-api'
 
-export function getSimplePreamble(): Message[] {
+export function getSimplePreamble(preInstruction?: string | undefined): Message[] {
     return [
         {
             speaker: 'human',
-            text: 'You are Cody, an AI coding assistant from Sourcegraph.',
+            text: `You are Cody, an AI coding assistant from Sourcegraph.${preInstruction ? ` ${preInstruction}` : ''}`,
         },
         {
             speaker: 'assistant',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Fixed support for the `cody.chat.preInstruction` setting. [pull/2255](https://github.com/sourcegraph/cody/pull/2255)
+
 ### Changed
 
 ## [0.18.4]

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, afterEach, vi } from 'vitest'
+import { SimpleChatModel } from './SimpleChatModel'
+import { DefaultPrompter } from './prompt'
+import * as vscode from 'vscode'
+
+describe('DefaultPrompter', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('constructs a prompt with no context', async () => {
+        const chat = new SimpleChatModel('a-model-id')
+        chat.addHumanMessage({ text: 'Hello' })
+
+        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(chat, {
+            getExplicitContext: () => [],
+            getEnhancedContext: () => Promise.resolve([])
+        }, true, 100000)
+
+        expect(prompt).toMatchInlineSnapshot(`
+          [
+            {
+              "speaker": "human",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph.",
+            },
+            {
+              "speaker": "assistant",
+              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
+            },
+            {
+              "speaker": "human",
+              "text": "Hello",
+            },
+          ]
+        `)
+        expect(warnings).toMatchInlineSnapshot('[]')
+        expect(newContextUsed).toMatchInlineSnapshot('[]')
+    })
+
+    it('adds the cody.chat.preInstruction vscode setting if set', async () => {
+        const getConfig = vi.spyOn(vscode.workspace, 'getConfiguration')
+        getConfig.mockImplementation((section, resource) => ({
+            get: vi.fn(() => 'Always respond with 🧀 emojis'),
+            has: vi.fn(() => true),
+            inspect: vi.fn(() => ({ key: 'key' })),
+            update: vi.fn(() => Promise.resolve())
+        }))
+
+        const chat = new SimpleChatModel('a-model-id')
+        chat.addHumanMessage({ text: 'Hello' })
+
+        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(chat, {
+            getExplicitContext: () => [],
+            getEnhancedContext: () => Promise.resolve([])
+        }, true, 100000)
+
+        expect(prompt).toMatchInlineSnapshot(`
+          [
+            {
+              "speaker": "human",
+              "text": "You are Cody, an AI coding assistant from Sourcegraph. Always respond with 🧀 emojis",
+            },
+            {
+              "speaker": "assistant",
+              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
+            },
+            {
+              "speaker": "human",
+              "text": "Hello",
+            },
+          ]
+        `)
+        expect(warnings).toMatchInlineSnapshot('[]')
+        expect(newContextUsed).toMatchInlineSnapshot('[]')
+    })
+})

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, afterEach, vi } from 'vitest'
-import { SimpleChatModel } from './SimpleChatModel'
-import { DefaultPrompter } from './prompt'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
+
+import { DefaultPrompter } from './prompt'
+import { SimpleChatModel } from './SimpleChatModel'
 
 describe('DefaultPrompter', () => {
     afterEach(() => {
@@ -12,10 +13,15 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(chat, {
-            getExplicitContext: () => [],
-            getEnhancedContext: () => Promise.resolve([])
-        }, true, 100000)
+        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(
+            chat,
+            {
+                getExplicitContext: () => [],
+                getEnhancedContext: () => Promise.resolve([]),
+            },
+            true,
+            100000
+        )
 
         expect(prompt).toMatchInlineSnapshot(`
           [
@@ -43,16 +49,21 @@ describe('DefaultPrompter', () => {
             get: vi.fn(() => 'Always respond with 🧀 emojis'),
             has: vi.fn(() => true),
             inspect: vi.fn(() => ({ key: 'key' })),
-            update: vi.fn(() => Promise.resolve())
+            update: vi.fn(() => Promise.resolve()),
         }))
 
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(chat, {
-            getExplicitContext: () => [],
-            getEnhancedContext: () => Promise.resolve([])
-        }, true, 100000)
+        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(
+            chat,
+            {
+                getExplicitContext: () => [],
+                getEnhancedContext: () => Promise.resolve([]),
+            },
+            true,
+            100000
+        )
 
         expect(prompt).toMatchInlineSnapshot(`
           [

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+
 import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
 import {
     isMarkdownFile,

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -51,7 +51,6 @@ export class DefaultPrompter implements IPrompter {
         const promptBuilder = new PromptBuilder(byteLimit)
         const newContextUsed: ContextItem[] = []
         const warnings: string[] = []
-
         const preInstruction: string | undefined = vscode.workspace.getConfiguration('cody.chat').get('preInstruction')
 
         const preambleMessages = getSimplePreamble(preInstruction)

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode'
 import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
 import {
     isMarkdownFile,
@@ -51,7 +52,9 @@ export class DefaultPrompter implements IPrompter {
         const newContextUsed: ContextItem[] = []
         const warnings: string[] = []
 
-        const preambleMessages = getSimplePreamble()
+        const preInstruction: string | undefined = vscode.workspace.getConfiguration('cody.chat').get('preInstruction')
+
+        const preambleMessages = getSimplePreamble(preInstruction)
         const preambleSucceeded = promptBuilder.tryAddToPrefix(preambleMessages)
         if (!preambleSucceeded) {
             throw new Error(`Preamble length exceeded context window size ${byteLimit}`)


### PR DESCRIPTION
This adds support for the `cody.chat.preInstruction` setting in simplified chat, especially important now we have a "Chat Settings" button in the top of the chat editor:

<img width="603" alt="Screenshot 2023-12-11 at 11 28 07 pm" src="https://github.com/sourcegraph/cody/assets/153/a22c7b32-bdff-4a56-83ee-99c05f5cc075">

<img width="603" alt="Screenshot 2023-12-11 at 11 28 13 pm" src="https://github.com/sourcegraph/cody/assets/153/d89a70ff-1721-44aa-ac29-8817364eb7f3">

- [x] Get it working
- [x] Tests

Fix #2165

## Test plan

- Edit the setting
- Type a message