### PR TITLE
Agent: add test case to accept autocomplete

### DIFF
--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -55,7 +55,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 341,
+          "headersSize": 324,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -81,26 +81,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:30.000Z",
+              "expires": "2024-12-13T11:31:19.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "28dbe346-7b23-4cb6-980f-264e8687a8bc"
+              "value": "d3ee1a7e-7266-4090-9bb7-f8ddd4432460"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:30.000Z",
+              "expires": "2023-12-13T12:01:19.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "NMrHsn76cnQ1pPFR5WycIGNnMpdaoGIIq4JOMQZ2q.M-1702450410-1-AXJWSTFkKKZKk6f5qhvgDd7th9Mx7oIR0cVBi8x15EKSQ/fGDFgyYTjdJDjnxR8w0eu4Uy9ysjDb2YvizEyIDCg="
+              "value": "may6UXHQOXRKIsxMsH3NTuS.bt7xYJCuO9ifYe9AVn0-1702467079-1-AWlgMkIVUJDn0ENN1RABpRGysVIuVvItDHtf3Ok5re3QUyRnWIwfvK4p+qnNm4MJT7wbuxhGP/Zd9fxB76AfAuA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:30 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:19 GMT"
             },
             {
               "name": "content-type",
@@ -113,6 +113,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "219"
             },
             {
               "name": "access-control-allow-credentials",
@@ -129,12 +141,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=28dbe346-7b23-4cb6-980f-264e8687a8bc; Expires=Fri, 13 Dec 2024 06:53:30 GMT; Secure"
+              "value": "sourcegraphDeviceId=d3ee1a7e-7266-4090-9bb7-f8ddd4432460; Expires=Fri, 13 Dec 2024 11:31:19 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=NMrHsn76cnQ1pPFR5WycIGNnMpdaoGIIq4JOMQZ2q.M-1702450410-1-AXJWSTFkKKZKk6f5qhvgDd7th9Mx7oIR0cVBi8x15EKSQ/fGDFgyYTjdJDjnxR8w0eu4Uy9ysjDb2YvizEyIDCg=; path=/; expires=Wed, 13-Dec-23 07:23:30 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=may6UXHQOXRKIsxMsH3NTuS.bt7xYJCuO9ifYe9AVn0-1702467079-1-AWlgMkIVUJDn0ENN1RABpRGysVIuVvItDHtf3Ok5re3QUyRnWIwfvK4p+qnNm4MJT7wbuxhGP/Zd9fxB76AfAuA=; path=/; expires=Wed, 13-Dec-23 12:01:19 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -150,15 +162,15 @@
             },
             {
               "name": "x-trace",
-              "value": "90be6d83bd305bcf675b5bc612604769"
+              "value": "f9130ccb129eb95f66526dc8716cc42f"
             },
             {
               "name": "x-trace-span",
-              "value": "8ee62f7222412d43"
+              "value": "4ed2d95726d5f399"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/90be6d83bd305bcf675b5bc612604769"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f9130ccb129eb95f66526dc8716cc42f"
             },
             {
               "name": "x-xss-protection",
@@ -182,21 +194,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a5788f45e97-CGK"
+              "value": "834de1500ee80b02-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:29.995Z",
-        "time": 366,
+        "startedDateTime": "2023-12-13T11:31:19.627Z",
+        "time": 216,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -204,407 +216,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 366
-        }
-      },
-      {
-        "_id": "26f7093bcc1d125e7768f46a33e590e8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 318,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "318"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:31.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "fc31b0f4-5042-4830-aff6-48ee00444aaf"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:31.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vIqX3fqodCegLqYJFi_4GkT1dDWRUqya99aqeQ9mKf8-1702450411-1-AVllAInMcITr8HvVIXoi41l4geDJMLGzBafwvkDRdQLwxMDYloOU1N1Tf84a/RFOGB6dW+huLVZ5S8lJXgBBB3E="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fc31b0f4-5042-4830-aff6-48ee00444aaf; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=vIqX3fqodCegLqYJFi_4GkT1dDWRUqya99aqeQ9mKf8-1702450411-1-AVllAInMcITr8HvVIXoi41l4geDJMLGzBafwvkDRdQLwxMDYloOU1N1Tf84a/RFOGB6dW+huLVZ5S8lJXgBBB3E=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "cdc7aed29e418f1993923c4ffc9a88a4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "17032974f2e29a32"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cdc7aed29e418f1993923c4ffc9a88a4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a5c9bce6cf8-CGK"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:30.830Z",
-        "time": 404,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 404
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 128,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 128,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:31.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1b298240-7609-49a7-9ad1-a44bdb9d7b12"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:31.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "0V3_mv3tj5twFQt7cGENiwD7VXyWQPlczq2BqnYYv98-1702450411-1-AYYHp2H2tM/Gl28D9gNdEyvydO1T3SjUNff/7vl53Q4noMXRlAov2JJPcbBaRatXqriiTmFyITg0Bz/vRnEWQKI="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1b298240-7609-49a7-9ad1-a44bdb9d7b12; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=0V3_mv3tj5twFQt7cGENiwD7VXyWQPlczq2BqnYYv98-1702450411-1-AYYHp2H2tM/Gl28D9gNdEyvydO1T3SjUNff/7vl53Q4noMXRlAov2JJPcbBaRatXqriiTmFyITg0Bz/vRnEWQKI=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f2035473d7caeadfd5d8d114b2684377"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "557b760abd3fce70"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f2035473d7caeadfd5d8d114b2684377"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a5c9bdf6d0a-CGK"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:30.831Z",
-        "time": 428,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 428
+          "wait": 216
         }
       },
       {
@@ -655,7 +267,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 341,
+          "headersSize": 324,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -681,26 +293,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:31.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "3dda4910-ad74-4a03-b52b-cf4ae784f7fe"
+              "value": "74efb3bb-3ab5-4abb-9e00-54a9807140e3"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:31.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "D08gIB594NA_ccoNSgdXhja72_43Dm8juZf.8a.J_ag-1702450411-1-Ab2Dzf0Gih+BEh5OKhBN3innI+prpbqB+43E/A3tiiuntlaQIpvGXtZDBNrMkAKTJxnZ+95J2C1iaocW6ZfxsKU="
+              "value": "h4CMUTJPSOBuVtUMU41EpHeb1Yk48TyJWgovuyJyXbU-1702467080-1-AbGfihTkgHyswvjrLmBjs0A2+adSbVydV0xqJ6/9mLkA17ut00jdSkXEOGq+fkbmwIZ+s/DUkVyGEW1b6tKJ3rs="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -713,6 +325,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "219"
             },
             {
               "name": "access-control-allow-credentials",
@@ -729,12 +353,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3dda4910-ad74-4a03-b52b-cf4ae784f7fe; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=74efb3bb-3ab5-4abb-9e00-54a9807140e3; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=D08gIB594NA_ccoNSgdXhja72_43Dm8juZf.8a.J_ag-1702450411-1-Ab2Dzf0Gih+BEh5OKhBN3innI+prpbqB+43E/A3tiiuntlaQIpvGXtZDBNrMkAKTJxnZ+95J2C1iaocW6ZfxsKU=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=h4CMUTJPSOBuVtUMU41EpHeb1Yk48TyJWgovuyJyXbU-1702467080-1-AbGfihTkgHyswvjrLmBjs0A2+adSbVydV0xqJ6/9mLkA17ut00jdSkXEOGq+fkbmwIZ+s/DUkVyGEW1b6tKJ3rs=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -750,15 +374,15 @@
             },
             {
               "name": "x-trace",
-              "value": "a160b4fc3e89f21470d9ebb48a75b472"
+              "value": "c268d39490aa02a25883736f289e7d33"
             },
             {
               "name": "x-trace-span",
-              "value": "3734242e020b4a1c"
+              "value": "8b410828a972cfa2"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a160b4fc3e89f21470d9ebb48a75b472"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c268d39490aa02a25883736f289e7d33"
             },
             {
               "name": "x-xss-protection",
@@ -782,21 +406,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a5c9c8bbe71-CGK"
+              "value": "834de1529b9b7130-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:30.826Z",
-        "time": 445,
+        "startedDateTime": "2023-12-13T11:31:20.062Z",
+        "time": 207,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -804,15 +428,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 445
+          "wait": 207
         }
       },
       {
-        "_id": "badec8750918600cec1a4695340e4feb",
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 444,
+          "bodySize": 155,
           "cookies": [],
           "headers": [
             {
@@ -838,7 +462,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "444"
+              "value": "155"
             },
             {
               "_fromType": "array",
@@ -855,52 +479,52 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 344,
+          "headersSize": 337,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.extension\",\"action\":\"installed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
           },
           "queryString": [
             {
-              "name": "RecordTelemetryEvents",
+              "name": "CurrentSiteCodyLlmConfiguration",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 131,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 131,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP8=\",\"/wMAHxQFwEUAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:31.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2cab990e-592f-4d04-8b85-d02e266b18dd"
+              "value": "a6b5519d-5092-4489-aa2d-149b687fb1c3"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:31.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "V1j9_INFDLbRZfLF3sjFvGziJS0elE_dHUQpYhobSoY-1702450411-1-Adjt0A5GEOsKWRz0WNFZwIuP3YgDJGk3XIWAuL4djJzYXKzF06X/AEcDsBILXrywrflewgvq4YPrJVqV1noDar8="
+              "value": "LKcBNAPPOzRLng8aywPL9Ll_jLJj.30mfchnRNM7_7o-1702467080-1-AZwdNfnUgP7KxXf4yBCmli89138Svk9A44UPSy6ZRPTN4hXvWR3FXmqnDxvSbrV6IYJ2D7GhE/uphgd8VIKmzNg="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -913,6 +537,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "219"
             },
             {
               "name": "access-control-allow-credentials",
@@ -929,12 +565,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2cab990e-592f-4d04-8b85-d02e266b18dd; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=a6b5519d-5092-4489-aa2d-149b687fb1c3; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=V1j9_INFDLbRZfLF3sjFvGziJS0elE_dHUQpYhobSoY-1702450411-1-Adjt0A5GEOsKWRz0WNFZwIuP3YgDJGk3XIWAuL4djJzYXKzF06X/AEcDsBILXrywrflewgvq4YPrJVqV1noDar8=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=LKcBNAPPOzRLng8aywPL9Ll_jLJj.30mfchnRNM7_7o-1702467080-1-AZwdNfnUgP7KxXf4yBCmli89138Svk9A44UPSy6ZRPTN4hXvWR3FXmqnDxvSbrV6IYJ2D7GhE/uphgd8VIKmzNg=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -950,15 +586,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e238d4edbad6fcbca02d09efc0c7668b"
+              "value": "13bc8980086d94d89e172a9cc3fb729f"
             },
             {
               "name": "x-trace-span",
-              "value": "ff0414fd7b09bcbe"
+              "value": "1f3b2ee735478c7b"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e238d4edbad6fcbca02d09efc0c7668b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/13bc8980086d94d89e172a9cc3fb729f"
             },
             {
               "name": "x-xss-protection",
@@ -982,21 +618,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a5f089f6d03-CGK"
+              "value": "834de152ac14b4f3-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:31.227Z",
-        "time": 413,
+        "startedDateTime": "2023-12-13T11:31:20.066Z",
+        "time": 205,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1004,7 +640,219 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 413
+          "wait": 205
+        }
+      },
+      {
+        "_id": "26f7093bcc1d125e7768f46a33e590e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 318,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "318"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 337,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "d38436be-7506-45a7-a0e0-24299db7b63a"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "IIeZ32cefo7ItAhUt.XuTSza3NcKLxNHaAL4FQRII2g-1702467080-1-AQEtofB2FGyE70WPlO62knfh4XEp+gELxDhvlgptXOZY+pudwQWkGeaqJWoJ47/zW+duHkfMCUhUf/wfh+IVVzs="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "219"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=d38436be-7506-45a7-a0e0-24299db7b63a; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=IIeZ32cefo7ItAhUt.XuTSza3NcKLxNHaAL4FQRII2g-1702467080-1-AQEtofB2FGyE70WPlO62knfh4XEp+gELxDhvlgptXOZY+pudwQWkGeaqJWoJ47/zW+duHkfMCUhUf/wfh+IVVzs=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "002bf8ff512e9b8d559483447528ec58"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "9c0f5f72f39c091d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/002bf8ff512e9b8d559483447528ec58"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de1529d2d56c1-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:20.065Z",
+        "time": 209,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 209
         }
       },
       {
@@ -1055,7 +903,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 334,
+          "headersSize": 317,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1072,35 +920,35 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
         },
         "response": {
-          "bodySize": 303,
+          "bodySize": 304,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 303,
-            "text": "[\"H4sIAAAAAAAAAyyOy2rDMBREf6XMWsSFmBIEpqU0u+I+IKHbG+nGVitb5koyCON/L266mxk4w1lgKRH0ApNFeEynyLJVZ6Fx/mq9+Q7l7cXU7UfTQKGneGZxV8f2OJDz0EkyK1gXJ0+lpYE3kDxLuXvOHf2EGQo0UyI5fb5Co09pirqqblvcdS71+ZIjiwlj4jHtTBiqXO0P9cP+cP84NzUUTLDlXcJxpItnC30lH1lhEjeQlH+XBXwLmA==\",\"/wyeYshiuBOa+u0V67quvwAAAP//AwDxGoXq9AAAAA==\"]"
+            "size": 304,
+            "text": "[\"H4sIAAAAAAAAAzSOQWrDMBRErxJmbWKXptAKSrtoyCaYUEholz/Sj60iS+ZLCrjGp+gJepZcrLhpdzNvMfNGGEoENUJnEfZpH1nmag0UDm+10x/hs355v0OBluKBxZ4sm3VH1kElyVzA2Ng7GmrqGAqXL0enLIvd5du5xYatxBg8CtCZEsn+dQuFNqU+qrK8slgtG5vafMyRRQef2KelDl2Zy5tVdV893D6dH1cooIMZdhLWno6Ozf9/L7YjGf6cRvA1IPyK9M1zM4N5ENM0TT8AAAD//wMAYDFO0fQAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:31.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "3704feec-d1a6-43a3-af84-a03c388ec543"
+              "value": "611ca4ef-dd52-486e-9113-dda5cd853877"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:31.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "o4.PU_Hh7jUekia3Kc6IdJYydNujyd_U2HF7vASMwpQ-1702450411-1-AWqsBhyKaFI/smeAwtZWvESg7kqeh5ciob149xdQPLoVh3r32vSO6s2wM7I7psCAOG1CgBUeeD7cwwWqvhFiqHQ="
+              "value": "ZQD_0xOZt8F8rMj2gc5Thk641auI84VV8VvZSD5M.gE-1702467080-1-AezWGnXkHexuHe1o82Q1wmzgZdfUrvvcvGH6Pawdr7yONejGD2VvV0wFuqQ24RmcMJa3VA3Kc63NvWMdxVlnXTE="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:31 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -1113,6 +961,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "219"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1129,12 +989,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3704feec-d1a6-43a3-af84-a03c388ec543; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=611ca4ef-dd52-486e-9113-dda5cd853877; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=o4.PU_Hh7jUekia3Kc6IdJYydNujyd_U2HF7vASMwpQ-1702450411-1-AWqsBhyKaFI/smeAwtZWvESg7kqeh5ciob149xdQPLoVh3r32vSO6s2wM7I7psCAOG1CgBUeeD7cwwWqvhFiqHQ=; path=/; expires=Wed, 13-Dec-23 07:23:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ZQD_0xOZt8F8rMj2gc5Thk641auI84VV8VvZSD5M.gE-1702467080-1-AezWGnXkHexuHe1o82Q1wmzgZdfUrvvcvGH6Pawdr7yONejGD2VvV0wFuqQ24RmcMJa3VA3Kc63NvWMdxVlnXTE=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1150,15 +1010,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3f9c6876ce536112f84e63ce624583cc"
+              "value": "666f1dbeb6eb3ad786f9b9e9e821c2ad"
             },
             {
               "name": "x-trace-span",
-              "value": "82e4f5ea10f4de6f"
+              "value": "0f968bdba5085de9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3f9c6876ce536112f84e63ce624583cc"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/666f1dbeb6eb3ad786f9b9e9e821c2ad"
             },
             {
               "name": "x-xss-protection",
@@ -1182,21 +1042,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a5f4d56be88-CGK"
+              "value": "834de153ec76b505-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:31.263Z",
-        "time": 400,
+        "startedDateTime": "2023-12-13T11:31:20.277Z",
+        "time": 201,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1204,15 +1064,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 400
+          "wait": 201
         }
       },
       {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_id": "badec8750918600cec1a4695340e4feb",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 147,
+          "bodySize": 444,
           "cookies": [],
           "headers": [
             {
@@ -1238,7 +1098,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "147"
+              "value": "444"
             },
             {
               "_fromType": "array",
@@ -1255,52 +1115,52 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 335,
+          "headersSize": 327,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.extension\",\"action\":\"installed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
           },
           "queryString": [
             {
-              "name": "FeatureFlags",
+              "name": "RecordTelemetryEvents",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 611,
+          "bodySize": 119,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 611,
-            "text": "[\"H4sIAAAAAAAA/5RUW27cMAy8i7/DC+wBcomiH7Q0axErSw5JxTGC3L1QagRJCnvTPwMacR7U+HWI7DxcXgc8c27siI9gb4rHzJMNl1+vQ+EZw2UINW60YqSQ2IeHoeMxXFwb3h6+ojqC5hpu5LBP2Ctn+ww2sIZEUpbmZKmulMS86nY4fr+RtlElHqI4BJjJmEFXySBX4Fxx94UoXpUUQRbYCb64sjmFOi9ZuDjZVpxfKMmUskzJpUzH\",\"pj/4TCJG1ntelcvty8DvZuMshbhw3lyCEQqPGcfh7GPrWqCWZDkPZtF6CPjLRJhHRNLa/DjknbRnh+I0siFS5jJRhCO41HInMbwsUJlRnPO5ZG5e33cDB0Wxd5GKsIUsZaJ6pUXxLLUZKZ4azO2Y+3u6gUP6mBqP7+3ZmCt47rSTOI25H/5cfA+o8dQ/HCUc1+KpSbiROauT16Z0rdpHJRSX0FtNzaAnPvcFFax0w7ZWPfE25jrS0nXZKh4SsYKtF1g9ND+ujiNjhuv7Nqve+Yt8icKVw91aHZ9OuoR7jzNibD/pLef/eoBb4VkCzS27ZCmg/Uhq+Wcfv9/e/gQAAP//dgwcdJIFAAA=\"]"
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:31.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0fe758af-abaf-401c-8556-7b20539b3007"
+              "value": "4ce4910f-f4d8-4ab7-a922-83034f394dba"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "QQcNOSQ8ngkYOIW8hnFDTinAEjFZE58CrPfVUkdKny8-1702450412-1-AakqEbw5EZq8XLxEtRJNjddiOqfxg4tsrO0HEm3dMyh2XrY83WMBdz96JK8GiKB4zLapl/sXCZP13SuN8nFAyh8="
+              "value": "U.zJerNpBeeLALWMhiBmlv8lBurNxteVkmmFZnGOzJ4-1702467080-1-AS8icZFmI9ks/VTfNp1eBj8MKA+cm1e+tyjfG3aDivKFn6hf0fn2ZBjfG0x0/4x72N9lIDpl/QQsCMADC+9MfvI="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -1315,6 +1175,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "219"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -1325,78 +1197,78 @@
             {
               "name": "cache-control",
               "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4ce4910f-f4d8-4ab7-a922-83034f394dba; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=U.zJerNpBeeLALWMhiBmlv8lBurNxteVkmmFZnGOzJ4-1702467080-1-AS8icZFmI9ks/VTfNp1eBj8MKA+cm1e+tyjfG3aDivKFn6hf0fn2ZBjfG0x0/4x72N9lIDpl/QQsCMADC+9MfvI=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "724b93a2025931d6f28884d95f4dd491"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3d41bc2639835cb0"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/724b93a2025931d6f28884d95f4dd491"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de153efafb500-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0fe758af-abaf-401c-8556-7b20539b3007; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=QQcNOSQ8ngkYOIW8hnFDTinAEjFZE58CrPfVUkdKny8-1702450412-1-AakqEbw5EZq8XLxEtRJNjddiOqfxg4tsrO0HEm3dMyh2XrY83WMBdz96JK8GiKB4zLapl/sXCZP13SuN8nFAyh8=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "da7780390b1dc583f8e51dfc5fb90341"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e6234e3a491521ee"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/da7780390b1dc583f8e51dfc5fb90341"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a61ed8cbe99-CGK"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:31.675Z",
-        "time": 366,
+        "startedDateTime": "2023-12-13T11:31:20.272Z",
+        "time": 208,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1404,202 +1276,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 366
-        }
-      },
-      {
-        "_id": "68618dc68610496fb5623c6778ea6c25",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 177,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "177"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:31.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2eaaf04d-1c4a-48c7-85ae-f81789882bc2"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "QeGz2SymEmLmHuiFQDRj1tJ8lq6kYyGji4ZGyrJocOE-1702450412-1-AREKHj4UytqzqwYFtGKBZul6Opx6peY9MQR6duLLbpQyRShY52rbyFWcON2EXsv7lnZwA/khOQhycuzsj4T1tLI="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2eaaf04d-1c4a-48c7-85ae-f81789882bc2; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=QeGz2SymEmLmHuiFQDRj1tJ8lq6kYyGji4ZGyrJocOE-1702450412-1-AREKHj4UytqzqwYFtGKBZul6Opx6peY9MQR6duLLbpQyRShY52rbyFWcON2EXsv7lnZwA/khOQhycuzsj4T1tLI=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c8bc32e42b3f9c456765270143ce19fc"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "bd59750984e295cc"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c8bc32e42b3f9c456765270143ce19fc"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a61e92b6cfa-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:31.677Z",
-        "time": 367,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 367
+          "wait": 208
         }
       },
       {
@@ -1650,7 +1327,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1667,229 +1344,34 @@
           "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:31.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a531f90e-cc3c-4056-847e-7156c76aa857"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "aJwLvpeYdrcqQQFhXEOyRB4ccTSyC7PNsm6XO9k_Lyw-1702450412-1-AStll763n8HEMUpsaruTqWg7vG4eSqtkbkqK1aHA8L51ODxed7uC8gryFBnv5IsT0QJs1KONp1KYC5gIUBTWfz8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a531f90e-cc3c-4056-847e-7156c76aa857; Expires=Fri, 13 Dec 2024 06:53:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=aJwLvpeYdrcqQQFhXEOyRB4ccTSyC7PNsm6XO9k_Lyw-1702450412-1-AStll763n8HEMUpsaruTqWg7vG4eSqtkbkqK1aHA8L51ODxed7uC8gryFBnv5IsT0QJs1KONp1KYC5gIUBTWfz8=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "499d760db889d8de9af66690335bc846"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1ca8508596fcaeeb"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/499d760db889d8de9af66690335bc846"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a61eebf6d18-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:31.680Z",
-        "time": 384,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 384
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
           "bodySize": 37,
           "content": {
             "mimeType": "application/json",
             "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:32.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "75cb1a81-4b5e-4377-bd59-82bd9ed9623d"
+              "value": "94c0c003-c9f9-464d-9cf6-8406fefd43e9"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Nq88i4yzg0I1rj0sYrLla0vU4Y09K7mT1VAA5CWt5ic-1702450412-1-AQJXmD8V/ZNNVl0A91P/qvO/gLYjR6T/t5Npa4kyFVTn4gpCP1d5iY+xUGqhbJzTV5/Nghl/GhwWe8k0tcrHK+4="
+              "value": "G8ic.FZshqHUEqSXqd.dO5aaebGuHydBl_r2XKVKjL4-1702467080-1-AR/adIUOGXqiIPIxqwiWUHuqCmTTupOph/ulu608ek0dz5h9y5wtB+WgP5vpPKKL1xSBsci7p8lytI8HAx+vMXs="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -1904,6 +1386,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -1918,12 +1412,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=75cb1a81-4b5e-4377-bd59-82bd9ed9623d; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+              "value": "sourcegraphDeviceId=94c0c003-c9f9-464d-9cf6-8406fefd43e9; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=Nq88i4yzg0I1rj0sYrLla0vU4Y09K7mT1VAA5CWt5ic-1702450412-1-AQJXmD8V/ZNNVl0A91P/qvO/gLYjR6T/t5Npa4kyFVTn4gpCP1d5iY+xUGqhbJzTV5/Nghl/GhwWe8k0tcrHK+4=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=G8ic.FZshqHUEqSXqd.dO5aaebGuHydBl_r2XKVKjL4-1702467080-1-AR/adIUOGXqiIPIxqwiWUHuqCmTTupOph/ulu608ek0dz5h9y5wtB+WgP5vpPKKL1xSBsci7p8lytI8HAx+vMXs=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1939,15 +1433,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d3a4fe9afc19fb2186de03244785a2fe"
+              "value": "8aa91405fffdbec6056d07639f75c69f"
             },
             {
               "name": "x-trace-span",
-              "value": "2720d44f354ba6da"
+              "value": "ae92697a3ba76b31"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d3a4fe9afc19fb2186de03244785a2fe"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8aa91405fffdbec6056d07639f75c69f"
             },
             {
               "name": "x-xss-protection",
@@ -1971,17 +1465,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a647a3f5eaa-CGK"
+              "value": "834de1554d05b51e-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.075Z",
-        "time": 381,
+        "startedDateTime": "2023-12-13T11:31:20.488Z",
+        "time": 204,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1989,15 +1483,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 381
+          "wait": 204
         }
       },
       {
-        "_id": "243255429fc6f137e796538de9eb469f",
+        "_id": "68618dc68610496fb5623c6778ea6c25",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 189,
+          "bodySize": 177,
           "cookies": [],
           "headers": [
             {
@@ -2023,7 +1517,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "189"
+              "value": "177"
             },
             {
               "_fromType": "array",
@@ -2040,598 +1534,13 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "031c7a55-3c42-49d2-97d9-78b79f4cdc77"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "tF_6.yTh1PpANhM_KGaKit59CayYTFvv85EoSB.GYbY-1702450412-1-AWXzWwzPcPQxFJURoLq+KY5CUkBgLIeDwl4wMbIR+0vzjPROI/tfpjl/0yFWaz6LSoWRVBECU9YAzU8HMkf31l4="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=031c7a55-3c42-49d2-97d9-78b79f4cdc77; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=tF_6.yTh1PpANhM_KGaKit59CayYTFvv85EoSB.GYbY-1702450412-1-AWXzWwzPcPQxFJURoLq+KY5CUkBgLIeDwl4wMbIR+0vzjPROI/tfpjl/0yFWaz6LSoWRVBECU9YAzU8HMkf31l4=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8b2ea7b5b7630971384a217611be223e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "920ea16f934311af"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8b2ea7b5b7630971384a217611be223e"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a647fc94ac5-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:32.080Z",
-        "time": 378,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 378
-        }
-      },
-      {
-        "_id": "f183d7475b363dc45d23134c3118a915",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 180,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "180"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "df189f46-aa93-4124-a6c5-664c5523f9c7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "IqgREh4plCj8hBOZ0BpGEUdPPwG5zpGZyc7r_kDvnw0-1702450412-1-AVkNUwUF+VCAY6nOHzYS2+ysG/0+1NstWSz1RYWUotScNnXB+l2ExZWtXErH0x4lJMTnV4CL9XPUVuMOTgLwHEw="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=df189f46-aa93-4124-a6c5-664c5523f9c7; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=IqgREh4plCj8hBOZ0BpGEUdPPwG5zpGZyc7r_kDvnw0-1702450412-1-AVkNUwUF+VCAY6nOHzYS2+ysG/0+1NstWSz1RYWUotScNnXB+l2ExZWtXErH0x4lJMTnV4CL9XPUVuMOTgLwHEw=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "1b2a5ccd0da2ca409270ff2a038c6b55"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "049e027e242f1fa8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1b2a5ccd0da2ca409270ff2a038c6b55"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a647d026cf2-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:32.082Z",
-        "time": 379,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 379
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "29748cda-6938-40df-8009-9db886e871da"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "yKDExzhR.Sqw84QJ7ezg2Wl76BPYaNgg5U4QRqmZ3lc-1702450412-1-Ad0dSYA8AzjJWoVhwEnZUkUGzrPZn0YXM0LgHTi1JguotJuIeHY1A4LtzA+Epxnqi4j0R5BYvcvklHD2/uazpFA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=29748cda-6938-40df-8009-9db886e871da; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=yKDExzhR.Sqw84QJ7ezg2Wl76BPYaNgg5U4QRqmZ3lc-1702450412-1-Ad0dSYA8AzjJWoVhwEnZUkUGzrPZn0YXM0LgHTi1JguotJuIeHY1A4LtzA+Epxnqi4j0R5BYvcvklHD2/uazpFA=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "e5b593dc48b4d07c6ebba530b2a9f59a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "503413e7735f961e"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e5b593dc48b4d07c6ebba530b2a9f59a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a647ced6cf1-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:32.077Z",
-        "time": 386,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 386
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
           },
           "queryString": [
             {
@@ -2650,26 +1559,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:32.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "4a0ccab8-4003-420f-bec3-2ad7da70b354"
+              "value": "e0944f08-39d5-4b1d-8433-2014d5186aff"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:32.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "WHEOuWkFa2lTYfgVERGuqsAiioTjBPdnqXYtqFyrldA-1702450412-1-AUiQLWtIkcG0lI8nQtkmQC3WLCH3cfYJGYcTFiJmyihG7Ufe1FklmSz9rZfmNM3jYOfEk3rQugiMBQxcTHT89fE="
+              "value": "0Wj2GRQr8vP8dVs7uJx9lJ8SoDdTfFgmuq_8CmRW1_E-1702467080-1-AQVz2PpbqAyehgF0v3rouRh0pXZE0II35hcy84JMJlnWwaw0iA3gAQ35C01qkjSjUIfgUotS7A9kOOBiBFTBQNA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:32 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -2682,6 +1591,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2698,12 +1619,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4a0ccab8-4003-420f-bec3-2ad7da70b354; Expires=Fri, 13 Dec 2024 06:53:32 GMT; Secure"
+              "value": "sourcegraphDeviceId=e0944f08-39d5-4b1d-8433-2014d5186aff; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=WHEOuWkFa2lTYfgVERGuqsAiioTjBPdnqXYtqFyrldA-1702450412-1-AUiQLWtIkcG0lI8nQtkmQC3WLCH3cfYJGYcTFiJmyihG7Ufe1FklmSz9rZfmNM3jYOfEk3rQugiMBQxcTHT89fE=; path=/; expires=Wed, 13-Dec-23 07:23:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=0Wj2GRQr8vP8dVs7uJx9lJ8SoDdTfFgmuq_8CmRW1_E-1702467080-1-AQVz2PpbqAyehgF0v3rouRh0pXZE0II35hcy84JMJlnWwaw0iA3gAQ35C01qkjSjUIfgUotS7A9kOOBiBFTBQNA=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2719,15 +1640,15 @@
             },
             {
               "name": "x-trace",
-              "value": "60520684ff255d88db59702765454545"
+              "value": "20317c07bf1d2184974717a62a796852"
             },
             {
               "name": "x-trace-span",
-              "value": "5ee93de3f835d2a2"
+              "value": "80de73f03debcdce"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/60520684ff255d88db59702765454545"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/20317c07bf1d2184974717a62a796852"
             },
             {
               "name": "x-xss-protection",
@@ -2751,17 +1672,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a647ad14ab5-CGK"
+              "value": "834de1554fd2568b-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.078Z",
-        "time": 433,
+        "startedDateTime": "2023-12-13T11:31:20.486Z",
+        "time": 206,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2769,7 +1690,219 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 433
+          "wait": 206
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 318,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 803,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 803,
+            "text": "[\"H4sIAAAAAAAA/5RVQZLj\",\"Ngz8i86LD/gB+4lUDhDVlhBTJBcAbStT8/cUva4pZzyUZ89sAuhmN/g2TOw8HN4GnDlWdkw/wV4VPyPPNhz+ehsSrxgOA0+rJOLEcXMJRkg8RkzDj6HdxHBwrXj/8YE3sIaF8iVBbZHSBc5aAv2bcfIuhEOAmYwRdJQIcgW64KJ5qsHJ6mhBpbjkZKTgCUoGPUsAcQi5poeOR472WCXkaSOunkNeS4SDJrHGmBRhC1HSTPlIRXGWXFv9XxXm1q94F0RSqU625AstYp5121Wme3gbsGjeB1wwUli4L+0XPHHkGp3MWUNuoi3bqNJ/6THmkQrPILuIh4VYwdYoqof6KMnL3pHTXFulyI4U+tI4Ila4boRrydrnd1c95ORITiMbplsbmuAIzRwvTNDkozWHEzlsT8jkyuZ0IyOcnGxLzldaZF6izItLmvu9fueJzBW8NnfN4jTGdvh9/W40r07jcaZVro/x/NyPRzqLiWclz1XpIr5Qyo4x59OLN2uuwnS7qwhS8A08x9gF5YLUrDYrl6W/BT5toMBh+YjlDtPvW5wsVw2fx3gKssypFrKqZ2zPe7CTe+V0+p8Bvjbqi6zdURPGuuOlD9FNJoysu6/zJ6thS7xKoLVGlygJdD9qK7Y/jnKLtqziRrgGYMJEx2Y82H4obiPgWqCyIjn3LfQ8rCuH3eK/qoTTzQP+OwJtJK6+ILmE9hdSNegOsa+/mj/7Y4pm+gc+Kkvqx+j+7gkXOmG7ZH0y3N/v7/8FAAD//9N81I7OBwAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "a9b1393c-9898-41cc-9bc4-c7a207296b26"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "wjZx50rhs4hr3Jd5H8zv5vccJ18zzl5FUQmQqETiynM-1702467080-1-AbcFWf5+Io6O2zuVSraJ4j/wkeVA3ZVquGOk2ilcxNtnGawfi9neBWJNcSpu/mnGlw7n/UFI9NaM4qMLzsnU/bA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=a9b1393c-9898-41cc-9bc4-c7a207296b26; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=wjZx50rhs4hr3Jd5H8zv5vccJ18zzl5FUQmQqETiynM-1702467080-1-AbcFWf5+Io6O2zuVSraJ4j/wkeVA3ZVquGOk2ilcxNtnGawfi9neBWJNcSpu/mnGlw7n/UFI9NaM4qMLzsnU/bA=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c4db0b4f08680d59d3caa0a0419378e6"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0f3ca496bf615f39"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c4db0b4f08680d59d3caa0a0419378e6"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de15548e8b4ed-OSL"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:20.487Z",
+        "time": 268,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 268
         }
       },
       {
@@ -2820,7 +1953,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2845,26 +1978,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0ebe16ae-ab16-4686-96ff-f5b5551bef47"
+              "value": "dbe8f078-a3c5-41bd-b8b9-bf552ded5cf1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HxOWljP9nbMgW55I7S06_eIrGLDkEzrT0nWtftvvO14-1702450413-1-AYB1Kanm6kYGYiIB+yrCmEJEk0nH7WE5lRT+JAWPlTYHoSDku8k81FwzKPnDVDEiqXlHjm2cU0+MRWugtSs8HU4="
+              "value": "UFGe65bhHCxPITdrDGG3UIg9WqGk7tIvS_R2MrAmufE-1702467080-1-AZzkDiZrV7ilETYOTy435gkLkQzK9p5QOR1SWgkNcCWmlGmj67IjHToNM/WHTAMg0D5Eu+djCYwm5FQUgtk3eLM="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -2877,6 +2010,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2893,12 +2038,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0ebe16ae-ab16-4686-96ff-f5b5551bef47; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=dbe8f078-a3c5-41bd-b8b9-bf552ded5cf1; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HxOWljP9nbMgW55I7S06_eIrGLDkEzrT0nWtftvvO14-1702450413-1-AYB1Kanm6kYGYiIB+yrCmEJEk0nH7WE5lRT+JAWPlTYHoSDku8k81FwzKPnDVDEiqXlHjm2cU0+MRWugtSs8HU4=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=UFGe65bhHCxPITdrDGG3UIg9WqGk7tIvS_R2MrAmufE-1702467080-1-AZzkDiZrV7ilETYOTy435gkLkQzK9p5QOR1SWgkNcCWmlGmj67IjHToNM/WHTAMg0D5Eu+djCYwm5FQUgtk3eLM=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2914,15 +2059,15 @@
             },
             {
               "name": "x-trace",
-              "value": "39bfad799b22b51a32c9c402a3c878a4"
+              "value": "00e7476cdfab48deb45c402ad2b4d02b"
             },
             {
               "name": "x-trace-span",
-              "value": "bdda7ba91fdc795d"
+              "value": "4b90a18ba600e97d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/39bfad799b22b51a32c9c402a3c878a4"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/00e7476cdfab48deb45c402ad2b4d02b"
             },
             {
               "name": "x-xss-protection",
@@ -2946,17 +2091,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a6958e66d12-CGK"
+              "value": "834de156bdd25688-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.856Z",
-        "time": 365,
+        "startedDateTime": "2023-12-13T11:31:20.700Z",
+        "time": 216,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2964,7 +2109,214 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 365
+          "wait": 216
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "cd03ad64-d83b-4b75-b899-c2d791a9cd56"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "MubSwANOMfTvcmB6DbHJVP_ov9LEMCKATSbO0PCv.Hc-1702467080-1-ASpaFe2Q/UkYVxAtgbmu/804GEYNQMf6jdC58sqzR8r8Xxa1EwM8//4DQVAxkSECLZA69nrObWp5rDVaxrxTIeI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=cd03ad64-d83b-4b75-b899-c2d791a9cd56; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=MubSwANOMfTvcmB6DbHJVP_ov9LEMCKATSbO0PCv.Hc-1702467080-1-ASpaFe2Q/UkYVxAtgbmu/804GEYNQMf6jdC58sqzR8r8Xxa1EwM8//4DQVAxkSECLZA69nrObWp5rDVaxrxTIeI=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "cc0da2a24b3a085ed5c768c3522017df"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "aa758508cc0605a0"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cc0da2a24b3a085ed5c768c3522017df"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de156bec9b505-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:20.702Z",
+        "time": 217,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 217
         }
       },
       {
@@ -3015,7 +2367,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3040,26 +2392,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e14af5e1-5b3e-49db-8ff6-b153e6961f7e"
+              "value": "69789915-16a2-4e5d-a568-e6383d88f62e"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "wjnYDzucyFiYDgqECDrlxD6wWBqBq8kXw.xEu3dBft8-1702450413-1-AVx3F/fHL7o8oDrnMP4GQFRkASP4BT8JKoFORxl+sjW1vmI+fi4Zf2+CjCNTsYPpcRKYDf+R5qdVDDZt8C5JqiM="
+              "value": "OQuvg18L8iPRu8ajKLshlU87BT0JxEX9iWVoEkArTzQ-1702467080-1-AVy2Abv/+EqGXQl/LdxzQOvZo3+ZbWh988oR5V2BJ6SP6NwyVrDjWOeKCV9WdR3EBxj9B6nBQW21q8Fu3wOOyeo="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -3074,6 +2426,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -3088,12 +2452,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e14af5e1-5b3e-49db-8ff6-b153e6961f7e; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=69789915-16a2-4e5d-a568-e6383d88f62e; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=wjnYDzucyFiYDgqECDrlxD6wWBqBq8kXw.xEu3dBft8-1702450413-1-AVx3F/fHL7o8oDrnMP4GQFRkASP4BT8JKoFORxl+sjW1vmI+fi4Zf2+CjCNTsYPpcRKYDf+R5qdVDDZt8C5JqiM=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=OQuvg18L8iPRu8ajKLshlU87BT0JxEX9iWVoEkArTzQ-1702467080-1-AVy2Abv/+EqGXQl/LdxzQOvZo3+ZbWh988oR5V2BJ6SP6NwyVrDjWOeKCV9WdR3EBxj9B6nBQW21q8Fu3wOOyeo=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3109,15 +2473,15 @@
             },
             {
               "name": "x-trace",
-              "value": "25d08161febdb4acf0b313e574dbb58b"
+              "value": "089f509cbbb7575b50df6d0a33c1dad0"
             },
             {
               "name": "x-trace-span",
-              "value": "fbda195972ec3bdd"
+              "value": "0467344c62efe08d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/25d08161febdb4acf0b313e574dbb58b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/089f509cbbb7575b50df6d0a33c1dad0"
             },
             {
               "name": "x-xss-protection",
@@ -3141,17 +2505,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a695eb16d1e-CGK"
+              "value": "834de156baaab500-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.864Z",
-        "time": 364,
+        "startedDateTime": "2023-12-13T11:31:20.708Z",
+        "time": 219,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3159,15 +2523,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 364
+          "wait": 219
         }
       },
       {
-        "_id": "abf571b71caf2e416903dc2620866f23",
+        "_id": "f183d7475b363dc45d23134c3118a915",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 436,
+          "bodySize": 180,
           "cookies": [],
           "headers": [
             {
@@ -3193,7 +2557,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "436"
+              "value": "180"
             },
             {
               "_fromType": "array",
@@ -3210,64 +2574,75 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 344,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
           },
           "queryString": [
             {
-              "name": "RecordTelemetryEvents",
+              "name": "EvaluateFeatureFlag",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 37,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "048cc3bf-3b8c-411e-8146-d7dec685a798"
+              "value": "d4118db0-dd4b-4a82-bc78-10ef5afd30f1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "KyAhQYDp5eTFrGo2VVwgsU4JHL8O1W48RrXbHRGllJg-1702450413-1-AWeraRrv+68/qdyj70y5ppzrbOMeuoJReqoTNOAOyX23YhT8Mq3GktQUQyLYquFYd7e3Qyte16j4WwRw8dHT5Sw="
+              "value": "hkOpc6XhArsnLh8iX9WMssiX0VZoD2ZEVkZMJ3othPg-1702467080-1-AZXF60vjM+/PSo1RERAlYAfnQ5/rJnUxdLyNEQemLSo57BVJhAs4ruf7UNtD/eeb93OKArRa5uqM+JfqAbp9gFE="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "37"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3284,12 +2659,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=048cc3bf-3b8c-411e-8146-d7dec685a798; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=d4118db0-dd4b-4a82-bc78-10ef5afd30f1; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=KyAhQYDp5eTFrGo2VVwgsU4JHL8O1W48RrXbHRGllJg-1702450413-1-AWeraRrv+68/qdyj70y5ppzrbOMeuoJReqoTNOAOyX23YhT8Mq3GktQUQyLYquFYd7e3Qyte16j4WwRw8dHT5Sw=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=hkOpc6XhArsnLh8iX9WMssiX0VZoD2ZEVkZMJ3othPg-1702467080-1-AZXF60vjM+/PSo1RERAlYAfnQ5/rJnUxdLyNEQemLSo57BVJhAs4ruf7UNtD/eeb93OKArRa5uqM+JfqAbp9gFE=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3305,15 +2680,15 @@
             },
             {
               "name": "x-trace",
-              "value": "1e7cb3debb12b6ca0519ddf08a8221e7"
+              "value": "5add46763d27fb0f045f05ce2d662e4c"
             },
             {
               "name": "x-trace-span",
-              "value": "4ec2c9eea9db5fe9"
+              "value": "c3ddcffc15b65861"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1e7cb3debb12b6ca0519ddf08a8221e7"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5add46763d27fb0f045f05ce2d662e4c"
             },
             {
               "name": "x-xss-protection",
@@ -3337,21 +2712,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a6979106d12-CGK"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
+              "value": "834de156bc5256c7-OSL"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.882Z",
-        "time": 352,
+        "startedDateTime": "2023-12-13T11:31:20.711Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3359,15 +2730,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 352
+          "wait": 218
         }
       },
       {
-        "_id": "37c9819d661e7a7c7feafb45c8579b01",
+        "_id": "243255429fc6f137e796538de9eb469f",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1188,
+          "bodySize": 189,
           "cookies": [],
           "headers": [
             {
@@ -3393,7 +2764,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "1188"
+              "value": "189"
             },
             {
               "_fromType": "array",
@@ -3410,51 +2781,51 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"bc4c317e-e047-4adf-a4b8-444f3a09f59c\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
           },
           "queryString": [
             {
-              "name": "LogEventMutation",
+              "name": "EvaluateFeatureFlag",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 26,
+          "bodySize": 37,
           "content": {
             "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "99dc8a86-d0e8-4941-8bc9-80472fa27dc0"
+              "value": "b77a2cb5-4c69-4067-b808-6388a56daa41"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XZ_iqK3GhL4Su.DX._Yhs4Zz1zs9LZJJydWGRraBN88-1702450413-1-Ab7g3AT2VPMTaKTeg5GhhpnYJORP5QG8mGWJY4UL1O5kz87MfjSvAW3zWTiqnqzOAlqBXG/cZjVAP+Z0Sy1fDSk="
+              "value": "Iz3tAfCGUgHUDcO_zV0C_2ViQyba9.v2nKS8h7qS1jc-1702467080-1-AYUKT3/7AscsLm7hMnxsl8lPcYEp5EfFqXk/grRZLdfEpK1iisJkY+xFtawPC8sA+6GNJ/BUV5PY+tvdJ6d+2aA="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -3462,11 +2833,23 @@
             },
             {
               "name": "content-length",
-              "value": "26"
+              "value": "37"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3483,12 +2866,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=99dc8a86-d0e8-4941-8bc9-80472fa27dc0; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=b77a2cb5-4c69-4067-b808-6388a56daa41; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=XZ_iqK3GhL4Su.DX._Yhs4Zz1zs9LZJJydWGRraBN88-1702450413-1-Ab7g3AT2VPMTaKTeg5GhhpnYJORP5QG8mGWJY4UL1O5kz87MfjSvAW3zWTiqnqzOAlqBXG/cZjVAP+Z0Sy1fDSk=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=Iz3tAfCGUgHUDcO_zV0C_2ViQyba9.v2nKS8h7qS1jc-1702467080-1-AYUKT3/7AscsLm7hMnxsl8lPcYEp5EfFqXk/grRZLdfEpK1iisJkY+xFtawPC8sA+6GNJ/BUV5PY+tvdJ6d+2aA=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3504,15 +2887,15 @@
             },
             {
               "name": "x-trace",
-              "value": "154f5c960ca477243c2a8c9d8cfc5c7b"
+              "value": "f8a4ddcfbe7ca92d153b61c6d5e8bc3b"
             },
             {
               "name": "x-trace-span",
-              "value": "103148f75e492c43"
+              "value": "3e132681fda20a9a"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/154f5c960ca477243c2a8c9d8cfc5c7b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f8a4ddcfbe7ca92d153b61c6d5e8bc3b"
             },
             {
               "name": "x-xss-protection",
@@ -3536,17 +2919,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a695f244ac7-CGK"
+              "value": "834de156bc2856c6-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.850Z",
-        "time": 411,
+        "startedDateTime": "2023-12-13T11:31:20.707Z",
+        "time": 229,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3554,7 +2937,214 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 411
+          "wait": 229
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "cd4a0bfc-065a-4d5e-947d-c5f3750ceb0a"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "esMM6LeReUhHaHRKUFlrpLftYPmt0HFmLR4rHorCMAU-1702467080-1-ARX4uq37a6erb8/P/MMbK0A+pHd+Mpbl4XSEkLpSnNrbAE4qnvgddfY2H5kcLEiUgx3I1BZrs38CKbI2cBEzK1I="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=cd4a0bfc-065a-4d5e-947d-c5f3750ceb0a; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=esMM6LeReUhHaHRKUFlrpLftYPmt0HFmLR4rHorCMAU-1702467080-1-ARX4uq37a6erb8/P/MMbK0A+pHd+Mpbl4XSEkLpSnNrbAE4qnvgddfY2H5kcLEiUgx3I1BZrs38CKbI2cBEzK1I=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d9b675a9d022307f5d41e2057ad2eb5f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0b47ab91b8fa74a1"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d9b675a9d022307f5d41e2057ad2eb5f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de156bb17b50f-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:20.704Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
         }
       },
       {
@@ -3605,7 +3195,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3630,26 +3220,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:20.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "248e3705-0e8c-49d3-bc05-de200451b561"
+              "value": "85211e11-5939-4726-bbff-b179e34bfb26"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:20.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "24PNgHSS6VwCTn05yJl7giBZ0R3PE24BEc1vw30er1s-1702450413-1-AVwVp/3O9CxbTvH61UcmUKLsCoKxl0bFfCy39XeT0wAyURA7WHLyaRxgUGbv/B3Kw1Nufz5jtjisvrN6uPZHcFs="
+              "value": "gjGaeZxwZsNU.ZODoEU9MZ4jD92lX8sjL4uIu_m14uo-1702467080-1-AfikPxEC7kVRjUQnzRxfK1mVK5PwZESWzgpki6GNKkLjU741zO5ErPWKDAEGdvJBOeZ5OaM+FXniuMTuP2YrQiY="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
             },
             {
               "name": "content-type",
@@ -3662,6 +3252,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3678,12 +3280,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=248e3705-0e8c-49d3-bc05-de200451b561; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=85211e11-5939-4726-bbff-b179e34bfb26; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=24PNgHSS6VwCTn05yJl7giBZ0R3PE24BEc1vw30er1s-1702450413-1-AVwVp/3O9CxbTvH61UcmUKLsCoKxl0bFfCy39XeT0wAyURA7WHLyaRxgUGbv/B3Kw1Nufz5jtjisvrN6uPZHcFs=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=gjGaeZxwZsNU.ZODoEU9MZ4jD92lX8sjL4uIu_m14uo-1702467080-1-AfikPxEC7kVRjUQnzRxfK1mVK5PwZESWzgpki6GNKkLjU741zO5ErPWKDAEGdvJBOeZ5OaM+FXniuMTuP2YrQiY=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3699,15 +3301,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e31bd09c80e0ddb721a1de8a347b1b6d"
+              "value": "e60895900f884ff2ffa75cc48a24d838"
             },
             {
               "name": "x-trace-span",
-              "value": "423e6093c614754e"
+              "value": "772287c5e8198428"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e31bd09c80e0ddb721a1de8a347b1b6d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e60895900f884ff2ffa75cc48a24d838"
             },
             {
               "name": "x-xss-protection",
@@ -3731,17 +3333,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a695aa96cf0-CGK"
+              "value": "834de156becf0b3d-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.865Z",
-        "time": 398,
+        "startedDateTime": "2023-12-13T11:31:20.710Z",
+        "time": 241,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3749,7 +3351,421 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 398
+          "wait": 241
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "d31599d2-b79e-40df-a0b8-66b9d0b21921"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "sqe9tH1viJYwjduBk.qK_YQ0nUQgxjym21uunIVGO2o-1702467080-1-AQj4QrqDAc7YykJvXdd6Um7RX0UleeQ9Vb+Y7q22ae/j3H8iMW0tZ6i507wkxpO/CrJx0IQzL9mwAhjRWrpJEJ0="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=d31599d2-b79e-40df-a0b8-66b9d0b21921; Expires=Fri, 13 Dec 2024 11:31:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=sqe9tH1viJYwjduBk.qK_YQ0nUQgxjym21uunIVGO2o-1702467080-1-AQj4QrqDAc7YykJvXdd6Um7RX0UleeQ9Vb+Y7q22ae/j3H8iMW0tZ6i507wkxpO/CrJx0IQzL9mwAhjRWrpJEJ0=; path=/; expires=Wed, 13-Dec-23 12:01:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "a442fbb0d4ffdff6e9c36cb2048d9904"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "8b0921a09e830148"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a442fbb0d4ffdff6e9c36cb2048d9904"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de156bb18569d-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:20.705Z",
+        "time": 252,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 252
+        }
+      },
+      {
+        "_id": "2057225ff0294a2be70cf4381f19fe8b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1188,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1188"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"0487dce9-7b5c-4206-9900-f6dca182f5fa\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "59e90ad6-83b7-4a0a-8445-7b416610c1ff"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "_I14TjVuxSE1jmGRI6j8rX4DmXaeYIUXk8wZU82IfPE-1702467081-1-ARBN9mKkfpXxQ0DjFuXhjuMPyFQCOZ6QyWLhfOmB/kOvip05Yx0QDm2ZxAWqu5gp8nzER4ovxEZMO4GlYr9Eo4M="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=59e90ad6-83b7-4a0a-8445-7b416610c1ff; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=_I14TjVuxSE1jmGRI6j8rX4DmXaeYIUXk8wZU82IfPE-1702467081-1-ARBN9mKkfpXxQ0DjFuXhjuMPyFQCOZ6QyWLhfOmB/kOvip05Yx0QDm2ZxAWqu5gp8nzER4ovxEZMO4GlYr9Eo4M=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "bfe7581e7cfaf9be593c7a4e2a38063c"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a24882c8d56df5a1"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bfe7581e7cfaf9be593c7a4e2a38063c"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de1599f2956aa-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:21.155Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
         }
       },
       {
@@ -3800,7 +3816,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 344,
+          "headersSize": 327,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3826,26 +3842,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "3ad3a13a-a3d8-4e5e-aa08-afe1c9e971e4"
+              "value": "300d5a56-e46a-421b-af68-7805025891f6"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:21.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ISa8S._pMJGqLSjip8uB9FWs93Jwogqm4FwcxO3JqVQ-1702450413-1-AemYtIJ8MaWEdNlFxT4YgqwZsFNSLhST6N1RhoW/IeO9qq21MaXn1l+uXO8DuM9bzzhJVQ8DFTYWpHCLR9sJGKM="
+              "value": "ctKlKosVwO6rVxKYKZ9iRN_.pdU.OBv_jEQnUtZils0-1702467081-1-Ab265gMA/LhnwlCQ1yvcIbLOEJ8M9UBJSdUxuluGQG8kdAIZHy34sCej2BSsEptNPL1bydw5xHN8na8gj1rihVk="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
             },
             {
               "name": "content-type",
@@ -3858,6 +3874,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3874,12 +3902,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3ad3a13a-a3d8-4e5e-aa08-afe1c9e971e4; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=300d5a56-e46a-421b-af68-7805025891f6; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=ISa8S._pMJGqLSjip8uB9FWs93Jwogqm4FwcxO3JqVQ-1702450413-1-AemYtIJ8MaWEdNlFxT4YgqwZsFNSLhST6N1RhoW/IeO9qq21MaXn1l+uXO8DuM9bzzhJVQ8DFTYWpHCLR9sJGKM=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ctKlKosVwO6rVxKYKZ9iRN_.pdU.OBv_jEQnUtZils0-1702467081-1-Ab265gMA/LhnwlCQ1yvcIbLOEJ8M9UBJSdUxuluGQG8kdAIZHy34sCej2BSsEptNPL1bydw5xHN8na8gj1rihVk=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3895,15 +3923,15 @@
             },
             {
               "name": "x-trace",
-              "value": "8a3dbc9bd946a1562e06c9b2a4015939"
+              "value": "408961699319df1f27668057968d4118"
             },
             {
               "name": "x-trace-span",
-              "value": "c24c24f5da35fcee"
+              "value": "17bcac94d31dbb93"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a3dbc9bd946a1562e06c9b2a4015939"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/408961699319df1f27668057968d4118"
             },
             {
               "name": "x-xss-protection",
@@ -3927,21 +3955,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a694bdc6d16-CGK"
+              "value": "834de1599a315694-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.852Z",
-        "time": 436,
+        "startedDateTime": "2023-12-13T11:31:21.156Z",
+        "time": 247,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3949,11 +3977,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 436
+          "wait": 247
         }
       },
       {
-        "_id": "fbf04e275fb8ab7b5f9dc1eaa9d4ce5b",
+        "_id": "56f4ad2e9882b3520b8055bce1df92e7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -4000,13 +4028,13 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 323,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"70bc8d64-59d0-465d-8245-358d9660f25d\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"e5bba036-1aa5-4a70-a6c9-f6bd78b714e8\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -4025,26 +4053,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8c13ed66-386f-432d-8a6a-5bc0803d825e"
+              "value": "9f781aa5-30b6-46f1-99ba-8dde3088edbd"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:33.000Z",
+              "expires": "2023-12-13T12:01:21.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XKiRMd_uvyZqF_i1H3FCVtipahlEPZXZ2LxIS_bBYFc-1702450413-1-AZ0HyZkseUkFLoam0JKVsCGmu0MKY/5JzPJq75ylL1ckXnRvKIrGQbDw0dd/8EF45qP8VBgHQrUzjs8W1QWmRcw="
+              "value": "cxvD7wmXsk1b11vzVTxz1.xH15yX3h.BEKq1Ht2vsOU-1702467081-1-AXqWq8d8PkSVtEAplRX2IrEhmH/coBcWfPB7dO6i8OHwgG2rgnmH5sbUlsMFoNYykxMBSuXPNeAMQ2goJnMc+Gw="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:33 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
             },
             {
               "name": "content-type",
@@ -4057,6 +4085,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4073,12 +4113,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8c13ed66-386f-432d-8a6a-5bc0803d825e; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=9f781aa5-30b6-46f1-99ba-8dde3088edbd; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=XKiRMd_uvyZqF_i1H3FCVtipahlEPZXZ2LxIS_bBYFc-1702450413-1-AZ0HyZkseUkFLoam0JKVsCGmu0MKY/5JzPJq75ylL1ckXnRvKIrGQbDw0dd/8EF45qP8VBgHQrUzjs8W1QWmRcw=; path=/; expires=Wed, 13-Dec-23 07:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=cxvD7wmXsk1b11vzVTxz1.xH15yX3h.BEKq1Ht2vsOU-1702467081-1-AXqWq8d8PkSVtEAplRX2IrEhmH/coBcWfPB7dO6i8OHwgG2rgnmH5sbUlsMFoNYykxMBSuXPNeAMQ2goJnMc+Gw=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4094,15 +4134,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5967b25c858dff8d523135440e0e546a"
+              "value": "a645b64c18d9450e25543e582fc18df1"
             },
             {
               "name": "x-trace-span",
-              "value": "4dcd4436d3bcdf35"
+              "value": "c9b75caa4b96dd2a"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5967b25c858dff8d523135440e0e546a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a645b64c18d9450e25543e582fc18df1"
             },
             {
               "name": "x-xss-protection",
@@ -4126,17 +4166,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a697d145ea8-CGK"
+              "value": "834de159a9cf56ba-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:32.881Z",
-        "time": 434,
+        "startedDateTime": "2023-12-13T11:31:21.170Z",
+        "time": 253,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4144,7 +4184,219 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 434
+          "wait": 253
+        }
+      },
+      {
+        "_id": "abf571b71caf2e416903dc2620866f23",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 436,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "436"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 119,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "bae44762-ac50-42c8-9c52-3d8d049fd478"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "gC3UwWDK2P3x.iQBlIhb9sQbvF7qvHi5hSSOTef6Xkk-1702467081-1-ASi4O/r3p6mA99e9jOWE2jtkmkA0s/QcROvvgwZW9nBd0RPKDo3HUMTFBYzSiQjL7ylwJgcaCSOMCeyRFv3Rm/s="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "218"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=bae44762-ac50-42c8-9c52-3d8d049fd478; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=gC3UwWDK2P3x.iQBlIhb9sQbvF7qvHi5hSSOTef6Xkk-1702467081-1-ASi4O/r3p6mA99e9jOWE2jtkmkA0s/QcROvvgwZW9nBd0RPKDo3HUMTFBYzSiQjL7ylwJgcaCSOMCeyRFv3Rm/s=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "22640ee581aed3ff95b185eddc0b6000"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5cc32ce5b165eaa5"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/22640ee581aed3ff95b185eddc0b6000"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de159aaaf56af-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:21.171Z",
+        "time": 264,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 264
         }
       },
       {
@@ -4195,7 +4447,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -4220,26 +4472,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:33.000Z",
+              "expires": "2024-12-13T11:31:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e094ec9d-da0f-42f6-93ec-2f27674d1111"
+              "value": "3248bd6d-8390-4ef0-9a20-660ef5820751"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:34.000Z",
+              "expires": "2023-12-13T12:01:21.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3C5adi3UgkS2gz_ylC8n44dDd2wdKvY5VGaJibICfxM-1702450414-1-Adi79mR9Qv3QhxApYbz+AMVpzV8ULlJhDCCqTKiduRJEdh0lU0O/Y6Zvu/EKRjpMxtYFg1RlC5sGov4MFIzi+O0="
+              "value": "vo7J9akAXoB7yheXjZi_Zhy_E0fFTrNKIWZZFmtZMZc-1702467081-1-Ab+Np5XfpnT9svsxdc2AQ9plinoYZOx9sIVSyoK092X0DKHm52ndt235xRhe37TVHVpjjQI/C15IyWEG7VlmeRs="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
             },
             {
               "name": "content-type",
@@ -4254,6 +4506,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -4268,12 +4532,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e094ec9d-da0f-42f6-93ec-2f27674d1111; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=3248bd6d-8390-4ef0-9a20-660ef5820751; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3C5adi3UgkS2gz_ylC8n44dDd2wdKvY5VGaJibICfxM-1702450414-1-Adi79mR9Qv3QhxApYbz+AMVpzV8ULlJhDCCqTKiduRJEdh0lU0O/Y6Zvu/EKRjpMxtYFg1RlC5sGov4MFIzi+O0=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=vo7J9akAXoB7yheXjZi_Zhy_E0fFTrNKIWZZFmtZMZc-1702467081-1-Ab+Np5XfpnT9svsxdc2AQ9plinoYZOx9sIVSyoK092X0DKHm52ndt235xRhe37TVHVpjjQI/C15IyWEG7VlmeRs=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4289,15 +4553,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d87fd3f020675080616b4f58731fc335"
+              "value": "f17081bb49001b04b225fff0ade2ea6d"
             },
             {
               "name": "x-trace-span",
-              "value": "4b750c37a4892dba"
+              "value": "18645c9bc01e2567"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d87fd3f020675080616b4f58731fc335"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f17081bb49001b04b225fff0ade2ea6d"
             },
             {
               "name": "x-xss-protection",
@@ -4321,17 +4585,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a6ea9656cf8-CGK"
+              "value": "834de15cac50568a-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:33.711Z",
-        "time": 349,
+        "startedDateTime": "2023-12-13T11:31:21.654Z",
+        "time": 216,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4339,787 +4603,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 349
-        }
-      },
-      {
-        "_id": "103c65b93dfa88c72eea86b3b023599e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 194,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "194"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "92fd89a1-1714-440c-89be-b6f5d7c9b408"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "S7WTnjOlzFYeaVvrKCnWS5VYnii_gTgCFf8S_wqem9M-1702450414-1-AXk3Wt7fjbWbX2MO0qk2cghhI+SttJi87TfNrWEilkaacX+IKEYXQeyGtjbF4v71EmvXosS6xG5rR7YiX8zRFMs="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=92fd89a1-1714-440c-89be-b6f5d7c9b408; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=S7WTnjOlzFYeaVvrKCnWS5VYnii_gTgCFf8S_wqem9M-1702450414-1-AXk3Wt7fjbWbX2MO0qk2cghhI+SttJi87TfNrWEilkaacX+IKEYXQeyGtjbF4v71EmvXosS6xG5rR7YiX8zRFMs=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "377a53adf85f89a488b91e9f86ba0568"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f21cf4e0184fde62"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/377a53adf85f89a488b91e9f86ba0568"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a6eafa23573-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:33.709Z",
-        "time": 429,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 429
-        }
-      },
-      {
-        "_id": "4cb0e95333a7b013a23cbf416464bd74",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7c74d2a1-142d-44fb-8b7e-83db23a9b0cc"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": ".QvxDGWpcf9V33h6JfN3OZ5FUnLflmV00Png4vaa9cM-1702450414-1-AU061LM68efWDdNy3Wc7RkiPrSTk08wcyWzwzklScQrzCYBvQ2RA8F2jr4uXZiS9V/ZUJE4qsxJtL/3dstH5nf8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7c74d2a1-142d-44fb-8b7e-83db23a9b0cc; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=.QvxDGWpcf9V33h6JfN3OZ5FUnLflmV00Png4vaa9cM-1702450414-1-AU061LM68efWDdNy3Wc7RkiPrSTk08wcyWzwzklScQrzCYBvQ2RA8F2jr4uXZiS9V/ZUJE4qsxJtL/3dstH5nf8=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8cd941b81cd61bae24c4153a46683708"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4d4e89c37d2fffa8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8cd941b81cd61bae24c4153a46683708"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a6eabb97239-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:33.708Z",
-        "time": 434,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 434
-        }
-      },
-      {
-        "_id": "3bfde46a074296956deef9dbd207df0b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 191,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "191"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ae02fdc5-4304-4423-a0f6-68446e564772"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "sskMGNDMegCf4eaUJjjlRBhpI_vmrh2NF28IFI0XmVY-1702450414-1-AZaU1WT91XfjgGxjVWeY9CIoIT55nkPwYE31M1uN0EwUemiJMAlaBHXJgCslt2c2OyKmhzxW2NOrbVFriJ26FYk="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ae02fdc5-4304-4423-a0f6-68446e564772; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=sskMGNDMegCf4eaUJjjlRBhpI_vmrh2NF28IFI0XmVY-1702450414-1-AZaU1WT91XfjgGxjVWeY9CIoIT55nkPwYE31M1uN0EwUemiJMAlaBHXJgCslt2c2OyKmhzxW2NOrbVFriJ26FYk=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "51263bbd6237c8c9d6a56c3066167874"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "5a8fd383ac6d0acc"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/51263bbd6237c8c9d6a56c3066167874"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a6eae5d356e-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:33.710Z",
-        "time": 432,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 432
-        }
-      },
-      {
-        "_id": "b0631b180e044100e370fb91fff490ce",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"70bc8d64-59d0-465d-8245-358d9660f25d\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-13T06:53:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "03f3bf33-feef-47c3-b6d4-0bfbc8463430"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "KO_oTkjSclbuaGOrLU7iBex6xPayl9eNxZQdv70TrI8-1702450414-1-AaRMFylLxVMWsVodbCvUihblJkDUGEBy5MKVF+SO5arHbF3cc4nGFjlpBCarmLrc+A7zCieNpR/MMTT8prXphe8="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=03f3bf33-feef-47c3-b6d4-0bfbc8463430; Expires=Fri, 13 Dec 2024 06:53:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=KO_oTkjSclbuaGOrLU7iBex6xPayl9eNxZQdv70TrI8-1702450414-1-AaRMFylLxVMWsVodbCvUihblJkDUGEBy5MKVF+SO5arHbF3cc4nGFjlpBCarmLrc+A7zCieNpR/MMTT8prXphe8=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c53d5c4a387ea0b39d3db6659946871c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "863e8f51db1badb7"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c53d5c4a387ea0b39d3db6659946871c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a6ea9255e9a-CGK"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:33.701Z",
-        "time": 442,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 442
+          "wait": 216
         }
       },
       {
@@ -5170,7 +4654,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5195,26 +4679,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:34.000Z",
+              "expires": "2024-12-13T11:31:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ed384a08-c875-4e2e-a103-d7cb4be88982"
+              "value": "f5d71b89-1051-4b43-a4b4-b921f0fcc6c0"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:34.000Z",
+              "expires": "2023-12-13T12:01:21.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "BSIO_x9feR0oFDrqXezP8EnOrZCiXvG4JExbVLDhhP4-1702450414-1-Afz6WUfMBbnpChwyQ/itKKHzQFktdn4eBmlWT4P/L6wxZoZknMwEXkB2Nx8LAGmhi4Te1tp+Knl6sLE7VCmFPqs="
+              "value": "orC2lEITVq9EowZA6x82hKKde575fSVnT9VRGKWI8Wg-1702467081-1-AXLvaguk3UPpUj+qHgro38uhSeqWy4hYv7wjyjI90FXqI+erk4ibHcGgce2bVQJk2Lk4TFT2Qi/2UVJAq6GZ1nY="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:34 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
             },
             {
               "name": "content-type",
@@ -5227,6 +4711,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5243,12 +4739,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ed384a08-c875-4e2e-a103-d7cb4be88982; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=f5d71b89-1051-4b43-a4b4-b921f0fcc6c0; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=BSIO_x9feR0oFDrqXezP8EnOrZCiXvG4JExbVLDhhP4-1702450414-1-Afz6WUfMBbnpChwyQ/itKKHzQFktdn4eBmlWT4P/L6wxZoZknMwEXkB2Nx8LAGmhi4Te1tp+Knl6sLE7VCmFPqs=; path=/; expires=Wed, 13-Dec-23 07:23:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=orC2lEITVq9EowZA6x82hKKde575fSVnT9VRGKWI8Wg-1702467081-1-AXLvaguk3UPpUj+qHgro38uhSeqWy4hYv7wjyjI90FXqI+erk4ibHcGgce2bVQJk2Lk4TFT2Qi/2UVJAq6GZ1nY=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5264,15 +4760,15 @@
             },
             {
               "name": "x-trace",
-              "value": "4fdfb603dedd61b1d35f24a54aa2ef22"
+              "value": "aa291a09b9d6b0ddb01de39dc010f1cc"
             },
             {
               "name": "x-trace-span",
-              "value": "c395b79f73ecb9fe"
+              "value": "5c2d94c035508d1f"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4fdfb603dedd61b1d35f24a54aa2ef22"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/aa291a09b9d6b0ddb01de39dc010f1cc"
             },
             {
               "name": "x-xss-protection",
@@ -5296,17 +4792,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a6eac8bbea7-CGK"
+              "value": "834de15c9a77b4ff-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:33.707Z",
-        "time": 469,
+        "startedDateTime": "2023-12-13T11:31:21.652Z",
+        "time": 236,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5314,7 +4810,835 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 469
+          "wait": 236
+        }
+      },
+      {
+        "_id": "103c65b93dfa88c72eea86b3b023599e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 194,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "194"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-hybrid\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "7f87c461-27ef-4557-80e6-3ada01e028d6"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "4bZ3tHphaOGXDrX4V7iBOWuqEEOmYZWqh2Qsev.Gzy0-1702467081-1-Af7ghHgb59BTEfD0PtfnHcE1iBEBl3Qu8kl382h2my2e16+oVAja1TP8KRyXEleENejdyQYr0ndWXVbVWxTzvWk="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=7f87c461-27ef-4557-80e6-3ada01e028d6; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=4bZ3tHphaOGXDrX4V7iBOWuqEEOmYZWqh2Qsev.Gzy0-1702467081-1-Af7ghHgb59BTEfD0PtfnHcE1iBEBl3Qu8kl382h2my2e16+oVAja1TP8KRyXEleENejdyQYr0ndWXVbVWxTzvWk=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "775944b973b7d39f8a23e55526cd011d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "30ea5b7f6732c394"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/775944b973b7d39f8a23e55526cd011d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de15ca85856ab-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:21.653Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
+        }
+      },
+      {
+        "_id": "4cb0e95333a7b013a23cbf416464bd74",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-starcoder-16b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "cf6a37ed-c547-4fe6-9804-69170a96b494"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "xOKibdnUQMfETvK1WPxO7DjhhRLbDDrkBIw2ecx9N6U-1702467081-1-ASSrNS7ghiDWC3sZiviDVTk1ufyNBLeX1t9y1A8XdMiP16X9FbAYQ53SW/vNyJdKqb2yelsSxdaYPWB8vowCuhE="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=cf6a37ed-c547-4fe6-9804-69170a96b494; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=xOKibdnUQMfETvK1WPxO7DjhhRLbDDrkBIw2ecx9N6U-1702467081-1-ASSrNS7ghiDWC3sZiviDVTk1ufyNBLeX1t9y1A8XdMiP16X9FbAYQ53SW/vNyJdKqb2yelsSxdaYPWB8vowCuhE=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "85977a8b810f65f14dc265e8df9eb946"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3558faa6a10c7318"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/85977a8b810f65f14dc265e8df9eb946"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de15ca8e8b524-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:21.652Z",
+        "time": 281,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 281
+        }
+      },
+      {
+        "_id": "3bfde46a074296956deef9dbd207df0b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 191,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "191"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-default-llama-code-7b\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "dc652f7d-5a50-47dd-b62d-3dce825542e2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Cr72uDV7TxrhodHI.dLnoUr8rzztNoqdkOWFPWa.zsE-1702467081-1-Ae6NP4NWQNjdbS0E8nNgAcb5pZj09UbGjMSY0LDjD7+VYeBKkNubxQtojNLm9LzjRsKmu/2tcZi4xLb2aZWjZ8M="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=dc652f7d-5a50-47dd-b62d-3dce825542e2; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Cr72uDV7TxrhodHI.dLnoUr8rzztNoqdkOWFPWa.zsE-1702467081-1-Ae6NP4NWQNjdbS0E8nNgAcb5pZj09UbGjMSY0LDjD7+VYeBKkNubxQtojNLm9LzjRsKmu/2tcZi4xLb2aZWjZ8M=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "33ff62af932e798f39ec3502b0a2e15f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e8e71c6153190585"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/33ff62af932e798f39ec3502b0a2e15f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de15cab7956c9-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:21.653Z",
+        "time": 281,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 281
+        }
+      },
+      {
+        "_id": "a3a2ecda53a9bdc15b04b1904f37266d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"e5bba036-1aa5-4a70-a6c9-f6bd78b714e8\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "4478d9ef-65c6-4b8a-99bb-eb81ff04acc3"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "EFxuk_s1lgQiePmxiaLqy81DwtphogWjeV_KKwv26dA-1702467081-1-AUlqkIFRKIpFGgdgwbeAOQhd4jVwgbz9RUHKsWiyKamtN7M8vGRrFxsCI6GCUqvkhXtjcdtARQ9mfZjeOWhfXAU="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4478d9ef-65c6-4b8a-99bb-eb81ff04acc3; Expires=Fri, 13 Dec 2024 11:31:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=EFxuk_s1lgQiePmxiaLqy81DwtphogWjeV_KKwv26dA-1702467081-1-AUlqkIFRKIpFGgdgwbeAOQhd4jVwgbz9RUHKsWiyKamtN7M8vGRrFxsCI6GCUqvkhXtjcdtARQ9mfZjeOWhfXAU=; path=/; expires=Wed, 13-Dec-23 12:01:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1b4817e301a65d2c9997579c0dd24747"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "aeae60d039c8b1ae"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1b4817e301a65d2c9997579c0dd24747"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de15c9e5256b7-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:21.648Z",
+        "time": 304,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 304
         }
       },
       {
@@ -5365,7 +5689,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 325,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5390,26 +5714,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:34.000Z",
+              "expires": "2024-12-13T11:31:22.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5990ee44-36bc-46f6-9c0c-acf400b17cf6"
+              "value": "c041ddf4-6780-4065-afa6-47d905ea3386"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:35.000Z",
+              "expires": "2023-12-13T12:01:22.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "4QPAlL.nea4FAdVoYntc8W62UCeJYMrnzKLdRq7dg_w-1702450415-1-ARxBAbx1EluI5ktUf8ntWvfZSqOYPJioM0xnuL01Lwp9NDke2eO0rmk2QMK/UtoscmhTPVJHOvRjjf5u88SHiKw="
+              "value": "g7ZH1CuqMuqzXUC7NmqK2WL2Ci_fDiiRRiVhd5XKUlU-1702467082-1-AVTWz8LvqrNrLYtG7fk71eD2Y+1USVa0+L+viFR3PxTJrTEEUBP4j6kWiIeK9oWR/EYCTsShfnk60iGZxiq3dZs="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:35 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:22 GMT"
             },
             {
               "name": "content-type",
@@ -5422,6 +5746,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5438,12 +5774,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5990ee44-36bc-46f6-9c0c-acf400b17cf6; Expires=Fri, 13 Dec 2024 06:53:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=c041ddf4-6780-4065-afa6-47d905ea3386; Expires=Fri, 13 Dec 2024 11:31:22 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=4QPAlL.nea4FAdVoYntc8W62UCeJYMrnzKLdRq7dg_w-1702450415-1-ARxBAbx1EluI5ktUf8ntWvfZSqOYPJioM0xnuL01Lwp9NDke2eO0rmk2QMK/UtoscmhTPVJHOvRjjf5u88SHiKw=; path=/; expires=Wed, 13-Dec-23 07:23:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=g7ZH1CuqMuqzXUC7NmqK2WL2Ci_fDiiRRiVhd5XKUlU-1702467082-1-AVTWz8LvqrNrLYtG7fk71eD2Y+1USVa0+L+viFR3PxTJrTEEUBP4j6kWiIeK9oWR/EYCTsShfnk60iGZxiq3dZs=; path=/; expires=Wed, 13-Dec-23 12:01:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5459,15 +5795,15 @@
             },
             {
               "name": "x-trace",
-              "value": "8a43eb40de9d3b9e422320012a9183ee"
+              "value": "ee78eb769880a327e4e7ceabab39fd97"
             },
             {
               "name": "x-trace-span",
-              "value": "fe6b698151814da7"
+              "value": "38c1f9c595a4ed63"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a43eb40de9d3b9e422320012a9183ee"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ee78eb769880a327e4e7ceabab39fd97"
             },
             {
               "name": "x-xss-protection",
@@ -5491,17 +5827,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a73df934ad0-CGK"
+              "value": "834de15f1fcb5696-OSL"
             }
           ],
