### PR TITLE
Chat: honor cody.codebase setting

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Honor the cody.codebase setting for manually setting the remote codebase context. [pulls/2415](https://github.com/sourcegraph/cody/pull/2415)
+
 ### Changed
 
 ## [1.0.1]

--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -48,8 +48,9 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
             vscode.workspace.onDidChangeWorkspaceFolders(() => this.updateStatus()),
             vscode.workspace.onDidChangeConfiguration(e => {
                 if (e.affectsConfiguration('cody.codebase')) {
-                    this.updateStatus()
+                    return this.updateStatus()
                 }
+                return Promise.resolve()
             }),
             this.eventEmitter
         )


### PR DESCRIPTION
Added cody.codebase support to the CodebaseStatusProvider, when the cody.codebase setting is set it should take priority over the git remote detection

resolves https://github.com/sourcegraph/cody/issues/2409

## Test plan
**When connected to enterprise (s2)**

Opened a local only repo (no git) - verified no embeddings mentioned in enhanced context
Set the cody.codebase setting to `github.com/sourcegraph/sourcegraph` verified enhanced context showed embeddings now available

Opened a repo with a git remote `hashicorp/go-multierror` - verified it showed no embeddings detected for this repo on remote
Set cody.codebase to `github.com/sourcegraph/sourcegraph` - verified it showed embeddings now available
 
**When connected to dotcom**
Opened a local only repo (no git) - embeddings not available (and no generation allowed)
Set the cody.codebase setting to `github.com/sourcegraph/sourcegraph` verified enhanced context showed embeddings now available

Opened a repo with a git remote `sourcegraph/handbook` - verified it showed  embeddings detected for this repo on remote
Set cody.codebase to `github.com/sourcegraph/sourcegraph` - verified it embeddings changed to this repo


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
