### PR TITLE
Fix rate limit number being displayed

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -54,7 +54,11 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                             typeof res.headers['x-is-cody-pro-user'] !== undefined &&
                             res.headers['x-is-cody-pro-user'] === 'false'
                         const retryAfter = res.headers['retry-after']
-                        const limit = res.headers['x-ratelimit-limit'] ? res.headers['x-ratelimit-limit'][0] : undefined
+
+                        const limit = res.headers['x-ratelimit-limit']
+                            ? getHeader(res.headers['x-ratelimit-limit'])
+                            : undefined
+
                         const error = new RateLimitError(
                             'chat messages and commands',
                             e.message,
@@ -141,4 +145,11 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
 
         return () => request.destroy()
     }
+}
+
+function getHeader(value: string | undefined | string[]): string | undefined {
+    if (Array.isArray(value)) {
+        return value[0]
+    }
+    return value
 }

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Fixes an issue where the wrong rate limite count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
+
 ### Changed
 
 ## [0.18.5]

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Fixes an issue where the wrong rate limite count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
+- Fixes an issue where the wrong rate limit count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
 
 ### Changed
 


### PR DESCRIPTION
We were calling `[0]` even though it was a string which lead to it picking the first character. So if the rate limit was `222` it would show up as `2`

## Test plan
<img width="584" alt="Screenshot 2023-12-12 at 22 06 57" src="https://github.com/sourcegraph/cody/assets/458591/1169b0bf-19a0-47dd-9ca0-12d0192340dd">

- Log in with rate limited David user
- Send a message

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