-          "headersSize": 1129,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:34.542Z",
-        "time": 408,
+        "startedDateTime": "2023-12-13T11:31:22.067Z",
+        "time": 201,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5509,7 +5845,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 408
+          "wait": 201
         }
       },
       {
@@ -5560,7 +5896,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 332,
+          "headersSize": 315,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5580,26 +5916,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:35.000Z",
+              "expires": "2024-12-13T11:31:22.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "41578c63-e0d7-4464-8901-94e63c1863a8"
+              "value": "3c926e69-401c-40c5-a3a7-60befcdb8ebc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:36.000Z",
+              "expires": "2023-12-13T12:01:22.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8aM_VkThkthR_oWFzVIB8G3qRNzOH4j6MJgZXTs7lfw-1702450416-1-AUZUDP3gkMiYvQIZsop385qxAaBOPOviEzRjR65Ulo5hYp0AcU9xvDzS56XlIZZRqBp0aCmBF26EvMAc//C9teA="
+              "value": "h0vWRu3bJOZHzT7GJeVwckHjxfJDG76uwSEEriA7Nc4-1702467082-1-AQZGTThu/CNxGRc0pZg9cB9gp5mmKAwiNpvLy8S6ALJvheT1uXQ9b1HjfYyLybXU1mgq0zbuv0in+vc8KLt/3/Q="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:36 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:22 GMT"
             },
             {
               "name": "content-type",
@@ -5612,6 +5948,18 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "217"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5628,12 +5976,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=41578c63-e0d7-4464-8901-94e63c1863a8; Expires=Fri, 13 Dec 2024 06:53:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=3c926e69-401c-40c5-a3a7-60befcdb8ebc; Expires=Fri, 13 Dec 2024 11:31:22 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=8aM_VkThkthR_oWFzVIB8G3qRNzOH4j6MJgZXTs7lfw-1702450416-1-AUZUDP3gkMiYvQIZsop385qxAaBOPOviEzRjR65Ulo5hYp0AcU9xvDzS56XlIZZRqBp0aCmBF26EvMAc//C9teA=; path=/; expires=Wed, 13-Dec-23 07:23:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=h0vWRu3bJOZHzT7GJeVwckHjxfJDG76uwSEEriA7Nc4-1702467082-1-AQZGTThu/CNxGRc0pZg9cB9gp5mmKAwiNpvLy8S6ALJvheT1uXQ9b1HjfYyLybXU1mgq0zbuv0in+vc8KLt/3/Q=; path=/; expires=Wed, 13-Dec-23 12:01:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5649,15 +5997,15 @@
             },
             {
               "name": "x-trace",
-              "value": "ea537434df525fd6aa0d1165cb6d6d3b"
+              "value": "e198dff6259d4a189d4e309cacb3cf1c"
             },
             {
               "name": "x-trace-span",
-              "value": "b83b6131848ce938"
+              "value": "01d52cc062592934"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ea537434df525fd6aa0d1165cb6d6d3b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e198dff6259d4a189d4e309cacb3cf1c"
             },
             {
               "name": "x-xss-protection",
@@ -5681,17 +6029,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a767d9a4acd-CGK"
+              "value": "834de1606dbf1c06-OSL"
             }
           ],
