### PR TITLE
Chat: Re-add /edit and /doc commands

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -941,13 +941,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const prompts =
                 allCommands?.filter(([id, { mode }]) => {
                     /** The /ask command is only useful outside of chat */
-                    const isRedudantCommand = id === '/ask'
+                    const isRedundantCommand = id === '/ask'
                     /**
                      * Hack: Custom edit commands are currently broken in this chat.
                      * We filter our anything that has this mode, apart from our own internal doc command - which we override ourselves
                      */
                     const isCustomEdit = (mode === 'edit' || mode === 'insert') && id !== '/doc'
-                    return !isRedudantCommand && !isCustomEdit
+                    return !isRedundantCommand && !isCustomEdit
                 }) || []
 
             void this.postMessage({

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -29,6 +29,7 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { View } from '../../../webviews/NavBar'
 import { getFullConfig } from '../../configuration'
+import { executeEdit } from '../../edit/execute'
 import { getFileContextFiles, getOpenTabsContextFile, getSymbolContextFiles } from '../../editor/utils/editor-context'
 import { VSCodeEditor } from '../../editor/vscode-editor'
 import { ContextStatusAggregator } from '../../local-context/enhanced-context-status'
@@ -508,6 +509,14 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 await this.clearAndRestartSession()
                 return
             }
+            if (text.match(/^\/edit(\s)?/)) {
+                await executeEdit({ instruction: text.replace(/^\/(edit)/, '').trim() }, 'chat')
+                return
+            }
+            if (text.match(/^\/doc(\s)?/)) {
+                await vscode.commands.executeCommand('cody.command.document-code')
+                return
+            }
             if (text === '/commands-settings') {
                 // User has clicked the settings button for commands
                 await vscode.commands.executeCommand('cody.settings.commands')
@@ -930,8 +939,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const allCommands = await this.editor.controllers.command?.getAllCommands(true)
             // HACK: filter out commands that make inline changes and /ask (synonymous with a generic question)
             const prompts =
-                allCommands?.filter(([id, { mode = '' }]) => {
-                    return !['/edit', '/doc', '/ask'].includes(id) && !['edit', 'insert'].includes(mode)
+                allCommands?.filter(([id]) => {
+                    return !['/ask'].includes(id)
                 }) || []
 
             void this.postMessage({

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -939,8 +939,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const allCommands = await this.editor.controllers.command?.getAllCommands(true)
             // HACK: filter out commands that make inline changes and /ask (synonymous with a generic question)
             const prompts =
-                allCommands?.filter(([id]) => {
-                    return !['/ask'].includes(id)
+                allCommands?.filter(([id, { mode }]) => {
+                    /** The /ask command is only useful outside of chat */
+                    const isRedudantCommand = id === '/ask'
+                    /**
+                     * Hack: Custom edit commands are currently broken in this chat.
+                     * We filter our anything that has this mode, apart from our own internal doc command - which we override ourselves
+                     */
+                    const isCustomEdit = (mode === 'edit' || mode === 'insert') && id !== '/doc'
+                    return !isRedudantCommand && !isCustomEdit
                 }) || []
 
             void this.postMessage({


### PR DESCRIPTION
## Description

Re-adds /edit and /doc commands purely as entry points away from chat.

Long term we will remove these from chat altogether, but this is a bandage fix for the release as we have various docs and marketing materials that shows these commands as part of this list.

Relevant thread: https://sourcegraph.slack.com/archives/C05AGQYD528/p1702428819446009

Further follow up on https://github.com/sourcegraph/cody/issues/2300

## Test plan

Edit:
1. Open chat
2. Type /edit with no instruction
3. Check re-prompted for instruction

Edit with text:
1. Open chat
2. Type /edit add some logs
3. Check edit executes

Doc:
1. Open chat
2. Type /doc
3. Check doc executes

Doc with no selection
1. Open chat
2. Type /doc
3. Check doc doesn't execute

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
