### PR TITLE
Custom Commands: Filter out insert and edit commands from chat input

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Update Getting Started Guide. [pull/2279](https://github.com/sourcegraph/cody/pull/2279)
+- Commands: Edit commands are no longer shown in the chat slash command menu. [pull/2339](https://github.com/sourcegraph/cody/pull/2339)
 
 ## [0.18.5]
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -914,8 +914,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const allCommands = await this.editor.controllers.command?.getAllCommands(true)
             // HACK: filter out commands that make inline changes and /ask (synonymous with a generic question)
             const prompts =
-                allCommands?.filter(([id]) => {
-                    return !['/edit', '/doc', '/ask'].includes(id)
+                allCommands?.filter(([id, { mode = '' }]) => {
+                    return !['/edit', '/doc', '/ask'].includes(id) && !['edit', 'insert'].includes(mode)
                 }) || []
 
             void this.postMessage({


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/2300

## Description

Filters out custom edit commands from the chat input

## Test plan

Create a custom command with a mode that can edit

Check it does not appear in the slash command menu

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