-          "headersSize": 1132,
+          "headersSize": 1239,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:34.959Z",
-        "time": 1213,
+        "startedDateTime": "2023-12-13T11:31:22.274Z",
+        "time": 506,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5699,7 +6047,845 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1213
+          "wait": 506
+        }
+      },
+      {
+        "_id": "7e6130e6290f6f581e2aca89845f25aa",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1228,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1228"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"e5bba036-1aa5-4a70-a6c9-f6bd78b714e8\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:23.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "b9ba1283-2756-4d01-b8c6-e56816cb6fe4"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "jiAH.aOD60ni_iNLoepx4WdRLccuAwFf1_q3nM_Rf5s-1702467083-1-AXzAhDFGOwQLzOTxaeFrNzz9/UyXmb85XxqDV7ncbTsDaxspV+7n6/S+hFH9dCw7o787YxeIjXai868/wPj29Z4="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "216"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=b9ba1283-2756-4d01-b8c6-e56816cb6fe4; Expires=Fri, 13 Dec 2024 11:31:23 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=jiAH.aOD60ni_iNLoepx4WdRLccuAwFf1_q3nM_Rf5s-1702467083-1-AXzAhDFGOwQLzOTxaeFrNzz9/UyXmb85XxqDV7ncbTsDaxspV+7n6/S+hFH9dCw7o787YxeIjXai868/wPj29Z4=; path=/; expires=Wed, 13-Dec-23 12:01:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1c42bd4361d69565e89b56aad7a91d06"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "bc47564961e6b2fa"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1c42bd4361d69565e89b56aad7a91d06"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de164c89e569d-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:22.967Z",
+        "time": 218,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 218
+        }
+      },
+      {
+        "_id": "ba35b3379ebf392c1df76d7403fea118",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1618,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1618"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 328,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"interactionID\":\"8be2cb87-6eaa-4a17-8169-08ecfbe43317\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":0.3361250013113022},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"fireworks\",\"providerModel\":\"starcoder-hybrid\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"8be2cb87-6eaa-4a17-8169-08ecfbe43317\",\"contextSummary\":{\"strategy\":\"jaccard-similarity\",\"duration\":0.3361250013113022,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\"}}}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:23.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "db1b32f6-4cc0-4dd7-9572-3d2b9f53d7b9"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "iMSIK9rPROktfWOcga3JlFmyr2gANBS9Tjgn4kxCW.Y-1702467083-1-AYb5Bvd5cgmkKagQlCxdrf30yeNGLVX3QbuwZX4wUYGxSilbyS7x5Z9GNQuiRxsfnJap4m98M42zsnuR1Q9miuI="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "216"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=db1b32f6-4cc0-4dd7-9572-3d2b9f53d7b9; Expires=Fri, 13 Dec 2024 11:31:23 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=iMSIK9rPROktfWOcga3JlFmyr2gANBS9Tjgn4kxCW.Y-1702467083-1-AYb5Bvd5cgmkKagQlCxdrf30yeNGLVX3QbuwZX4wUYGxSilbyS7x5Z9GNQuiRxsfnJap4m98M42zsnuR1Q9miuI=; path=/; expires=Wed, 13-Dec-23 12:01:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "00fb1d0cd2aac863e9e703f434fd27a9"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "42b3579af78ba65a"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/00fb1d0cd2aac863e9e703f434fd27a9"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de164ca3056a5-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:22.970Z",
+        "time": 220,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 220
+        }
+      },
+      {
+        "_id": "6b40801b36f095de43f8ce5613ef349c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1986,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1986"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 323,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"e5bba036-1aa5-4a70-a6c9-f6bd78b714e8\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"fireworks\\\",\\\"providerModel\\\":\\\"starcoder-hybrid\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"8be2cb87-6eaa-4a17-8169-08ecfbe43317\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"jaccard-similarity\\\",\\\"duration\\\":0.3361250013113022,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:23.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "93da893b-b2ff-4e7d-bcb8-1caf70270599"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "gC6A04QMUPPDNXlc5o.RuZiJ.PtCZlWWgF0poEcjfT8-1702467083-1-AVKXLryU4ZA6HcZCldGjfwa9OwS3EOprbB42g8L6VQiggDgBOOnE/xILM1QW3q7LLNzGvEzerof4tJXmrT4jiYg="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "216"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=93da893b-b2ff-4e7d-bcb8-1caf70270599; Expires=Fri, 13 Dec 2024 11:31:23 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=gC6A04QMUPPDNXlc5o.RuZiJ.PtCZlWWgF0poEcjfT8-1702467083-1-AVKXLryU4ZA6HcZCldGjfwa9OwS3EOprbB42g8L6VQiggDgBOOnE/xILM1QW3q7LLNzGvEzerof4tJXmrT4jiYg=; path=/; expires=Wed, 13-Dec-23 12:01:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1899f44fdadf0c979d337322ddfcf898"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "93eadfc7747a2423"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1899f44fdadf0c979d337322ddfcf898"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de164caf2b50b-OSL"
+            }
+          ],
+          "headersSize": 1236,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:22.968Z",
+        "time": 224,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 224
+        }
+      },
+      {
+        "_id": "ce0d0da0cf9aa1ef9a39f599573e3501",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 458,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "458"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2024-12-13T11:31:23.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "a35d9722-fe7c-4fc3-8960-25d5f5413191"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2023-12-13T12:01:23.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "0z32bYI1zMij_tP5jP9ri1y9gshRlhMmo0d9s_68I68-1702467083-1-AZwrhm3FjSlPT94Y782fgz+iAqdbhICwpd51sWorrK4bG07Ox2dpOeKTAa2MtMxHuDn+51/Y9sCApqO5FAjdeDA="
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 13 Dec 2023 11:31:23 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "216"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=a35d9722-fe7c-4fc3-8960-25d5f5413191; Expires=Fri, 13 Dec 2024 11:31:23 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=0z32bYI1zMij_tP5jP9ri1y9gshRlhMmo0d9s_68I68-1702467083-1-AZwrhm3FjSlPT94Y782fgz+iAqdbhICwpd51sWorrK4bG07Ox2dpOeKTAa2MtMxHuDn+51/Y9sCApqO5FAjdeDA=; path=/; expires=Wed, 13-Dec-23 12:01:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "51bb750ea6fb92240eec2e2b2070caa7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "23926e92cd41554b"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/51bb750ea6fb92240eec2e2b2070caa7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "834de164cc4456b5-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1268,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2023-12-13T11:31:22.969Z",
+        "time": 227,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 227
         }
       },
       {
@@ -5750,7 +6936,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 344,
+          "headersSize": 327,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5776,26 +6962,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:36.000Z",
+              "expires": "2024-12-13T11:31:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "eceaa784-560a-4f1f-ab92-d9ed394a4327"
+              "value": "05e6c90a-4274-4990-8379-cec8b943fd4d"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:36.000Z",
+              "expires": "2023-12-13T12:01:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HJlZ4nbWNMGdX_hGJsJK7B2COrCflyhHS.oXhhwSioc-1702450416-1-ARcUNG6vSIMQIfrwP73ryxgwuh5mBMn4yt6kHgltx1tQXPFqfEQ2ffvRHLaTiAhIJPSN5jdZ6UJmWNmZRkb8tqA="
+              "value": "YLm8Z7x8cvVNcMdnxAPidIcSw5eTsF7SpqoVh5nqY0Y-1702467083-1-AfeBk1VvR/kQP1hm8jegrXRfqyDQiSrseoqbMhUv4AbLVbZSbz8gUWTcbqWNgJbQOAeeFA5SPV87Oo71NNwp+cs="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:36 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:23 GMT"
             },
             {
               "name": "content-type",
@@ -5808,6 +6994,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "216"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5824,12 +7022,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=eceaa784-560a-4f1f-ab92-d9ed394a4327; Expires=Fri, 13 Dec 2024 06:53:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=05e6c90a-4274-4990-8379-cec8b943fd4d; Expires=Fri, 13 Dec 2024 11:31:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HJlZ4nbWNMGdX_hGJsJK7B2COrCflyhHS.oXhhwSioc-1702450416-1-ARcUNG6vSIMQIfrwP73ryxgwuh5mBMn4yt6kHgltx1tQXPFqfEQ2ffvRHLaTiAhIJPSN5jdZ6UJmWNmZRkb8tqA=; path=/; expires=Wed, 13-Dec-23 07:23:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=YLm8Z7x8cvVNcMdnxAPidIcSw5eTsF7SpqoVh5nqY0Y-1702467083-1-AfeBk1VvR/kQP1hm8jegrXRfqyDQiSrseoqbMhUv4AbLVbZSbz8gUWTcbqWNgJbQOAeeFA5SPV87Oo71NNwp+cs=; path=/; expires=Wed, 13-Dec-23 12:01:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5845,15 +7043,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3cad9137c676db41fcc85890940ba1a2"
+              "value": "ae1ce4c52bf053764ec0b07a023db9e3"
             },
             {
               "name": "x-trace-span",
-              "value": "57d88503670ab1a5"
+              "value": "a483904b60411114"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3cad9137c676db41fcc85890940ba1a2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ae1ce4c52bf053764ec0b07a023db9e3"
             },
             {
               "name": "x-xss-protection",
@@ -5877,21 +7075,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "834c4a806c146d18-CGK"
+              "value": "834de1660ccd0b06-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1161,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-13T06:53:36.556Z",
-        "time": 356,
+        "startedDateTime": "2023-12-13T11:31:23.175Z",
+        "time": 217,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5899,15 +7097,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 356
+          "wait": 217
         }
       },
       {
-        "_id": "34fa3baab68c77b4e329fd24907b91f7",
+        "_id": "c75526ff72eff650934d864c4cd06c99",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1300,
+          "bodySize": 1314,
           "cookies": [],
           "headers": [
             {
@@ -5931,2371 +7129,46 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 261,
+          "headersSize": 244,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum?\"},{\"speaker\":\"assistant\"}]}"
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work with me inside a text editor.\\n\\nImportant rules to follow in all your responses:\\n- All code snippets must be markdown-formatted, and enclosed in triple backticks.\\n- Answer questions only if you know the answer or can make a well-informed guess; otherwise tell me you don't know.\\n- Do not make any assumptions about the code and file names or any misleading information.\"},{\"speaker\":\"assistant\",\"text\":\"Understood. I am Cody, an AI assistant developed by Sourcegraph to help with programming tasks.\\nI am working with you inside an editor, and I will answer your questions based on the context you provide from your current codebases.\\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\\nI will enclose any code snippets I provide in markdown backticks.\\nI will let you know if I need more information to answer a question.\"},{\"speaker\":\"human\",\"text\":\"(Reply as Cody, a coding assistant developed by Sourcegraph. If context is available: never make any assumptions nor provide any misleading or hypothetical examples.) How do I implement sum in JavaScript?\"},{\"speaker\":\"assistant\"}]}"
           },
           "queryString": [],
           "url": "https://sourcegraph.com/.api/completions/stream"
         },
         "response": {
-          "bodySize": 46196,
+          "bodySize": 32589,
           "content": {
             "mimeType": "text/event-stream",
-            "size": 46196,
-            "text": "event: completion\ndata: {\"completion\":\" I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum`\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try again\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try again!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" I apologize, but without more context I do not have enough information to provide a specific implementation of a `sum` function. A `sum` function could be implemented in many different ways depending on the language, data types, and intended usage. If you can provide more details about the goal, programming language, data types, and any existing code, I may be able to suggest a more specific implementation. As an AI assistant, I aim to provide helpful information based on the details available rather than make assumptions. Please let me know if you can provide any additional context, and I'm happy to try again!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "size": 32589,
+            "text": "event: completion\ndata: {\"completion\":\" Here\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total =\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i =\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n   \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total +=\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i];\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers =\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result =\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers);\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n//\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result =\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum of\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum of the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum of the numbers\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum of the numbers.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is how to implement a sum function in JavaScript:\\n\\n```js\\nfunction sum(arr) {\\n  let total = 0;\\n  for (let i = 0; i \\u003c arr.length; i++) {\\n    total += arr[i]; \\n  }\\n  return total;\\n}\\n```\\n\\nTo use:\\n\\n```js\\nconst numbers = [1, 2, 3, 4, 5];\\n\\nconst result = sum(numbers); \\n// result = 15\\n```\\n\\nThis implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum of the numbers.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
           "cookies": [
             {
-              "expires": "2024-12-13T06:53:36.000Z",
+              "expires": "2024-12-13T11:31:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "61749dac-9d85-475e-8364-6825cdecc2d1"
+              "value": "4dc0f660-7bef-45c7-9609-486bfed1f4ba"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-13T07:23:37.000Z",
+              "expires": "2023-12-13T12:01:25.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "zGCQLbPRCWdO_5jsYRmlSaklk9OB9I756TupS6E0R3U-1702450417-1-AWZnWhbFYJ+aMdm5ylY2p/ysXSyqf/BaeO5uPWF4of15YqBKHWfZZRiy/QElGY7s5qPjUzdELZp6ivLvAOcy32s="
+              "value": "AE4QlYQBFZEVUfNPsYvoz_zLpxy7PsrcYNsJ6xYrzt4-1702467085-1-ATjMko3VeunFin2Omvd65TdQtmvgU4L+BGnEcSVLCLSgKrNZhMbRhXzB8HvXXra/WvkiwK9gYodu15Ww97ilG40="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 13 Dec 2023 06:53:37 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=61749dac-9d85-475e-8364-6825cdecc2d1; Expires=Fri, 13 Dec 2024 06:53:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=zGCQLbPRCWdO_5jsYRmlSaklk9OB9I756TupS6E0R3U-1702450417-1-AWZnWhbFYJ+aMdm5ylY2p/ysXSyqf/BaeO5uPWF4of15YqBKHWfZZRiy/QElGY7s5qPjUzdELZp6ivLvAOcy32s=; path=/; expires=Wed, 13-Dec-23 07:23:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "2b88f4453f6e96f1417ed9735276e472"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "aa9bda62d9b84a4c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2b88f4453f6e96f1417ed9735276e472"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "834c4a7e0aad6cfa-CGK"
-            }
-          ],
-          "headersSize": 1132,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-13T06:53:36.184Z",
-        "time": 6856,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 6856
-        }
-      },
-      {
-        "_id": "648b7bd2fc47e7d1c610409c95476db3",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 444,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "444"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.extension\",\"action\":\"installed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "cd2d4078-fb4a-4602-89a5-15496a2f11a7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Y1lvynPH2uQ7HRJ9qs9xOnGkq5HSY7Kq3IgtiNGX3H0-1702308657-1-AYzFFgjqQtF2fsFKuh/eUYz2PNFQSqeNxI+LWQWKp4yIzbvqTA81avmYwwyqpACFbfXSYFvYXWIAF0WAzPQO4pc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cd2d4078-fb4a-4602-89a5-15496a2f11a7; Expires=Wed, 11 Dec 2024 15:30:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Y1lvynPH2uQ7HRJ9qs9xOnGkq5HSY7Kq3IgtiNGX3H0-1702308657-1-AYzFFgjqQtF2fsFKuh/eUYz2PNFQSqeNxI+LWQWKp4yIzbvqTA81avmYwwyqpACFbfXSYFvYXWIAF0WAzPQO4pc=; path=/; expires=Mon, 11-Dec-23 16:00:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d62d67e7f995c79f2ec5bfc9399e5ec4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "82fc38f74d8f77ec"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d62d67e7f995c79f2ec5bfc9399e5ec4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec591ff78b4fd-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:56.909Z",
-        "time": 235,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 235
-        }
-      },
-      {
-        "_id": "ec63b0ebd75c1eb935ebb5a38774cbfa",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1188,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1188"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"b082cc68-2e36-4764-acaf-68f97ad92a0f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b8499d72-db97-4d9d-8b7b-44491f3e86fa"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OtCcP2OBVYyg.xk49kAK6dfUSvdtl4MJNyJKPkpaUNE-1702308658-1-AVvAyYnYrEhLJZa+o+5INfmisMqLzyfoKCciOeg7/yyizFGVSo6AKjYbEZg8eLX25VKarE5xhWmxoJXaIWuXBW4="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b8499d72-db97-4d9d-8b7b-44491f3e86fa; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=OtCcP2OBVYyg.xk49kAK6dfUSvdtl4MJNyJKPkpaUNE-1702308658-1-AVvAyYnYrEhLJZa+o+5INfmisMqLzyfoKCciOeg7/yyizFGVSo6AKjYbEZg8eLX25VKarE5xhWmxoJXaIWuXBW4=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "a1f46153dd809745c850f937eeb9ef6b"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7ca0d0c638e41400"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a1f46153dd809745c850f937eeb9ef6b"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec597f81156b7-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.843Z",
-        "time": 290,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 290
-        }
-      },
-      {
-        "_id": "7312be94c5e3b8902993db416276cf04",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1186,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1186"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"1ec4f4ab-4a7f-402c-a0e5-5b14cfe46729\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "44e146d1-552c-4dbc-a615-2cdb6e785b6f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xUooyOA0MTvhhkiSbmkjR_8JobseH8gjp72CSiXLt28-1702308658-1-ASio6HJbyQjWi6wSKUmgH6+6nygSTY3cXvVqCBs1tUhmYKWCcRW8Xl/3h90OS3ju0/3q6ZIFrLPGlOwKirTLglM="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=44e146d1-552c-4dbc-a615-2cdb6e785b6f; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=xUooyOA0MTvhhkiSbmkjR_8JobseH8gjp72CSiXLt28-1702308658-1-ASio6HJbyQjWi6wSKUmgH6+6nygSTY3cXvVqCBs1tUhmYKWCcRW8Xl/3h90OS3ju0/3q6ZIFrLPGlOwKirTLglM=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "19a1d491fec98ff426e5ac1ce6d2c1b9"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4c60a47c1ae4a80c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/19a1d491fec98ff426e5ac1ce6d2c1b9"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5980c84569d-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.874Z",
-        "time": 292,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 292
-        }
-      },
-      {
-        "_id": "c6fff7961bbfc269c8c577f2e1929038",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 436,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "436"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a401b577-1026-488e-a7ac-21557a57f424"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "X_kekK9bdgjwihN0Sfnr.4o1oIegUZfYlODuRfbkeQk-1702308658-1-AWnLONF5BUHe/1bZ1oe7tVjK5te3cks7h5NiEc48BJV0tOlbmHb2yENi4XVf+immAKEFWDubr7bcOIwcMbv3Axs="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a401b577-1026-488e-a7ac-21557a57f424; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=X_kekK9bdgjwihN0Sfnr.4o1oIegUZfYlODuRfbkeQk-1702308658-1-AWnLONF5BUHe/1bZ1oe7tVjK5te3cks7h5NiEc48BJV0tOlbmHb2yENi4XVf+immAKEFWDubr7bcOIwcMbv3Axs=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ec5b1c44aa0a364edade57f41fda2995"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2492108f40784920"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ec5b1c44aa0a364edade57f41fda2995"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec598085f568a-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.875Z",
-        "time": 295,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 295
-        }
-      },
-      {
-        "_id": "78b16a1b0ad38fb4611e80c039f06be3",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 439,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "439"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.2\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d36b43d3-c2b3-41be-95d4-054100c0948f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "eA66hqjyxf1rt3A8DfdsIeaJn4TTzzctdXBOREmKa7E-1702308658-1-AQZeSxESrOmFIwSavAJGkO2iCsWNQoCbcnrPsLfhGa6TKl6ILyJL4JpOsGd0YgtC1HNRqydWpvylEsFYUFCCA3Y="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d36b43d3-c2b3-41be-95d4-054100c0948f; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=eA66hqjyxf1rt3A8DfdsIeaJn4TTzzctdXBOREmKa7E-1702308658-1-AQZeSxESrOmFIwSavAJGkO2iCsWNQoCbcnrPsLfhGa6TKl6ILyJL4JpOsGd0YgtC1HNRqydWpvylEsFYUFCCA3Y=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "bfef90ffa7d2574c74341ae82b017978"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d8e9ee84387032fc"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bfef90ffa7d2574c74341ae82b017978"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec597f93db52d-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1161,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:57.845Z",
-        "time": 429,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 429
-        }
-      },
-      {
-        "_id": "758d269925a8d561b9ba4a8a102eab02",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"1ec4f4ab-4a7f-402c-a0e5-5b14cfe46729\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:58.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "dbb5e9d0-041a-4898-a060-c8f64432426f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:00:58.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "7Y_1BYSHuWISVOTmvlv7v2GuLnnpAlpc.opqfpNYqHg-1702308658-1-Ac9d1GUthwGjpnVPIxnXOdt4TRaa+aSAhg1Y9qOWHfS8Jv/2m+b7EQpedy7+w6f4sg37Le6RXxiwB0PIcXtVkeA="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:30:58 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=dbb5e9d0-041a-4898-a060-c8f64432426f; Expires=Wed, 11 Dec 2024 15:30:58 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=7Y_1BYSHuWISVOTmvlv7v2GuLnnpAlpc.opqfpNYqHg-1702308658-1-Ac9d1GUthwGjpnVPIxnXOdt4TRaa+aSAhg1Y9qOWHfS8Jv/2m+b7EQpedy7+w6f4sg37Le6RXxiwB0PIcXtVkeA=; path=/; expires=Mon, 11-Dec-23 16:00:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "27850b9c6fb9c1ff76579b86fdcd6e74"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "89b819c87bf01ac5"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/27850b9c6fb9c1ff76579b86fdcd6e74"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec59bb820067b-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:58.455Z",
-        "time": 269,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 269
-        }
-      },
-      {
-        "_id": "5ec902ad888d3f30a2f2822dded053a3",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 297,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip;q=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "traceparent",
-              "value": "00-49d7ec5f9f4b1db5d895721c73510469-6a3da7a40c3201dc-01"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-sourcegraph-should-trace",
-              "value": "1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "297"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 433,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"maxTokensToSample\":256,\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"timeoutMs\":15000,\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 172,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 172,
-            "text": "event: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" return a + b;\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:30:59.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "72905efd-2a91-470b-8542-36cb257b8460"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:01:00.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "C00EPy4KsMKWo6VhJhWNMZVc._XZ2Czd0EIVYvAizN0-1702308660-1-ASOdihH6KhFwX+rXFLM62MpUhY0E5R6yM64vPG2VdACQ9szEozPexweWatcLs/IASKwlJ19OP7td6ZNPyJBOzgE="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:31:00 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=72905efd-2a91-470b-8542-36cb257b8460; Expires=Wed, 11 Dec 2024 15:30:59 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=C00EPy4KsMKWo6VhJhWNMZVc._XZ2Czd0EIVYvAizN0-1702308660-1-ASOdihH6KhFwX+rXFLM62MpUhY0E5R6yM64vPG2VdACQ9szEozPexweWatcLs/IASKwlJ19OP7td6ZNPyJBOzgE=; path=/; expires=Mon, 11-Dec-23 16:01:00 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "49d7ec5f9f4b1db5d895721c73510469"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e36c7206b56e45d9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/49d7ec5f9f4b1db5d895721c73510469"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5a00fb2568f-OSL"
-            }
-          ],
-          "headersSize": 1132,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:30:59.162Z",
-        "time": 966,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 966
-        }
-      },
-      {
-        "_id": "fa2e827c627cced081072c7650b66882",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 22200,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 169,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":70654}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"},{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"philipp\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"f9635ab5a6a1fbc323a590f824226b42\",\"spanId\":\"1ddb0736be41c03e\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657253000000\",\"endTimeUnixNano\":\"1702308657474375167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"fad36e281812f5ad46b91f48017aecbf\",\"spanId\":\"daac365c346c2bc1\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657254000000\",\"endTimeUnixNano\":\"1702308657475114083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9865d3ce38ab72223a32dd35bc98bb7c\",\"spanId\":\"cea1baefb1cf4248\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657252000000\",\"endTimeUnixNano\":\"1702308657479819959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c34919c306001a70fac7c67f0e25abe5\",\"spanId\":\"df8db5b0fd495e0d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657253000000\",\"endTimeUnixNano\":\"1702308657483272291\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"eb065694fde28c59545e7e85df5292ed\",\"spanId\":\"9b79aad53a6d23a5\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702308657255000000\",\"endTimeUnixNano\":\"1702308657489886708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"9a3877f68645881e822bb93c73f4c6ef\",\"spanId\":\"725038101352bc15\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702308657255000000\",\"endTimeUnixNano\":\"1702308657491501375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f5bf6deb66dd532411d579056bd95e39\",\"spanId\":\"0176d48d01450202\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308657254000000\",\"endTimeUnixNano\":\"1702308657597812375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8607b431523815b2f918225add01eaec\",\"spanId\":\"93bcd6310d4e1083\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702308657599000000\",\"endTimeUnixNano\":\"1702308657835928416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5e804ad12777fa4eb8415183df5b8280\",\"spanId\":\"68da18945eb7bf96\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308657859000000\",\"endTimeUnixNano\":\"1702308658090880667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b47b2e389aab8979f02507bd5f574e6b\",\"spanId\":\"3a2b0b399225b907\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657841000000\",\"endTimeUnixNano\":\"1702308658093696334\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b62bb9611a7d700c166441747b0906ee\",\"spanId\":\"acb81d61aa583ca2\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657841000000\",\"endTimeUnixNano\":\"1702308658096326584\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"92916f068d903d0acf6be1a087d9b58a\",\"spanId\":\"8b8e61d49a0be709\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657839000000\",\"endTimeUnixNano\":\"1702308658096208917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"23bd940e38e17a6e767616da9e30f7a1\",\"spanId\":\"08c805862c095a81\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308657858000000\",\"endTimeUnixNano\":\"1702308658099427458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b76a368f3ba6447c9fe1422647042fc6\",\"spanId\":\"420da615b29f42ee\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657840000000\",\"endTimeUnixNano\":\"1702308658102368000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b300c407a38ac9554ba68ab6fe98c62d\",\"spanId\":\"0aa9ccc9ba09df04\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1702308657860000000\",\"endTimeUnixNano\":\"1702308658112551583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"60c7edb4d7bd74eeae487c32cb6ea365\",\"spanId\":\"7adddd25c063ec49\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702308657858000000\",\"endTimeUnixNano\":\"1702308658114418042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cbba19b4cc9ba480af9ee021643426cd\",\"spanId\":\"56ba6bf34704329d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657841000000\",\"endTimeUnixNano\":\"1702308658115343250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c09017be322b3c368d4e9aff2bbcd529\",\"spanId\":\"f663be89e9e75e34\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657841000000\",\"endTimeUnixNano\":\"1702308658117979834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c94fdb1fbc4f9b4af48c8b0395246dbb\",\"spanId\":\"96a9c897d007b09f\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702308657839000000\",\"endTimeUnixNano\":\"1702308658120844833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b886910e8858bd6b0ba890768d75ca1d\",\"spanId\":\"ba9a85bb856b9bc1\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702308657859000000\",\"endTimeUnixNano\":\"1702308658121315917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"80273764fdb9f3c4ab680dadc359672b\",\"spanId\":\"adf5f88d9fe345e3\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702308657861000000\",\"endTimeUnixNano\":\"1702308658124495125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d6c2edbae5924d16dfe96dd9fd1e4f8e\",\"spanId\":\"b3cb2dadb85a2d81\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702308657859000000\",\"endTimeUnixNano\":\"1702308658129008500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"99dda39242ece91f4be1752157aa3ebd\",\"spanId\":\"0412a9b954e49c2f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657840000000\",\"endTimeUnixNano\":\"1702308658131080500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6fdfb776a292d622b71fbcf405f74220\",\"spanId\":\"08c2b2cbdc12995f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657841000000\",\"endTimeUnixNano\":\"1702308658133337958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5c8a666a22eeee59988237cda46cd43c\",\"spanId\":\"3b2802df52bc78bd\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702308657838000000\",\"endTimeUnixNano\":\"1702308658135497625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6e94e984d31bc18ed45360d3c45ad986\",\"spanId\":\"63dadc173702592f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657861000000\",\"endTimeUnixNano\":\"1702308658151003500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0016a38d0f3c0fd25ce26ca732c024c2\",\"spanId\":\"20f0eb4ce65e1897\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308657860000000\",\"endTimeUnixNano\":\"1702308658156038375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2ff277a3c650051f478cf15cf9db56f0\",\"spanId\":\"98013e5a661a3201\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702308657861000000\",\"endTimeUnixNano\":\"1702308658169265708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d74ec606de29119b28ac6c43c3fba06a\",\"spanId\":\"10d6e95dc4aaee5b\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702308657861000000\",\"endTimeUnixNano\":\"1702308658172803250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2e77c0ee5bde8c9ed47bbd430962b50d\",\"spanId\":\"63ad9cbe3ada37fa\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702308657839000000\",\"endTimeUnixNano\":\"1702308658279593458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6cf3628a29ade5dd7527a860d0fdb918\",\"spanId\":\"827b5f24abbb7fdb\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308658091000000\",\"endTimeUnixNano\":\"1702308658303426417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0fd858da0bc93e2b1790b627ff0225c6\",\"spanId\":\"73534bad11850764\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658097000000\",\"endTimeUnixNano\":\"1702308658325036958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"488eb301e4685ac92c765d01de05e82c\",\"spanId\":\"006877d1c823b86e\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702308658129000000\",\"endTimeUnixNano\":\"1702308658447935375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d44ea505f7563d961f279e78afe5408f\",\"spanId\":\"bed51099e825c111\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308658449000000\",\"endTimeUnixNano\":\"1702308658696625208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5f72a9aa09b9557688fb2fbc82ed0607\",\"spanId\":\"678b3577edc65679\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658700741583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2526fc79f0bbe5b1e567d061bed91756\",\"spanId\":\"14b92c3d0d3c7d36\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658703275875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c001bb67adea84cc8649a7d75d3dcaed\",\"spanId\":\"781d7b8f0bd606e3\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658713759125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4fdd408cc9c30731ea3c6cd8ef5d3d99\",\"spanId\":\"171c83c81ec08664\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658451000000\",\"endTimeUnixNano\":\"1702308658714999583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c48f3bc9dab8df69e02da5fce46b0bbd\",\"spanId\":\"8ae00ea3aa9cbcfa\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658718988375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"36fdb56a7592a7debdf5b9fd024e0394\",\"spanId\":\"2f8872e8ac75147a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658723036167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c5766fb5f99fc67bc89a69e83be54e15\",\"spanId\":\"1edd2c32016ba951\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658451000000\",\"endTimeUnixNano\":\"1702308658724688625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"52393b5414ce6bcf740c6865d3961f66\",\"spanId\":\"591401d3a14526af\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702308658450000000\",\"endTimeUnixNano\":\"1702308658727140375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a28ba2506bf23bba1e5ba9ae946275c3\",\"spanId\":\"9edce53e14354fa9\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658738399458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"1341fa6b67ee0167c413c7617cd023be\",\"spanId\":\"e1e2ee8cc70d69ea\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308658450000000\",\"endTimeUnixNano\":\"1702308658737659083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d1285be6ad45915e46d22e758a5e10c3\",\"spanId\":\"f11d40f9d35ef2c9\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658453000000\",\"endTimeUnixNano\":\"1702308658741564083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e0bd0990d777dada5ff1f2d05e311dad\",\"spanId\":\"723c742e5ad62c05\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658451000000\",\"endTimeUnixNano\":\"1702308658741334875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"13d5bf78834e15ffb09cc040b7732d09\",\"spanId\":\"c0cde6f06f5d51a6\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702308658451000000\",\"endTimeUnixNano\":\"1702308658742239500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"742f4fc35e2b8e7e126ad270ad72a3c2\",\"spanId\":\"8097a90b1533fef5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658451000000\",\"endTimeUnixNano\":\"1702308658743123834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b263a80d6a17d2c66abdd165b682056c\",\"spanId\":\"0fee0b0bbb58be41\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658744991375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c1a775cb058a4e2ecb3a401e469a2b10\",\"spanId\":\"f73239e6d3233780\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658452000000\",\"endTimeUnixNano\":\"1702308658748406209\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d6740d887a8c90591353f6a392d2e326\",\"spanId\":\"923c6ebd805e4930\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308658697000000\",\"endTimeUnixNano\":\"1702308658935109667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0bc8262b5eaca48b304c4aca884a19cd\",\"spanId\":\"0ee0911e108e6b19\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702308658738000000\",\"endTimeUnixNano\":\"1702308658977456709\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"12b041720d102cd9\",\"parentSpanId\":\"6a3da7a40c3201dc\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702308658937000000\",\"endTimeUnixNano\":\"1702308659151910625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"0678c233ce645d8a\",\"parentSpanId\":\"6a3da7a40c3201dc\",\"name\":\"autocomplete.debounce\",\"kind\":1,\"startTimeUnixNano\":\"1702308659154000000\",\"endTimeUnixNano\":\"1702308659154276792\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"0054bdba5c82a12b\",\"parentSpanId\":\"143387b8c95cca26\",\"name\":\"autocomplete.retrieve.jaccard-similarity\",\"kind\":1,\"startTimeUnixNano\":\"1702308659155000000\",\"endTimeUnixNano\":\"1702308659155751125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"143387b8c95cca26\",\"parentSpanId\":\"6a3da7a40c3201dc\",\"name\":\"autocomplete.retrieve\",\"kind\":1,\"startTimeUnixNano\":\"1702308659154000000\",\"endTimeUnixNano\":\"1702308659155318208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"daf2b10cd2467ea8\",\"parentSpanId\":\"6a3da7a40c3201dc\",\"name\":\"autocomplete.generate\",\"kind\":1,\"startTimeUnixNano\":\"1702308659158000000\",\"endTimeUnixNano\":\"1702308660134372375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"6d2598cbac788626\",\"parentSpanId\":\"6a3da7a40c3201dc\",\"name\":\"autocomplete.post-process\",\"kind\":1,\"startTimeUnixNano\":\"1702308660135000000\",\"endTimeUnixNano\":\"1702308660135165500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49d7ec5f9f4b1db5d895721c73510469\",\"spanId\":\"6a3da7a40c3201dc\",\"name\":\"autocomplete.provideInlineCompletionItems\",\"kind\":1,\"startTimeUnixNano\":\"1702308658936000000\",\"endTimeUnixNano\":\"1702308660135958584\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e5b5932619a268f86d808523d3e81b4f\",\"spanId\":\"f6d2186f802e21b5\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702308660138000000\",\"endTimeUnixNano\":\"1702308660353437250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"18dad3a2b22f50d906037959b5f27803\",\"spanId\":\"0ff79563c649c234\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702308660354000000\",\"endTimeUnixNano\":\"1702308660581618250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
-        },
-        "response": {
-          "bodySize": 21,
-          "content": {
-            "mimeType": "application/json",
-            "size": 21,
-            "text": "{\"partialSuccess\":{}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T15:31:02.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "924d6ed6-1476-4b82-954d-7ee69554058f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T16:01:02.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "t9.oqf5h4k8ku0TYFOE1Phf_JN79GWzRcfl16sZSgbQ-1702308662-1-Ac1sf6HrYh3pABXXN3NIjq/YEKb6hQQC4QzMUAQ7UeiNz7X4W7gjYGEIQISxSYbGuVc/O7sr7GAW1COiNBrnJuc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 15:31:02 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "21"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=924d6ed6-1476-4b82-954d-7ee69554058f; Expires=Wed, 11 Dec 2024 15:31:02 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=t9.oqf5h4k8ku0TYFOE1Phf_JN79GWzRcfl16sZSgbQ-1702308662-1-Ac1sf6HrYh3pABXXN3NIjq/YEKb6hQQC4QzMUAQ7UeiNz7X4W7gjYGEIQISxSYbGuVc/O7sr7GAW1COiNBrnJuc=; path=/; expires=Mon, 11-Dec-23 16:01:02 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Authorization,Cookie,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b28457d1ddbde905d7b7a1019a264aa5"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "224e9f3df4d25c15"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b28457d1ddbde905d7b7a1019a264aa5"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833ec5b4e9f80b41-OSL"
-            }
-          ],
-          "headersSize": 1014,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T15:31:02.491Z",
-        "time": 241,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 241
-        }
-      },
-      {
-        "_id": "efff9ad70f807698f19da301255925a5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1186,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1186"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"30191e96-ee4f-432a-904f-3e57ae30ddc9\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T13:53:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "42d857be-d23b-4de7-b08c-107ac9a1cd5b"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T14:23:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "_DxAhvdHKfP1tP9O2tBWVaTYv0fteXFS8bJ3jCF7a90-1702302813-1-AadvzhxC/OUzfV7LDW7dKnMLrQGkts0DChWemaqa0VldBthaH9SNkQRyUtUvaYchWZN6RmDKihMtaoG7nwlK5bk="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 13:53:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=42d857be-d23b-4de7-b08c-107ac9a1cd5b; Expires=Wed, 11 Dec 2024 13:53:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=_DxAhvdHKfP1tP9O2tBWVaTYv0fteXFS8bJ3jCF7a90-1702302813-1-AadvzhxC/OUzfV7LDW7dKnMLrQGkts0DChWemaqa0VldBthaH9SNkQRyUtUvaYchWZN6RmDKihMtaoG7nwlK5bk=; path=/; expires=Mon, 11-Dec-23 14:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d8238397b9f2084c57433a7edb758258"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "a021282671669072"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d8238397b9f2084c57433a7edb758258"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833e36e66fa07129-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T13:53:33.115Z",
-        "time": 260,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 260
-        }
-      },
-      {
-        "_id": "14484f09aa36ac579297fddd21ad7528",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1188,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1188"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"235f5c3d-c87d-42d5-a0d7-647ee55aeb73\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T13:53:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "86cdfc47-bf70-4ab5-b2e4-f27876674486"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T14:23:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "WkBAGbrfTGp0YT3HyhDw2QSKRWDO4dPbTX6SMpNp7Gs-1702302813-1-AZOXIJcYzt3e/oLzpyRPuSoQu70Wk/wLWTDdMsrixtvAZCScVnONcVjIL7eR83XhzyKy8a93wz84GahBSTk/ZIY="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 13:53:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=86cdfc47-bf70-4ab5-b2e4-f27876674486; Expires=Wed, 11 Dec 2024 13:53:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=WkBAGbrfTGp0YT3HyhDw2QSKRWDO4dPbTX6SMpNp7Gs-1702302813-1-AZOXIJcYzt3e/oLzpyRPuSoQu70Wk/wLWTDdMsrixtvAZCScVnONcVjIL7eR83XhzyKy8a93wz84GahBSTk/ZIY=; path=/; expires=Mon, 11-Dec-23 14:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c964cbdecda37955961db793e3fe294d"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "467948ab3a4a16fd"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c964cbdecda37955961db793e3fe294d"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833e36e6580156c5-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T13:53:33.095Z",
-        "time": 284,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 284
-        }
-      },
-      {
-        "_id": "fcefb2dd2dd38751e452f781d64b06bd",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"30191e96-ee4f-432a-904f-3e57ae30ddc9\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T13:53:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e0ca33b6-15d6-49eb-852f-0f1c6e21a68f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T14:23:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ezof7mM9TYiFyaLNx_N_m7jp7MF7xI9ciGh5JxttyuI-1702302813-1-AUA3XX2hGjnCi6+2oE0z0SV7hiRCkzKre/UjNkId4lCpaV0scdBFu1hXGeL4RX+c+A7fVFBSx3yfLcVT+xrK3ls="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 13:53:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e0ca33b6-15d6-49eb-852f-0f1c6e21a68f; Expires=Wed, 11 Dec 2024 13:53:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ezof7mM9TYiFyaLNx_N_m7jp7MF7xI9ciGh5JxttyuI-1702302813-1-AUA3XX2hGjnCi6+2oE0z0SV7hiRCkzKre/UjNkId4lCpaV0scdBFu1hXGeL4RX+c+A7fVFBSx3yfLcVT+xrK3ls=; path=/; expires=Mon, 11-Dec-23 14:23:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d534834759e94a9c7465e443727023f9"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "81aba1571cc02482"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d534834759e94a9c7465e443727023f9"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833e36e98fd956b5-OSL"
-            }
-          ],
-          "headersSize": 1129,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T13:53:33.599Z",
-        "time": 255,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 255
-        }
-      },
-      {
-        "_id": "0d16a033a475b66e0dc0d6a4321be2a8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 297,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip;q=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "traceparent",
-              "value": "00-7f5b3d9d5ddec8b68364734367aded72-964c56c770cbe086-01"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-sourcegraph-should-trace",
-              "value": "1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "297"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 433,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"messages\":[{\"speaker\":\"human\",\"text\":\"<filename>file.ts<fim_prefix>// \\nfunction sum(a: number, b: number) {\\n   <fim_suffix>\\n}<fim_middle>\"}],\"maxTokensToSample\":256,\"temperature\":0.2,\"topK\":0,\"model\":\"fireworks/starcoder-16b\",\"stopSequences\":[\"\\n\\n\",\"\\n\\r\\n\"],\"timeoutMs\":15000,\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 98,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 98,
-            "text": "event: completion\ndata: {\"completion\":\" return a + b\",\"stopReason\":\"stop\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T13:53:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c1becbb8-870c-4f56-9e0c-f56a8776d5c3"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T14:23:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "MrJC74BK7CwMLAjbqLejtUrSDYC8cCbF4u_Orw2vXNY-1702302815-1-Ad4iP6YL6mNTrvCFpKhYSAeATDsUhYGEBj6axvTcwc12Mcv1DLWF6Eu1Yv+EkiHpHg5kJ1ZZlz1qawDHdnIb708="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 13:53:35 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:25 GMT"
             },
             {
               "name": "content-type",
@@ -8311,7 +7184,7 @@
             },
             {
               "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
             },
             {
               "name": "cf-rate-limit-action",
@@ -8319,7 +7192,7 @@
             },
             {
               "name": "retry-after",
-              "value": "600"
+              "value": "216"
             },
             {
               "name": "access-control-allow-credentials",
@@ -8336,12 +7209,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c1becbb8-870c-4f56-9e0c-f56a8776d5c3; Expires=Wed, 11 Dec 2024 13:53:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=4dc0f660-7bef-45c7-9609-486bfed1f4ba; Expires=Fri, 13 Dec 2024 11:31:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=MrJC74BK7CwMLAjbqLejtUrSDYC8cCbF4u_Orw2vXNY-1702302815-1-Ad4iP6YL6mNTrvCFpKhYSAeATDsUhYGEBj6axvTcwc12Mcv1DLWF6Eu1Yv+EkiHpHg5kJ1ZZlz1qawDHdnIb708=; path=/; expires=Mon, 11-Dec-23 14:23:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=AE4QlYQBFZEVUfNPsYvoz_zLpxy7PsrcYNsJ6xYrzt4-1702467085-1-ATjMko3VeunFin2Omvd65TdQtmvgU4L+BGnEcSVLCLSgKrNZhMbRhXzB8HvXXra/WvkiwK9gYodu15Ww97ilG40=; path=/; expires=Wed, 13-Dec-23 12:01:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -8357,15 +7230,15 @@
             },
             {
               "name": "x-trace",
-              "value": "7f5b3d9d5ddec8b68364734367aded72"
+              "value": "b18c2d49ee3811b663c15476f683a7dd"
             },
             {
               "name": "x-trace-span",
-              "value": "b5eeb8be50e583c3"
+              "value": "e9b6aea42fab5dee"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7f5b3d9d5ddec8b68364734367aded72"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b18c2d49ee3811b663c15476f683a7dd"
             },
             {
               "name": "x-xss-protection",
@@ -8389,7 +7262,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833e36edbd85b4ee-OSL"
+              "value": "834de164cc7156c4-OSL"
             }
           ],
           "headersSize": 1239,
