### PR TITLE
use context.globalStorageUri for symf indexes

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -865,7 +865,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
     private async postCodyCommands(): Promise<void> {
         const send = async (): Promise<void> => {
             await this.editor.controllers.command?.refresh()
-            const prompts = (await this.editor.controllers.command?.getAllCommands(true)) || []
+            const allCommands = await this.editor.controllers.command?.getAllCommands(true)
+            // HACK: filter out commands that make inline changes and /ask (synonymous with a generic question)
+            const prompts =
+                allCommands?.filter(([id]) => {
+                    return !['/edit', '/doc', '/test', '/ask'].includes(id)
+                }) || []
+
             void this.postMessage({
                 type: 'custom-prompts',
                 prompts,

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -49,7 +49,28 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         private sourcegraphServerEndpoint: string | null,
         private authToken: string | null
     ) {
-        this.indexRoot = path.join(os.homedir(), '.cody-symf')
+        const indexRoot = path.join(context.globalStorageUri.fsPath, 'symf', 'indexroot')
+        void SymfRunner.removeOldIndexRoot(indexRoot)
+        this.indexRoot = indexRoot
+    }
+
+    // TODO(beyang): remove after GA
+    private static removeOldIndexRoot(newIndexRoot: string): void {
+        const oldIndexRoot = path.join(os.homedir(), '.cody-symf')
+        fs.stat(oldIndexRoot, (oldIndexRootStatErr, stats) => {
+            if (oldIndexRootStatErr) {
+                return
+            }
+            fs.stat(newIndexRoot, newIndexRootStatErr => {
+                if (!newIndexRootStatErr) {
+                    return
+                }
+                if (!stats.isDirectory()) {
+                    return
+                }
+                void rm(oldIndexRoot, { recursive: true, force: true })
+            })
+        })
     }
 
     public dispose(): void {

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -57,20 +57,24 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
     // TODO(beyang): remove after GA
     private static removeOldIndexRoot(newIndexRoot: string): void {
         const oldIndexRoot = path.join(os.homedir(), '.cody-symf')
-        fs.stat(oldIndexRoot, (oldIndexRootStatErr, stats) => {
-            if (oldIndexRootStatErr) {
-                return
-            }
-            fs.stat(newIndexRoot, newIndexRootStatErr => {
-                if (!newIndexRootStatErr) {
+        try {
+            fs.stat(oldIndexRoot, (oldIndexRootStatErr, stats) => {
+                if (oldIndexRootStatErr) {
                     return
                 }
-                if (!stats.isDirectory()) {
-                    return
-                }
-                void rm(oldIndexRoot, { recursive: true, force: true })
+                fs.stat(newIndexRoot, newIndexRootStatErr => {
+                    if (!newIndexRootStatErr) {
+                        return
+                    }
+                    if (!stats.isDirectory()) {
+                        return
+                    }
+                    void rm(oldIndexRoot, { recursive: true, force: true })
+                })
             })
-        })
+        } catch {
+            logDebug('SymfRunner.removeOldIndexRoot', 'Failed to remove old index root', oldIndexRoot)
+        }
     }
 
     public dispose(): void {


### PR DESCRIPTION
Previously, symf indexes for Cody were stored at `~/.cody-symf`. This moves them under the VS Code extension directory (where they'll be automatically if uninstall is triggered.

Also fixes https://github.com/sourcegraph/cody/issues/2172 by hiding slash commands in the chat input if they are inline edit commands.

## Test plan

- [ ] On main, do a Cody search within a repository to ensure an index is built. Check that the index exists at `~/.cody-symf`.
- [ ] Check out this branch. Restart Cody.
- [ ] Check that `~/.cody-symf` has been removed and the new index exists at `context.globalStorageUri` (you may need to set a breakpoint in the constructor of `SymfRunner` to determine the value of `context.globalStorageUri).