### PR TITLE
VSCode: Make embeddings errors visible, resume indexing on restart

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Context: Incomplete embeddings indexing status can seen in the status bar. On macOS and Linux, indexing can be resumed by clicking there. However Windows users will still see an OS error 5 (access denied) when retrying indexing. [pull/2265](https://github.com/sourcegraph/cody/pull/2265)
+
 ### Fixed
 
 - Autocomplete: Don't show loading indicator when a user is rate limited. [pull/2314](https://github.com/sourcegraph/cody/pull/2314)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -349,11 +349,6 @@
         "when": "cody.activated"
       },
       {
-        "command": "cody.status-bar.embeddings",
-        "title": "Cody Embeddings",
-        "when": "cody.embeddings.notice"
-      },
-      {
         "command": "cody.show-page",
         "category": "Cody",
         "title": "Open Account Page",
@@ -500,6 +495,11 @@
         "group": "Cody",
         "icon": "$(clear-all)",
         "when": "cody.activated && cody.hasChatHistory"
+      },
+      {
+        "command": "cody.embeddings.resolveIssue",
+        "title": "Cody Embeddings",
+        "when": "cody.embeddings.hasIssue"
       }
     ],
     "keybindings": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -577,6 +577,10 @@
           "when": "cody.activated"
         },
         {
+          "command": "cody.embeddings.resolveIssue",
+          "when": "false"
+        },
+        {
           "command": "cody.focus",
           "title": "Cody: Sign In",
           "when": "!cody.activated"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -349,6 +349,11 @@
         "when": "cody.activated"
       },
       {
+        "command": "cody.status-bar.embeddings",
+        "title": "Cody Embeddings",
+        "when": "cody.embeddings.notice"
+      },
+      {
         "command": "cody.show-page",
         "category": "Cody",
         "title": "Open Account Page",

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.2.11763'
+const defaultBfgVersion = '5.2.12523'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.2.12523'
+const defaultBfgVersion = '5.2.12528'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -72,7 +72,6 @@ export interface IndexRequestModeNew {
 
 export interface IndexRequestModeContinue {
     type: 'continue'
-    repoName: string
 }
 
 export interface IndexResult {

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -31,7 +31,14 @@ export interface QueryResult {
 }
 
 export interface IndexRequest {
-    path: string
+    repoPath: string
+    mode: IndexRequestMode
+}
+
+export type IndexRequestMode = IndexRequestModeNew
+
+export interface IndexRequestModeNew {
+    type: 'new'
     model: string
     dimension: number
 }
@@ -64,24 +71,23 @@ export type Requests = {
 export type ProgressValue = Progress | ProgressError | ProgressDone
 
 export interface Progress {
-    Progress: {
-        currentPath: string
-        repoName: string
-        repoPath: string
-        numItems: number
-        totalItems: number
-    }
+    type: 'progress'
+    currentPath: string
+    repoName: string
+    repoPath: string
+    numItems: number
+    totalItems: number
 }
 
 export interface ProgressDone {
-    Done: string
+    type: 'done'
+    repoName: string
 }
 
 export interface ProgressError {
-    Error: {
-        repoName: string
-        message: string
-    }
+    type: 'error'
+    repoName: string
+    message: string
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -14,6 +14,11 @@ export interface ChunkingPolicy {
     pathsToExcludeRegexp: string
 }
 
+export interface QueryParams {
+    repoName: string
+    query: string
+}
+
 export interface QueryResultSet {
     results: QueryResult[]
 }
@@ -31,22 +36,32 @@ export interface IndexRequest {
     dimension: number
 }
 
+export interface IndexResult {
+    repoName: string
+}
+
+export interface LoadResult {
+    repoName: string
+}
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type Requests = {
     'embeddings/echo': [string, string]
     // Instruct local embeddings to index the specified repository path.
-    'embeddings/index': [IndexRequest, {}]
+    'embeddings/index': [IndexRequest, IndexResult]
     // Initializes the local embeddings service. You must call this first.
     'embeddings/initialize': [InitializeParams, {}]
     // Searches for and loads an index for the specified repository name.
-    'embeddings/load': [string, {}]
+    'embeddings/load': [string, LoadResult]
     // Queries loaded index.
-    'embeddings/query': [string, QueryResultSet]
+    'embeddings/query': [QueryParams, QueryResultSet]
     // Sets the Sourcegraph access token.
-    'embeddings/set-token': [string, undefined]
+    'embeddings/set-token': [string, {}]
+    // Shuts down the local embeddings service.
+    'embeddings/shutdown': [{}, {}]
 }
 
-export type ProgressValue = Progress | ProgressError | 'Done'
+export type ProgressValue = Progress | ProgressError | ProgressDone
 
 export interface Progress {
     Progress: {
@@ -58,8 +73,15 @@ export interface Progress {
     }
 }
 
+export interface ProgressDone {
+    Done: string
+}
+
 export interface ProgressError {
-    Error: string
+    Error: {
+        repoName: string
+        message: string
+    }
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -30,17 +30,49 @@ export interface QueryResult {
     content: string
 }
 
+export interface IndexHealthRequest {
+    // The name of the repository to scrutinize the index for. Note, this
+    // is a repo name, like github.com/sourcegraph/cody, not a file path.
+    repoName: string
+}
+
+export type IndexHealthResult = IndexHealthResultFound | IndexHealthResultNotFound
+
+export interface IndexHealthResultFound {
+    type: 'found'
+    repoName: string
+    format: 'App' | 'LocalEmbeddings'
+    commit: string
+    model: string
+    dimension: number
+    numItems: number
+    numItemsDeleted: number
+    numItemsNeedEmbedding: number
+    numItemsFailed: number
+    numFiles: number
+}
+
+export interface IndexHealthResultNotFound {
+    type: 'notFound'
+    repoName: string
+}
+
 export interface IndexRequest {
     repoPath: string
     mode: IndexRequestMode
 }
 
-export type IndexRequestMode = IndexRequestModeNew
+export type IndexRequestMode = IndexRequestModeNew | IndexRequestModeContinue
 
 export interface IndexRequestModeNew {
     type: 'new'
     model: string
     dimension: number
+}
+
+export interface IndexRequestModeContinue {
+    type: 'continue'
+    repoName: string
 }
 
 export interface IndexResult {
@@ -56,6 +88,8 @@ export type Requests = {
     'embeddings/echo': [string, string]
     // Instruct local embeddings to index the specified repository path.
     'embeddings/index': [IndexRequest, IndexResult]
+    // Get statistics for the index for a given repository name.
+    'embeddings/index-health': [IndexHealthRequest, IndexHealthResult]
     // Initializes the local embeddings service. You must call this first.
     'embeddings/initialize': [InitializeParams, {}]
     // Searches for and loads an index for the specified repository name.

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -181,7 +181,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                         this.lastError = undefined
                         const percent = Math.floor((100 * obj.numItems) / obj.totalItems)
                         if (this.statusBar) {
-                            this.statusBar.text = `$(loading~spin) Cody Embeddings (${percent.toFixed(0)}%)`
+                            this.statusBar.text = `$(cody-logo-heavy) Indexing Embeddings… (${percent.toFixed(0)}%)`
                             this.statusBar.backgroundColor = undefined
                             this.statusBar.tooltip = obj.currentPath
                             this.statusBar.show()
@@ -195,20 +195,6 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                     }
                     case 'done': {
                         this.lastError = undefined
-
-                        if (this.statusBar) {
-                            this.statusBar.text = '$(sparkle) Cody Embeddings'
-                            this.statusBar.backgroundColor = undefined
-                            this.statusBar.show()
-
-                            // TODO: Instead of a self-dismissing status bar, use a VSCode
-                            // notification with a button to focus chat.
-
-                            // Hide this notification after a while.
-                            const statusBar = this.statusBar
-                            this.statusBar = undefined
-                            setTimeout(() => statusBar.hide(), 30_000)
-                        }
                         this.loadAfterIndexing()
                         return
                     }
@@ -260,7 +246,15 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                 const loadedOk = await this.eagerlyLoad(path)
                 logDebug('LocalEmbeddingsController', 'load after indexing "done"', path, loadedOk)
                 this.changeEmitter.fire(this)
+                if (loadedOk) {
+                    await vscode.window.showInformationMessage('✨ Embeddings Index Complete')
+                }
             })()
+        }
+
+        if (this.statusBar) {
+            this.statusBar.dispose()
+            this.statusBar = undefined
         }
 
         this.pathBeingIndexed = undefined
@@ -504,7 +498,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
     private updateIssueStatusBar(): void {
         this.statusBar?.dispose()
         this.statusBar = vscode.window.createStatusBarItem('cody-local-embeddings', vscode.StatusBarAlignment.Right, 0)
-        this.statusBar.text = '$(warning) Cody Embeddings'
+        this.statusBar.text = '$(cody-logo-heavy) Embeddings Incomplete'
         const needsEmbeddingMessage = this.lastHealth?.numItemsNeedEmbedding
             ? `\n\n${this.lastHealth?.numItemsNeedEmbedding} of ${this.lastHealth?.numItems} items need embedding. Click to resolve.`
             : ''

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -181,7 +181,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                         this.lastError = undefined
                         const percent = Math.floor((100 * obj.numItems) / obj.totalItems)
                         if (this.statusBar) {
-                            this.statusBar.text = `$(cody-logo-heavy) Indexing Embeddings… (${percent.toFixed(0)}%)`
+                            this.statusBar.text = `Indexing Embeddings… (${percent.toFixed(0)}%)`
                             this.statusBar.backgroundColor = undefined
                             this.statusBar.tooltip = obj.currentPath
                             this.statusBar.show()
@@ -247,7 +247,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                 logDebug('LocalEmbeddingsController', 'load after indexing "done"', path, loadedOk)
                 this.changeEmitter.fire(this)
                 if (loadedOk) {
-                    await vscode.window.showInformationMessage('✨ Embeddings Index Complete')
+                    await vscode.window.showInformationMessage('✨ Cody Embeddings Index Complete')
                 }
             })()
         }
@@ -498,13 +498,16 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
     private updateIssueStatusBar(): void {
         this.statusBar?.dispose()
         this.statusBar = vscode.window.createStatusBarItem('cody-local-embeddings', vscode.StatusBarAlignment.Right, 0)
-        this.statusBar.text = '$(cody-logo-heavy) Embeddings Incomplete'
+        this.statusBar.text = 'Embeddings Incomplete'
         const needsEmbeddingMessage = this.lastHealth?.numItemsNeedEmbedding
-            ? `\n\n${this.lastHealth?.numItemsNeedEmbedding} of ${this.lastHealth?.numItems} items need embedding. Click to resolve.`
+            ? `\n\n${this.lastHealth?.numItemsNeedEmbedding} of ${this.lastHealth
+                  ?.numItems} items are missing from Cody's Embeddings Index for ${
+                  this.lastRepo?.path || 'this repository'
+              }. Click to resolve.`
             : ''
         const errorMessage = this.lastError ? `\n\nError: ${this.lastError}` : ''
         this.statusBar.tooltip = new vscode.MarkdownString(
-            `#### Cody Embeddings\n\n${this.lastRepo?.path} index is incomplete.${needsEmbeddingMessage}${errorMessage}`
+            `#### Cody Embeddings Incomplete\n\n${needsEmbeddingMessage}${errorMessage}`
         )
         this.statusBar.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
         this.statusBar.command = 'cody.embeddings.resolveIssue'
@@ -522,14 +525,17 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                 try {
                     const errorMessage = this.lastError ? `\n\nError: ${this.lastError}` : ''
                     const choice = await vscode.window.showWarningMessage(
-                        `${this.lastHealth?.numItemsNeedEmbedding} of ${this.lastHealth?.numItems} items need embedding.${errorMessage}`,
-                        'Retry',
+                        `${this.lastHealth?.numItemsNeedEmbedding} of ${this.lastHealth
+                            ?.numItems} items are missing from Cody's Embeddings Index for ${
+                            this.lastRepo?.path || 'this repository'
+                        }.${errorMessage}`,
+                        'Index',
                         'Cancel'
                     )
                     switch (choice) {
                         case 'Cancel':
                             return
-                        case 'Retry':
+                        case 'Index':
                             await this.indexRetry()
                     }
                 } catch (error: any) {

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -48,6 +48,7 @@ const test = helpers.test
                 use({
                     'cody.testing.localEmbeddings.model': 'stub/stub',
                     'cody.testing.localEmbeddings.indexLibraryPath': dir,
+                    'cody.experimental.cody-engine.path': '/Users/dpc/projects/bfg-private/target/release/bfg',
                 })
             )
         },

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -48,7 +48,6 @@ const test = helpers.test
                 use({
                     'cody.testing.localEmbeddings.model': 'stub/stub',
                     'cody.testing.localEmbeddings.indexLibraryPath': dir,
-                    'cody.experimental.cody-engine.path': '/Users/dpc/projects/bfg-private/target/release/bfg',
                 })
             )
         },

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -53,6 +53,11 @@ const test = helpers.test
         },
     })
 