@@ -8398,8 +7271,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T13:53:34.294Z",
-        "time": 1064,
+        "startedDateTime": "2023-12-13T11:31:22.971Z",
+        "time": 6823,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8407,178 +7280,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1064
+          "wait": 6823
         }
       },
       {
-        "_id": "5cbebcdf50fb05caa52bee8fa212ddb5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 19117,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "user-agent",
-              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 169,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":56083}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"},{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"philipp\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"236142494f157270bfbec5a7ce5da47d\",\"spanId\":\"53fc63df5441100f\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702302812861000000\",\"endTimeUnixNano\":\"1702302813082028541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"92d778019684d10010387e28ee8846d0\",\"spanId\":\"16351f3484198e8e\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813089000000\",\"endTimeUnixNano\":\"1702302813331067250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7ddbbe70a6204f29e8718a67a7c96bd3\",\"spanId\":\"0afa08c64f435101\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302813106000000\",\"endTimeUnixNano\":\"1702302813341802125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e6eb1738f0e5285366c6ece16413cfe4\",\"spanId\":\"457ad0113fea782a\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702302813107000000\",\"endTimeUnixNano\":\"1702302813342359416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"028745bed0a3bca292ef2a811c1690bc\",\"spanId\":\"5e9a9127837889e6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813093000000\",\"endTimeUnixNano\":\"1702302813345175292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3c66449145e714e336facc9ebb97b791\",\"spanId\":\"7cdf1efc08355a21\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302813107000000\",\"endTimeUnixNano\":\"1702302813346421333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e68c85d2f8f184d6f6086bd08383a91a\",\"spanId\":\"7ae29eac7504f0d1\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813093000000\",\"endTimeUnixNano\":\"1702302813353121917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e6417c1cfc4255e7acfa6f6dc5397d2b\",\"spanId\":\"01c59651e9eb78c1\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813094000000\",\"endTimeUnixNano\":\"1702302813352901708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0fb23b30eb4f98485913bb7b2d0c353e\",\"spanId\":\"57056245c0a45428\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813093000000\",\"endTimeUnixNano\":\"1702302813354096292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a1cbc9f3ebceb726a5bc9ddf758b7277\",\"spanId\":\"815f0cfbd95c52cb\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813108000000\",\"endTimeUnixNano\":\"1702302813354737834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f6a0e04936306689223dd9c56f9adcf7\",\"spanId\":\"5676a433844602eb\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702302813107000000\",\"endTimeUnixNano\":\"1702302813355028709\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5e74d9bc67c76f17e17dbfb1ba3e8e79\",\"spanId\":\"327dbbc4b217cfeb\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1702302813108000000\",\"endTimeUnixNano\":\"1702302813356322875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"49b6560ee8405d02a1bf8e0088b13982\",\"spanId\":\"6e2663c120ac60a5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813094000000\",\"endTimeUnixNano\":\"1702302813357075500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e2839f2bd897c76e4bb1fee367235be8\",\"spanId\":\"fa0456098d788333\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813091000000\",\"endTimeUnixNano\":\"1702302813356679792\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7ca8c338b276e23259759b2fd546607c\",\"spanId\":\"375ed4b8d7ae54f8\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702302813088000000\",\"endTimeUnixNano\":\"1702302813357542625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"fc3c15ad6a5b57bb447139a4c5dcd9d7\",\"spanId\":\"612b0c8d4bb8e864\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813109000000\",\"endTimeUnixNano\":\"1702302813370086083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"62f9eef9a72db8d4f7dbce649cbc8998\",\"spanId\":\"b1bca769afbc993a\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702302813087000000\",\"endTimeUnixNano\":\"1702302813372715625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"447ee9059ca6f2879c9baec7bb64df9b\",\"spanId\":\"5da8940d9b7484f9\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702302813108000000\",\"endTimeUnixNano\":\"1702302813377376917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"e46d3f5154c1e0fb8668506d831972a3\",\"spanId\":\"818703e0cd2d0505\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702302813085000000\",\"endTimeUnixNano\":\"1702302813381805750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6e4d868a23b77c783f6e52e518a70208\",\"spanId\":\"5af5868f71c2ece2\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702302813108000000\",\"endTimeUnixNano\":\"1702302813382251875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"66cc889efe0226a9c17cc2b33d90c405\",\"spanId\":\"e5efd8d1cc375924\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702302813107000000\",\"endTimeUnixNano\":\"1702302813383794208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c831a0a5b45dd19d47667c765a0f9752\",\"spanId\":\"2857601fb2d7aa43\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702302813108000000\",\"endTimeUnixNano\":\"1702302813389176000\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"82e48edd9de390059fd15b015b2b8ab2\",\"spanId\":\"f1ebcee01d97be53\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813331000000\",\"endTimeUnixNano\":\"1702302813564679750\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f8813a093d94df1e4cd0b713e5b20529\",\"spanId\":\"b67e77b34a7ee0b0\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702302813355000000\",\"endTimeUnixNano\":\"1702302813587974292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6f306e4f24aba1f7cbe01500a41dc896\",\"spanId\":\"f8cd3e78b0428e27\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302813347000000\",\"endTimeUnixNano\":\"1702302813628744291\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"77bc8acb61bcc0936c7e4af426ada256\",\"spanId\":\"4da79e2c5fbed513\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302813593000000\",\"endTimeUnixNano\":\"1702302813829451791\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f2f0b592f14e5c5cbc802b7e7e793667\",\"spanId\":\"162deda52d971d79\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813595000000\",\"endTimeUnixNano\":\"1702302813837093500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"da62a4b981032774bb994bc13851c005\",\"spanId\":\"67c82f9de10f56c6\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302813592000000\",\"endTimeUnixNano\":\"1702302813837400333\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"aaa318f61731b0ffddd39ec00170d597\",\"spanId\":\"13c8031bc25bc73c\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813594000000\",\"endTimeUnixNano\":\"1702302813843068667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"25f30f34c271fa49d02f206fc38933a3\",\"spanId\":\"7cb06c6cc376eb32\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702302813593000000\",\"endTimeUnixNano\":\"1702302813845940958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4b48136b24430171d1b5dd7d4ffa0174\",\"spanId\":\"e3d771e02ee7221d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813594000000\",\"endTimeUnixNano\":\"1702302813848080541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"da74fedbf7f2247e9e13af67b2f741b6\",\"spanId\":\"a57c2a9a12c2a5de\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813596000000\",\"endTimeUnixNano\":\"1702302813849342167\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d4fd5e65df1b876262e110d28dfade60\",\"spanId\":\"5ce24f5dbae68275\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813594000000\",\"endTimeUnixNano\":\"1702302813854047459\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7c254b9e93e359b8367dafb3fea84ab6\",\"spanId\":\"80bf7edf33dc567d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813594000000\",\"endTimeUnixNano\":\"1702302813853995625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"aff8f7e9294367c2bf74f473169f0d01\",\"spanId\":\"3c957ab46798394f\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813596000000\",\"endTimeUnixNano\":\"1702302813855223458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"38a2bef3a284ab55c07e08b49bf283f2\",\"spanId\":\"71a92de4308dfaf2\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702302813593000000\",\"endTimeUnixNano\":\"1702302813856751834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6b842a4d357316a29a28ed89fcbb06a7\",\"spanId\":\"42def8b10fd2ef52\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813595000000\",\"endTimeUnixNano\":\"1702302813858036458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8e8f1d7680d2e30b2e83ca41dc8ea0e5\",\"spanId\":\"be1f88c58bf3f269\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813594000000\",\"endTimeUnixNano\":\"1702302813861971500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"a7daf846fde0361b439b4e3387323472\",\"spanId\":\"d36638375793a0f4\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813595000000\",\"endTimeUnixNano\":\"1702302813863860041\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"dab5b5546ed406dc15072142ea58fd23\",\"spanId\":\"aae45e06da1464cc\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813596000000\",\"endTimeUnixNano\":\"1702302813870223875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ac8b2ac97104954afe726e47e451b0d6\",\"spanId\":\"b09ba0e478a5096c\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302813595000000\",\"endTimeUnixNano\":\"1702302813910723875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6c371e5b92f8e66052360559c5d34a0a\",\"spanId\":\"8f6dd71dceb6b019\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302813837000000\",\"endTimeUnixNano\":\"1702302814062753708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8d69ada3a30b68b04cf428c54d236345\",\"spanId\":\"2a8cee0c7665b5dc\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702302813830000000\",\"endTimeUnixNano\":\"1702302814079588917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"e81f6c19c148309d\",\"parentSpanId\":\"c83142bf79ea34e8\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702302814065000000\",\"endTimeUnixNano\":\"1702302814286917916\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"faa53fa728014827\",\"parentSpanId\":\"c83142bf79ea34e8\",\"name\":\"autocomplete.debounce\",\"kind\":1,\"startTimeUnixNano\":\"1702302814287000000\",\"endTimeUnixNano\":\"1702302814287060833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"50210083a5e044d0\",\"parentSpanId\":\"8c7d6cbd9dfd5273\",\"name\":\"autocomplete.retrieve.jaccard-similarity\",\"kind\":1,\"startTimeUnixNano\":\"1702302814288000000\",\"endTimeUnixNano\":\"1702302814288538959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"8c7d6cbd9dfd5273\",\"parentSpanId\":\"c83142bf79ea34e8\",\"name\":\"autocomplete.retrieve\",\"kind\":1,\"startTimeUnixNano\":\"1702302814288000000\",\"endTimeUnixNano\":\"1702302814288936958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"964c56c770cbe086\",\"parentSpanId\":\"c83142bf79ea34e8\",\"name\":\"autocomplete.generate\",\"kind\":1,\"startTimeUnixNano\":\"1702302814289000000\",\"endTimeUnixNano\":\"1702302815364866459\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"3eb9bdb0774dde72\",\"parentSpanId\":\"c83142bf79ea34e8\",\"name\":\"autocomplete.post-process\",\"kind\":1,\"startTimeUnixNano\":\"1702302815365000000\",\"endTimeUnixNano\":\"1702302815365318625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7f5b3d9d5ddec8b68364734367aded72\",\"spanId\":\"c83142bf79ea34e8\",\"name\":\"autocomplete.provideInlineCompletionItems\",\"kind\":1,\"startTimeUnixNano\":\"1702302814064000000\",\"endTimeUnixNano\":\"1702302815366954917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b447e55834ebe2e9ca45a695349e0194\",\"spanId\":\"ec52e94bf46bcede\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702302815369000000\",\"endTimeUnixNano\":\"1702302815586032542\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"1f556318f7487cf437197bbe13522da6\",\"spanId\":\"01251bff9269f74f\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702302815588000000\",\"endTimeUnixNano\":\"1702302815817876459\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
-        },
-        "response": {
-          "bodySize": 21,
-          "content": {
-            "mimeType": "application/json",
-            "size": 21,
-            "text": "{\"partialSuccess\":{}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-11T13:53:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "37bd81a4-4bc0-4de2-a780-13a75d4843fd"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T14:23:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "sgAMsE.4ugufZ3wJyEwRI0ZoBeh9lARu_Wjw4zlOZ4Y-1702302818-1-AevXlW8GRQObglLpMDY9JMRhGjS0PSs5IVmv/mWE4jJjWb++IJtAtT6KZDBUs7Kta3hoEi7sfGBh0Z9+HvZwmxc="
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Mon, 11 Dec 2023 13:53:38 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "21"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "596"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=37bd81a4-4bc0-4de2-a780-13a75d4843fd; Expires=Wed, 11 Dec 2024 13:53:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=sgAMsE.4ugufZ3wJyEwRI0ZoBeh9lARu_Wjw4zlOZ4Y-1702302818-1-AevXlW8GRQObglLpMDY9JMRhGjS0PSs5IVmv/mWE4jJjWb++IJtAtT6KZDBUs7Kta3hoEi7sfGBh0Z9+HvZwmxc=; path=/; expires=Mon, 11-Dec-23 14:23:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Authorization,Cookie,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "e160fc958335ddb890d563b091b792c0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7517b458cfa5700a"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e160fc958335ddb890d563b091b792c0"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "833e37057fc8568b-OSL"
-            }
-          ],
-          "headersSize": 1121,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-11T13:53:38.094Z",
-        "time": 202,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 202
-        }
-      },
-      {
-        "_id": "6e8757c1b2321e792bf73394ce8dbbef",
+        "_id": "104eefc8beb5e21c45fc9d88de3da88d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -8625,13 +7331,13 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 323,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"d7cc0c37-0fa6-4e45-91a0-3b702b4e5bdf\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"a2dbd928-3f53-4abc-acf4-cc5e7236234a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -8650,26 +7356,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T11:38:42.000Z",
+              "expires": "2024-12-13T11:31:01.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7211fdc3-dddd-48b3-a75b-9f36dffcb8a0"
+              "value": "4114765f-b6fc-4592-bd0b-b4212c1a5f69"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T12:08:42.000Z",
+              "expires": "2023-12-13T12:01:01.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "drMJAZCBilkxfYFfDSGKaoNnIBu2WfZv10fuY2U.BYM-1702294722-1-AShXlPigJ96JOC5MGhvwZqm+U+E0g6IQQ9zSydpuy4OmZ7sW3ExmYg784yrB269vmHD7g3IxSKxJRhnbTNiBrd8="
+              "value": "csPKF10qj9EuiOYdbV.1ERZ0oPq8DcVMvKUsgxVszTc-1702467061-1-AfVniVEYTKG52rs9svCNTmrpje0wi7/Ti2N+CPupj/fzWlMCFawVnVCCoGuelnHka18E/cncOwfdNzOnmBQDMvI="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 11:38:42 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:01 GMT"
             },
             {
               "name": "content-type",
@@ -8693,7 +7399,7 @@
             },
             {
               "name": "retry-after",
-              "value": "474"
+              "value": "238"
             },
             {
               "name": "access-control-allow-credentials",
@@ -8710,12 +7416,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7211fdc3-dddd-48b3-a75b-9f36dffcb8a0; Expires=Wed, 11 Dec 2024 11:38:42 GMT; Secure"
+              "value": "sourcegraphDeviceId=4114765f-b6fc-4592-bd0b-b4212c1a5f69; Expires=Fri, 13 Dec 2024 11:31:01 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=drMJAZCBilkxfYFfDSGKaoNnIBu2WfZv10fuY2U.BYM-1702294722-1-AShXlPigJ96JOC5MGhvwZqm+U+E0g6IQQ9zSydpuy4OmZ7sW3ExmYg784yrB269vmHD7g3IxSKxJRhnbTNiBrd8=; path=/; expires=Mon, 11-Dec-23 12:08:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=csPKF10qj9EuiOYdbV.1ERZ0oPq8DcVMvKUsgxVszTc-1702467061-1-AfVniVEYTKG52rs9svCNTmrpje0wi7/Ti2N+CPupj/fzWlMCFawVnVCCoGuelnHka18E/cncOwfdNzOnmBQDMvI=; path=/; expires=Wed, 13-Dec-23 12:01:01 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -8731,15 +7437,15 @@
             },
             {
               "name": "x-trace",
-              "value": "0bd6e988312f7daec9192d68f04a2f73"
+              "value": "266f20f85397b45bca647c5df9005e5b"
             },
             {
               "name": "x-trace-span",
-              "value": "dadc1b791a4c314a"
+              "value": "bbb4cb8bad20502e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0bd6e988312f7daec9192d68f04a2f73"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/266f20f85397b45bca647c5df9005e5b"
             },
             {
               "name": "x-xss-protection",
@@ -8763,7 +7469,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833d715d7e7c0b41-OSL"
+              "value": "834de0dd487d5685-OSL"
             }
           ],
           "headersSize": 1236,
