### PR TITLE
Autocomplete: fix invalid position

### DIFF
--- a/vscode/src/completions/providers/dynamic-multiline.ts
+++ b/vscode/src/completions/providers/dynamic-multiline.ts
@@ -26,7 +26,7 @@ export function getUpdatedDocContext(params: GetUpdatedDocumentContextParams): D
 
     const firstLine = getFirstLine(initialCompletion)
     const matchingSuffixLength = getMatchingSuffixLength(firstLine, currentLineSuffix)
-    const updatedPosition = position.translate(0, firstLine.length - 1)
+    const updatedPosition = position.translate(0, Math.max(firstLine.length - 1, 0))
 
     completionPostProcessLogger.info({
         completionPostProcessId,


### PR DESCRIPTION
## Context

- Closes #2288 

## Test plan

Generate multiline completions starting with an empty new line (e.g., if it starts with a line break). 
