### PR TITLE
Agent: enable source maps in tests

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -97,7 +97,7 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
             'SRC_ENDPOINT must match clientInfo.extensionConfiguration.serverEndpoint'
         )
     }
-    const agentProcess = spawn('node', [agentScript, 'jsonrpc'], {
+    const agentProcess = spawn('node', ['--enable-source-maps', agentScript, 'jsonrpc'], {
         stdio: 'pipe',
         cwd: agentDir,
         env: {


### PR DESCRIPTION
## Test plan
Manually failed a test and confirmed that it shows a stack trace.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