@@ -8772,8 +7478,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T11:38:42.046Z",
-        "time": 283,
+        "startedDateTime": "2023-12-13T11:31:01.266Z",
+        "time": 250,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8781,11 +7487,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 283
+          "wait": 250
         }
       },
       {
-        "_id": "f5a3a5b8b3a008f3b1a6133b8f1fc988",
+        "_id": "4f20788ba0812dc9b668e7f5f5929d0d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -8832,13 +7538,13 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 323,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"79e2e19f-e7ad-4108-8f0d-cf66dfc3702b\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"99d64dc9-c203-4c0d-ba65-46a33f6798d0\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -8857,26 +7563,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T11:38:42.000Z",
+              "expires": "2024-12-13T11:31:01.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "a313d321-3ca1-403a-9344-78ec62a98f14"
+              "value": "2eae8c18-4441-48d1-a450-1989375e2d2f"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T12:08:42.000Z",
+              "expires": "2023-12-13T12:01:01.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HtViDqjbaHD2Grym8gEVvAD_YrCkZKmXvIwkikqqSQ4-1702294722-1-AeO6CZ+M95NZhlEqso5r4ek5s8vHkuLSYBNU3NqpwMeCk7lEApJXuuaah1H2MxAT5DZK95XyLagfTqz2ZCdKJyY="
+              "value": "GJcmiQmb.HN36776CTO7u82qqlKr3fNvjfK8PEjSYZE-1702467061-1-ATyQKqnDSRYzCltRy9Yc0Lt4keGlhslw+6kTWfoXa8Z/gccxL9rI334UfClfAPuqumX7brtcWtbuAvNEztgFv58="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 11:38:42 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:01 GMT"
             },
             {
               "name": "content-type",
@@ -8900,7 +7606,7 @@
             },
             {
               "name": "retry-after",
-              "value": "474"
+              "value": "238"
             },
             {
               "name": "access-control-allow-credentials",
@@ -8917,12 +7623,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a313d321-3ca1-403a-9344-78ec62a98f14; Expires=Wed, 11 Dec 2024 11:38:42 GMT; Secure"
+              "value": "sourcegraphDeviceId=2eae8c18-4441-48d1-a450-1989375e2d2f; Expires=Fri, 13 Dec 2024 11:31:01 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HtViDqjbaHD2Grym8gEVvAD_YrCkZKmXvIwkikqqSQ4-1702294722-1-AeO6CZ+M95NZhlEqso5r4ek5s8vHkuLSYBNU3NqpwMeCk7lEApJXuuaah1H2MxAT5DZK95XyLagfTqz2ZCdKJyY=; path=/; expires=Mon, 11-Dec-23 12:08:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=GJcmiQmb.HN36776CTO7u82qqlKr3fNvjfK8PEjSYZE-1702467061-1-ATyQKqnDSRYzCltRy9Yc0Lt4keGlhslw+6kTWfoXa8Z/gccxL9rI334UfClfAPuqumX7brtcWtbuAvNEztgFv58=; path=/; expires=Wed, 13-Dec-23 12:01:01 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -8938,15 +7644,15 @@
             },
             {
               "name": "x-trace",
-              "value": "37aaa104b6842926a833e37e27236160"
+              "value": "1a718e7a14e090a01cd79d8f4249b382"
             },
             {
               "name": "x-trace-span",
-              "value": "8520e6da31cfc97c"
+              "value": "6fd85cd680805796"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/37aaa104b6842926a833e37e27236160"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1a718e7a14e090a01cd79d8f4249b382"
             },
             {
               "name": "x-xss-protection",
@@ -8970,7 +7676,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833d715d882956c4-OSL"
+              "value": "834de0dd5a6ab52d-OSL"
             }
           ],
           "headersSize": 1236,
