### PR TITLE
VSCode: Fix local embeddings e2e test to specifically check that *embeddings* are indexed

### DIFF
--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -113,7 +113,7 @@ test.extend<helpers.WorkspaceDirectory>({
     await expect(enableEmbeddingsButton).toBeVisible({ timeout: 60000 })
     await enableEmbeddingsButton.click()
 
-    await expect(chatFrame.getByText('Indexed')).toBeVisible({ timeout: 30000 })
+    await expect(chatFrame.getByText('Embeddings — Indexed')).toBeVisible({ timeout: 30000 })
 
     // Search the embeddings. This test uses the "stub" embedding model, which
     // is deterministic, but the searches are not semantic.


### PR DESCRIPTION
When we enabled search, Search — Indexed started appearing in the enhanced context selector. This will cause spurious passes in `local-embeddings.test.ts` which was just looking for the text "Indexed"; and spurious failures when the word "Indexed" appears twice, for search *and* embeddings.

Fix the test by looking specifically for "Embeddings — Indexed".

## Test plan

Note, this passed locally before this change, so check that we did not break it. But the real test is whether CI results are accurate now.

```
pnpm test:e2e -- local-embeddings.test.ts
```
