### PR TITLE
Update rate limit error wording for Cody Pro users

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -31,7 +31,9 @@ export class RateLimitError extends Error {
         public readonly retryAfter?: string | null
     ) {
         super(message)
-        this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
+        this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for ${
+            upgradeIsAvailable ? 'the month' : 'today'
+        }.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)
                 ? new Date(Date.now() + parseInt(retryAfter, 10) * 1000)

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -31,7 +31,7 @@ export class RateLimitError extends Error {
         public readonly retryAfter?: string | null
     ) {
         super(message)
-        this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for the month.`
+        this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)
                 ? new Date(Date.now() + parseInt(retryAfter, 10) * 1000)

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -526,8 +526,7 @@ describe('InlineCompletionItemProvider', () => {
             expect(addError).toHaveBeenCalledWith(
                 expect.objectContaining({
                     title: 'Cody Autocomplete Disabled Due to Rate Limit',
-                    description:
-                        "You've used all 1234 autocompletions for today. Usage will reset tomorrow at 1:00 PM",
+                    description: "You've used all 1234 autocompletions for today. Usage will reset tomorrow at 1:00 PM",
                 })
             )
 

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -527,7 +527,7 @@ describe('InlineCompletionItemProvider', () => {
                 expect.objectContaining({
                     title: 'Cody Autocomplete Disabled Due to Rate Limit',
                     description:
-                        "You've used all 1234 autocompletions for the month. Usage will reset tomorrow at 1:00 PM",
+                        "You've used all 1234 autocompletions for today. Usage will reset tomorrow at 1:00 PM",
                 })
             )
 
@@ -557,7 +557,7 @@ describe('InlineCompletionItemProvider', () => {
                         title: canUpgrade
                             ? 'Upgrade to Continue Using Cody Autocomplete'
                             : 'Cody Autocomplete Disabled Due to Rate Limit',
-                        description: "You've used all 1234 autocompletions for the month.",
+                        description: `You've used all 1234 autocompletions for ${canUpgrade ? 'the month' : 'today'}.`,
                     })
                 )
 


### PR DESCRIPTION
Fixes #2272

## Test plan

- Logged in as rate limited pro user, verified rate limit error message changed
- Logged in as rate limited free user, verified rate limit error message unchanged