@@ -8979,8 +7685,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T11:38:42.077Z",
-        "time": 281,
+        "startedDateTime": "2023-12-13T11:31:01.282Z",
+        "time": 341,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8988,11 +7694,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 281
+          "wait": 341
         }
       },
       {
-        "_id": "52ce7c21354e3b7de4b33555162c9f0e",
+        "_id": "51f5b444bf1e6b7cbc6ea0e88b1fab12",
         "_order": 0,
         "cache": {},
         "request": {
@@ -9039,13 +7745,13 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 323,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"79e2e19f-e7ad-4108-8f0d-cf66dfc3702b\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.2\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.2\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"99d64dc9-c203-4c0d-ba65-46a33f6798d0\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -9064,26 +7770,26 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-11T11:38:43.000Z",
+              "expires": "2024-12-13T11:31:01.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "028b4084-d641-451d-a4ca-2dd7cf23710d"
+              "value": "6f490abc-f152-4045-851f-6cbdc3402e0b"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T12:08:43.000Z",
+              "expires": "2023-12-13T12:01:02.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "SpqTzvwm9LJgCqbfJBkmtu7O.dfTApC85tPzjvivr8I-1702294723-1-AUQjAhCbMypq7x/Jz8a5WMcSDEDbmlbO8Dr0JzLZzRlB7MSv8ziFGdqvddy+8Gedbgn6eaOWs1w0PbR6XLBp85U="
+              "value": "VBui0aUX14j2p488bhC52xejh8PdBTh3dazPkvNnoq4-1702467062-1-AeJHKuYt6+j/jR8oJErlg+4ushyApvbU8beSq4SY6i5todm12yi/J+dq7Dc0azxBHXsTpuUZnbk2I5n+td+2ltE="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 11:38:43 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:02 GMT"
             },
             {
               "name": "content-type",
@@ -9107,7 +7813,7 @@
             },
             {
               "name": "retry-after",
-              "value": "473"
+              "value": "237"
             },
             {
               "name": "access-control-allow-credentials",
@@ -9124,12 +7830,12 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=028b4084-d641-451d-a4ca-2dd7cf23710d; Expires=Wed, 11 Dec 2024 11:38:43 GMT; Secure"
+              "value": "sourcegraphDeviceId=6f490abc-f152-4045-851f-6cbdc3402e0b; Expires=Fri, 13 Dec 2024 11:31:01 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=SpqTzvwm9LJgCqbfJBkmtu7O.dfTApC85tPzjvivr8I-1702294723-1-AUQjAhCbMypq7x/Jz8a5WMcSDEDbmlbO8Dr0JzLZzRlB7MSv8ziFGdqvddy+8Gedbgn6eaOWs1w0PbR6XLBp85U=; path=/; expires=Mon, 11-Dec-23 12:08:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=VBui0aUX14j2p488bhC52xejh8PdBTh3dazPkvNnoq4-1702467062-1-AeJHKuYt6+j/jR8oJErlg+4ushyApvbU8beSq4SY6i5todm12yi/J+dq7Dc0azxBHXsTpuUZnbk2I5n+td+2ltE=; path=/; expires=Wed, 13-Dec-23 12:01:02 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -9145,15 +7851,15 @@
             },
             {
               "name": "x-trace",
-              "value": "ae25ab84e9da84d16e64c24d954fcf47"
+              "value": "37351c96386d8a13f76db13c60abcb89"
             },
             {
               "name": "x-trace-span",
-              "value": "21d8f86406292ca5"
+              "value": "4ad4470ae02a2843"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ae25ab84e9da84d16e64c24d954fcf47"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/37351c96386d8a13f76db13c60abcb89"
             },
             {
               "name": "x-xss-protection",
@@ -9177,7 +7883,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "833d7162cdb556bf-OSL"
+              "value": "834de0e04d98b503-OSL"
             }
           ],
           "headersSize": 1236,
