### PR TITLE
Autocomplete: remove `scminput` from the autocomplete languages setting default value

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -810,15 +810,13 @@
         "cody.autocomplete.languages": {
           "order": 5,
           "type": "object",
-          "markdownDescription": "Enables or disables code autocompletions for specified [language ids](https://code.visualstudio.com/docs/languages/identifiers). `\"*\"` is the default fallback if no language-specific setting is found.\n\nThe default setting: \n\n```json\n{\n  \"*\": true,\n  \"scminput\": false\n}\n```\n\nTo disable autocomplete for a given [language id](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) set its value to `false`, for example:\n\n```json\n{\n  \"*\": true,\n  \"scminput\": false,\n  \"plaintext\": false\n}\n```",
+          "markdownDescription": "Enables or disables code autocompletions for specified [language ids](https://code.visualstudio.com/docs/languages/identifiers). `\"*\"` is the default fallback if no language-specific setting is found.\n\nThe default setting: \n\n```json\n{\n  \"*\": true\n}\n```\n\nTo disable autocomplete for a given [language id](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers) set its value to `false`, for example:\n\n```json\n{\n  \"*\": true,\n  \"plaintext\": false\n}\n```",
           "default": {
-            "*": true,
-            "scminput": false
+            "*": true
           },
           "examples": [
             {
               "*": true,
-              "scminput": false,
               "plaintext": false
             }
           ]

--- a/vscode/src/completions/create-inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.test.ts
@@ -7,13 +7,11 @@ describe('getInlineCompletionItemProviderFilters', () => {
         const filters = await getInlineCompletionItemProviderFilters({
             '*': true,
             go: false,
-            scminput: false,
         })
 
         const enabledLanguages = filters.map(f => f.language)
 
         expect(enabledLanguages).not.include('go')
-        expect(enabledLanguages).not.include('scminput')
         expect(enabledLanguages).include('typescript')
         expect(enabledLanguages).include('javascript')
     })
@@ -23,7 +21,8 @@ describe('getInlineCompletionItemProviderFilters', () => {
             '*': false,
             go: true,
             typescript: true,
-            scminput: false,
+            rust: false,
+            scminput: true,
         })
 
         const enabledLanguages = filters.map(f => f.language)

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -142,6 +142,13 @@ export async function createInlineCompletionItemProvider({
     }
 }
 
+// Languages which should be disabled, but they are not present in
+// https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
+// But they exist in the `vscode.languages.getLanguages()` return value.
+//
+// To avoid confusing users with unknown language IDs, we disable them here programmatically.
+const DISABLED_LANGUAGES = new Set(['scminput'])
+
 export async function getInlineCompletionItemProviderFilters(
     autocompleteLanguages: Record<string, boolean>
 ): Promise<vscode.DocumentFilter[]> {
@@ -149,7 +156,10 @@ export async function getInlineCompletionItemProviderFilters(
     const languageIds = await vscode.languages.getLanguages()
 
     return languageIds.flatMap(language => {
-        const enabled = language in perLanguageConfig ? perLanguageConfig[language] : isEnabledForAll
+        const enabled =
+            !DISABLED_LANGUAGES.has(language) && language in perLanguageConfig
+                ? perLanguageConfig[language]
+                : isEnabledForAll
 
         return enabled ? [{ language, scheme: 'file' }] : []
     })

--- a/vscode/src/completions/providers/createProvider.test.ts
+++ b/vscode/src/completions/providers/createProvider.test.ts
@@ -20,7 +20,7 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     chatPreInstruction: 'My name is John Doe.',
     useContext: 'embeddings',
     autocomplete: true,
-    autocompleteLanguages: { '*': true, scminput: false },
+    autocompleteLanguages: { '*': true },
     commandCodeLenses: false,
     editorTitleCommandIcon: true,
     experimentalChatPredictions: false,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -20,7 +20,6 @@ describe('getConfiguration', () => {
             autocomplete: true,
             autocompleteLanguages: {
                 '*': true,
-                scminput: false,
             },
             commandCodeLenses: false,
             editorTitleCommandIcon: true,
@@ -69,7 +68,7 @@ describe('getConfiguration', () => {
                     case 'cody.autocomplete.enabled':
                         return false
                     case 'cody.autocomplete.languages':
-                        return { '*': true, scminput: false }
+                        return { '*': true }
                     case 'cody.experimental.chatPredictions':
                         return true
                     case 'cody.commandCodeLenses':
@@ -142,7 +141,6 @@ describe('getConfiguration', () => {
             autocomplete: false,
             autocompleteLanguages: {
                 '*': true,
-                scminput: false,
             },
             experimentalChatPredictions: true,
             commandCodeLenses: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -82,7 +82,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         autocomplete: config.get(CONFIG_KEY.autocompleteEnabled, true),
         autocompleteLanguages: config.get(CONFIG_KEY.autocompleteLanguages, {
             '*': true,
-            scminput: false,
         }),
         chatPreInstruction: config.get(CONFIG_KEY.chatPreInstruction),
         commandCodeLenses: config.get(CONFIG_KEY.commandCodeLenses, false),


### PR DESCRIPTION
## Context

- Removes `scminput` from the default values of the `cody. auto-complete.languages` setting to avoid confusing users with unknown language IDs. 
- Keeps autocomplete disabled for `scminput`.
- [Slack thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1702330574550309).

## Test plan

Updated unit tests.
