### PR TITLE
Chat: Fix settings menu not opening on click

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Fixes an issue where the wrong rate limit count was shown. [pull/2312](https://github.com/sourcegraph/cody/pull/2312)
 - Chat: Fix icon rendering on the null state. [pull/2336](https://github.com/sourcegraph/cody/pull/2336)
 - Chat: Reopened chat panels now use the correct chat title. [pull/2345](https://github.com/sourcegraph/cody/pull/2345)
+- Chat: Fixed an issue where the command settings menu would not open when clicked. [pull/2346](https://github.com/sourcegraph/cody/pull/2346)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -497,10 +497,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const args = { requestID }
             telemetryService.log('CodyVSCodeExtension:chatPredictions:used', args, { hasV2Event: true })
         }
+
         // If this is a slash command, run it with custom prompt recipe instead
         if (text.startsWith('/')) {
             if (text.match(/^\/r(eset)?$/)) {
                 await this.clearAndRestartSession()
+                return
+            }
+            if (text === '/commands-settings') {
+                await vscode.commands.executeCommand('cody.settings.commands')
                 return
             }
             return this.executeRecipe('custom-prompt', text.trim(), 'chat', userContextFiles, addEnhancedContext)

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -505,6 +505,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 return
             }
             if (text === '/commands-settings') {
+                // User has clicked the settings button for commands
                 await vscode.commands.executeCommand('cody.settings.commands')
                 return
             }


### PR DESCRIPTION
## Description

closes https://github.com/sourcegraph/cody/issues/2317

This is something else which was covered in the chat logic but hasn't been lifted over to here yet

### Before 

![image](https://github.com/sourcegraph/cody/assets/9516420/9cbcb24e-b42c-4523-81b4-b36cf262e36c)

### After

<img width="673" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/189c0d58-da34-4e78-803e-754a9deab6fc">


## Test plan

Click this button

<img width="248" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/816d725c-7d55-4728-b248-ef04d0f7f8c0">

Check menu opens

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
