### PR TITLE
Chat: send `openLLMDropdown:clicked` only on dropdown open

### DIFF
--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -19,6 +19,7 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
     userInfo,
 }) => {
     const [currentModel, setCurrentModel] = useState(models.find(m => m.default) || models[0])
+    const dropdownRef = useRef<DropdownProps>(null)
 
     const isCodyProUser = userInfo.isDotComUser && userInfo.isCodyProUser
     const isEnterpriseUser = !userInfo.isDotComUser
@@ -54,8 +55,6 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
     if (!models.length || models.length < 1) {
         return null
     }
-
-    const dropdownRef = useRef<DropdownProps>(null)
 
     const enabledDropdownProps: Pick<DropdownProps, 'title' | 'onClickCapture'> = {
         title: `This chat is using ${currentModel.title}. Start a new chat to choose a different model.`,


### PR DESCRIPTION
## Context

- Part of https://github.com/sourcegraph/cody/issues/2311
- Send `openLLMDropdown:clicked` only on dropdown open

## Test plan

For the `CodyVSCodeExtension:openLLMDropdown:clicked` event, it fires only when:
- the dropdown is open-able AND opens
- Don't fire if the dropdown is disabled, if the dropdown is closing, or if the user clicks and LLM which causes the dropdown to close.
