### PR TITLE
HACK: Work around rate limiting errors by parsing the SSE message and reverse-engineering the headers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,7 @@
       "outFiles": ["${workspaceRoot}/vscode/dist/**/*.js"],
       "env": {
         "NODE_ENV": "development",
-        "CODY_DEBUG_ENABLE": "true",
-        "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
+        "CODY_DEBUG_ENABLE": "true"
         // Enable the Node debug protocol for the TypeScript server:
         // "TSS_DEBUG": "5859"
       }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "outFiles": ["${workspaceRoot}/vscode/dist/**/*.js"],
       "env": {
         "NODE_ENV": "development",
-        "CODY_DEBUG_ENABLE": "true"
+        "CODY_DEBUG_ENABLE": "true",
+        "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
         // Enable the Node debug protocol for the TypeScript server:
         // "TSS_DEBUG": "5859"
       }

--- a/lib/shared/src/sourcegraph-api/completions/codyRateLimitWorkaround.ts
+++ b/lib/shared/src/sourcegraph-api/completions/codyRateLimitWorkaround.ts
@@ -1,7 +1,7 @@
 import { RateLimitError } from '../errors'
 import { graphqlClient } from '../graphql'
 
-export function convertCodyGatewayErrorToRateLimitError(error: string): Promise<RateLimitError> {
+export function convertCodyGatewayErrorToRateLimitError(error: string, feature: string): Promise<RateLimitError> {
     return new Promise(resolve => {
         const limit = /exceeded the rate limit of (\d+) requests/.exec(error)
         const retryAfter = /Retry after (.*)\n/.exec(error)
@@ -14,7 +14,7 @@ export function convertCodyGatewayErrorToRateLimitError(error: string): Promise<
                     throw user
                 }
                 const rateLimitError = new RateLimitError(
-                    'chat messages and commands',
+                    feature,
                     error,
                     !user.codyProEnabled,
                     limit ? parseInt(limit[0], 10) : undefined,
@@ -24,7 +24,7 @@ export function convertCodyGatewayErrorToRateLimitError(error: string): Promise<
             })
             .catch(() => {
                 const rateLimitError = new RateLimitError(
-                    'chat messages and commands',
+                    feature,
                     error,
                     true,
                     limit ? parseInt(limit[0], 10) : undefined,

--- a/lib/shared/src/sourcegraph-api/completions/codyRateLimitWorkaround.ts
+++ b/lib/shared/src/sourcegraph-api/completions/codyRateLimitWorkaround.ts
@@ -1,0 +1,36 @@
+import { RateLimitError } from '../errors'
+import { graphqlClient } from '../graphql'
+
+export function convertCodyGatewayErrorToRateLimitError(error: string): Promise<RateLimitError> {
+    return new Promise(resolve => {
+        const limit = /exceeded the rate limit of (\d+) requests/.exec(error)
+        const retryAfter = /Retry after (.*)\n/.exec(error)
+
+        graphqlClient
+            .getCurrentUserCodyProEnabled()
+            .then(user => {
+                console.log({ user })
+                if (!('codyProEnabled' in user)) {
+                    throw user
+                }
+                const rateLimitError = new RateLimitError(
+                    'chat messages and commands',
+                    error,
+                    !user.codyProEnabled,
+                    limit ? parseInt(limit[0], 10) : undefined,
+                    retryAfter ? retryAfter[0] : undefined
+                )
+                resolve(rateLimitError)
+            })
+            .catch(() => {
+                const rateLimitError = new RateLimitError(
+                    'chat messages and commands',
+                    error,
+                    true,
+                    limit ? parseInt(limit[0], 10) : undefined,
+                    retryAfter ? retryAfter[0] : undefined
+                )
+                resolve(rateLimitError)
+            })
+    })
+}

--- a/lib/shared/src/sourcegraph-api/completions/codyRateLimitWorkaround.ts
+++ b/lib/shared/src/sourcegraph-api/completions/codyRateLimitWorkaround.ts
@@ -9,7 +9,6 @@ export function convertCodyGatewayErrorToRateLimitError(error: string, feature: 
         graphqlClient
             .getCurrentUserCodyProEnabled()
             .then(user => {
-                console.log({ user })
                 if (!('codyProEnabled' in user)) {
                     throw user
                 }

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -126,7 +126,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         ) {
                             // Extract stuff from this string:
                             // 'Sourcegraph Cody Gateway: unexpected status code 429: you have exceeded the rate limit of 10 requests. Retry after 2023-12-15 14:36:37 +0000 UTC\n'
-                            convertCodyGatewayErrorToRateLimitError(event.error)
+                            convertCodyGatewayErrorToRateLimitError(event.error, 'chat messages and commands')
                                 .then(error => {
                                     cb.onError(error, 429)
                                 })

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -118,6 +118,8 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         return
                     }
 
+                    // HACK: convert rate limit errors to RateLimitError instances, parsing metadata
+                    // from the error message
                     for (const event of parseResult.events) {
                         if (
                             isDotCom(this.config.serverEndpoint) &&

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -2,11 +2,13 @@ import http from 'http'
 import https from 'https'
 
 import { isError } from '../../utils'
+import { isDotCom } from '../environments'
 import { RateLimitError } from '../errors'
 import { customUserAgent } from '../graphql/client'
 import { toPartialUtf8String } from '../utils'
 
 import { SourcegraphCompletionsClient } from './client'
+import { convertCodyGatewayErrorToRateLimitError } from './codyRateLimitWorkaround'
 import { parseEvents } from './parse'
 import { CompletionCallbacks, CompletionParameters } from './types'
 
@@ -114,6 +116,25 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     if (isError(parseResult)) {
                         console.error(parseResult)
                         return
+                    }
+
+                    for (const event of parseResult.events) {
+                        if (
+                            isDotCom(this.config.serverEndpoint) &&
+                            event.type === 'error' &&
+                            event.error.startsWith('Sourcegraph Cody Gateway: unexpected status code 429: ')
+                        ) {
+                            // Extract stuff from this string:
+                            // 'Sourcegraph Cody Gateway: unexpected status code 429: you have exceeded the rate limit of 10 requests. Retry after 2023-12-15 14:36:37 +0000 UTC\n'
+                            convertCodyGatewayErrorToRateLimitError(event.error)
+                                .then(error => {
+                                    cb.onError(error, 429)
+                                })
+                                .catch(() => {
+                                    // This promise always resolves
+                                })
+                            return
+                        }
                     }
 
                     log?.onEvents(parseResult.events)

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -3,10 +3,12 @@ import type {
     CompletionLogger,
     CompletionsClientConfig,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
+import { convertCodyGatewayErrorToRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/codyRateLimitWorkaround'
 import type {
     CompletionParameters,
     CompletionResponse,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import {
     isAbortError,
     NetworkError,
@@ -147,6 +149,17 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
                 const iterator = createSSEIterator(response.body as any as AsyncIterableIterator<BufferSource>)
 
                 for await (const chunk of iterator) {
+                    if (chunk.event === 'error') {
+                        if (
+                            isDotCom(config.serverEndpoint) &&
+                            chunk.event.startsWith('Sourcegraph Cody Gateway: unexpected status code 429: ')
+                        ) {
+                            // Extract stuff from this string:
+                            // 'Sourcegraph Cody Gateway: unexpected status code 429: you have exceeded the rate limit of 10 requests. Retry after 2023-12-15 14:36:37 +0000 UTC\n'
+                            throw await convertCodyGatewayErrorToRateLimitError(chunk.event)
+                        }
+                    }
+
                     if (chunk.event === 'completion') {
                         if (signal?.aborted) {
                             break // Stop processing the already received chunks.

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -104,17 +104,11 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
             .then(({ stdout }) => stdout.trim())
             .catch(error => {
                 if (isError(error) && error.message.includes('429')) {
-                    // The rate limit error constructed below does not have the proper PLG errors.
-                    // Instead, we continue here and wait for the rate limit error that will come
-                    // from the generation request.
+                    // HACK: if we hit a rate limit error from symf, just return the original
+                    // user query without term expansion, because we expect that we'll immediately
+                    // hit a rate limit error again when the chat request is sent (but there
+                    // we'll have the appropriate metadata to handle it properly).
                     return userQuery
-
-                    // // HACK: we should move the query term expansion code into the agent so
-                    // // we can handle this less hackily.
-                    // // This also assumes an upgrade path is available. It's unlikely we'll
-                    // // hit this limit on a chat request, so this is mainly to satisfy the
-                    // // e2e test.
-                    // throw new RateLimitError('chat messages and commands', error.message, true)
                 }
                 throw error
             })


### PR DESCRIPTION
This attempts to work around the rate limiting header issues and instead parses the first SSE payload error text and tries to reverse-engineer the PLG headers.

To do that, we parse the error string, e.g.:

```
Sourcegraph Cody Gateway: unexpected status code 429: you have exceeded the rate limit of 10 requests. Retry after 2023-12-15 14:36:37 +0000 UTC\n
```

To get the quota and the retry after field, and make a request to the backend to find out if the user is already a pro user.

## Test plan

### For chat

https://github.com/sourcegraph/cody/assets/458591/fca610e3-f3a5-4b5d-9f0c-5b765e18512f

### For code completions


https://github.com/sourcegraph/cody/assets/458591/ebba8005-0ee9-4ee8-825d-637415252689



<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
