### PR TITLE
Edit: Flush diffs on apply

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1051,6 +1051,7 @@ export class FixupController
         // currently do not always show the correct positions for edits.
         // TODO: Improve the diff handling so that decorations more accurately reflect the edits.
         if (task.state === CodyTaskState.applied) {
+            this.updateDiffs() // Flush any diff updates first, so they aren't scheduled after the completion.
             this.decorator.didCompleteTask(task)
         }
     }


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/2082

## Description

Diffs can be scheduled - these update decorations, but this can conflict with removing the decorations when a task is applied.

So we have a race condition where it is possible that:
1. The task is applied, and decorations are removed
2. Later, a scheduled diff updates and re-applies the old decorations

To work around this, we just ensure that any scheduled diff updates are ran before we finally remove all decorations

## Test plan

1. Run an edit
2. Confirm that decorations are not shown on apply

1. Run the `/doc` command
2. Confirm that decorations are not shown on apply

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
