### PR TITLE
Ensure all explicitly-mentioned files are included in chats

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1351,7 +1351,15 @@ function contextFilesToContextItems(
     return Promise.all(
         files.map(async (file: ContextFile): Promise<ContextItem> => {
             const range = viewRangeToRange(file.range)
-            const uri = file.uri || vscode.Uri.file(file.fileName)
+            const uri = file.uri
+                ? // This object may have came via postMessage and might not be a
+                  // real vscode.Uri instance so convert it if required (otherwise
+                  // toString() later will be '[Object object]' and not what we
+                  // expect).
+                  typeof file.uri === 'object'
+                    ? vscode.Uri.from(file.uri)
+                    : file.uri
+                : vscode.Uri.file(file.fileName)
             let text = file.content
             if (!text && fetchContent) {
                 text = await editor.getTextEditorContentForFile(uri, range)

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -89,6 +89,9 @@ test('@-file empty state', async ({ page, sidebar }) => {
         )
     ).toBeVisible()
 
+    // Also ensure we have the right number of files in the context.
+    await expect(chatPanelFrame.getByText('Context: 2 files')).toBeVisible()
+
     // Check pressing tab after typing a complete filename.
     // https://github.com/sourcegraph/cody/issues/2200
     await chatInput.focus()


### PR DESCRIPTION
Because the search results come from inside the webview, the URIs are not real vscode.Uri instances. The code that computes IDs for each context to de-dupe them uses `contextItem.uri.toString()` which would be `[Object object]`.

![image](https://github.com/sourcegraph/cody/assets/1078012/272f9ef4-0c89-40ab-9b8b-8eb10e3e619f)

This converts them back to real `vscode.Uris` which fixes the de-dupe check.

Fixes https://github.com/sourcegraph/cody/issues/2402

(fyi @kalanchan )

## Test plan

- Run `pnpm test:e2e at-file` to run the automated test which verifies after asking about two files that the context has a count of two
- Or manually mention two files in chat and ensure both appear in context and that the model is aware of both file contents (or export the chat and confirm that both files appear in the context)
