### PR TITLE
Fix code lenses feature

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: Honor the cody.codebase setting for manually setting the remote codebase context. [pulls/2415](https://github.com/sourcegraph/cody/pull/2415)
+- Fixes the Code Lenses feature. [issues/2428](https://github.com/sourcegraph/cody/issues/2428)
 
 ### Changed
 

--- a/vscode/src/editor/EditorCodeLenses.ts
+++ b/vscode/src/editor/EditorCodeLenses.ts
@@ -53,7 +53,7 @@ export class EditorCodeLenses implements vscode.CodeLensProvider {
      */
     private updateConfig(): void {
         const config = vscode.workspace.getConfiguration('cody')
-        this.isEnabled = config.get('experimental.commandLenses') as boolean
+        this.isEnabled = config.get('commandCodeLenses') as boolean
 
         if (this.isEnabled && !this._disposables.length) {
             this.init()


### PR DESCRIPTION
Closes #2428

Looks like a whoopsie after the recent setting name change.

## Test plan

<img width="2163" alt="Screenshot 2023-12-18 at 12 54 32" src="https://github.com/sourcegraph/cody/assets/458591/d8a063c2-2b99-4dbc-bbfd-3678064405f0">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
