### PR TITLE
Do not await `showSetupNotification`

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -562,7 +562,7 @@ const register = async (
         )
     }
 
-    await showSetupNotification(initialConfig)
+    void showSetupNotification(initialConfig)
 
     // Clean up old onboarding experiment state
     void OnboardingExperiment.cleanUpCachedSelection()


### PR DESCRIPTION
"Continue setting up Cody" prompt does not need to be `await`ed; waiting on it breaks flow.

## Test plan

Tested locally.
