### PR TITLE
Embeddings: Display accurate percent done; do not toast continued embeddings failure

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Context: The "Continue Indexing" button works on Windows. [issues/2328](https://github.com/sourcegraph/cody/issues/2328)
+- Context: The "Embeddings Incomplete" status bar item shows an accurate percent completion. Previously we showed the percent *in*complete, but labeled it percent complete. We no longer display a spurious "Cody Embeddings Index Complete" toast if indexing fails a second time. [pull/2368](https://github.com/sourcegraph/cody/pull/2368)
 
 ### Changed
 

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -246,7 +246,7 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
                 const loadedOk = await this.eagerlyLoad(path)
                 logDebug('LocalEmbeddingsController', 'load after indexing "done"', path, loadedOk)
                 this.changeEmitter.fire(this)
-                if (loadedOk) {
+                if (loadedOk && !this.lastError) {
                     await vscode.window.showInformationMessage('✨ Cody Embeddings Index Complete')
                 }
             })()
@@ -500,7 +500,9 @@ export class LocalEmbeddingsController implements LocalEmbeddingsFetcher, Contex
         if (!this.lastHealth?.numItemsNeedEmbedding) {
             return ''
         }
-        const percentDone = Math.floor((100 * this.lastHealth.numItemsNeedEmbedding) / this.lastHealth.numItems)
+        const percentDone = Math.floor(
+            (100 * (this.lastHealth.numItems - this.lastHealth.numItemsNeedEmbedding)) / this.lastHealth.numItems
+        )
         return `${options?.prefix || ''}Cody Embeddings index for ${
             this.lastRepo?.path || 'this repository'
         } is only ${percentDone.toFixed(0)}% complete.${options?.suffix || ''}`


### PR DESCRIPTION
- Do not display "Cody Embeddings Index Complete" if there's an error from the last local embeddings indexing attempt.
- Display the local embeddings percent *complete* in the status bar. Previously we displayed the percent *in*complete.

## Test plan

See https://www.loom.com/share/869556cee0dc42e4b1694f924c9e61fd?sid=8234ac0d-c984-4def-a31f-5d474d5b294d

0. Sign in with a rate-limited token.
1. Generate an incomplete embeddings index by opening a repo without embeddings, starting chat, enabling embeddings, and let it hit the rate limit. Alternatively, kill the cody-engine process and reload VSCode.
2. The status bar should indicate an appropriate, low percentage completion.
3. Resume indexing to hit the failure again. You should not see a sparkle toast that the index is complete when indexing fails.
4. Sign in with an account which can generate embeddings and resume indexing again.
5. The index should complete and you see a sparkle toast.
