### PR TITLE
Agent: enable source maps in `pnpm agent`

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -15,7 +15,7 @@
     "build": "cd .. && pnpm build && cd agent && node src/esbuild.mjs",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
-    "agent:debug": "pnpm run build && node --inspect ./dist/index.js",
+    "agent:debug": "pnpm run build && node --inspect --enable-source-maps ./dist/index.js",
     "build-ts": "tsc --build",
     "build-agent-binaries": "pnpm run build && cp dist/index.js dist/agent.js && pkg -t latest-linux-arm64,latest-linux-x64,latest-macos-arm64,latest-macos-x64,latest-win-x64 dist/agent.js --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "lint": "pnpm run lint:js",


### PR DESCRIPTION
Forgot this in the previous PR
## Test plan

n/a
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
