### PR TITLE
Chore: Remove some GHA `ifs` that didn't work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
           service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
-        if: ${{github.repository_owner == 'sourcegraph'}}
       - uses: google-github-actions/setup-gcloud@v0
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
@@ -135,7 +134,6 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
           service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
-        if: ${{github.repository_owner == 'sourcegraph'}}
       - uses: google-github-actions/setup-gcloud@v0
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
These were added to try to allow third-party forks to successfully run our GitHub Actions CI steps… but alas they did nothing.

## Test plan

- N/A