### PR TITLE
Edit: Fix malformed comments from doc command with selection

### DIFF
--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -232,10 +232,7 @@ function getDocCommandRange(
         }
     }
 
-    if (languageId === 'python') {
-        const adjustedStartPosition = new vscode.Position(selection.start.line + 1, 0)
-        return new vscode.Selection(adjustedStartPosition, selection.end)
-    }
-
-    return selection
+    const startLine = languageId === 'python' ? selection.start.line + 1 : selection.start.line
+    const adjustedStartPosition = new vscode.Position(startLine, 0)
+    return new vscode.Selection(adjustedStartPosition, selection.end)
 }

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -220,11 +220,8 @@ export function addSelectionToPrompt(prompt: string, code: string): string {
 function getDocCommandRange(
     editor: vscode.TextEditor,
     selection: vscode.Selection,
-    languageId?: string
+    languageId: string
 ): vscode.Selection {
-    const startLine = languageId === 'python' ? selection.start.line + 1 : selection.start.line
-    const pos = new vscode.Position(startLine, 0)
-
     // move the current selection to the defined selection in the text editor document
     if (editor) {
         const visibleRange = editor.visibleRanges
@@ -235,5 +232,10 @@ function getDocCommandRange(
         }
     }
 
-    return new vscode.Selection(pos, pos)
+    if (languageId === 'python') {
+        const adjustedStartPosition = new vscode.Position(selection.start.line + 1, 0)
+        return new vscode.Selection(adjustedStartPosition, selection.end)
+    }
+
+    return selection
 }


### PR DESCRIPTION
## Description

closes https://github.com/sourcegraph/cody/issues/2058

`getDocCommandRange` for the `/doc` command was returning the incorrect selection. It was overriding the end position rather than just adjusting the start position for python.

This meant that the edit command was treating this as an `add` (no selected code thus nothing to edit)

### Before

https://github.com/sourcegraph/cody/assets/9516420/62121460-3ddf-47d1-9b41-f86d94f43e12


### After

https://github.com/sourcegraph/cody/assets/9516420/23519065-fd6c-4969-b034-e0530330d328



## Test plan

1. Highlight some code where there is not already a folding range
2. Use the "doc" command via the chat or right click menu
3. Check that the inserted documentation is correct

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
