### PR TITLE
Settings: Relabel "symf Context" as "Search Context"

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Settings: Relabel "symf Context" as "Search Context". [pull/2285](https://github.com/sourcegraph/cody/pull/2285)
+
 ## [0.18.4]
 
 ### Added

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -132,9 +132,9 @@ export function createStatusBar(): CodyStatusBar {
                     true
                 ),
                 createFeatureToggle(
-                    'Symf Context',
-                    'Experimental',
-                    'Enable context fetched via symf',
+                    'Search Context',
+                    'Beta',
+                    'Enable using the natural language search index as an Enhanced Context chat source',
                     'cody.experimental.symfContext',
                     c => c.experimentalSymfContext,
                     false


### PR DESCRIPTION
Fixes #2162 

| Before | After |
| - | - |
| <img width="633" alt="Screenshot 2023-12-12 at 5 37 48 pm" src="https://github.com/sourcegraph/cody/assets/153/62825cc1-5418-4101-8c6c-1937cd051da4"> | <img width="633" alt="Screenshot 2023-12-12 at 5 30 25 pm" src="https://github.com/sourcegraph/cody/assets/153/2017e3df-16f0-459c-9f36-2c8fd07cabba"> |

## Test plan

- Open settings
- Verify label