### PR TITLE
Hide LLM dropdown for enterprise users

### DIFF
--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -188,14 +188,18 @@ export const Transcript: React.FunctionComponent<
     return (
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
             <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
-                {!!chatModels?.length && ChatModelDropdownMenu && onCurrentChatModelChange && userInfo && (
-                    <ChatModelDropdownMenu
-                        models={chatModels}
-                        disabled={transcript.length > 1}
-                        onCurrentChatModelChange={onCurrentChatModelChange}
-                        userInfo={userInfo}
-                    />
-                )}
+                {!!chatModels?.length &&
+                    ChatModelDropdownMenu &&
+                    onCurrentChatModelChange &&
+                    userInfo &&
+                    userInfo.isDotComUser && (
+                        <ChatModelDropdownMenu
+                            models={chatModels}
+                            disabled={transcript.length > 1}
+                            onCurrentChatModelChange={onCurrentChatModelChange}
+                            userInfo={userInfo}
+                        />
+                    )}
                 {earlierMessages.map(messageToTranscriptItem(0))}
                 <div ref={lastHumanMessageTopRef} />
                 {lastInteractionMessages.map(messageToTranscriptItem(earlierMessages.length))}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Hide the LLM dropdown in the new Chat UX for enterprise instances where there is no choice to switch models. [pulls/2393](https://github.com/sourcegraph/cody/pull/2393)
+
 ## [1.0.0]
 
 ### Added


### PR DESCRIPTION
c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1702648955261399?thread_ts=1702602272.959489&cid=C05AGQYD528

The current experience is poor since it does not show proper names and appears just broken. Also you can not _change_ the model for enterprise setups anyways (we have a hard check for this on the backend).

## Test plan


- `sg start` locally
<img width="589" alt="Screenshot 2023-12-15 at 14 57 51" src="https://github.com/sourcegraph/cody/assets/458591/b2a81eb0-1fed-47b1-9bba-0045a999cef7">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
