### PR TITLE
Chat: Fix cody icon font usage

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Autocomplete: Don't show loading indicator when a user is rate limited. [pull/2314](https://github.com/sourcegraph/cody/pull/2314)
 - Fixes an issue where the wrong rate limit count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
+- Chat: Fix icon rendering on the null state. [pull/2336](https://github.com/sourcegraph/cody/pull/2336)
 
 ### Changed
 

--- a/vscode/webviews/index.html
+++ b/vscode/webviews/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/vscode/webviews/index.html
+++ b/vscode/webviews/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
@@ -6,7 +6,7 @@
         <!-- This content security policy also implicitly disables inline scripts and styles. -->
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource}; font-src {cspSource};"
+            content="default-src 'none'; img-src {cspSource} https:; script-src {cspSource}; style-src {cspSource}; font-src data: {cspSource};"
         />
         <!-- DO NOT REMOVE: THIS FILE IS THE ENTRY FILE FOR CODY WEBVIEW -->
         <title>Cody</title>


### PR DESCRIPTION
This adds `data:` support for font loading to allow inline bundled fonts (like the cody icon set)

## Test plan

<img width="556" alt="Screenshot 2023-12-13 at 12 21 59" src="https://github.com/sourcegraph/cody/assets/458591/5f00a50c-8e18-4e40-a4f3-52d64b894ddf">


<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