@@ -9186,8 +7892,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T11:38:42.934Z",
-        "time": 465,
+        "startedDateTime": "2023-12-13T11:31:01.756Z",
+        "time": 258,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9195,31 +7901,21 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 465
+          "wait": 258
         }
       },
       {
-        "_id": "32408e07c75baea29758a86785347844",
+        "_id": "7ad9905d84c65d9408d330b000907ed7",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1229,
+          "bodySize": 1987,
           "cookies": [],
           "headers": [
             {
               "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip;q=0"
-            },
-            {
-              "_fromType": "array",
               "name": "authorization",
               "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
             },
             {
               "_fromType": "array",
@@ -9228,18 +7924,8 @@
             },
             {
               "_fromType": "array",
-              "name": "traceparent",
-              "value": "00-2b4660063d2180035fd472932c479c9d-182a63100992f0c8-01"
-            },
-            {
-              "_fromType": "array",
               "name": "user-agent",
               "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "x-sourcegraph-should-trace",
-              "value": "1"
             },
             {
               "_fromType": "array",
@@ -9249,65 +7935,80 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "1229"
+              "value": "1987"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
             },
             {
               "name": "host",
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 434,
+          "headersSize": 323,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"temperature\":0.5,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in <CODE5711> tags. You only response with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.\"},{\"speaker\":\"assistant\",\"text\":\"I am a code completion AI with exceptional context-awareness designed to auto-complete nested code blocks with high-quality code that seamlessly integrates with surrounding code.\"},{\"speaker\":\"human\",\"text\":\"Below is the code from file path file.ts. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: \\n```\\nfunction sum(a: number, b: number) {\\n   <CODE5711></CODE5711> \\n}\\n```\"},{\"speaker\":\"assistant\",\"text\":\"<CODE5711>function sum(a: number, b: number) {\"}],\"maxTokensToSample\":256,\"stopSequences\":[\"\\n\\nHuman:\",\"</CODE5711>\"],\"timeoutMs\":15000,\"stream\":true}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"99d64dc9-c203-4c0d-ba65-46a33f6798d0\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"fireworks\\\",\\\"providerModel\\\":\\\"starcoder-hybrid\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"de1ed97c-90d4-44e2-9245-7879515cf2c4\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"jaccard-similarity\\\",\\\"duration\\\":0.33662499487400055,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
         },
         "response": {
-          "bodySize": 619,
+          "bodySize": 26,
           "content": {
-            "mimeType": "text/event-stream",
-            "size": 619,
-            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T11:38:44.000Z",
+              "expires": "2024-12-13T11:31:03.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "f6cbfb35-4ce2-4c6b-88c4-a10c32f6bd5a"
+              "value": "24a7af94-c3a7-40b5-b174-22b92cb73bcc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T12:08:45.000Z",
+              "expires": "2023-12-13T12:01:03.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "nv1I1GA6nHqAfvBQKlKaBhKHjJUroyJwcDaGUCYT3U4-1702294725-1-AemednhhfrsON29Rp0dSAzdKCNO1X9w+3T74mOgk4TiofJsxAtQz2GWFunq6RDDo8PkofsFumJ7pSMggniySwZA="
+              "value": "QB0AHP3mjayrXD9Kz.pocd3RpgC74mob8QSLRw8pY_4-1702467063-1-AZAxu/XhG5nGrE7UPTeDsb770Pc433Uc+kNmNDDAy196W0tRAP9J0a5nrR0NyEp0pB9l7mChlzaXW55t6xYK3Hc="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 11:38:45 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:03 GMT"
             },
             {
               "name": "content-type",
-              "value": "text/event-stream"
+              "value": "application/json"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "26"
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             },
             {
               "name": "cf-rate-limit-rule-id",
@@ -9319,7 +8020,7 @@
             },
             {
               "name": "retry-after",
-              "value": "472"
+              "value": "236"
             },
             {
               "name": "access-control-allow-credentials",
@@ -9331,17 +8032,17 @@
             },
             {
               "name": "cache-control",
-              "value": "no-cache"
+              "value": "no-cache, max-age=0"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f6cbfb35-4ce2-4c6b-88c4-a10c32f6bd5a; Expires=Wed, 11 Dec 2024 11:38:44 GMT; Secure"
+              "value": "sourcegraphDeviceId=24a7af94-c3a7-40b5-b174-22b92cb73bcc; Expires=Fri, 13 Dec 2024 11:31:03 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=nv1I1GA6nHqAfvBQKlKaBhKHjJUroyJwcDaGUCYT3U4-1702294725-1-AemednhhfrsON29Rp0dSAzdKCNO1X9w+3T74mOgk4TiofJsxAtQz2GWFunq6RDDo8PkofsFumJ7pSMggniySwZA=; path=/; expires=Mon, 11-Dec-23 12:08:45 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=QB0AHP3mjayrXD9Kz.pocd3RpgC74mob8QSLRw8pY_4-1702467063-1-AZAxu/XhG5nGrE7UPTeDsb770Pc433Uc+kNmNDDAy196W0tRAP9J0a5nrR0NyEp0pB9l7mChlzaXW55t6xYK3Hc=; path=/; expires=Wed, 13-Dec-23 12:01:03 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -9357,15 +8058,15 @@
             },
             {
               "name": "x-trace",
-              "value": "2b4660063d2180035fd472932c479c9d"
+              "value": "1bd068b5d4aaf79775b60c72b7786bd5"
             },
             {
               "name": "x-trace-span",
-              "value": "040fad51f1fd09a4"
+              "value": "cb9f7df5e07f2bbb"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2b4660063d2180035fd472932c479c9d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1bd068b5d4aaf79775b60c72b7786bd5"
             },
             {
               "name": "x-xss-protection",
@@ -9389,17 +8090,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833d716b0f2256c9-OSL"
+              "value": "834de0e889915691-OSL"
             }
           ],
-          "headersSize": 1239,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T11:38:44.228Z",
-        "time": 1331,
+        "startedDateTime": "2023-12-13T11:31:03.083Z",
+        "time": 220,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9407,70 +8108,102 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1331
+          "wait": 220
         }
       },
       {
-        "_id": "5c72bc6a5f49643773eef0fe10836075",
+        "_id": "96966391b5988a8be5d80cb7b0923d0a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 21859,
+          "bodySize": 1228,
           "cookies": [],
           "headers": [
             {
-              "name": "content-type",
-              "value": "application/json"
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
               "name": "user-agent",
-              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1228"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
             },
             {
               "name": "host",
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 169,
+          "headersSize": 323,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "application/json",
+            "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":47906}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"},{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"philipp\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"895280200eed727ed003d6afa5557cf7\",\"spanId\":\"2194cfd7b892e490\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294721326000000\",\"endTimeUnixNano\":\"1702294721539306375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f25bafd2f04dde3d1b33f832d12cb674\",\"spanId\":\"07f7e1ea1cc93930\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294721326000000\",\"endTimeUnixNano\":\"1702294721549851917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3abff3d2382112c020ec58445d1f548b\",\"spanId\":\"b116d988629656ed\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294721327000000\",\"endTimeUnixNano\":\"1702294721552682791\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ce602db328e6955e71decf2e830a8fb4\",\"spanId\":\"5e21624a49eda339\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294721324000000\",\"endTimeUnixNano\":\"1702294721721146500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"8eeb76a0fb48e30cb5882b8049a1080e\",\"spanId\":\"2d69baa1f38e3d07\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702294721327000000\",\"endTimeUnixNano\":\"1702294721731941042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c6db10d1bbd90dcfe194e739eafd3561\",\"spanId\":\"34c13d919a9823cf\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702294721327000000\",\"endTimeUnixNano\":\"1702294721823141416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"630a6412096420ebb1d6dfb7095a2563\",\"spanId\":\"75e8f2fd1feb8301\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702294721824000000\",\"endTimeUnixNano\":\"1702294722038640917\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f8db9e7f2c9352b86bf98f7f1deac2b5\",\"spanId\":\"4f3bb09d88768a2d\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722044000000\",\"endTimeUnixNano\":\"1702294722290389958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0f4f3731b7da648cfdc8d08ae8ac5145\",\"spanId\":\"6930b2e7fec2e247\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294722064000000\",\"endTimeUnixNano\":\"1702294722292165958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"688b902999e5214e2e9e7dbf82ea346b\",\"spanId\":\"2a5b6dd15618772c\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702294722043000000\",\"endTimeUnixNano\":\"1702294722298884541\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2127c4aa7f330b0da69041f15ab1e106\",\"spanId\":\"ac932174d8ebdc06\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294722063000000\",\"endTimeUnixNano\":\"1702294722298696500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"c80447397bfa72fd99acb64606ed61cb\",\"spanId\":\"9985f8cbcd697a1c\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702294722063000000\",\"endTimeUnixNano\":\"1702294722303027334\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"28027b53bf4194fad023de8ed1d1317d\",\"spanId\":\"6b9bf4ddea4abf0a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722044000000\",\"endTimeUnixNano\":\"1702294722304506667\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"980eb3186e400767b6177280c2ea8035\",\"spanId\":\"51b48e6545ed2890\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722044000000\",\"endTimeUnixNano\":\"1702294722307916458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f3d5df2947e809ba3f2997165c794c49\",\"spanId\":\"0e000af0694dacf5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722044000000\",\"endTimeUnixNano\":\"1702294722324857083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0fdba1e750c708137096085fc93637d2\",\"spanId\":\"aa922e245688b3ea\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702294722042000000\",\"endTimeUnixNano\":\"1702294722331153083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"4d400edf6a0b076cfecdf7b331b33d4a\",\"spanId\":\"b3f0766f9131d3dd\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722065000000\",\"endTimeUnixNano\":\"1702294722334428125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"0dcef6a4bfb74d3faeae2839b447d14a\",\"spanId\":\"726333da2ddc30b2\",\"name\":\"graphql.fetch.CurrentSiteCodyLlmConfiguration\",\"kind\":1,\"startTimeUnixNano\":\"1702294722063000000\",\"endTimeUnixNano\":\"1702294722336378250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d5cbc79da67e3637b5a37f8c48ba58b6\",\"spanId\":\"7326420f685af1b3\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722045000000\",\"endTimeUnixNano\":\"1702294722340936209\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5846a7db14b5c9116da96c42a2292db6\",\"spanId\":\"71f4edbbc4446c6e\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702294722043000000\",\"endTimeUnixNano\":\"1702294722340716209\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"309547a70865992216f1565c4893d8ac\",\"spanId\":\"4af5bc65a982f8b9\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702294722066000000\",\"endTimeUnixNano\":\"1702294722342404542\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b7df306b2e1fcc87c79a40bcbf8828ac\",\"spanId\":\"580873a0da6710ed\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702294722066000000\",\"endTimeUnixNano\":\"1702294722360018416\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3ca9a4ce979adde8be33ba2a88156543\",\"spanId\":\"0499ea785f00f126\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294722292000000\",\"endTimeUnixNano\":\"1702294722504517708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"7ca05021dc7fbf035b2213f705ec0905\",\"spanId\":\"4d09622621211a49\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702294722067000000\",\"endTimeUnixNano\":\"1702294722526033125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ef2d5bda4d82b4cb4810d3d5cc1b9f93\",\"spanId\":\"c5500fa0c71207d5\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702294722064000000\",\"endTimeUnixNano\":\"1702294722730697417\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"acc6a1296cb6a603f01e6660c8bdaea8\",\"spanId\":\"f9895b4ec1bb1e7b\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722067000000\",\"endTimeUnixNano\":\"1702294722813440375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f34d130497570f8a01d3eccb04a72f24\",\"spanId\":\"d01d143fa15a4da6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722043000000\",\"endTimeUnixNano\":\"1702294722817684958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"3ae04c5582d28cec7c896189f4868615\",\"spanId\":\"de2d7222ce6e6a43\",\"name\":\"graphql.fetch.SiteIdentification\",\"kind\":1,\"startTimeUnixNano\":\"1702294722066000000\",\"endTimeUnixNano\":\"1702294722820567292\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cb788de0b236ceb09ed83dcfa56de913\",\"spanId\":\"28febe3dea35f095\",\"name\":\"graphql.fetch.CurrentUser\",\"kind\":1,\"startTimeUnixNano\":\"1702294722337000000\",\"endTimeUnixNano\":\"1702294722927607584\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"19d92a4a1c5e993961bc5cc8776c5415\",\"spanId\":\"a5ef94b19914bce8\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722045000000\",\"endTimeUnixNano\":\"1702294723013731083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"732a6fe253fa3e5fc07a01c17aa421d2\",\"spanId\":\"8d19f6d40f0b2384\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723016000000\",\"endTimeUnixNano\":\"1702294723233995875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b38b02fcd76bb68cc11e654b16dc1801\",\"spanId\":\"ef32c011229160a7\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723016000000\",\"endTimeUnixNano\":\"1702294723239557625\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"cb0f305bece7cec679d018bc9e06de16\",\"spanId\":\"a22162f4448ef2be\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723016000000\",\"endTimeUnixNano\":\"1702294723241011959\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d3ccf333fe45aaeb91ca697878c1ea2e\",\"spanId\":\"125491c6581c7527\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723014000000\",\"endTimeUnixNano\":\"1702294723246837875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"93362ca6ea089f45bee18b8fe460a761\",\"spanId\":\"1b84dd98db94dfad\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723016000000\",\"endTimeUnixNano\":\"1702294723249834875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"687c1a2fa40302ad61f39d5bb9a526f8\",\"spanId\":\"e579229b9ab62fd5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723016000000\",\"endTimeUnixNano\":\"1702294723250450375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"715ef583766488ed86ac1f03f2e66804\",\"spanId\":\"c1579ba971a4325e\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723017000000\",\"endTimeUnixNano\":\"1702294723265322916\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"fbf9db5fa554ab7a28c360ecd98a76a8\",\"spanId\":\"b7cd310de3e7c1af\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294722931000000\",\"endTimeUnixNano\":\"1702294723296323791\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f2fd237c90b582f1d2faab610edb6699\",\"spanId\":\"565878441af6b5e6\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294722930000000\",\"endTimeUnixNano\":\"1702294723295945458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"61135eea818ba65e912e40e3591a0893\",\"spanId\":\"dbd631c0cfdcfb62\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294722929000000\",\"endTimeUnixNano\":\"1702294723313920083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"d8d75bd4f60e53b5cbc099cabfd19d04\",\"spanId\":\"c695dc1df47ea8d7\",\"name\":\"graphql.fetch.LogEventMutation\",\"kind\":1,\"startTimeUnixNano\":\"1702294722930000000\",\"endTimeUnixNano\":\"1702294723402487833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ec68cee3c548fcd5b289593783a25de8\",\"spanId\":\"de3e600443cbf926\",\"name\":\"graphql.fetch.FeatureFlags\",\"kind\":1,\"startTimeUnixNano\":\"1702294722931000000\",\"endTimeUnixNano\":\"1702294723426580375\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"b16f3e3b2bb252c7074af53be5919d92\",\"spanId\":\"55f2985ff90a0eb7\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294723314000000\",\"endTimeUnixNano\":\"1702294723516706833\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"639697da1df507cadada7b4953164528\",\"spanId\":\"15a241f99b7165ec\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723015000000\",\"endTimeUnixNano\":\"1702294723596811084\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"29dc871764b82c82a70bffd440491307\",\"spanId\":\"ae6c97990c263c43\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723015000000\",\"endTimeUnixNano\":\"1702294723599614458\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2e8cff61866367d3e111de93839f7dc9\",\"spanId\":\"df3a58ad417e819a\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723015000000\",\"endTimeUnixNano\":\"1702294723686301125\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2793700b2a8063648a61b10e9fc73c7e\",\"spanId\":\"9d6f6d8fbf3cbd8c\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723016000000\",\"endTimeUnixNano\":\"1702294723892478208\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"04aff73a8e0b0450652273df38b2a7a7\",\"spanId\":\"3b59b813a2ff8ec5\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723895000000\",\"endTimeUnixNano\":\"1702294724119109500\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"a66f91ab728321f1\",\"parentSpanId\":\"3fd46dba1793899b\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723519000000\",\"endTimeUnixNano\":\"1702294724221512875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"accc10f0dc7ef602\",\"parentSpanId\":\"3fd46dba1793899b\",\"name\":\"autocomplete.debounce\",\"kind\":1,\"startTimeUnixNano\":\"1702294724222000000\",\"endTimeUnixNano\":\"1702294724222041042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"e5a1749375dcf73e\",\"parentSpanId\":\"a314c1a70f0934e0\",\"name\":\"autocomplete.retrieve.jaccard-similarity\",\"kind\":1,\"startTimeUnixNano\":\"1702294724222000000\",\"endTimeUnixNano\":\"1702294724222456583\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"a314c1a70f0934e0\",\"parentSpanId\":\"3fd46dba1793899b\",\"name\":\"autocomplete.retrieve\",\"kind\":1,\"startTimeUnixNano\":\"1702294724222000000\",\"endTimeUnixNano\":\"1702294724222740958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"ccc3d09121c5daf0a98614893243a574\",\"spanId\":\"11039d8b9552ffed\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723893000000\",\"endTimeUnixNano\":\"1702294724732382792\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"6356fadd78707b228d66772cf70cbc04\",\"spanId\":\"879d21e78a1be3fe\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702294723296000000\",\"endTimeUnixNano\":\"1702294724786613042\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"f2d8efaa3f8d0656c9b60009fb483e1a\",\"spanId\":\"c1d3a62ae67df3b8\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723894000000\",\"endTimeUnixNano\":\"1702294724795181334\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"1ccf63ef046a732d2f4e0c6ffb8cf3a1\",\"spanId\":\"1a180b03216ff412\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723894000000\",\"endTimeUnixNano\":\"1702294724796685708\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"bd3fdbad1da7e69ca55c540b71e27d92\",\"spanId\":\"852ae1b1ee9784a6\",\"name\":\"graphql.fetch.EvaluateFeatureFlag\",\"kind\":1,\"startTimeUnixNano\":\"1702294723895000000\",\"endTimeUnixNano\":\"1702294724817910792\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"182a63100992f0c8\",\"parentSpanId\":\"3fd46dba1793899b\",\"name\":\"autocomplete.generate\",\"kind\":1,\"startTimeUnixNano\":\"1702294724223000000\",\"endTimeUnixNano\":\"1702294726177078250\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"15763e09e04d5df9\",\"parentSpanId\":\"3fd46dba1793899b\",\"name\":\"autocomplete.post-process\",\"kind\":1,\"startTimeUnixNano\":\"1702294726177000000\",\"endTimeUnixNano\":\"1702294726177242875\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"2b4660063d2180035fd472932c479c9d\",\"spanId\":\"3fd46dba1793899b\",\"name\":\"autocomplete.provideInlineCompletionItems\",\"kind\":1,\"startTimeUnixNano\":\"1702294723518000000\",\"endTimeUnixNano\":\"1702294726178877834\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"99d64dc9-c203-4c0d-ba65-46a33f6798d0\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"0.18.5\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"0.18.5\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
-          "queryString": [],
-          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
         },
         "response": {
-          "bodySize": 21,
+          "bodySize": 26,
           "content": {
             "mimeType": "application/json",
-            "size": 21,
-            "text": "{\"partialSuccess\":{}}"
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T11:38:46.000Z",
+              "expires": "2024-12-13T11:31:03.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "81f8fb86-4474-4118-8239-5d7854d3b6e6"
+              "value": "3ba1f208-ee9c-4bc1-9bad-8a8d1a419f84"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T12:08:46.000Z",
+              "expires": "2023-12-13T12:01:03.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "E11wo.S5HWtbQfFFygPWgH0zEoeeG6d3.rmNVRExP3M-1702294726-1-AbGxTdDgaogF3A35s7StSnlJMTm0D+b8Hmruo2qst2ZtCi8hVfqB6xMBEOpcOIDJnkcztj4XVof3Dgqau1xkJ3Q="
+              "value": "T3WllKGMGl4oCLsWxNtnqENL9CVhhaea9J2RDHtttck-1702467063-1-AeAYHhzpjY/Ym7MMT/TasDUJvzR9XXKD6WBWiHQNX9GyDthYfbV+/0dUZCffkMckxxohYZVxlkDxG0IN4p89Jq0="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 11:38:46 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:03 GMT"
             },
             {
               "name": "content-type",
@@ -9478,11 +8211,11 @@
             },
             {
               "name": "content-length",
-              "value": "21"
+              "value": "26"
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             },
             {
               "name": "cf-rate-limit-rule-id",
@@ -9494,7 +8227,15 @@
             },
             {
               "name": "retry-after",
-              "value": "470"
+              "value": "236"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
             },
             {
               "name": "cache-control",
@@ -9503,16 +8244,16 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=81f8fb86-4474-4118-8239-5d7854d3b6e6; Expires=Wed, 11 Dec 2024 11:38:46 GMT; Secure"
+              "value": "sourcegraphDeviceId=3ba1f208-ee9c-4bc1-9bad-8a8d1a419f84; Expires=Fri, 13 Dec 2024 11:31:03 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=E11wo.S5HWtbQfFFygPWgH0zEoeeG6d3.rmNVRExP3M-1702294726-1-AbGxTdDgaogF3A35s7StSnlJMTm0D+b8Hmruo2qst2ZtCi8hVfqB6xMBEOpcOIDJnkcztj4XVof3Dgqau1xkJ3Q=; path=/; expires=Mon, 11-Dec-23 12:08:46 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=T3WllKGMGl4oCLsWxNtnqENL9CVhhaea9J2RDHtttck-1702467063-1-AeAYHhzpjY/Ym7MMT/TasDUJvzR9XXKD6WBWiHQNX9GyDthYfbV+/0dUZCffkMckxxohYZVxlkDxG0IN4p89Jq0=; path=/; expires=Wed, 13-Dec-23 12:01:03 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
-              "value": "Cookie,Authorization,Cookie,Cookie"
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
             {
               "name": "x-content-type-options",
@@ -9524,15 +8265,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f1325273789327f4859543b9d22816fe"
+              "value": "526204ae4222b4245ef1d0475b8a4f95"
             },
             {
               "name": "x-trace-span",
-              "value": "2e6a6013b70b69f6"
+              "value": "4b46d75cdd348d3e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f1325273789327f4859543b9d22816fe"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/526204ae4222b4245ef1d0475b8a4f95"
             },
             {
               "name": "x-xss-protection",
@@ -9556,17 +8297,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "833d71797d3b712f-OSL"
+              "value": "834de0e88a70b527-OSL"
             }
           ],
-          "headersSize": 1121,
+          "headersSize": 1236,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T11:38:46.548Z",
-        "time": 211,
+        "startedDateTime": "2023-12-13T11:31:03.082Z",
+        "time": 228,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9574,82 +8315,115 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 211
+          "wait": 228
         }
       },
       {
-        "_id": "69f0a75e8c483dd790ebd41449c65383",
+        "_id": "4ee0f1443a1b4fb4937fa9fd795d5eeb",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1972,
+          "bodySize": 1620,
           "cookies": [],
           "headers": [
             {
-              "name": "content-type",
-              "value": "application/json"
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
               "name": "user-agent",
-              "value": "OTel-OTLP-Exporter-JavaScript/0.45.1"
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1620"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
             },
             {
               "name": "host",
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 169,
+          "headersSize": 328,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
-            "mimeType": "application/json",
+            "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"cody-client\"}},{\"key\":\"telemetry.sdk.language\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"telemetry.sdk.name\",\"value\":{\"stringValue\":\"opentelemetry\"}},{\"key\":\"telemetry.sdk.version\",\"value\":{\"stringValue\":\"1.18.1\"}},{\"key\":\"service.version\",\"value\":{\"stringValue\":\"0.18.2\"}},{\"key\":\"process.pid\",\"value\":{\"intValue\":47906}},{\"key\":\"process.executable.name\",\"value\":{\"stringValue\":\"node\"}},{\"key\":\"process.executable.path\",\"value\":{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"}},{\"key\":\"process.command_args\",\"value\":{\"arrayValue\":{\"values\":[{\"stringValue\":\"/Users/philipp/.local/share/rtx/installs/node/20.4.0/bin/node\"},{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"},{\"stringValue\":\"jsonrpc\"}]}}},{\"key\":\"process.runtime.version\",\"value\":{\"stringValue\":\"20.4.0\"}},{\"key\":\"process.runtime.name\",\"value\":{\"stringValue\":\"nodejs\"}},{\"key\":\"process.runtime.description\",\"value\":{\"stringValue\":\"Node.js\"}},{\"key\":\"process.command\",\"value\":{\"stringValue\":\"/Users/philipp/dev/cody/agent/dist/index.js\"}},{\"key\":\"process.owner\",\"value\":{\"stringValue\":\"philipp\"}}],\"droppedAttributesCount\":0},\"scopeSpans\":[{\"scope\":{\"name\":\"cody\",\"version\":\"0.1\"},\"spans\":[{\"traceId\":\"7bbd54a44389be372627be3c8588f1c0\",\"spanId\":\"0a431ffe23b64f93\",\"name\":\"graphql.fetch.SiteProductVersion\",\"kind\":1,\"startTimeUnixNano\":\"1702294726180000000\",\"endTimeUnixNano\":\"1702294726989522958\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0},{\"traceId\":\"5316c18aaab794bbaa5244a7011d1e03\",\"spanId\":\"32470923a475d427\",\"name\":\"graphql.fetch.RecordTelemetryEvents\",\"kind\":1,\"startTimeUnixNano\":\"1702294726990000000\",\"endTimeUnixNano\":\"1702294728226789083\",\"attributes\":[],\"droppedAttributesCount\":0,\"events\":[],\"droppedEventsCount\":0,\"status\":{\"code\":0},\"links\":[],\"droppedLinksCount\":0}]}]}]}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"0.18.5\"},\"parameters\":{\"version\":0,\"interactionID\":\"de1ed97c-90d4-44e2-9245-7879515cf2c4\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":0.33662499487400055},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"fireworks\",\"providerModel\":\"starcoder-hybrid\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"de1ed97c-90d4-44e2-9245-7879515cf2c4\",\"contextSummary\":{\"strategy\":\"jaccard-similarity\",\"duration\":0.33662499487400055,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\"}}}}]}}"
           },
