### PR TITLE
chat: display CTA to create new chat when context limit reached

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -2,7 +2,7 @@
 
 export { ChatContextStatus } from './chat/context'
 export { ChatButton, ChatMessage, ChatError } from './chat/transcript/messages'
-export { RateLimitError } from './sourcegraph-api/errors'
+export { RateLimitError, ContextWindowLimitError } from './sourcegraph-api/errors'
 export { renderCodyMarkdown } from './chat/markdown'
 export { basename, pluralize, isDefined, dedupeWith } from './common'
 export { ContextFile, PreciseContext } from './codebase-context/messages'

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -106,3 +106,12 @@ export function isAbortError(error: unknown): boolean {
 }
 
 export class TimeoutError extends Error {}
+
+export class ContextWindowLimitError extends Error {
+    public static readonly errorName = 'ContextWindowLimitError'
+    public readonly name = ContextWindowLimitError.errorName
+
+    constructor(public readonly message: string) {
+        super(message)
+    }
+}

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { ChatError, RateLimitError } from '@sourcegraph/cody-shared'
+import { ChatError, ContextWindowLimitError, RateLimitError } from '@sourcegraph/cody-shared'
 
 import { ApiPostMessage, ChatButtonProps, UserAccountInfo } from '../Chat'
 
@@ -25,6 +25,16 @@ export const ErrorItem: React.FunctionComponent<{
         )
     }
 
+    if (typeof error !== 'string' && error.name === ContextWindowLimitError.errorName && postMessage) {
+        return (
+            <ContextWindowLimitErrorItem
+                error={error as ContextWindowLimitError}
+                ChatButtonComponent={ChatButtonComponent}
+                postMessage={postMessage}
+            />
+        )
+    }
+
     return <RequestErrorItem error={error.message} />
 })
 
@@ -38,6 +48,35 @@ export const RequestErrorItem: React.FunctionComponent<{
         <div className="cody-chat-error">
             <span>Request failed: </span>
             {error}
+        </div>
+    )
+})
+
+export const ContextWindowLimitErrorItem: React.FunctionComponent<{
+    error: ContextWindowLimitError
+    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
+    postMessage: ApiPostMessage
+}> = React.memo(function ContextWindowLimitErrorItemContent({ error, ChatButtonComponent, postMessage }) {
+    const onClick = useCallback(() => {
+        postMessage({ command: 'reset' })
+    }, [postMessage])
+
+    return (
+        <div className={styles.errorItem}>
+            <div className={styles.icon}>
+                <span className="codicon codicon-warning" />
+            </div>
+            <div className={styles.body}>
+                <header>
+                    <h1>Context limit reached</h1>
+                    <p>{error.message}</p>
+                </header>
+                {ChatButtonComponent && (
+                    <div className={styles.actions}>
+                        <ChatButtonComponent label="Start new chat" action="" appearance="primary" onClick={onClick} />
+                    </div>
+                )}
+            </div>
         </div>
     )
 })

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -92,7 +92,7 @@ export class SimpleChatModel {
         })
     }
 
-    public getLastHumanMessages(): MessageWithContext | undefined {
+    public getLastHumanMessage(): MessageWithContext | undefined {
         return this.messagesWithContext.findLast(message => message.message.speaker === 'human')
     }
 

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -13,7 +13,11 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(
+        const {
+            prompt,
+            contextLimitWarnings: warnings,
+            newContextUsed,
+        } = await new DefaultPrompter().makePrompt(
             chat,
             {
                 getExplicitContext: () => [],
@@ -55,7 +59,11 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const { prompt, warnings, newContextUsed } = await new DefaultPrompter().makePrompt(
+        const {
+            prompt,
+            contextLimitWarnings: warnings,
+            newContextUsed,
+        } = await new DefaultPrompter().makePrompt(
             chat,
             {
                 getExplicitContext: () => [],

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -28,7 +28,7 @@ export interface IPrompter {
         byteLimit: number
     ): Promise<{
         prompt: Message[]
-        warnings: string[]
+        contextLimitWarnings: string[]
         newContextUsed: ContextItem[]
     }>
 }
@@ -46,7 +46,7 @@ export class DefaultPrompter implements IPrompter {
         byteLimit: number
     ): Promise<{
         prompt: Message[]
-        warnings: string[]
+        contextLimitWarnings: string[]
         newContextUsed: ContextItem[]
     }> {
         const promptBuilder = new PromptBuilder(byteLimit)
@@ -69,7 +69,7 @@ export class DefaultPrompter implements IPrompter {
                 warnings.push(`Ignored ${reverseTranscript.length - i} transcript messages due to context limit`)
                 return {
                     prompt: promptBuilder.build(),
-                    warnings,
+                    contextLimitWarnings: warnings,
                     newContextUsed,
                 }
             }
@@ -84,7 +84,7 @@ export class DefaultPrompter implements IPrompter {
             newContextUsed.push(...used)
             if (limitReached) {
                 warnings.push('Ignored current user-specified context items due to context limit')
-                return { prompt: promptBuilder.build(), warnings, newContextUsed }
+                return { prompt: promptBuilder.build(), contextLimitWarnings: warnings, newContextUsed }
             }
         }
 
@@ -98,7 +98,7 @@ export class DefaultPrompter implements IPrompter {
             )
             if (limitReached) {
                 warnings.push('Ignored prior context items due to context limit')
-                return { prompt: promptBuilder.build(), warnings, newContextUsed }
+                return { prompt: promptBuilder.build(), contextLimitWarnings: warnings, newContextUsed }
             }
         }
 
@@ -127,7 +127,7 @@ export class DefaultPrompter implements IPrompter {
 
         return {
             prompt: promptBuilder.build(),
-            warnings,
+            contextLimitWarnings: warnings,
             newContextUsed,
         }
     }

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -88,6 +88,9 @@ export type WebviewMessage =
           uriJSON: unknown
           range: { start: { line: number; character: number }; end: { line: number; character: number } }
       }
+    | {
+          command: 'reset'
+      }
 
 /**
  * A message sent from the extension host to the webview.

--- a/vscode/webviews/App.css
+++ b/vscode/webviews/App.css
@@ -46,8 +46,8 @@ button {
 
 .close-btn {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 0.65rem;
+    right: 0.25rem;
     background: none;
     border: none;
     color: var(--vscode-input-foreground);


### PR DESCRIPTION
Also display warning nicely:
<img width="699" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/177b3460-ce3e-4bfe-a551-c44e91a3559c">

Partially addresses https://github.com/sourcegraph/cody/issues/2352

## Test plan

Test locally:
- [ ] Modify `getContextWindowForModel` to return a low number (e.g., 1000)
- [ ] Send 2 messages to hit the context limit