### PR TITLE
Chat: use the correct user tier in the upsell event

### DIFF
--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -55,16 +55,16 @@ export const RateLimitErrorItem: React.FunctionComponent<{
     // has not since upgraded.
     const isEnterpriseUser = userInfo?.isDotComUser !== true
     const canUpgrade = error.upgradeIsAvailable && !userInfo?.isCodyProUser
-    const tier = isEnterpriseUser ? 'enterprise' : userInfo?.isCodyProUser ? 'pro' : 'free'
+    const tier = isEnterpriseUser ? 'enterprise' : canUpgrade ? 'free' : 'pro'
 
     // Only log once on mount
     React.useEffect(() => {
         // Log as abuseUsageLimit if pro user run into rate limit
         postMessage({
             command: 'event',
-            eventName: userInfo?.isCodyProUser
-                ? 'CodyVSCodeExtension:abuseUsageLimitCTA:shown'
-                : 'CodyVSCodeExtension:upsellUsageLimitCTA:shown',
+            eventName: canUpgrade
+                ? 'CodyVSCodeExtension:upsellUsageLimitCTA:shown'
+                : 'CodyVSCodeExtension:abuseUsageLimitCTA:shown',
             properties: { limit_type: 'chat_commands', tier },
         })
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -591,8 +591,10 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 return
             }
 
+            const isEnterpriseUser = this.config.isDotComUser !== true
             const canUpgrade = error.upgradeIsAvailable
-            const tier = this.config.isDotComUser ? 'enterprise' : canUpgrade ? 'free' : 'pro'
+            const tier = isEnterpriseUser ? 'enterprise' : canUpgrade ? 'free' : 'pro'
+
             let errorTitle: string
             let pageName: string
             if (canUpgrade) {


### PR DESCRIPTION
## Context

- Closes of https://github.com/sourcegraph/cody/issues/2311
- Use the correct user tier in the upsell event.
- Use the correct event when pro users hit the usage limit.

## Test plan

- For the `CodyVSCodeExtension:upsellUsageLimitCTA:shown` event, ensure the correct "tier" is being passed into the payload. The tier should be the tier the user is on.
- For users on the Pro tier, when they hit the abuse limit for chat/commands or autocompletes and the abuse UI shows up, we should log `CodyVSCodeExtension:abuseUsageLimitCTA:shown`
