### PR TITLE
Settings: Remove the "Simple Chat Context" setting

### DIFF
--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -139,14 +139,6 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.experimentalSymfContext,
                     false
                 ),
-                createFeatureToggle(
-                    'Simple Chat Context',
-                    'Experimental',
-                    'Enable the new simplifed chat context fetcher',
-                    'cody.experimental.simpleChatContext',
-                    c => c.experimentalSimpleChatContext,
-                    true
-                ),
                 { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
                 {
                     label: '$(gear) Cody Extension Settings',

--- a/vscode/test/e2e/command.test.ts
+++ b/vscode/test/e2e/command.test.ts
@@ -28,7 +28,7 @@ test('submit command from command palette', async ({ page, sidebar }) => {
     await expect(chatPanelFrame.getByText('hello from the assistant')).toBeVisible()
 
     // Click on the file link in chat
-    await chatPanelFrame.getByRole('button', {name: '@index.html'}).click()
+    await chatPanelFrame.getByRole('button', { name: '@index.html' }).click()
 
     // Check if the file is opened
     await expect(page.getByRole('list').getByText('index.html')).toBeVisible()

--- a/vscode/test/e2e/command.test.ts
+++ b/vscode/test/e2e/command.test.ts
@@ -7,16 +7,6 @@ test('submit command from command palette', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 
-    await page.getByRole('button', { name: 'cody-logo-heavy, Cody Settings' }).click()
-    await page
-        .getByRole('option', {
-            name: 'Simple Chat Context, Experimental, Enable the new simplifed chat context fetcher',
-        })
-        .locator('span')
-        .filter({ hasText: 'Experimental' })
-        .first()
-        .click()
-
     // Open the File Explorer view from the sidebar
     await sidebarExplorer(page).click()
     // Open the index.html file from the tree view
@@ -30,20 +20,16 @@ test('submit command from command palette', async ({ page, sidebar }) => {
 
     // Find the chat iframe
     const chatPanelFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+
     // Check if the command shows up with the current file name
-    await expect(chatPanelFrame.getByText('/explain @index.html')).toBeVisible()
+    await chatPanelFrame.getByText('✨ Context: 1 file').click()
+
     // Check if assistant responsed
     await expect(chatPanelFrame.getByText('hello from the assistant')).toBeVisible()
 
-    // Close the file
-    await page.getByRole('tab', { name: 'index.html', exact: true }).getByText('index.html').click()
-    await page
-        .getByRole('tab', { name: 'index.html, Editor Group 1' })
-        .getByRole('button', { name: /Close.*/ })
-        .click()
-
     // Click on the file link in chat
-    await chatPanelFrame.getByRole('link', { name: '@index.html' }).click()
+    await chatPanelFrame.getByRole('button', {name: '@index.html'}).click()
+
     // Check if the file is opened
     await expect(page.getByRole('list').getByText('index.html')).toBeVisible()
 })


### PR DESCRIPTION
Removes the following "Simple Chat Context" setting from the settings quickpick, as it'll only be used internally or for specific support requests.

<img width="635" alt="Screenshot 2023-12-12 at 5 41 40 pm" src="https://github.com/sourcegraph/cody/assets/153/53f8714d-ad30-474d-9f3d-4905f014e8bf">

## Test plan

- Opened settings
- Verified it's gone