### PR TITLE
Autocomplete: Remove syntacticPostProcessing flag

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -166,9 +166,6 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.debug ?? false
             case 'cody.debug.verbose':
                 return connectionConfig?.verboseDebug ?? false
-            case 'cody.autocomplete.experimental.syntacticPostProcessing':
-                // False because we don't embed WASM with the agent yet.
-                return false
             case 'cody.codebase':
                 return connectionConfig?.codebase
             case 'cody.advanced.agent.ide':

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -51,7 +51,6 @@ export interface Configuration {
     /**
      * Experimental autocomplete
      */
-    autocompleteExperimentalSyntacticPostProcessing?: boolean
     autocompleteExperimentalDynamicMultilineCompletions?: boolean
     autocompleteExperimentalHotStreak?: boolean
     autocompleteExperimentalGraphContext: 'lsp-light' | 'bfg' | 'bfg-mixed' | null

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -129,6 +129,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Replace "Sign Out" with an account dialog. [pull/2233](https://github.com/sourcegraph/cody/pull/2233)
 - Chat: Update chat icon and transcript gradient. [pull/2254](https://github.com/sourcegraph/cody/pull/2254)
+- Remove the experimental `syntacticPostProcessing` flag. This behavior is now the default.
 
 ## [0.18.2]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -958,11 +958,6 @@
           "default": false,
           "markdownDescription": "Format completions on accept using [the default document formatter](https://code.visualstudio.com/docs/editor/codebasics#_formatting)."
         },
-        "cody.autocomplete.experimental.syntacticPostProcessing": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Rank autocomplete results with tree-sitter."
-        },
         "cody.autocomplete.experimental.dynamicMultilineCompletions": {
           "type": "boolean",
           "default": false,

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -39,7 +39,6 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     autocompleteAdvancedModel: null,
     autocompleteAdvancedAccessToken: null,
     autocompleteCompleteSuggestWidgetSelection: false,
-    autocompleteExperimentalSyntacticPostProcessing: false,
     autocompleteExperimentalGraphContext: null,
     autocompleteTimeouts: {},
     testingLocalEmbeddingsEndpoint: undefined,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -42,7 +42,6 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: null,
             autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteFormatOnAccept: true,
-            autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalDynamicMultilineCompletions: false,
             autocompleteExperimentalHotStreak: false,
             autocompleteExperimentalGraphContext: null,
@@ -118,8 +117,6 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.formatOnAccept':
                         return true
-                    case 'cody.autocomplete.experimental.syntacticPostProcessing':
-                        return true
                     case 'cody.autocomplete.experimental.dynamicMultilineCompletions':
                         return false
                     case 'cody.autocomplete.experimental.hotStreak':
@@ -169,7 +166,6 @@ describe('getConfiguration', () => {
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteFormatOnAccept: true,
-            autocompleteExperimentalSyntacticPostProcessing: true,
             autocompleteExperimentalDynamicMultilineCompletions: false,
             autocompleteExperimentalHotStreak: false,
             autocompleteExperimentalGraphContext: 'lsp-light',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -113,10 +113,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         experimentalGuardrails: getHiddenSetting('experimental.guardrails', isTesting),
         experimentalLocalSymbols: getHiddenSetting('experimental.localSymbols', false),
 
-        autocompleteExperimentalSyntacticPostProcessing: getHiddenSetting(
-            'autocomplete.experimental.syntacticPostProcessing',
-            true
-        ),
         autocompleteExperimentalDynamicMultilineCompletions: getHiddenSetting(
             'autocomplete.experimental.dynamicMultilineCompletions',
             false

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -117,12 +117,10 @@ const register = async (
         PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
     }
 
-    if (config.autocompleteExperimentalSyntacticPostProcessing) {
-        parseAllVisibleDocuments()
+    parseAllVisibleDocuments()
 
-        disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
-        disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
-    }
+    disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
+    disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
 
     // Enable tracking for pasting chat responses into editor text
     disposables.push(


### PR DESCRIPTION
I think we're pretty settled on the decision to ship this, so let's rm the flag.

The presence of the flag actually caused tree sitter to _not_ work on Agent even though the WASM implementation should work (cc @olafurpg). 

## Test plan

- The flag was already set to be enabled by default, this just removes the flag.

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
