### PR TITLE
Autocomplete: Don't show loading spinner when rate limited

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Autocomplete: Don't show loading indicator when a user is rate limited. [pull/2314](https://github.com/sourcegraph/cody/pull/2314)
+
 ### Changed
 
 ## [0.18.5]

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -249,7 +249,14 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             let stopLoading: () => void | undefined
             const setIsLoading = (isLoading: boolean): void => {
                 if (isLoading) {
-                    stopLoading = this.config.statusBar.startLoading('Completions are being generated')
+                    // We do not want to show a loading spinner when the user is rate limited to
+                    // avoid visual churn.
+                    //
+                    // We still make the request to find out if the user is still rate limited.
+                    const hasRateLimitError = this.config.statusBar.hasError(RateLimitError.errorName)
+                    if (!hasRateLimitError) {
+                        stopLoading = this.config.statusBar.startLoading('Completions are being generated')
+                    }
                 } else {
                     stopLoading?.()
                 }


### PR DESCRIPTION
As the title says

## Test plan


https://github.com/sourcegraph/cody/assets/458591/4eb3f9b6-e0c2-4503-aa9c-082b1a4b49b5

- Be rate limited
- Trigger completions

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
