### PR TITLE
Chat Context: Provide relative path as current file

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Don't show loading indicator when a user is rate limited. [pull/2314](https://github.com/sourcegraph/cody/pull/2314)
 - Fixes an issue where the wrong rate limit count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
 - Chat: Fix icon rendering on the null state. [pull/2336](https://github.com/sourcegraph/cody/pull/2336)
+- Chat: The current file, when included as context, is now shown as a relative path and is a clickable link. [pull/2344](https://github.com/sourcegraph/cody/pull/2344)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -988,7 +988,7 @@ class ContextProvider implements IContextProvider {
         return [
             {
                 text: visible.content,
-                uri: visible.fileUri || vscode.Uri.file(visible.fileName),
+                uri: vscode.Uri.file(visible.fileName),
             },
         ]
     }


### PR DESCRIPTION
## Description

The `fileUri` provided will be absolute. Instead, we always want to use a better Uri based on the relative file path that we already know.

closes https://github.com/sourcegraph/cody/issues/2331

## Test plan

1. Start chat, ask "what does this file do?"
2. Check context
3. Confirm current file is shown relative to users editor directory root.
4. Confirm context is correctly used
5. Confirm current file is clickable

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
