### PR TITLE
Edit: Fix doc command jumping unnecessarily

### DIFF
--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -222,17 +222,14 @@ function getDocCommandRange(
     selection: vscode.Selection,
     languageId: string
 ): vscode.Selection {
-    // move the current selection to the defined selection in the text editor document
-    if (editor) {
-        const visibleRange = editor.visibleRanges
-        // reveal the range of the selection minus 5 lines if visibleRange doesn't contain the selection
-        if (!visibleRange.some(range => range.contains(selection))) {
-            // reveal the range of the selection minus 5 lines
-            editor?.revealRange(selection, vscode.TextEditorRevealType.InCenter)
-        }
-    }
-
     const startLine = languageId === 'python' ? selection.start.line + 1 : selection.start.line
     const adjustedStartPosition = new vscode.Position(startLine, 0)
+
+    if (editor && !editor.visibleRanges.some(range => range.contains(adjustedStartPosition))) {
+        // reveal the range of the selection if visibleRange doesn't contain the selection
+        // we only use the start position as it is possible that the selection covers more than the entire visible area
+        editor.revealRange(selection, vscode.TextEditorRevealType.InCenter)
+    }
+
     return new vscode.Selection(adjustedStartPosition, selection.end)
 }


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/2101

## Description

It is possible that the selection contains more code than is visible on the screen.

In this case, visibleRanges will never contain the entire selection.

We only really care about the start position of the selection (where the edit will be inserted). We use that position instead.

## Test plan

Run the /doc command on a large function when the entry point is already visible

Check the editor does not scroll unnecessarily

Run the /doc command on a large function when the entry point is NOT visible

Check the editor does scroll the entry point into view