### PR TITLE
Fix keyDown:Paste:clicked events

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: Fixed support for the `cody.chat.preInstruction` setting. [pull/2255](https://github.com/sourcegraph/cody/pull/2255)
+- Fixes an issue where pasting into the document was not properly tracked. [pull/2293](https://github.com/sourcegraph/cody/pull/2293)
 
 ### Changed
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -42,6 +42,7 @@ import { getAccessToken, secretStorage, VSCodeSecretStorage } from './services/S
 import { createStatusBar } from './services/StatusBar'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
+import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
 import { workspaceActionsOnConfigChange } from './services/utils/workspace-action'
 import { TestSupport } from './test-support'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
@@ -122,6 +123,18 @@ const register = async (
         disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
         disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))
     }
+
+    // Enable tracking for pasting chat responses into editor text
+    disposables.push(
+        vscode.workspace.onDidChangeTextDocument(async e => {
+            const changedText = e.contentChanges[0]?.text
+            // Skip if the document is not a file or if the copied text is from insert
+            if (!changedText || e.document.uri.scheme !== 'file') {
+                return
+            }
+            await onTextDocumentChange(changedText)
+        })
+    )
 
     const authProvider = new AuthProvider(initialConfig)
     await authProvider.init()


### PR DESCRIPTION
Fixes #2292

Previously, detecting pastes into the document required the inline chat controller to be listening for changes. Since that was removed in #2079, we no longer detected pasts. This brings this behavior back via a dedicated event listener we add in `main`.

## Test plan

- Ask cody to gen code
- Copy it
- Paste it into a doc

<img width="1132" alt="Screenshot 2023-12-12 at 11 22 37" src="https://github.com/sourcegraph/cody/assets/458591/d3c14317-b7ad-4270-a41f-30448781d149">

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
