### PR TITLE
Chat: Remove Chat Suggestions setting that no longer works

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Chat: Removed 'Chat Suggestions' setting. [pull/2284](https://github.com/sourcegraph/cody/pull/2284)
+
 ## [0.18.4]
 
 ### Added

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -124,14 +124,6 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.commandCodeLenses
                 ),
                 createFeatureToggle(
-                    'Chat Suggestions',
-                    'Experimental',
-                    'Enable automatically suggested chat questions',
-                    'cody.experimental.chatPredictions',
-                    c => c.experimentalChatPredictions,
-                    true
-                ),
-                createFeatureToggle(
                     'Symf Context',
                     'Experimental',
                     'Enable context fetched via symf',


### PR DESCRIPTION
This removes the experimental "Chat Suggestions" from the settings menu. Fixes #2281 

| Before | After |
| - | - |
|  <img width="633" alt="Screenshot 2023-12-12 at 5 11 31 pm" src="https://github.com/sourcegraph/cody/assets/153/6bc0b991-1803-493a-83ad-ba11750ffc26"> | <img width="633" alt="Screenshot 2023-12-12 at 5 11 08 pm" src="https://github.com/sourcegraph/cody/assets/153/c6e3684a-164b-4408-9d93-b3de3b5dee79"> |

## Test plan

- Opened settings menu
- Verified no longer there