### PR TITLE
Edit: Do not scroll into view on complete

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Settings: Relabel "symf Context" as "Search Context". [pull/2285](https://github.com/sourcegraph/cody/pull/2285)
 - Chat: Removed 'Chat Suggestions' setting. [pull/2284](https://github.com/sourcegraph/cody/pull/2284)
+- Edit: Completed edits are no longer scrolled back into view in the active file. [pull/2297](https://github.com/sourcegraph/cody/pull/2297)
 
 ## [0.18.4]
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -436,8 +436,6 @@ export class FixupController
             return
         }
 
-        visibleEditor?.revealRange(task.selectionRange)
-
         // We will format this code once applied, so we avoid placing an undo stop after this edit to avoid cluttering the undo stack.
         const applyEditOptions = { undoStopBefore: true, undoStopAfter: false }
         const editOk = task.insertMode


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/2259

## Description

Previously we would always scroll a completed task into view on completion.

We have a bug with this already (https://github.com/sourcegraph/cody/issues/2259).

One fix here is just to scroll this into view when the code is NOT already in view.

However, I think this might actually be annoying behaviour. The user already gets a notification for edits that are made if the file is not currently active. It seems overly aggressive to force their scroll back to the code when editing an active file.

## Test plan

1. Edit code in a large file
2. Scroll the code out of view
3. Check we don't hijack the scroll


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