+test.beforeAll(() => {
+    // These tests depend on downloading cody-engine, which can be slow.
+    test.slow()
+})
+
 test.extend<helpers.WorkspaceDirectory>({
     // Playwright needs empty pattern to specify "no dependencies".
     // eslint-disable-next-line no-empty-pattern
@@ -76,7 +81,7 @@ test.extend<helpers.WorkspaceDirectory>({
     // Embeddings is visible at first as cody-engine starts...
     await expect(chatFrame.getByText('Embeddings')).toBeVisible()
     // ...and displays this message when the engine works out this is not a git repo.
-    await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible()
+    await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible({ timeout: 60000 })
     await expect(chatFrame.getByText('Folder is not a Git repository.')).toBeVisible()
 })
 
@@ -86,7 +91,7 @@ test('git repositories without a remote should explain the issue', async ({ page
     const chatFrame = await newChat(page)
     const enhancedContextButton = chatFrame.getByTitle('Configure Enhanced Context')
     await enhancedContextButton.click()
-    await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible()
+    await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible({ timeout: 60000 })
     await expect(chatFrame.getByText('Git repository is missing a remote origin.')).toBeVisible()
 })
 
@@ -105,7 +110,7 @@ test.extend<helpers.WorkspaceDirectory>({
 
     const enableEmbeddingsButton = chatFrame.getByText('Enable Embeddings')
     // This may take a while, we download and start cody-engine
-    await expect(enableEmbeddingsButton).toBeVisible({ timeout: 300000 })
+    await expect(enableEmbeddingsButton).toBeVisible({ timeout: 60000 })
     await enableEmbeddingsButton.click()
 
     await expect(chatFrame.getByText('Indexed')).toBeVisible({ timeout: 30000 })


### PR DESCRIPTION
- If an incomplete index is loaded, explain the situation in the status bar.
- User can resume an incomplete index.
- Displays error messages from local embeddings in the UI.
- Updates the local embeddings protocol to 0.1.2. The client now learns the "names" (identifying keys) of repositories it is loading and indexing, so events can be related to the repositories they belong to. New methods to query the status of indexes and resume indexing.

https://www.loom.com/share/242be2c7abcd49d19e1709e0529651b1
UX refresh: https://www.loom.com/share/2654feb99c9f4985add94470a362bec7
 
## Test plan

Manual test:

1. Open a repository which doesn't have any embeddings.
2. Start generating local embeddings.
3. In Activity Monitor, kill the cody-engine process, leaving a partial index. Note, there's no handling process death, so the indexing process will appear to simply halt.
4. Reload the VScode window to work around the dead process.
5. Confirm there's a status bar entry indicating the index is incomplete.
6. Start a chat. Queries should use the incomplete index.
7. Interact with the status bar to resume indexing.
8. When indexing is done, queries should use the completed index.

To generate an unusual failure mode, edit another git repo's remote to match the partial index and open that folder. Then resume indexing. This should display an error message about the repo not having the specific commit the index was created at. (This resumes an incomplete index, it does not update an index to a new commit.)

Automated test:

`pnpm test:e2e -- local-embeddings.test.ts`