-          "queryString": [],
-          "url": "https://sourcegraph.com/-/debug/otlp/v1/traces"
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 21,
+          "bodySize": 112,
           "content": {
+            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 21,
-            "text": "{\"partialSuccess\":{}}"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-11T11:38:52.000Z",
+              "expires": "2024-12-13T11:31:03.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d4433289-2554-4a5a-ba15-1a98f3c09bf1"
+              "value": "286973c1-4511-4fca-8a2d-f5b86e6adc42"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-11T12:08:52.000Z",
+              "expires": "2023-12-13T12:01:03.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "TB3kZtXXwr.y.wNdmH5VmP6sHvsFI6q70nWlmQlrncc-1702294732-1-ARHXLBdk31BEHp3NO7DNRmkiI1UiVYqLtBTo9cT7veZ+kxgE3t4LBQtqH/I2VyMs3AaT3Wp/IPlO0LFqgTyVHw4="
+              "value": "ffDI4Vqa1EnMWxPVIG8SKY5FrH7a3LdyE6wMQjlCG7o-1702467063-1-AXdxNrYW6Go7p86SWmaAZGLr+D9Hy7U4nSeH9tHy1j3QuvaomY1AOoXib/akW3ZOnTuXIvtNjg33MRYdPrZYqmw="
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Mon, 11 Dec 2023 11:38:52 GMT"
+              "value": "Wed, 13 Dec 2023 11:31:03 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "content-length",
-              "value": "21"
+              "name": "transfer-encoding",
+              "value": "chunked"
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             },
             {
               "name": "cf-rate-limit-rule-id",
@@ -9661,7 +8435,15 @@
             },
             {
               "name": "retry-after",
-              "value": "464"
+              "value": "236"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
             },
             {
               "name": "cache-control",
@@ -9670,16 +8452,16 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d4433289-2554-4a5a-ba15-1a98f3c09bf1; Expires=Wed, 11 Dec 2024 11:38:52 GMT; Secure"
+              "value": "sourcegraphDeviceId=286973c1-4511-4fca-8a2d-f5b86e6adc42; Expires=Fri, 13 Dec 2024 11:31:03 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=TB3kZtXXwr.y.wNdmH5VmP6sHvsFI6q70nWlmQlrncc-1702294732-1-ARHXLBdk31BEHp3NO7DNRmkiI1UiVYqLtBTo9cT7veZ+kxgE3t4LBQtqH/I2VyMs3AaT3Wp/IPlO0LFqgTyVHw4=; path=/; expires=Mon, 11-Dec-23 12:08:52 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ffDI4Vqa1EnMWxPVIG8SKY5FrH7a3LdyE6wMQjlCG7o-1702467063-1-AXdxNrYW6Go7p86SWmaAZGLr+D9Hy7U4nSeH9tHy1j3QuvaomY1AOoXib/akW3ZOnTuXIvtNjg33MRYdPrZYqmw=; path=/; expires=Wed, 13-Dec-23 12:01:03 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
-              "value": "Cookie,Authorization,Cookie,Cookie"
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
             {
               "name": "x-content-type-options",
@@ -9691,15 +8473,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3bc8ccd6a6dc2511d9153f52be7fc0d2"
+              "value": "114242f5e3edba24dff7c4581cb6d8c5"
             },
             {
               "name": "x-trace-span",
-              "value": "95958d662c9fcb0d"
+              "value": "c0e72ac8210f0421"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3bc8ccd6a6dc2511d9153f52be7fc0d2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/114242f5e3edba24dff7c4581cb6d8c5"
             },
             {
               "name": "x-xss-protection",
@@ -9723,17 +8505,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "833d719b497e712f-OSL"
+              "value": "834de0e88bf95699-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
             }
           ],
-          "headersSize": 1121,
+          "headersSize": 1268,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-11T11:38:51.993Z",
-        "time": 175,
+        "startedDateTime": "2023-12-13T11:31:03.085Z",
+        "time": 225,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -9741,7 +8527,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 175
+          "wait": 225
         }
       }
     ],

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -2,9 +2,10 @@ import assert from 'assert'
 import { execSync, spawn } from 'child_process'
 import path from 'path'
 
-import { afterAll, beforeAll, describe, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { Uri } from 'vscode'
 
+import { ChatMessage } from '@sourcegraph/cody-shared'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 
 import { MessageHandler } from './jsonrpc-alias'
@@ -41,35 +42,30 @@ export class TestClient extends MessageHandler {
 }
 
 const dotcom = 'https://sourcegraph.com'
-const clients: { name: string; clientInfo: ClientInfo }[] = [
-    {
-        name: 'FullConfig',
-        clientInfo: {
-            name: 'test-client',
-            version: 'v1',
-            workspaceRootUri: 'file:///path/to/foo',
-            workspaceRootPath: '/path/to/foo',
-            extensionConfiguration: {
-                anonymousUserID: 'abcde1234',
-                accessToken: process.env.SRC_ACCESS_TOKEN ?? 'sgp_RRRRRRRREEEEEEEDDDDDDAAACCCCCTEEEEEEEDDD',
-                serverEndpoint: dotcom,
-                customHeaders: {},
-                autocompleteAdvancedProvider: 'anthropic',
-                autocompleteAdvancedAccessToken: '',
-                autocompleteAdvancedServerEndpoint: '',
-                debug: false,
-                verboseDebug: false,
-            },
-        },
+const clientInfo: ClientInfo = {
+    name: 'test-client',
+    version: 'v1',
+    workspaceRootUri: 'file:///path/to/foo',
+    workspaceRootPath: '/path/to/foo',
+    extensionConfiguration: {
+        anonymousUserID: 'abcde1234',
+        accessToken: process.env.SRC_ACCESS_TOKEN ?? 'sgp_RRRRRRRREEEEEEEDDDDDDAAACCCCCTEEEEEEEDDD',
+        serverEndpoint: dotcom,
+        customHeaders: {},
+        autocompleteAdvancedProvider: 'anthropic',
+        autocompleteAdvancedAccessToken: '',
+        autocompleteAdvancedServerEndpoint: '',
+        debug: false,
+        verboseDebug: false,
     },
-]
+}
 
 const cwd = process.cwd()
 const agentDir = path.basename(cwd) === 'agent' ? cwd : path.join(cwd, 'agent')
 const recordingDirectory = path.join(agentDir, 'recordings')
 const agentScript = path.join(agentDir, 'dist', 'index.js')
 
-describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo }) => {
+describe('Agent', () => {
     // Uncomment the code block below to disable agent tests. Feel free to do this to unblock
     // merging a PR if the agent tests are failing. If you decide to uncomment this block, please
     // post in #wg-cody-agent to let the team know the tests have been disabled so that we can
@@ -79,8 +75,8 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
     //     return
     // }
 
-    if (process.env.VITEST_ONLY && !process.env.VITEST_ONLY.includes(name)) {
-        it(name + ' tests are skipped due to VITEST_ONLY environment variable', () => {})
+    if (process.env.VITEST_ONLY && !process.env.VITEST_ONLY.includes('Agent')) {
+        it('Agent tests are skipped due to VITEST_ONLY environment variable', () => {})
         return
     }
     const client = new TestClient()
@@ -104,7 +100,7 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
             CODY_SHIM_TESTING: 'true',
             CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
             CODY_RECORDING_DIRECTORY: recordingDirectory,
-            CODY_RECORDING_NAME: name,
+            CODY_RECORDING_NAME: 'FullConfig',
             ...process.env,
         },
     })
@@ -155,11 +151,18 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
             position: { line: 1, character: 3 },
             triggerKind: 'Invoke',
         })
-        assert(completions.items.length > 0, 'Completions should not be empty')
+        const texts = completions.items.map(item => item.insertText)
+        expect(completions.items.length).toBeGreaterThan(0)
+        expect(texts).toMatchInlineSnapshot(`
+          [
+            "   return a + b;",
+          ]
+        `)
+        client.notify('autocomplete/completionAccepted', { completionID: completions.items[0].id })
     }, 10_000)
 
+    const messages: ChatMessage[] = []
     const streamingChatMessages = new Promise<void>((resolve, reject) => {
-        let hasReceivedNonNullMessage = false
         let isResolved = false
         client.registerNotification('chat/updateMessageInProgress', msg => {
             if (msg === null) {
@@ -167,23 +170,54 @@ describe.each(clients)('describe StandardAgent with $name', ({ name, clientInfo 
                     return
                 }
                 isResolved = true
-                if (hasReceivedNonNullMessage) {
+                if (messages.length > 0) {
                     resolve()
                 } else {
                     reject(new Error('Received null message before non-null message'))
                 }
             } else {
-                hasReceivedNonNullMessage = true
+                messages.push(msg)
             }
         })
     })
 
     it('allows us to execute recipes properly', async () => {
-        await client.executeRecipe('chat-question', 'How do I implement sum?')
+        await client.executeRecipe('chat-question', 'How do I implement sum in JavaScript?')
     }, 20_000)
 
     // Timeout is 100ms because we await on `recipes/execute` in the previous test
-    it('executing a recipe sends chat/updateMessageInProgress notifications', () => streamingChatMessages, 100)
+    it('executing a recipe sends chat/updateMessageInProgress notifications', async () => {
+        await streamingChatMessages
+        expect(messages.slice(-1)[0]).toMatchInlineSnapshot(`
+          {
+            "contextFiles": [],
+            "preciseContext": [],
+            "speaker": "assistant",
+            "text": " Here is how to implement a sum function in JavaScript:
+
+          \`\`\`js
+          function sum(arr) {
+            let total = 0;
+            for (let i = 0; i < arr.length; i++) {
+              total += arr[i]; 
+            }
+            return total;
+          }
+          \`\`\`
+
+          To use:
+
+          \`\`\`js
+          const numbers = [1, 2, 3, 4, 5];
+
+          const result = sum(numbers); 
+          // result = 15
+          \`\`\`
+
+          This implements a simple sum function that takes an array of numbers, iterates through the array, and returns the total sum of the numbers.",
+          }
+        `)
+    }, 100)
 
     // TODO Fix test - fails intermittently on macOS on Github Actions
     // e.g. https://github.com/sourcegraph/cody/actions/runs/7191096335/job/19585263054#step:9:1723

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -188,7 +188,15 @@ describe('Agent', () => {
     // Timeout is 100ms because we await on `recipes/execute` in the previous test
     it('executing a recipe sends chat/updateMessageInProgress notifications', async () => {
         await streamingChatMessages
-        expect(messages.slice(-1)[0]).toMatchInlineSnapshot(`
+        const actual = messages.at(-1)
+        if (actual?.text) {
+            // trim trailing whitespace from the autocomplete result that Prettier removes causing the inline snapshot assertion to fail.
+            actual.text = actual.text
+                .split('\n')
+                .map(line => line.trimEnd())
+                .join('\n')
+        }
+        expect(actual).toMatchInlineSnapshot(`
           {
             "contextFiles": [],
             "preciseContext": [],
@@ -199,7 +207,7 @@ describe('Agent', () => {
           function sum(arr) {
             let total = 0;
             for (let i = 0; i < arr.length; i++) {
-              total += arr[i]; 
+              total += arr[i];
             }
             return total;
           }
@@ -210,7 +218,7 @@ describe('Agent', () => {
           \`\`\`js
           const numbers = [1, 2, 3, 4, 5];
 
-          const result = sum(numbers); 
+          const result = sum(numbers);
           // result = 15
           \`\`\`
 

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -345,9 +345,32 @@ export function setAgent(newAgent: Agent): void {
     agent = newAgent
 }
 
+const webviewPanel: vscode.WebviewPanel = {
+    active: false,
+    dispose: () => {},
+    onDidChangeViewState: emptyEvent(),
+    onDidDispose: emptyEvent(),
+    options: { enableFindWidget: false, retainContextWhenHidden: false },
+    reveal: () => {},
+    title: 'title',
+    viewColumn: undefined,
+    viewType: 'markdown.preview',
+    visible: false,
+    webview: {
+        asWebviewUri(localResource) {
+            return localResource
+        },
+        cspSource: 'cspSource',
+        html: '<p>html</p>',
+        onDidReceiveMessage: emptyEvent(),
+        options: {},
+        postMessage: () => Promise.resolve(true),
+    },
+}
 const _window: Partial<typeof vscode.window> = {
     createTreeView: () => ({ visible: false }) as any,
     tabGroups,
+    createWebviewPanel: () => webviewPanel,
     registerCustomEditorProvider: () => emptyDisposable,
     registerFileDecorationProvider: () => emptyDisposable,
     registerTerminalLinkProvider: () => emptyDisposable,

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -8,6 +8,7 @@ import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { View } from '../../../webviews/NavBar'
+import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
 import { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import { SymfRunner } from '../../local-context/symf'
 import { logDebug } from '../../log'
@@ -280,6 +281,9 @@ export async function addWebviewViewHTML(
     extensionUri: vscode.Uri,
     view: vscode.WebviewView | vscode.WebviewPanel
 ): Promise<void> {
+    if (isRunningInsideAgent()) {
+        return
+    }
     const webviewPath = vscode.Uri.joinPath(extensionUri, 'dist', 'webviews')
     // Create Webview using vscode/index.html
     const root = vscode.Uri.joinPath(webviewPath, 'index.html')

--- a/vscode/src/jsonrpc/isRunningInsideAgent.ts
+++ b/vscode/src/jsonrpc/isRunningInsideAgent.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode'
+
+export function isRunningInsideAgent(): boolean {
+    return vscode.workspace.getConfiguration().get<boolean>('cody.advanced.agent.running', false)
+}

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -128,7 +128,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
     public async start(): Promise<void> {
         logDebug('LocalEmbeddingsController', 'start')
         await this.getService()
-        const repoUri = vscode.workspace.workspaceFolders?.[0].uri
+        const repoUri = vscode.workspace.workspaceFolders?.[0]?.uri
         if (repoUri) {
             await this.eagerlyLoad(repoUri.fsPath)
         }
@@ -276,7 +276,8 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
             return []
         }
         // TODO: Summarize the path with ~, etc.
-        const path = this.lastRepo?.path || vscode.workspace.workspaceFolders?.[0].uri.fsPath || '(No workspace loaded)'
+        const path =
+            this.lastRepo?.path || vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath || '(No workspace loaded)'
         if (!this.lastRepo) {
             return [
                 {


### PR DESCRIPTION
Previously, the agent tests didn't test the case where the client sends a notification for an accepted autocomplete request. Turns out that this notification caused uncaught errors that may have been the root cause behind sourcegraph/jetbrains#191

This PR adds a test case to reproduce the situation where a client accepts an autocomplete request and fixes the errors that happen when doing so.

## Test plan

Green CI.
<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
