### PR TITLE
Autocomplete: remove stop sequences for dynamuc multliline completions

### DIFF
--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -77,30 +77,30 @@
             "encoding": "base64",
             "mimeType": "application/json",
             "size": 136,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamxhaWFvFGBkbGuoZGuoaG8aZ6RrqpieaWKclpSWZGqZZKtbW1AAAAAP//AwDIQfWASQAAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamJsYWxvFGBkbGuoZGuobG8aZ6RrqWZqbGFqbmloapiaZKtbW1AAAAAP//AwDIRFy8SQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T15:30:56.000Z",
+              "expires": "2024-12-13T06:53:30.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1601735d-dc31-424c-aa20-cc23899e1d96"
+              "value": "28dbe346-7b23-4cb6-980f-264e8687a8bc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:56.000Z",
+              "expires": "2023-12-13T07:23:30.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "WolSsnXsJ23yLdwHnR.g4kTkQdgR5cNy0mggTWQUgK0-1702308656-1-AcmR350tjUlW7L6cetYqckPJCn+NJxJ7jDSSAYwUYrYceJ11YiSWGkL4L776dyOAAFcBmXuXBkdRudYY3VFOvlE="
+              "value": "NMrHsn76cnQ1pPFR5WycIGNnMpdaoGIIq4JOMQZ2q.M-1702450410-1-AXJWSTFkKKZKk6f5qhvgDd7th9Mx7oIR0cVBi8x15EKSQ/fGDFgyYTjdJDjnxR8w0eu4Uy9ysjDb2YvizEyIDCg="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:56 GMT"
+              "value": "Wed, 13 Dec 2023 06:53:30 GMT"
             },
             {
               "name": "content-type",
@@ -129,12 +129,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1601735d-dc31-424c-aa20-cc23899e1d96; Expires=Wed, 11 Dec 2024 15:30:56 GMT; Secure"
+              "value": "sourcegraphDeviceId=28dbe346-7b23-4cb6-980f-264e8687a8bc; Expires=Fri, 13 Dec 2024 06:53:30 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=WolSsnXsJ23yLdwHnR.g4kTkQdgR5cNy0mggTWQUgK0-1702308656-1-AcmR350tjUlW7L6cetYqckPJCn+NJxJ7jDSSAYwUYrYceJ11YiSWGkL4L776dyOAAFcBmXuXBkdRudYY3VFOvlE=; path=/; expires=Mon, 11-Dec-23 16:00:56 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=NMrHsn76cnQ1pPFR5WycIGNnMpdaoGIIq4JOMQZ2q.M-1702450410-1-AXJWSTFkKKZKk6f5qhvgDd7th9Mx7oIR0cVBi8x15EKSQ/fGDFgyYTjdJDjnxR8w0eu4Uy9ysjDb2YvizEyIDCg=; path=/; expires=Wed, 13-Dec-23 07:23:30 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -150,15 +150,15 @@
             },
             {
               "name": "x-trace",
-              "value": "86381d197971dfcbe471dc8e046c5fc3"
+              "value": "90be6d83bd305bcf675b5bc612604769"
             },
             {
               "name": "x-trace-span",
-              "value": "1fd7d9fa01cb4952"
+              "value": "8ee62f7222412d43"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/86381d197971dfcbe471dc8e046c5fc3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/90be6d83bd305bcf675b5bc612604769"
             },
             {
               "name": "x-xss-protection",
@@ -182,7 +182,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833ec58c8d9b56b1-OSL"
+              "value": "834c4a5788f45e97-CGK"
             },
             {
               "name": "content-encoding",
@@ -195,8 +195,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T15:30:56.029Z",
-        "time": 236,
+        "startedDateTime": "2023-12-13T06:53:29.995Z",
+        "time": 366,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -204,407 +204,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 236
-        }
-      },
-      {
-        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 164,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "164"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 341,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "SiteIdentification",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:56.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2f072cc4-461c-407c-adc3-2b00ffc86985"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:56.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "V.yHQh9a53ACIUhj2YV.RMZMFduKzJFa1k4ImNL8Pnw-1702308656-1-AVnZDX0X283SOaQ3KjK2QF65esk+5crQY3kOi8tXKnqueihN+XpUkPJvTc9mJdTfhew6nfJ6UvPqDKDqwiPXUU4="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:56 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2f072cc4-461c-407c-adc3-2b00ffc86985; Expires=Wed, 11 Dec 2024 15:30:56 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=V.yHQh9a53ACIUhj2YV.RMZMFduKzJFa1k4ImNL8Pnw-1702308656-1-AVnZDX0X283SOaQ3KjK2QF65esk+5crQY3kOi8tXKnqueihN+XpUkPJvTc9mJdTfhew6nfJ6UvPqDKDqwiPXUU4=; path=/; expires=Mon, 11-Dec-23 16:00:56 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "cd30c91bb0335a9c931d58fbdf395579"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "cae10269f013a0a1"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cd30c91bb0335a9c931d58fbdf395579"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec58fa87b5687-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:56.545Z",
-        "time": 215,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 215
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 128,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 128,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:56.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "793f4e80-c325-4d86-bb5e-2b661a688dc6"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:56.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "_e3tqTv6ZJoEVgM1Rkyf1psb6_cGq.ywAEYNic4G9y8-1702308656-1-AQKzkz+2i9vpAbdWDCmThNPsjSCdMZyv+oPEycs8KGxl85tBPi6DvcGhEf6OUN6A6nHttuWF8P2ZHSl1YxnrMHY="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:56 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=793f4e80-c325-4d86-bb5e-2b661a688dc6; Expires=Wed, 11 Dec 2024 15:30:56 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=_e3tqTv6ZJoEVgM1Rkyf1psb6_cGq.ywAEYNic4G9y8-1702308656-1-AQKzkz+2i9vpAbdWDCmThNPsjSCdMZyv+oPEycs8KGxl85tBPi6DvcGhEf6OUN6A6nHttuWF8P2ZHSl1YxnrMHY=; path=/; expires=Mon, 11-Dec-23 16:00:56 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "560b11117861c17f2348a25d6701d03c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4725d5030fbcca26"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/560b11117861c17f2348a25d6701d03c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec58fbebab500-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:56.555Z",
-        "time": 214,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 214
+          "wait": 366
         }
       },
       {
@@ -681,26 +281,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T15:30:56.000Z",
+              "expires": "2024-12-13T06:53:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0c05143b-8b0c-45c2-b3d0-c6fee3199fbf"
+              "value": "fc31b0f4-5042-4830-aff6-48ee00444aaf"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:56.000Z",
+              "expires": "2023-12-13T07:23:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3PYp4ZnDMRoDovrekN_jYU7d9Ae1ci4xJF08GyaiBEo-1702308656-1-AaldU8uxFd8pVjUupMPZ8vook3/NKgeXcGMSmDArNR0jE3oGClVRrG6GtMKEdSnpjKvtyQMwdV9e3PapdflRX5E="
+              "value": "vIqX3fqodCegLqYJFi_4GkT1dDWRUqya99aqeQ9mKf8-1702450411-1-AVllAInMcITr8HvVIXoi41l4geDJMLGzBafwvkDRdQLwxMDYloOU1N1Tf84a/RFOGB6dW+huLVZ5S8lJXgBBB3E="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:56 GMT"
+              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
             },
             {
               "name": "content-type",
@@ -729,12 +329,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0c05143b-8b0c-45c2-b3d0-c6fee3199fbf; Expires=Wed, 11 Dec 2024 15:30:56 GMT; Secure"
+              "value": "sourcegraphDeviceId=fc31b0f4-5042-4830-aff6-48ee00444aaf; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3PYp4ZnDMRoDovrekN_jYU7d9Ae1ci4xJF08GyaiBEo-1702308656-1-AaldU8uxFd8pVjUupMPZ8vook3/NKgeXcGMSmDArNR0jE3oGClVRrG6GtMKEdSnpjKvtyQMwdV9e3PapdflRX5E=; path=/; expires=Mon, 11-Dec-23 16:00:56 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=vIqX3fqodCegLqYJFi_4GkT1dDWRUqya99aqeQ9mKf8-1702450411-1-AVllAInMcITr8HvVIXoi41l4geDJMLGzBafwvkDRdQLwxMDYloOU1N1Tf84a/RFOGB6dW+huLVZ5S8lJXgBBB3E=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -750,15 +350,15 @@
             },
             {
               "name": "x-trace",
-              "value": "6d15670de00cdf080506004c5d299683"
+              "value": "cdc7aed29e418f1993923c4ffc9a88a4"
             },
             {
               "name": "x-trace-span",
-              "value": "43b891af3e7802d2"
+              "value": "17032974f2e29a32"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6d15670de00cdf080506004c5d299683"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cdc7aed29e418f1993923c4ffc9a88a4"
             },
             {
               "name": "x-xss-protection",
@@ -782,7 +382,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833ec58fb9dc5693-OSL"
+              "value": "834c4a5c9bce6cf8-CGK"
             },
             {
               "name": "content-encoding",
@@ -795,8 +395,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T15:30:56.553Z",
-        "time": 218,
+        "startedDateTime": "2023-12-13T06:53:30.830Z",
+        "time": 404,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -804,7 +404,607 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 218
+          "wait": 404
+        }
+      },
+      {
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 155,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "155"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 128,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 128,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:31.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1b298240-7609-49a7-9ad1-a44bdb9d7b12"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:31.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "0V3_mv3tj5twFQt7cGENiwD7VXyWQPlczq2BqnYYv98-1702450411-1-AYYHp2H2tM/Gl28D9gNdEyvydO1T3SjUNff/7vl53Q4noMXRlAov2JJPcbBaRatXqriiTmFyITg0Bz/vRnEWQKI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1b298240-7609-49a7-9ad1-a44bdb9d7b12; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=0V3_mv3tj5twFQt7cGENiwD7VXyWQPlczq2BqnYYv98-1702450411-1-AYYHp2H2tM/Gl28D9gNdEyvydO1T3SjUNff/7vl53Q4noMXRlAov2JJPcbBaRatXqriiTmFyITg0Bz/vRnEWQKI=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "f2035473d7caeadfd5d8d114b2684377"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "557b760abd3fce70"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f2035473d7caeadfd5d8d114b2684377"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a5c9bdf6d0a-CGK"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:30.831Z",
+        "time": 428,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 428
+        }
+      },
+      {
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 164,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "164"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 341,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "SiteIdentification",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:31.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3dda4910-ad74-4a03-b52b-cf4ae784f7fe"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:31.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "D08gIB594NA_ccoNSgdXhja72_43Dm8juZf.8a.J_ag-1702450411-1-Ab2Dzf0Gih+BEh5OKhBN3innI+prpbqB+43E/A3tiiuntlaQIpvGXtZDBNrMkAKTJxnZ+95J2C1iaocW6ZfxsKU="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3dda4910-ad74-4a03-b52b-cf4ae784f7fe; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=D08gIB594NA_ccoNSgdXhja72_43Dm8juZf.8a.J_ag-1702450411-1-Ab2Dzf0Gih+BEh5OKhBN3innI+prpbqB+43E/A3tiiuntlaQIpvGXtZDBNrMkAKTJxnZ+95J2C1iaocW6ZfxsKU=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "a160b4fc3e89f21470d9ebb48a75b472"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3734242e020b4a1c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a160b4fc3e89f21470d9ebb48a75b472"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a5c9c8bbe71-CGK"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:30.826Z",
+        "time": 445,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 445
+        }
+      },
+      {
+        "_id": "badec8750918600cec1a4695340e4feb",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 444,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "444"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.extension\",\"action\":\"installed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:31.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2cab990e-592f-4d04-8b85-d02e266b18dd"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:31.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "V1j9_INFDLbRZfLF3sjFvGziJS0elE_dHUQpYhobSoY-1702450411-1-Adjt0A5GEOsKWRz0WNFZwIuP3YgDJGk3XIWAuL4djJzYXKzF06X/AEcDsBILXrywrflewgvq4YPrJVqV1noDar8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2cab990e-592f-4d04-8b85-d02e266b18dd; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=V1j9_INFDLbRZfLF3sjFvGziJS0elE_dHUQpYhobSoY-1702450411-1-Adjt0A5GEOsKWRz0WNFZwIuP3YgDJGk3XIWAuL4djJzYXKzF06X/AEcDsBILXrywrflewgvq4YPrJVqV1noDar8=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e238d4edbad6fcbca02d09efc0c7668b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "ff0414fd7b09bcbe"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e238d4edbad6fcbca02d09efc0c7668b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a5f089f6d03-CGK"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:31.227Z",
+        "time": 413,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 413
         }
       },
       {
@@ -872,35 +1072,35 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
         },
         "response": {
-          "bodySize": 295,
+          "bodySize": 303,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 295,
-            "text": "[\"H4sIAAAAAAAAAzSOwWrDMBBEf6XM2cQtOJAKTHvJLTWhwaHXjbSNFGRLrKSAMf73krq9zczhzZthKBPUDF1EeMx9YnlUZ6Bw/uq8voXn7tY3H9e2RQVL6czivh2b/UDOQ2UpXMG4FD1NHQ0MhaN13sX4dIqOU0IFulMm6T8PULA5x6Tqet3S5uqyLZeSWHQYM495o8NQl7rZ7ravL2/3tkEFHcx0lLAf6eLZ/L9GcQPJ9Gcyg9cAy96H9w==\",\"uFqkX4kHFMuyLD8AAAD//wMAiyRMdPMAAAA=\"]"
+            "size": 303,
+            "text": "[\"H4sIAAAAAAAAAyyOy2rDMBREf6XMWsSFmBIEpqU0u+I+IKHbG+nGVitb5koyCON/L266mxk4w1lgKRH0ApNFeEynyLJVZ6Fx/mq9+Q7l7cXU7UfTQKGneGZxV8f2OJDz0EkyK1gXJ0+lpYE3kDxLuXvOHf2EGQo0UyI5fb5Co09pirqqblvcdS71+ZIjiwlj4jHtTBiqXO0P9cP+cP84NzUUTLDlXcJxpItnC30lH1lhEjeQlH+XBXwLmA==\",\"/wyeYshiuBOa+u0V67quvwAAAP//AwDxGoXq9AAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T15:30:56.000Z",
+              "expires": "2024-12-13T06:53:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ecee1876-a60d-4c04-895e-1fcf182dcb37"
+              "value": "3704feec-d1a6-43a3-af84-a03c388ec543"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:56.000Z",
+              "expires": "2023-12-13T07:23:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "v6c3ZJhYldqNwaTlv4ZJ_rX0NUrmSo3okguvJUglQe0-1702308656-1-AVK+PYFeVtBb690XG6RqzkCtqSWcj7+thB5MLzX95tl6gGrHZy3BECmMRDVmuBv3VXmUQ9CyHxU4WZuUHaPT3ZE="
+              "value": "o4.PU_Hh7jUekia3Kc6IdJYydNujyd_U2HF7vASMwpQ-1702450411-1-AWqsBhyKaFI/smeAwtZWvESg7kqeh5ciob149xdQPLoVh3r32vSO6s2wM7I7psCAOG1CgBUeeD7cwwWqvhFiqHQ="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:56 GMT"
+              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
             },
             {
               "name": "content-type",
@@ -929,12 +1129,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ecee1876-a60d-4c04-895e-1fcf182dcb37; Expires=Wed, 11 Dec 2024 15:30:56 GMT; Secure"
+              "value": "sourcegraphDeviceId=3704feec-d1a6-43a3-af84-a03c388ec543; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=v6c3ZJhYldqNwaTlv4ZJ_rX0NUrmSo3okguvJUglQe0-1702308656-1-AVK+PYFeVtBb690XG6RqzkCtqSWcj7+thB5MLzX95tl6gGrHZy3BECmMRDVmuBv3VXmUQ9CyHxU4WZuUHaPT3ZE=; path=/; expires=Mon, 11-Dec-23 16:00:56 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=o4.PU_Hh7jUekia3Kc6IdJYydNujyd_U2HF7vASMwpQ-1702450411-1-AWqsBhyKaFI/smeAwtZWvESg7kqeh5ciob149xdQPLoVh3r32vSO6s2wM7I7psCAOG1CgBUeeD7cwwWqvhFiqHQ=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -950,15 +1150,15 @@
             },
             {
               "name": "x-trace",
-              "value": "431a046fa504643d5277e7c7271c3a08"
+              "value": "3f9c6876ce536112f84e63ce624583cc"
             },
             {
               "name": "x-trace-span",
-              "value": "6dfe890ba9feff6a"
+              "value": "82e4f5ea10f4de6f"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/431a046fa504643d5277e7c7271c3a08"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3f9c6876ce536112f84e63ce624583cc"
             },
             {
               "name": "x-xss-protection",
@@ -982,7 +1182,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833ec5910b021bfe-OSL"
+              "value": "834c4a5f4d56be88-CGK"
             },
             {
               "name": "content-encoding",
@@ -995,8 +1195,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T15:30:56.775Z",
-        "time": 221,
+        "startedDateTime": "2023-12-13T06:53:31.263Z",
+        "time": 400,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1004,7 +1204,4873 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 221
+          "wait": 400
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 335,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 611,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 611,
+            "text": "[\"H4sIAAAAAAAA/5RUW27cMAy8i7/DC+wBcomiH7Q0axErSw5JxTGC3L1QagRJCnvTPwMacR7U+HWI7DxcXgc8c27siI9gb4rHzJMNl1+vQ+EZw2UINW60YqSQ2IeHoeMxXFwb3h6+ojqC5hpu5LBP2Ctn+ww2sIZEUpbmZKmulMS86nY4fr+RtlElHqI4BJjJmEFXySBX4Fxx94UoXpUUQRbYCb64sjmFOi9ZuDjZVpxfKMmUskzJpUzH\",\"pj/4TCJG1ntelcvty8DvZuMshbhw3lyCEQqPGcfh7GPrWqCWZDkPZtF6CPjLRJhHRNLa/DjknbRnh+I0siFS5jJRhCO41HInMbwsUJlRnPO5ZG5e33cDB0Wxd5GKsIUsZaJ6pUXxLLUZKZ4azO2Y+3u6gUP6mBqP7+3ZmCt47rSTOI25H/5cfA+o8dQ/HCUc1+KpSbiROauT16Z0rdpHJRSX0FtNzaAnPvcFFax0w7ZWPfE25jrS0nXZKh4SsYKtF1g9ND+ujiNjhuv7Nqve+Yt8icKVw91aHZ9OuoR7jzNibD/pLef/eoBb4VkCzS27ZCmg/Uhq+Wcfv9/e/gQAAP//dgwcdJIFAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:31.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "0fe758af-abaf-401c-8556-7b20539b3007"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "QQcNOSQ8ngkYOIW8hnFDTinAEjFZE58CrPfVUkdKny8-1702450412-1-AakqEbw5EZq8XLxEtRJNjddiOqfxg4tsrO0HEm3dMyh2XrY83WMBdz96JK8GiKB4zLapl/sXCZP13SuN8nFAyh8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=0fe758af-abaf-401c-8556-7b20539b3007; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=QQcNOSQ8ngkYOIW8hnFDTinAEjFZE58CrPfVUkdKny8-1702450412-1-AakqEbw5EZq8XLxEtRJNjddiOqfxg4tsrO0HEm3dMyh2XrY83WMBdz96JK8GiKB4zLapl/sXCZP13SuN8nFAyh8=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "da7780390b1dc583f8e51dfc5fb90341"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e6234e3a491521ee"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/da7780390b1dc583f8e51dfc5fb90341"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a61ed8cbe99-CGK"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:31.675Z",
+        "time": 366,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 366
+        }
+      },
+      {
+        "_id": "68618dc68610496fb5623c6778ea6c25",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 177,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "177"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:31.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2eaaf04d-1c4a-48c7-85ae-f81789882bc2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "QeGz2SymEmLmHuiFQDRj1tJ8lq6kYyGji4ZGyrJocOE-1702450412-1-AREKHj4UytqzqwYFtGKBZul6Opx6peY9MQR6duLLbpQyRShY52rbyFWcON2EXsv7lnZwA/khOQhycuzsj4T1tLI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2eaaf04d-1c4a-48c7-85ae-f81789882bc2; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=QeGz2SymEmLmHuiFQDRj1tJ8lq6kYyGji4ZGyrJocOE-1702450412-1-AREKHj4UytqzqwYFtGKBZul6Opx6peY9MQR6duLLbpQyRShY52rbyFWcON2EXsv7lnZwA/khOQhycuzsj4T1tLI=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c8bc32e42b3f9c456765270143ce19fc"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "bd59750984e295cc"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c8bc32e42b3f9c456765270143ce19fc"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a61e92b6cfa-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:31.677Z",
+        "time": 367,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 367
+        }
+      },
+      {
+        "_id": "457ee78ea180e105401d1713fa553a05",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 171,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "171"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:31.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "a531f90e-cc3c-4056-847e-7156c76aa857"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "aJwLvpeYdrcqQQFhXEOyRB4ccTSyC7PNsm6XO9k_Lyw-1702450412-1-AStll763n8HEMUpsaruTqWg7vG4eSqtkbkqK1aHA8L51ODxed7uC8gryFBnv5IsT0QJs1KONp1KYC5gIUBTWfz8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=a531f90e-cc3c-4056-847e-7156c76aa857; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=aJwLvpeYdrcqQQFhXEOyRB4ccTSyC7PNsm6XO9k_Lyw-1702450412-1-AStll763n8HEMUpsaruTqWg7vG4eSqtkbkqK1aHA8L51ODxed7uC8gryFBnv5IsT0QJs1KONp1KYC5gIUBTWfz8=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "499d760db889d8de9af66690335bc846"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "1ca8508596fcaeeb"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/499d760db889d8de9af66690335bc846"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a61eebf6d18-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:31.680Z",
+        "time": 384,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 384
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "75cb1a81-4b5e-4377-bd59-82bd9ed9623d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Nq88i4yzg0I1rj0sYrLla0vU4Y09K7mT1VAA5CWt5ic-1702450412-1-AQJXmD8V/ZNNVl0A91P/qvO/gLYjR6T/t5Npa4kyFVTn4gpCP1d5iY+xUGqhbJzTV5/Nghl/GhwWe8k0tcrHK+4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=75cb1a81-4b5e-4377-bd59-82bd9ed9623d; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Nq88i4yzg0I1rj0sYrLla0vU4Y09K7mT1VAA5CWt5ic-1702450412-1-AQJXmD8V/ZNNVl0A91P/qvO/gLYjR6T/t5Npa4kyFVTn4gpCP1d5iY+xUGqhbJzTV5/Nghl/GhwWe8k0tcrHK+4=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d3a4fe9afc19fb2186de03244785a2fe"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "2720d44f354ba6da"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d3a4fe9afc19fb2186de03244785a2fe"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a647a3f5eaa-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.075Z",
+        "time": 381,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 381
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "031c7a55-3c42-49d2-97d9-78b79f4cdc77"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "tF_6.yTh1PpANhM_KGaKit59CayYTFvv85EoSB.GYbY-1702450412-1-AWXzWwzPcPQxFJURoLq+KY5CUkBgLIeDwl4wMbIR+0vzjPROI/tfpjl/0yFWaz6LSoWRVBECU9YAzU8HMkf31l4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=031c7a55-3c42-49d2-97d9-78b79f4cdc77; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=tF_6.yTh1PpANhM_KGaKit59CayYTFvv85EoSB.GYbY-1702450412-1-AWXzWwzPcPQxFJURoLq+KY5CUkBgLIeDwl4wMbIR+0vzjPROI/tfpjl/0yFWaz6LSoWRVBECU9YAzU8HMkf31l4=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8b2ea7b5b7630971384a217611be223e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "920ea16f934311af"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8b2ea7b5b7630971384a217611be223e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a647fc94ac5-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.080Z",
+        "time": 378,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 378
+        }
+      },
+      {
+        "_id": "f183d7475b363dc45d23134c3118a915",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 180,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "180"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "df189f46-aa93-4124-a6c5-664c5523f9c7"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "IqgREh4plCj8hBOZ0BpGEUdPPwG5zpGZyc7r_kDvnw0-1702450412-1-AVkNUwUF+VCAY6nOHzYS2+ysG/0+1NstWSz1RYWUotScNnXB+l2ExZWtXErH0x4lJMTnV4CL9XPUVuMOTgLwHEw="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=df189f46-aa93-4124-a6c5-664c5523f9c7; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=IqgREh4plCj8hBOZ0BpGEUdPPwG5zpGZyc7r_kDvnw0-1702450412-1-AVkNUwUF+VCAY6nOHzYS2+ysG/0+1NstWSz1RYWUotScNnXB+l2ExZWtXErH0x4lJMTnV4CL9XPUVuMOTgLwHEw=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1b2a5ccd0da2ca409270ff2a038c6b55"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "049e027e242f1fa8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1b2a5ccd0da2ca409270ff2a038c6b55"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a647d026cf2-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.082Z",
+        "time": 379,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 379
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "29748cda-6938-40df-8009-9db886e871da"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "yKDExzhR.Sqw84QJ7ezg2Wl76BPYaNgg5U4QRqmZ3lc-1702450412-1-Ad0dSYA8AzjJWoVhwEnZUkUGzrPZn0YXM0LgHTi1JguotJuIeHY1A4LtzA+Epxnqi4j0R5BYvcvklHD2/uazpFA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=29748cda-6938-40df-8009-9db886e871da; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=yKDExzhR.Sqw84QJ7ezg2Wl76BPYaNgg5U4QRqmZ3lc-1702450412-1-Ad0dSYA8AzjJWoVhwEnZUkUGzrPZn0YXM0LgHTi1JguotJuIeHY1A4LtzA+Epxnqi4j0R5BYvcvklHD2/uazpFA=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e5b593dc48b4d07c6ebba530b2a9f59a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "503413e7735f961e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e5b593dc48b4d07c6ebba530b2a9f59a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a647ced6cf1-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.077Z",
+        "time": 386,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 386
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "4a0ccab8-4003-420f-bec3-2ad7da70b354"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "WHEOuWkFa2lTYfgVERGuqsAiioTjBPdnqXYtqFyrldA-1702450412-1-AUiQLWtIkcG0lI8nQtkmQC3WLCH3cfYJGYcTFiJmyihG7Ufe1FklmSz9rZfmNM3jYOfEk3rQugiMBQxcTHT89fE="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4a0ccab8-4003-420f-bec3-2ad7da70b354; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=WHEOuWkFa2lTYfgVERGuqsAiioTjBPdnqXYtqFyrldA-1702450412-1-AUiQLWtIkcG0lI8nQtkmQC3WLCH3cfYJGYcTFiJmyihG7Ufe1FklmSz9rZfmNM3jYOfEk3rQugiMBQxcTHT89fE=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "60520684ff255d88db59702765454545"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5ee93de3f835d2a2"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/60520684ff255d88db59702765454545"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a647ad14ab5-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.078Z",
+        "time": 433,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 433
+        }
+      },
+      {
+        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 160,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "160"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "0ebe16ae-ab16-4686-96ff-f5b5551bef47"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "HxOWljP9nbMgW55I7S06_eIrGLDkEzrT0nWtftvvO14-1702450413-1-AYB1Kanm6kYGYiIB+yrCmEJEk0nH7WE5lRT+JAWPlTYHoSDku8k81FwzKPnDVDEiqXlHjm2cU0+MRWugtSs8HU4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=0ebe16ae-ab16-4686-96ff-f5b5551bef47; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=HxOWljP9nbMgW55I7S06_eIrGLDkEzrT0nWtftvvO14-1702450413-1-AYB1Kanm6kYGYiIB+yrCmEJEk0nH7WE5lRT+JAWPlTYHoSDku8k81FwzKPnDVDEiqXlHjm2cU0+MRWugtSs8HU4=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "39bfad799b22b51a32c9c402a3c878a4"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "bdda7ba91fdc795d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/39bfad799b22b51a32c9c402a3c878a4"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6958e66d12-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.856Z",
+        "time": 365,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 365
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "e14af5e1-5b3e-49db-8ff6-b153e6961f7e"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "wjnYDzucyFiYDgqECDrlxD6wWBqBq8kXw.xEu3dBft8-1702450413-1-AVx3F/fHL7o8oDrnMP4GQFRkASP4BT8JKoFORxl+sjW1vmI+fi4Zf2+CjCNTsYPpcRKYDf+R5qdVDDZt8C5JqiM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=e14af5e1-5b3e-49db-8ff6-b153e6961f7e; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=wjnYDzucyFiYDgqECDrlxD6wWBqBq8kXw.xEu3dBft8-1702450413-1-AVx3F/fHL7o8oDrnMP4GQFRkASP4BT8JKoFORxl+sjW1vmI+fi4Zf2+CjCNTsYPpcRKYDf+R5qdVDDZt8C5JqiM=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "25d08161febdb4acf0b313e574dbb58b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "fbda195972ec3bdd"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/25d08161febdb4acf0b313e574dbb58b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a695eb16d1e-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.864Z",
+        "time": 364,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 364
+        }
+      },
+      {
+        "_id": "abf571b71caf2e416903dc2620866f23",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 436,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "436"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "048cc3bf-3b8c-411e-8146-d7dec685a798"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "KyAhQYDp5eTFrGo2VVwgsU4JHL8O1W48RrXbHRGllJg-1702450413-1-AWeraRrv+68/qdyj70y5ppzrbOMeuoJReqoTNOAOyX23YhT8Mq3GktQUQyLYquFYd7e3Qyte16j4WwRw8dHT5Sw="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=048cc3bf-3b8c-411e-8146-d7dec685a798; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=KyAhQYDp5eTFrGo2VVwgsU4JHL8O1W48RrXbHRGllJg-1702450413-1-AWeraRrv+68/qdyj70y5ppzrbOMeuoJReqoTNOAOyX23YhT8Mq3GktQUQyLYquFYd7e3Qyte16j4WwRw8dHT5Sw=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1e7cb3debb12b6ca0519ddf08a8221e7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4ec2c9eea9db5fe9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1e7cb3debb12b6ca0519ddf08a8221e7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6979106d12-CGK"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.882Z",
+        "time": 352,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 352
+        }
+      },
+      {
+        "_id": "37c9819d661e7a7c7feafb45c8579b01",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1188,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1188"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"bc4c317e-e047-4adf-a4b8-444f3a09f59c\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "99dc8a86-d0e8-4941-8bc9-80472fa27dc0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XZ_iqK3GhL4Su.DX._Yhs4Zz1zs9LZJJydWGRraBN88-1702450413-1-Ab7g3AT2VPMTaKTeg5GhhpnYJORP5QG8mGWJY4UL1O5kz87MfjSvAW3zWTiqnqzOAlqBXG/cZjVAP+Z0Sy1fDSk="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=99dc8a86-d0e8-4941-8bc9-80472fa27dc0; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=XZ_iqK3GhL4Su.DX._Yhs4Zz1zs9LZJJydWGRraBN88-1702450413-1-Ab7g3AT2VPMTaKTeg5GhhpnYJORP5QG8mGWJY4UL1O5kz87MfjSvAW3zWTiqnqzOAlqBXG/cZjVAP+Z0Sy1fDSk=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "154f5c960ca477243c2a8c9d8cfc5c7b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "103148f75e492c43"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/154f5c960ca477243c2a8c9d8cfc5c7b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a695f244ac7-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.850Z",
+        "time": 411,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 411
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "248e3705-0e8c-49d3-bc05-de200451b561"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "24PNgHSS6VwCTn05yJl7giBZ0R3PE24BEc1vw30er1s-1702450413-1-AVwVp/3O9CxbTvH61UcmUKLsCoKxl0bFfCy39XeT0wAyURA7WHLyaRxgUGbv/B3Kw1Nufz5jtjisvrN6uPZHcFs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=248e3705-0e8c-49d3-bc05-de200451b561; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=24PNgHSS6VwCTn05yJl7giBZ0R3PE24BEc1vw30er1s-1702450413-1-AVwVp/3O9CxbTvH61UcmUKLsCoKxl0bFfCy39XeT0wAyURA7WHLyaRxgUGbv/B3Kw1Nufz5jtjisvrN6uPZHcFs=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e31bd09c80e0ddb721a1de8a347b1b6d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "423e6093c614754e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e31bd09c80e0ddb721a1de8a347b1b6d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a695aa96cf0-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.865Z",
+        "time": 398,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 398
+        }
+      },
+      {
+        "_id": "85ed16d9691aa5c6052296dcbf9bd756",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 439,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "439"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "3ad3a13a-a3d8-4e5e-aa08-afe1c9e971e4"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ISa8S._pMJGqLSjip8uB9FWs93Jwogqm4FwcxO3JqVQ-1702450413-1-AemYtIJ8MaWEdNlFxT4YgqwZsFNSLhST6N1RhoW/IeO9qq21MaXn1l+uXO8DuM9bzzhJVQ8DFTYWpHCLR9sJGKM="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=3ad3a13a-a3d8-4e5e-aa08-afe1c9e971e4; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ISa8S._pMJGqLSjip8uB9FWs93Jwogqm4FwcxO3JqVQ-1702450413-1-AemYtIJ8MaWEdNlFxT4YgqwZsFNSLhST6N1RhoW/IeO9qq21MaXn1l+uXO8DuM9bzzhJVQ8DFTYWpHCLR9sJGKM=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8a3dbc9bd946a1562e06c9b2a4015939"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c24c24f5da35fcee"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a3dbc9bd946a1562e06c9b2a4015939"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a694bdc6d16-CGK"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.852Z",
+        "time": 436,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 436
+        }
+      },
+      {
+        "_id": "fbf04e275fb8ab7b5f9dc1eaa9d4ce5b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1186,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1186"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"70bc8d64-59d0-465d-8245-358d9660f25d\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "8c13ed66-386f-432d-8a6a-5bc0803d825e"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XKiRMd_uvyZqF_i1H3FCVtipahlEPZXZ2LxIS_bBYFc-1702450413-1-AZ0HyZkseUkFLoam0JKVsCGmu0MKY/5JzPJq75ylL1ckXnRvKIrGQbDw0dd/8EF45qP8VBgHQrUzjs8W1QWmRcw="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=8c13ed66-386f-432d-8a6a-5bc0803d825e; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=XKiRMd_uvyZqF_i1H3FCVtipahlEPZXZ2LxIS_bBYFc-1702450413-1-AZ0HyZkseUkFLoam0JKVsCGmu0MKY/5JzPJq75ylL1ckXnRvKIrGQbDw0dd/8EF45qP8VBgHQrUzjs8W1QWmRcw=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "5967b25c858dff8d523135440e0e546a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4dcd4436d3bcdf35"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5967b25c858dff8d523135440e0e546a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a697d145ea8-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:32.881Z",
+        "time": 434,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 434
+        }
+      },
+      {
+        "_id": "ac7fc975d31f02e814346a770195c756",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 192,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "192"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "e094ec9d-da0f-42f6-93ec-2f27674d1111"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "3C5adi3UgkS2gz_ylC8n44dDd2wdKvY5VGaJibICfxM-1702450414-1-Adi79mR9Qv3QhxApYbz+AMVpzV8ULlJhDCCqTKiduRJEdh0lU0O/Y6Zvu/EKRjpMxtYFg1RlC5sGov4MFIzi+O0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=e094ec9d-da0f-42f6-93ec-2f27674d1111; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=3C5adi3UgkS2gz_ylC8n44dDd2wdKvY5VGaJibICfxM-1702450414-1-Adi79mR9Qv3QhxApYbz+AMVpzV8ULlJhDCCqTKiduRJEdh0lU0O/Y6Zvu/EKRjpMxtYFg1RlC5sGov4MFIzi+O0=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d87fd3f020675080616b4f58731fc335"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4b750c37a4892dba"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d87fd3f020675080616b4f58731fc335"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6ea9656cf8-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:33.711Z",
+        "time": 349,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 349
+        }
+      },
+      {
+        "_id": "103c65b93dfa88c72eea86b3b023599e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "92fd89a1-1714-440c-89be-b6f5d7c9b408"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "S7WTnjOlzFYeaVvrKCnWS5VYnii_gTgCFf8S_wqem9M-1702450414-1-AXk3Wt7fjbWbX2MO0qk2cghhI+SttJi87TfNrWEilkaacX+IKEYXQeyGtjbF4v71EmvXosS6xG5rR7YiX8zRFMs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=92fd89a1-1714-440c-89be-b6f5d7c9b408; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=S7WTnjOlzFYeaVvrKCnWS5VYnii_gTgCFf8S_wqem9M-1702450414-1-AXk3Wt7fjbWbX2MO0qk2cghhI+SttJi87TfNrWEilkaacX+IKEYXQeyGtjbF4v71EmvXosS6xG5rR7YiX8zRFMs=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "377a53adf85f89a488b91e9f86ba0568"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "f21cf4e0184fde62"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/377a53adf85f89a488b91e9f86ba0568"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6eafa23573-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:33.709Z",
+        "time": 429,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 429
+        }
+      },
+      {
+        "_id": "4cb0e95333a7b013a23cbf416464bd74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "7c74d2a1-142d-44fb-8b7e-83db23a9b0cc"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": ".QvxDGWpcf9V33h6JfN3OZ5FUnLflmV00Png4vaa9cM-1702450414-1-AU061LM68efWDdNy3Wc7RkiPrSTk08wcyWzwzklScQrzCYBvQ2RA8F2jr4uXZiS9V/ZUJE4qsxJtL/3dstH5nf8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=7c74d2a1-142d-44fb-8b7e-83db23a9b0cc; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=.QvxDGWpcf9V33h6JfN3OZ5FUnLflmV00Png4vaa9cM-1702450414-1-AU061LM68efWDdNy3Wc7RkiPrSTk08wcyWzwzklScQrzCYBvQ2RA8F2jr4uXZiS9V/ZUJE4qsxJtL/3dstH5nf8=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8cd941b81cd61bae24c4153a46683708"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4d4e89c37d2fffa8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8cd941b81cd61bae24c4153a46683708"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6eabb97239-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:33.708Z",
+        "time": 434,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 434
+        }
+      },
+      {
+        "_id": "3bfde46a074296956deef9dbd207df0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ae02fdc5-4304-4423-a0f6-68446e564772"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "sskMGNDMegCf4eaUJjjlRBhpI_vmrh2NF28IFI0XmVY-1702450414-1-AZaU1WT91XfjgGxjVWeY9CIoIT55nkPwYE31M1uN0EwUemiJMAlaBHXJgCslt2c2OyKmhzxW2NOrbVFriJ26FYk="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ae02fdc5-4304-4423-a0f6-68446e564772; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=sskMGNDMegCf4eaUJjjlRBhpI_vmrh2NF28IFI0XmVY-1702450414-1-AZaU1WT91XfjgGxjVWeY9CIoIT55nkPwYE31M1uN0EwUemiJMAlaBHXJgCslt2c2OyKmhzxW2NOrbVFriJ26FYk=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "51263bbd6237c8c9d6a56c3066167874"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5a8fd383ac6d0acc"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/51263bbd6237c8c9d6a56c3066167874"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6eae5d356e-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:33.710Z",
+        "time": 432,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 432
+        }
+      },
+      {
+        "_id": "b0631b180e044100e370fb91fff490ce",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"70bc8d64-59d0-465d-8245-358d9660f25d\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "03f3bf33-feef-47c3-b6d4-0bfbc8463430"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "KO_oTkjSclbuaGOrLU7iBex6xPayl9eNxZQdv70TrI8-1702450414-1-AaRMFylLxVMWsVodbCvUihblJkDUGEBy5MKVF+SO5arHbF3cc4nGFjlpBCarmLrc+A7zCieNpR/MMTT8prXphe8="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=03f3bf33-feef-47c3-b6d4-0bfbc8463430; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=KO_oTkjSclbuaGOrLU7iBex6xPayl9eNxZQdv70TrI8-1702450414-1-AaRMFylLxVMWsVodbCvUihblJkDUGEBy5MKVF+SO5arHbF3cc4nGFjlpBCarmLrc+A7zCieNpR/MMTT8prXphe8=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c53d5c4a387ea0b39d3db6659946871c"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "863e8f51db1badb7"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c53d5c4a387ea0b39d3db6659946871c"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6ea9255e9a-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:33.701Z",
+        "time": 442,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 442
+        }
+      },
+      {
+        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 190,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "190"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ed384a08-c875-4e2e-a103-d7cb4be88982"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "BSIO_x9feR0oFDrqXezP8EnOrZCiXvG4JExbVLDhhP4-1702450414-1-Afz6WUfMBbnpChwyQ/itKKHzQFktdn4eBmlWT4P/L6wxZoZknMwEXkB2Nx8LAGmhi4Te1tp+Knl6sLE7VCmFPqs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ed384a08-c875-4e2e-a103-d7cb4be88982; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=BSIO_x9feR0oFDrqXezP8EnOrZCiXvG4JExbVLDhhP4-1702450414-1-Afz6WUfMBbnpChwyQ/itKKHzQFktdn4eBmlWT4P/L6wxZoZknMwEXkB2Nx8LAGmhi4Te1tp+Knl6sLE7VCmFPqs=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4fdfb603dedd61b1d35f24a54aa2ef22"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c395b79f73ecb9fe"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4fdfb603dedd61b1d35f24a54aa2ef22"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a6eac8bbea7-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:33.707Z",
+        "time": 469,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 469
+        }
+      },
+      {
+        "_id": "7449140909c921a511332d4c1de94c1f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 182,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "5990ee44-36bc-46f6-9c0c-acf400b17cf6"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:35.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "4QPAlL.nea4FAdVoYntc8W62UCeJYMrnzKLdRq7dg_w-1702450415-1-ARxBAbx1EluI5ktUf8ntWvfZSqOYPJioM0xnuL01Lwp9NDke2eO0rmk2QMK/UtoscmhTPVJHOvRjjf5u88SHiKw="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=5990ee44-36bc-46f6-9c0c-acf400b17cf6; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=4QPAlL.nea4FAdVoYntc8W62UCeJYMrnzKLdRq7dg_w-1702450415-1-ARxBAbx1EluI5ktUf8ntWvfZSqOYPJioM0xnuL01Lwp9NDke2eO0rmk2QMK/UtoscmhTPVJHOvRjjf5u88SHiKw=; path=/; expires=Wed, 13-Dec-23 07:23:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8a43eb40de9d3b9e422320012a9183ee"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "fe6b698151814da7"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a43eb40de9d3b9e422320012a9183ee"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a73df934ad0-CGK"
+            }
+          ],
+          "headersSize": 1129,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:34.542Z",
+        "time": 408,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 408
+        }
+      },
+      {
+        "_id": "9fa50298412f03abaf099d541c08a7dc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 297,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip;q=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "297"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 332,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"timeoutMs\":15000,\"maxTokensToSample\":256,\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stream\":true}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/code"
+        },
+        "response": {
+          "bodySize": 172,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 172,
+            "text": "event: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:35.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "41578c63-e0d7-4464-8901-94e63c1863a8"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "8aM_VkThkthR_oWFzVIB8G3qRNzOH4j6MJgZXTs7lfw-1702450416-1-AUZUDP3gkMiYvQIZsop385qxAaBOPOviEzRjR65Ulo5hYp0AcU9xvDzS56XlIZZRqBp0aCmBF26EvMAc//C9teA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=41578c63-e0d7-4464-8901-94e63c1863a8; Expires=Fri, 13 Dec 2024 06:53:35 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=8aM_VkThkthR_oWFzVIB8G3qRNzOH4j6MJgZXTs7lfw-1702450416-1-AUZUDP3gkMiYvQIZsop385qxAaBOPOviEzRjR65Ulo5hYp0AcU9xvDzS56XlIZZRqBp0aCmBF26EvMAc//C9teA=; path=/; expires=Wed, 13-Dec-23 07:23:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "ea537434df525fd6aa0d1165cb6d6d3b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "b83b6131848ce938"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ea537434df525fd6aa0d1165cb6d6d3b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a767d9a4acd-CGK"
+            }
+          ],
+          "headersSize": 1132,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:34.959Z",
+        "time": 1213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1213
+        }
+      },
+      {
+        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 333,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "333"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "eceaa784-560a-4f1f-ab92-d9ed394a4327"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "HJlZ4nbWNMGdX_hGJsJK7B2COrCflyhHS.oXhhwSioc-1702450416-1-ARcUNG6vSIMQIfrwP73ryxgwuh5mBMn4yt6kHgltx1tQXPFqfEQ2ffvRHLaTiAhIJPSN5jdZ6UJmWNmZRkb8tqA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=eceaa784-560a-4f1f-ab92-d9ed394a4327; Expires=Fri, 13 Dec 2024 06:53:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=HJlZ4nbWNMGdX_hGJsJK7B2COrCflyhHS.oXhhwSioc-1702450416-1-ARcUNG6vSIMQIfrwP73ryxgwuh5mBMn4yt6kHgltx1tQXPFqfEQ2ffvRHLaTiAhIJPSN5jdZ6UJmWNmZRkb8tqA=; path=/; expires=Wed, 13-Dec-23 07:23:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3cad9137c676db41fcc85890940ba1a2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "57d88503670ab1a5"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3cad9137c676db41fcc85890940ba1a2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a806c146d18-CGK"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1161,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:36.556Z",
+        "time": 356,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 356
+        }
+      },
+      {
+        "_id": "34fa3baab68c77b4e329fd24907b91f7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1300,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip;q=0"
+            },
+            {
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 261,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/stream"
+        },
+        "response": {
+          "bodySize": 46196,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 46196,
+            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try again\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try again!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try again!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T06:53:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "61749dac-9d85-475e-8364-6825cdecc2d1"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T07:23:37.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "zGCQLbPRCWdO_5jsYRmlSaklk9OB9I756TupS6E0R3U-1702450417-1-AWZnWhbFYJ+aMdm5ylY2p/ysXSyqf/BaeO5uPWF4of15YqBKHWfZZRiy/QElGY7s5qPjUzdELZp6ivLvAOcy32s="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 06:53:37 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=61749dac-9d85-475e-8364-6825cdecc2d1; Expires=Fri, 13 Dec 2024 06:53:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=zGCQLbPRCWdO_5jsYRmlSaklk9OB9I756TupS6E0R3U-1702450417-1-AWZnWhbFYJ+aMdm5ylY2p/ysXSyqf/BaeO5uPWF4of15YqBKHWfZZRiy/QElGY7s5qPjUzdELZp6ivLvAOcy32s=; path=/; expires=Wed, 13-Dec-23 07:23:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "2b88f4453f6e96f1417ed9735276e472"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "aa9bda62d9b84a4c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2b88f4453f6e96f1417ed9735276e472"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834c4a7e0aad6cfa-CGK"
+            }
+          ],
+          "headersSize": 1132,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T06:53:36.184Z",
+        "time": 6856,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 6856
         }
       },
       {
@@ -1205,2156 +6271,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 235
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 335,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 771,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 771,
-            "text": "[\"H4sIAAAAAAAA/5RVW47bSAy8i77DC8wBconFflDsskS41a2QbNvawdx90Y6xiyQjefwnoIuvYrH0PiQOHt7eB1w4Nw6k7+Bohu+ZJx/e/nofCi8Y3gapaSOZOWipcqaAx/Bt6FEY3sIaPr79il2tHgO4RZW6rBkBSuo8ZpBBNslaJqonWg0Xrc3J8KPBw/9PeOLsxxmllsAtaDxNtOgN6UnwFeN9vn2Yg01m0rK2IJ/rlWb1qLZ9IbNr\",\"wsi2ywiLwF07Bb4tY80UBuzCH63cZyxBIzsSZS4TJQQktJb9plarqUmQt9HFdO1oJ4ddVEAsUls5oOHzcAMn2NezTLYK/VNx3pdRIGNB2Ea4rdWO9XZcaZ/3tGghLpy3UHFC6TJMLyi3s9546h+BItt+qZEu6hrVKGozumrMVGpgrPXsr9wKTtxykAeb1M76vI2mrzS9l4K8NhNMxuv8RNW4rTBdUILzC5XDWLRMxxH9Yjjvp33Iv+BKZ2zXagfH/aOpnO+Dxk/eT9V6SzNKqHTLo+awA2/5XSPCMv/nWAeVf2qJPAy8dEubNGjM/fHp9Eh3oRhEV+yLw7grUBcNJ9wESEj3Abs//0LznzssYexB980olyDfSvCNZp3mrNN8HP9YwRPlPVDG5Xy09AcsYWwHJcdcR1r7qflVQ2ZiA3t3YgtpR3+HxyawjEhktcVTZ63XAvNZ16849kkzjv36kwvcCi8qtLQcmrWAHk/dTX+f5O+Pj38DAAD//1XrjxCrBwAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b3869691-749a-4c71-ac66-ccce271b815d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "tQQL2GEarzVu7YeHirRatXybmZDCHveVsqRJk5K.puk-1702308657-1-AUc8TaQgyLWW3JbnpjdKKqiYKdXoznpzbDlAx+qlnx3AH/E6jLWO4HbVw7dj1yzoVDaCnEKGHJULEfIKpMGVVXo="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b3869691-749a-4c71-ac66-ccce271b815d; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=tQQL2GEarzVu7YeHirRatXybmZDCHveVsqRJk5K.puk-1702308657-1-AUc8TaQgyLWW3JbnpjdKKqiYKdXoznpzbDlAx+qlnx3AH/E6jLWO4HbVw7dj1yzoVDaCnEKGHJULEfIKpMGVVXo=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "2bee3447a9713bf62fb32064a6fe5e59"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "25a1c825438245e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2bee3447a9713bf62fb32064a6fe5e59"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5928adeb51e-OSL"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.007Z",
-        "time": 215,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 215
-        }
-      },
-      {
-        "_id": "68618dc68610496fb5623c6778ea6c25",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 177,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "177"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d11e5112-e8f8-4425-96d9-95e10281d32e"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "RdWap5N3fv9b0LY2Nnqam4OMVZch.G.zAUjtNhuqpsY-1702308657-1-AVzaoJGhBMxvikedPHXDHJSCRU8YNL6zGKDyFHZbCEvVKnmbW8iJqmE8DLF+pj9Wlobp/9i8Fp/C5F6S7zKgGi8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d11e5112-e8f8-4425-96d9-95e10281d32e; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=RdWap5N3fv9b0LY2Nnqam4OMVZch.G.zAUjtNhuqpsY-1702308657-1-AVzaoJGhBMxvikedPHXDHJSCRU8YNL6zGKDyFHZbCEvVKnmbW8iJqmE8DLF+pj9Wlobp/9i8Fp/C5F6S7zKgGi8=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "be817b881344071f5897fd527e123789"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4f4379e5fe18f181"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/be817b881344071f5897fd527e123789"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec592898956b5-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.006Z",
-        "time": 222,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 222
-        }
-      },
-      {
-        "_id": "457ee78ea180e105401d1713fa553a05",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 171,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "171"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-chat-mock-test\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "61b9d7d1-69b7-4eb1-8289-8f4c2e653dc6"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "nTXmf2XWqlB5RV.T_V.M8272m_DUg3D94R49dYEbdm4-1702308657-1-AZAwGfvNdkV9OOSkPdHif4vtrX27za4lsm/6blh7IWYwO6URViPzL+bLDZfjz55aMUgES0XI0v/gQ/9xw5Egut8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=61b9d7d1-69b7-4eb1-8289-8f4c2e653dc6; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=nTXmf2XWqlB5RV.T_V.M8272m_DUg3D94R49dYEbdm4-1702308657-1-AZAwGfvNdkV9OOSkPdHif4vtrX27za4lsm/6blh7IWYwO6URViPzL+bLDZfjz55aMUgES0XI0v/gQ/9xw5Egut8=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "15d2917aae08879725e21c48ca3d49ba"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f0482cee3903486d"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/15d2917aae08879725e21c48ca3d49ba"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5928ddd56ba-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.009Z",
-        "time": 225,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 225
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "82f4595c-17b5-4bc5-936d-6b31af1498ea"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Yfs4wxVwMyv.RroSYf7CDphomkUf7CJDpBE1SWUn610-1702308657-1-AWWb9L7HsOGBFDrWm4y/fDZYD8RmLYIO9ePsQvlmtGZqw4izSHtedf8+KR2nyq4BzDdU1TspSN2TulS31PX/tI8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=82f4595c-17b5-4bc5-936d-6b31af1498ea; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Yfs4wxVwMyv.RroSYf7CDphomkUf7CJDpBE1SWUn610-1702308657-1-AWWb9L7HsOGBFDrWm4y/fDZYD8RmLYIO9ePsQvlmtGZqw4izSHtedf8+KR2nyq4BzDdU1TspSN2TulS31PX/tI8=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "e56aa8cc210f8eed8be24b1896a52944"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "deac8d3610ea9f33"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e56aa8cc210f8eed8be24b1896a52944"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5942c6d5689-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.258Z",
-        "time": 213,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 213
-        }
-      },
-      {
-        "_id": "f183d7475b363dc45d23134c3118a915",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 180,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "180"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "aff5fc2b-33e4-4ccb-8e28-ce0d71545109"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "pO8Q06D2Zc6MEJP.AAKxiI73O_JuZHEuUAqenPni9Z4-1702308657-1-AQiLrjycZYBimvoP5N5CvFE2/geHWYRFNOUQY6Mope6AoR9aU4NHAUxJmcsu/DoDIrTQDjGPOmZiFHuccTqcR5E="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=aff5fc2b-33e4-4ccb-8e28-ce0d71545109; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=pO8Q06D2Zc6MEJP.AAKxiI73O_JuZHEuUAqenPni9Z4-1702308657-1-AQiLrjycZYBimvoP5N5CvFE2/geHWYRFNOUQY6Mope6AoR9aU4NHAUxJmcsu/DoDIrTQDjGPOmZiFHuccTqcR5E=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "73745b93cd57102893adc5c20688744c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2c444d035eaf0889"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/73745b93cd57102893adc5c20688744c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5942a2056c6-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.261Z",
-        "time": 211,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 211
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "dec1677b-1f9b-42de-893a-fd4aca298b63"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "s2Mdw2PZWbWxkSmir6Y0d8a6L8zsT0cPszB.aLDRZ6M-1702308657-1-AXaqwzc6dtvLkgl+9ABEvvlkoN6bF+N1dfWfDhbylUpsGwjP79kIysuCNirHzKUTvTCnqtZofc9OiVpw3x/a7Ro="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=dec1677b-1f9b-42de-893a-fd4aca298b63; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=s2Mdw2PZWbWxkSmir6Y0d8a6L8zsT0cPszB.aLDRZ6M-1702308657-1-AXaqwzc6dtvLkgl+9ABEvvlkoN6bF+N1dfWfDhbylUpsGwjP79kIysuCNirHzKUTvTCnqtZofc9OiVpw3x/a7Ro=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c531bd7b6c024df1256a79e5f9521d75"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "3b3abc2642855b86"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c531bd7b6c024df1256a79e5f9521d75"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5942d32b50c-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.256Z",
-        "time": 221,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 221
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "f18a0a01-257a-4fd8-92dd-9e99842880b7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "LulUK3z0VuApF1RetTXFPJp5a53talgHmhCYD6RtQSs-1702308657-1-ASRCJfqH43YGt7L72D5MTv/SU9TFefcyIuLFIcsNFUOPY/A9iu1ZR9e6Q1reYgXHlf0V6w7nTt42OPCfy9wi9cM="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f18a0a01-257a-4fd8-92dd-9e99842880b7; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=LulUK3z0VuApF1RetTXFPJp5a53talgHmhCYD6RtQSs-1702308657-1-ASRCJfqH43YGt7L72D5MTv/SU9TFefcyIuLFIcsNFUOPY/A9iu1ZR9e6Q1reYgXHlf0V6w7nTt42OPCfy9wi9cM=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4a9f1016ec5370e1e439913b111d5f45"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7dd7d4b399359972"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4a9f1016ec5370e1e439913b111d5f45"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59428c556c4-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.260Z",
-        "time": 220,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 220
-        }
-      },
-      {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e39e542b-f7b6-455c-99a8-d4bfaae0edc3"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "3J__2jTcVLKpSgyDCmfp0XAeyB0pSWBT_9buAnVBGJY-1702308658-1-Ac4f8B8f3kfynjNzexFxpYUNfE7cFCTrh5hPrX35WTHdFRyfEx44B9uZOZqSh4amre/bD/W6YDvoRCG7M/5o71s="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e39e542b-f7b6-455c-99a8-d4bfaae0edc3; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=3J__2jTcVLKpSgyDCmfp0XAeyB0pSWBT_9buAnVBGJY-1702308658-1-Ac4f8B8f3kfynjNzexFxpYUNfE7cFCTrh5hPrX35WTHdFRyfEx44B9uZOZqSh4amre/bD/W6YDvoRCG7M/5o71s=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "cc6d036fde6586a55f0fecbadea0c395"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "fb6d136b89ddcbea"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cc6d036fde6586a55f0fecbadea0c395"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5980af0569a-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.855Z",
-        "time": 234,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 234
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "bad23824-0804-4455-85bb-22b8f7590271"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "F8ZIxt3wHYadaJTLp0VlzayNGtSk8od4JPFikdC.D9I-1702308658-1-AVgCC2SWFDCbBi+JermlWnEIPBuHu5SivEHb+u9ARDIgTlxyMFF6Lm47zLQCUWAcQBc3T+2Vb6nze2hw7BRrNac="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=bad23824-0804-4455-85bb-22b8f7590271; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=F8ZIxt3wHYadaJTLp0VlzayNGtSk8od4JPFikdC.D9I-1702308658-1-AVgCC2SWFDCbBi+JermlWnEIPBuHu5SivEHb+u9ARDIgTlxyMFF6Lm47zLQCUWAcQBc3T+2Vb6nze2hw7BRrNac=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "106379972dfc8d4b1fea8f1222d7e21f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f463104824f0cbf3"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/106379972dfc8d4b1fea8f1222d7e21f"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec597f91856c6-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.851Z",
-        "time": 239,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 239
-        }
-      },
-      {
-        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 160,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "160"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "0326e929-c9e9-45c1-a206-6b5e72ecc4b5"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "eg52w_d6baL92LGeW1EzcJRlJPsOOvJ5dwrcVJZZ2l4-1702308658-1-AUWloLhuaaZh0GHCadpxbN6BwKsIaV8bFYCKzcfbQruVz0ZGoqcqcHviYZqLoZeTWrvw/3Ww1ENhQJqJ6gXuxVQ="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0326e929-c9e9-45c1-a206-6b5e72ecc4b5; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=eg52w_d6baL92LGeW1EzcJRlJPsOOvJ5dwrcVJZZ2l4-1702308658-1-AUWloLhuaaZh0GHCadpxbN6BwKsIaV8bFYCKzcfbQruVz0ZGoqcqcHviYZqLoZeTWrvw/3Ww1ENhQJqJ6gXuxVQ=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b4d398930e840accda272895ba8679e1"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "63f2328ec11efa5c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b4d398930e840accda272895ba8679e1"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec597fe56712f-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.848Z",
-        "time": 247,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 247
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ac1b9a7f-ae49-4b98-9a01-b6ee39092119"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": ".1PIL1L2GJii28Pt4Xqx4Sn2OKAn7KH.Aao6hRn_nX0-1702308658-1-Ac346NLYWoid8jjOnpKsAoPg/RS17St0H0Y4V7VUiWPcvhE/G+fL3/jQU1iRCTRzi/luOUKISX3t+5xSq8wnd1s="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ac1b9a7f-ae49-4b98-9a01-b6ee39092119; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=.1PIL1L2GJii28Pt4Xqx4Sn2OKAn7KH.Aao6hRn_nX0-1702308658-1-Ac346NLYWoid8jjOnpKsAoPg/RS17St0H0Y4V7VUiWPcvhE/G+fL3/jQU1iRCTRzi/luOUKISX3t+5xSq8wnd1s=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "dc5510f868c401195941e67dec1d5f75"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "32e856c2fe0d4c2f"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dc5510f868c401195941e67dec1d5f75"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec597fe4db509-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.854Z",
-        "time": 261,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 261
         }
       },
       {
@@ -4148,201 +7064,6 @@
         }
       },
       {
-        "_id": "d0a44c73c9a40015e5cf59b1a6d37e61",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 190,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "190"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "cdcc03d7-ccb0-4b3f-a981-70cd7490c30f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Q2hLn_FuI3n4F.4mP1mWhU8HYT6qXiVyvpOfG1PHhoc-1702308658-1-AZEmsRzCv23PvAzTEEr4iul1RiCDkmcnssM0UMyJj8ANrtrgaEiP7i4o7qnN/NJfYqftgYS2qWOz9h3TRVCAPu8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cdcc03d7-ccb0-4b3f-a981-70cd7490c30f; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Q2hLn_FuI3n4F.4mP1mWhU8HYT6qXiVyvpOfG1PHhoc-1702308658-1-AZEmsRzCv23PvAzTEEr4iul1RiCDkmcnssM0UMyJj8ANrtrgaEiP7i4o7qnN/NJfYqftgYS2qWOz9h3TRVCAPu8=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "0f76844fb7029ea9bc294e97fb8c3a66"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ea1e1c7eb1768f88"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0f76844fb7029ea9bc294e97fb8c3a66"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59bcada7129-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.461Z",
-        "time": 251,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 251
-        }
-      },
-      {
         "_id": "758d269925a8d561b9ba4a8a102eab02",
         "_order": 0,
         "cache": {},
@@ -4535,986 +7256,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 269
-        }
-      },
-      {
-        "_id": "3bfde46a074296956deef9dbd207df0b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "8af0f3e0-73d2-485a-9943-bc396176fc13"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9vPJJK8ZJZ2dD.OVFURpxYtvS0EdTJ7SgnUNwtsxuu0-1702308658-1-ATvUNwxOmuSNhUKigetcpno5jIKRkX8O8iXwelaJT2/GDouzpWSEbrfT5VIiEqztGfaKswpK17u1CTWF5hSyWJw="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8af0f3e0-73d2-485a-9943-bc396176fc13; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=9vPJJK8ZJZ2dD.OVFURpxYtvS0EdTJ7SgnUNwtsxuu0-1702308658-1-ATvUNwxOmuSNhUKigetcpno5jIKRkX8O8iXwelaJT2/GDouzpWSEbrfT5VIiEqztGfaKswpK17u1CTWF5hSyWJw=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "df01016fc3bb82dc09aaff38deaf0575"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "0aedc556a389395f"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/df01016fc3bb82dc09aaff38deaf0575"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59bc83f56b5-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.466Z",
-        "time": 269,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 269
-        }
-      },
-      {
-        "_id": "103c65b93dfa88c72eea86b3b023599e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "413ce11b-279b-4f74-8d05-174d3bb005ab"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "LAuX2TxUVXTbkoAknWYg.vGZKU2.calL1wGv2PP2540-1702308658-1-AWEKWvLkwC3YdSwf5Wd/kDVa7n8c+aEzqWQi4DBPyy+/uWBHzEZBTqjZVFF3/gMLxgmFRmPprBm/5+ur/BxLOmc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=413ce11b-279b-4f74-8d05-174d3bb005ab; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=LAuX2TxUVXTbkoAknWYg.vGZKU2.calL1wGv2PP2540-1702308658-1-AWEKWvLkwC3YdSwf5Wd/kDVa7n8c+aEzqWQi4DBPyy+/uWBHzEZBTqjZVFF3/gMLxgmFRmPprBm/5+ur/BxLOmc=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4b66e1b298c9c55fa57e327fa1e42b68"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "3750cf70ed8e17c6"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4b66e1b298c9c55fa57e327fa1e42b68"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59bcf275689-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.464Z",
-        "time": 273,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 273
-        }
-      },
-      {
-        "_id": "4cb0e95333a7b013a23cbf416464bd74",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a4e90e4f-32e1-48f5-9fc2-7a48aaf1dd1a"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "c2wtpqrBLou9p7YOEAro.Gqz2uaoXdNRXbQArdjrj1o-1702308658-1-AdovEDoXPu7bQU/FPT0Iglw7Xbje0Q0395sV5uyKL6t71trSroMq/KUGX9S4dDAuA2nFLMVPMXEFd2Xx5T4nu3s="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a4e90e4f-32e1-48f5-9fc2-7a48aaf1dd1a; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=c2wtpqrBLou9p7YOEAro.Gqz2uaoXdNRXbQArdjrj1o-1702308658-1-AdovEDoXPu7bQU/FPT0Iglw7Xbje0Q0395sV5uyKL6t71trSroMq/KUGX9S4dDAuA2nFLMVPMXEFd2Xx5T4nu3s=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8c35d313441e06cb0b0d7cc50580993e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "54648ef5898a240c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8c35d313441e06cb0b0d7cc50580993e"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59bcb485684-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.462Z",
-        "time": 279,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 279
-        }
-      },
-      {
-        "_id": "ac7fc975d31f02e814346a770195c756",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 192,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "192"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-13b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "721130b1-bd6b-4c01-bd8c-95414ef56a9b"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "C.bO0Rz88YYKMlqDZ3oim7pDoMaYy5Uzargg9fjWXcs-1702308658-1-AVTkuFPPCwCu/LNYH9c9b+KVjte8nIPUnvE9CJPi/Pv8YhOMndo0k4XaUWH0rcb81oGzxOt9O7dZonC0HTa+BfE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=721130b1-bd6b-4c01-bd8c-95414ef56a9b; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=C.bO0Rz88YYKMlqDZ3oim7pDoMaYy5Uzargg9fjWXcs-1702308658-1-AVTkuFPPCwCu/LNYH9c9b+KVjte8nIPUnvE9CJPi/Pv8YhOMndo0k4XaUWH0rcb81oGzxOt9O7dZonC0HTa+BfE=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ce3c336f2e16900d8f1a77356e3e8f59"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2e323fe618b7baab"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ce3c336f2e16900d8f1a77356e3e8f59"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59bcadd7129-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.468Z",
-        "time": 274,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 274
-        }
-      },
-      {
-        "_id": "7449140909c921a511332d4c1de94c1f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 182,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "traceparent",
-              "value": "00-49d7ec5f9f4b1db5d895721c73510469-6a3da7a40c3201dc-01"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "182"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 412,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:59.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "425a2cb8-6dad-4e84-911c-68eb880a3456"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:59.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ApU99N3Zk8IJlhqULMbCdoYsASrUAn6zdC0wVZJNI2Y-1702308659-1-AUM45Hf+2R93aJ/8sYu6z+nNvT2+NrouteyV1ae2XH++Pg7Ar55lFuNICEnr+iFqGg+iv+obxDRvz1m0SgZS5QU="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:59 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=425a2cb8-6dad-4e84-911c-68eb880a3456; Expires=Wed, 11 Dec 2024 15:30:59 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ApU99N3Zk8IJlhqULMbCdoYsASrUAn6zdC0wVZJNI2Y-1702308659-1-AUM45Hf+2R93aJ/8sYu6z+nNvT2+NrouteyV1ae2XH++Pg7Ar55lFuNICEnr+iFqGg+iv+obxDRvz1m0SgZS5QU=; path=/; expires=Mon, 11-Dec-23 16:00:59 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "49d7ec5f9f4b1db5d895721c73510469"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7f4fb608244a84c5"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/49d7ec5f9f4b1db5d895721c73510469"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59e985256ae-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.939Z",
-        "time": 207,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 207
         }
       },
       {
@@ -5718,206 +7459,6 @@
         }
       },
       {
-        "_id": "b7174d7e27c967a8ec5d0724959fd4f9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 333,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "333"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"test-client\",\"clientVersion\":\"v1\"},\"parameters\":{\"version\":0}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:31:00.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "f82d2d59-c12a-4299-aa11-a1f00ec3c993"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:01:00.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "81.OspFS1b07ql1LOmLwD_iWhrEamc6miwT6_TOzV8Y-1702308660-1-AdvD3PZK9qUysjAIeiWG9H5sP3nqr5Hos7SR59pRELHjYSbYJ5wbXGZaSAcWBw/ftUcUUhiuKy8dT4mRGiJIPFA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:31:00 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f82d2d59-c12a-4299-aa11-a1f00ec3c993; Expires=Wed, 11 Dec 2024 15:31:00 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=81.OspFS1b07ql1LOmLwD_iWhrEamc6miwT6_TOzV8Y-1702308660-1-AdvD3PZK9qUysjAIeiWG9H5sP3nqr5Hos7SR59pRELHjYSbYJ5wbXGZaSAcWBw/ftUcUUhiuKy8dT4mRGiJIPFA=; path=/; expires=Mon, 11-Dec-23 16:01:00 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ceb6b371196e813b31096f8a0188e851"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "db9dacb5467d3200"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ceb6b371196e813b31096f8a0188e851"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5a77c61b509-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:31:00.355Z",
-        "time": 223,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 223
-        }
-      },
-      {
         "_id": "fa2e827c627cced081072c7650b66882",
         "_order": 0,
         "cache": {},
@@ -6070,177 +7611,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 241
-        }
-      },
-      {
-        "_id": "34fa3baab68c77b4e329fd24907b91f7",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1300,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "gzip;q=0"
-            },
-            {
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 261,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/stream"
-        },
-        "response": {
-          "bodySize": 52767,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 52767,
-            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate implementation for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate implementation for your\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate implementation for your needs\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate implementation for your needs.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the context you provide, rather than making assumptions. Please let me know if you can provide any additional details that may help me understand the problem and suggest an appropriate implementation for your needs.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:31:00.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "175eefa2-877b-4fb8-ace1-4b99bc72f7e0"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:01:02.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Msl7_xpZW_VGxsu1a3GnOYryxy8SYEMOGSdxo7gBbFM-1702308662-1-AQvArcd1U49Dfl3ExmxU57T1iyW4aHntK5+2Ncpg5mTZDkMW+KIYUV7vaHWE6/fko7iMtfg3TgUzMAjj0mvmjR0="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:31:02 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=175eefa2-877b-4fb8-ace1-4b99bc72f7e0; Expires=Wed, 11 Dec 2024 15:31:00 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Msl7_xpZW_VGxsu1a3GnOYryxy8SYEMOGSdxo7gBbFM-1702308662-1-AQvArcd1U49Dfl3ExmxU57T1iyW4aHntK5+2Ncpg5mTZDkMW+KIYUV7vaHWE6/fko7iMtfg3TgUzMAjj0mvmjR0=; path=/; expires=Mon, 11-Dec-23 16:01:02 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6e706d39a3ad1075260b791c91d6450c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2ab80b79ece1eede"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6e706d39a3ad1075260b791c91d6450c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5a62b8db50b-OSL"
-            }
-          ],
-          "headersSize": 1132,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:31:00.142Z",
-        "time": 10937,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 10937
         }
       },
       {

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -31,14 +31,33 @@ const MULTI_LINE_STOP_SEQUENCES = [CLOSING_CODE_TAG]
 const SINGLE_LINE_STOP_SEQUENCES = [CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE]
 
 const SINGLE_LINE_COMPLETION_ARGS: Pick<CodeCompletionsParams, 'maxTokensToSample' | 'stopSequences' | 'timeoutMs'> = {
+    timeoutMs: 5_000,
     maxTokensToSample: 50,
     stopSequences: SINGLE_LINE_STOP_SEQUENCES,
-    timeoutMs: 5_000,
 }
+
 const MULTI_LINE_COMPLETION_ARGS: Pick<CodeCompletionsParams, 'maxTokensToSample' | 'stopSequences' | 'timeoutMs'> = {
+    timeoutMs: 15_000,
     maxTokensToSample: MAX_RESPONSE_TOKENS,
     stopSequences: MULTI_LINE_STOP_SEQUENCES,
+}
+
+const DYNAMIC_MULTLILINE_COMPLETIONS_ARGS: Pick<
+    CodeCompletionsParams,
+    'maxTokensToSample' | 'stopSequences' | 'timeoutMs'
+> = {
     timeoutMs: 15_000,
+    maxTokensToSample: MAX_RESPONSE_TOKENS,
+    // Do not stop after two consecutive new lines to get the full syntax node content. For example:
+    //
+    // function quickSort(array) {
+    //   if (array.length <= 1) {
+    //     return array
+    //   }
+    //
+    //   // the implementation continues here after two new lines.
+    // }
+    stopSequences: undefined,
 }
 
 interface UnstableOpenAIOptions {
@@ -134,9 +153,14 @@ ${OPENING_CODE_TAG}${infillBlock}`
             topP: 0.5,
         }
 
-        const fetchAndProcessCompletionsImpl = dynamicMultilineCompletions
-            ? fetchAndProcessDynamicMultilineCompletions
-            : fetchAndProcessCompletions
+        let fetchAndProcessCompletionsImpl = fetchAndProcessCompletions
+        if (dynamicMultilineCompletions) {
+            // If the feature flag is enabled use params adjusted for the experiment.
+            Object.assign(requestParams, DYNAMIC_MULTLILINE_COMPLETIONS_ARGS)
+
+            // Use an alternative fetch completions implementation.
+            fetchAndProcessCompletionsImpl = fetchAndProcessDynamicMultilineCompletions
+        }
 
         tracer?.params(requestParams)
 


### PR DESCRIPTION
## Context

- Stop sequences were intentionally removed from the dynamic multiline completion request params. 
- This PR reverts relevant changes from https://github.com/sourcegraph/cody/pull/2118 to preserve this change.

## Test plan

Try generating multiline completion with two consecutive new lines and ensure they are not truncated in the middle.
