### PR TITLE
Chat: Fix chat panel titles

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Don't show loading indicator when a user is rate limited. [pull/2314](https://github.com/sourcegraph/cody/pull/2314)
 - Fixes an issue where the wrong rate limit count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
 - Chat: Fix icon rendering on the null state. [pull/2336](https://github.com/sourcegraph/cody/pull/2336)
+- Chat: Reopened chat panels now use the correct chat title. [pull/2345](https://github.com/sourcegraph/cody/pull/2345)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -188,6 +188,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
      */
     public async createWebviewPanel(
         activePanelViewColumn?: vscode.ViewColumn,
+        _chatId?: string,
         lastQuestion?: string
     ): Promise<vscode.WebviewPanel> {
         // Checks if the webview panel already exists and is visible.


### PR DESCRIPTION
## Description

closes https://github.com/sourcegraph/cody/issues/2260

Fixes the title of reopened chat panels.

We were using the `chatId` by accident before, due to a mistake when calling this function

> [!NOTE]  
> We could just not pass the `chatId` but we have two implementations of the ChatPanelProvider right now. One relies on the `chatId` and one doesn't. Will start a thread on Slack to discuss this as it can be quite confusing to debug!

### Before

<img width="340" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/3fbab1d9-1514-4f71-961c-ce7a617b06da">

### After

<img width="346" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/5cb40b39-644e-4043-bf59-30c1f3f27fb4">


## Test plan

1. Create a chat and ask a question
2. Close the chat
3. Reopen the chat by selecting it from the chat history in the sidebar
4. Inspect the title

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
