### PR TITLE
VS Code: Release 1.0.0

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [1.0.0]
+
+### Added
+
 - Adds support for Mixtral by Mistral in the LLM dropdown list. [issues/2307](https://github.com/sourcegraph/cody/issues/2307)
 
 ### Fixed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "0.18.6",
+  "version": "1.0.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Release 1.0.0

## Test plan

trivial change; just updating version numbers
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
