### PR TITLE
telemetry-v2: fix splitSafeMetadata to generate acceptable type

### DIFF
--- a/vscode/src/services/telemetry-v2.test.ts
+++ b/vscode/src/services/telemetry-v2.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
+import { NoOpTelemetryRecorderProvider } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
+import { TelemetryEventInput } from '@sourcegraph/telemetry'
+
 import { splitSafeMetadata } from './telemetry-v2'
 
 describe('splitSafeMetadata', () => {
@@ -111,5 +114,71 @@ describe('splitSafeMetadata', () => {
 
         // sanity-check original parameters are not mutated
         expect(parameters).toStrictEqual(originalParameters)
+    })
+
+    it('can be provided to TelemetryRecorder', () => {
+        // This test just validates that the returned types of splitSafeMetadata
+        // are accepted by telemetryRecorder.recordEvent
+        const events: TelemetryEventInput[] = []
+        const telemetryRecorder = new NoOpTelemetryRecorderProvider([
+            {
+                processEvent: event => {
+                    events.push(event)
+                },
+            },
+        ]).getRecorder()
+        const { metadata, privateMetadata } = splitSafeMetadata({
+            number: 3,
+            float: 3.14,
+            true: true,
+            false: false,
+            string: 'string',
+            object: { key: 'value', safeVar: 3 },
+        })
+        telemetryRecorder.recordEvent('telemetry-v2.test', 'splitSafeMetadata', {
+            metadata,
+            privateMetadata,
+        })
+        // Assert processed event
+        expect(events).toHaveLength(1)
+        expect(events[0]).toEqual({
+            action: 'splitSafeMetadata',
+            feature: 'telemetry-v2.test',
+            parameters: {
+                metadata: [
+                    {
+                        key: 'number',
+                        value: 3,
+                    },
+                    {
+                        key: 'float',
+                        value: 3.14,
+                    },
+                    {
+                        key: 'true',
+                        value: 1,
+                    },
+                    {
+                        key: 'false',
+                        value: 0,
+                    },
+                    {
+                        key: 'object.safeVar',
+                        value: 3,
+                    },
+                ],
+                privateMetadata: {
+                    object: {
+                        key: 'value',
+                        safeVar: 3,
+                    },
+                    string: 'string',
+                },
+                version: 0,
+            },
+            source: {
+                client: '',
+            },
+        })
     })
 })


### PR DESCRIPTION
The current returned type is too "loose" to be accepted directly by `telemetryRecorder.recordEvent`. This change makes it stricter (but still correct based on the intended behaviour of the helper) with some type hackery, courtesy of StackOverflow.

Previously, this kind of worked by accident because we "broadened" the type beforehand.

## Test plan

New and existing unit tests.