### PR TITLE
Handle connection close events with no prior errors or messages

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Fixes an issue where GPT 3.5 requests were sometimes left hanging. [pull/2391](https://github.com/sourcegraph/cody/pull/2391)
+
 ### Changed
 
 ## [1.0.0]

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Fixes an issue where GPT 3.5 requests were sometimes left hanging. [pull/2391](https://github.com/sourcegraph/cody/pull/2391)
+- Fixes an issue where GPT 3.5 requests were sometimes left hanging. [pull/2386](https://github.com/sourcegraph/cody/pull/2386)
 
 ### Changed
 


### PR DESCRIPTION
Welcome to callback hell. Even though we handle a bazillion cases here, we did never call any of the callbacks if:

- The connection opens
- We receive headers
- However, none of these headers indicate errors
- And we receive no body and instead closes

This adds some form of handling for this so the request doesn't appear stuck.

We should also make it so the backend indicates the error in the response somehow (c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1702648140278529)

## Test plan

- git revert 2a00da01ae8b83ecd5450af7be2682c32edf3080 (to bring back the issue that beyang fixed)
- Create a chat message with GPT 3.5

<img width="589" alt="Screenshot 2023-12-15 at 14 57 51" src="https://github.com/sourcegraph/cody/assets/458591/ad81411a-2881-47ef-8ff1-f45d987fb5cb">

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
