### PR TITLE
Autocomplete: log raw error in the development env

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -9,7 +9,7 @@ export interface CompletionLogger {
     ):
         | undefined
         | {
-              onError: (error: string) => void
+              onError: (error: string, rawError?: unknown) => void
               onComplete: (response: string | CompletionResponse | string[] | CompletionResponse[]) => void
               onEvents: (events: Event[]) => void
           }

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -45,7 +45,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 // If the request failed with a rate limit error, wraps the
                 // error in RateLimitError.
                 function handleError(e: Error): void {
-                    log?.onError(e.message)
+                    log?.onError(e.message, e)
 
                     if (res.statusCode === 429) {
                         // Check for explicit false, because if the header is not set, there
@@ -132,7 +132,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     'Could not connect to Cody. Please ensure that Cody app is running or that you are connected to the Sourcegraph server.'
                 )
             }
-            log?.onError(error.message)
+            log?.onError(error.message, e)
             cb.onError(error)
         })
 

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -169,7 +169,7 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
                 }
 
                 const message = `error parsing streaming CodeCompletionResponse: ${error}`
-                log?.onError(message)
+                log?.onError(message, error)
                 throw new TracedError(message, traceId)
             }
         } else {
@@ -187,7 +187,7 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
                 }
             } catch (error) {
                 const message = `error parsing response CodeCompletionResponse: ${error}, response text: ${result}`
-                log?.onError(message)
+                log?.onError(message, error)
                 throw new TracedError(message, traceId)
             }
         }

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -103,11 +103,16 @@ export const logger: CompletionLogger = {
         let hasFinished = false
         let lastCompletion = ''
 
-        function onError(err: string): void {
+        function onError(err: string, rawError?: unknown): void {
             if (hasFinished) {
                 return
             }
             hasFinished = true
+
+            if (process.env.NODE_ENV === 'development') {
+                console.error(rawError)
+            }
+
             logError(
                 'CompletionLogger:onError',
                 JSON.stringify({


### PR DESCRIPTION
## Context

- Log the raw error with the stack trace to the console in the development environment.
- Part of #2288 

## Test plan

n/a
