### PR TITLE
Fix: Handle Azure DevOps Codebase URLs Automatically from Git Metadata

### DIFF
--- a/lib/shared/src/utils.test.ts
+++ b/lib/shared/src/utils.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, test } from 'vitest'
 import { convertGitCloneURLToCodebaseName, convertGitCloneURLToCodebaseNameOrError, isError } from './utils'
 
 describe('convertGitCloneURLToCodebaseName', () => {
+    test('converst Azure DevOps URL', () => {
+        expect(convertGitCloneURLToCodebaseName('https://dev.azure.com/organization/project/_git/repository')).toEqual(
+            'dev.azure.com/organization/project/repository'
+        )
+    })
+
     test('converts GitHub SSH URL', () => {
         expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph.git')).toEqual(
             'github.com/sourcegraph/sourcegraph'

--- a/lib/shared/src/utils.ts
+++ b/lib/shared/src/utils.ts
@@ -5,6 +5,8 @@ export const isError = (value: unknown): value is Error => value instanceof Erro
 // - "github:sourcegraph/sourcegraph" a common SSH host alias
 // - "https://github.com/sourcegraph/deploy-sourcegraph-k8s.git"
 // - "git@github.com:sourcegraph/sourcegraph.git"
+// - "https://dev.azure.com/organization/project/_git/repository"
+
 export function convertGitCloneURLToCodebaseName(cloneURL: string): string | null {
     const result = convertGitCloneURLToCodebaseNameOrError(cloneURL)
     if (isError(result)) {
@@ -34,6 +36,10 @@ export function convertGitCloneURLToCodebaseNameOrError(cloneURL: string): strin
             return `${host}/${owner}/${repo}`
         }
         const uri = new URL(cloneURL)
+        // Handle Azure DevOps URLs
+        if (uri.hostname && uri.hostname.includes('dev.azure') && uri.pathname) {
+            return `${uri.hostname}${uri.pathname.replace('/_git', '')}`
+        }
         // Handle GitHub URLs
         if (uri.protocol.startsWith('github') || uri.href.startsWith('github')) {
             return `github.com/${uri.pathname.replace('.git', '')}`


### PR DESCRIPTION
# Azure DevOps (ADO) URLs

ADO repository URLs follow the format:

`https://dev.azure.com/organization/project/_git/repository` and currently the Sourcegraph enterprise instances remove the protocol, i.e. `https://`, and additionally filter out the `/_git` tag inside the URL:

`https://dev.azure.com/organization/project/_git/repository` -> `dev.azure.com/organization/project/repository`

However, the VS Code extension for Cody currently only has logic to handle removing the protocol and does not filter the `/_git` from the URL, making automatic pulling of embeddings from an enterprise instance impossible, as the repository names do not match.

As a result, ADO developers must set the `codebase` setting, manually, on a repository by repository basis while using Cody in VS Code if they want embeddings. 

This PR updates the existing exception logic for repository codebase name detection and formatting to account for this additional `/_git` noise, and enable automatic codebase detection and embedding pull for enhanced context.

## Test plan
Unit tests are in place to ensure proper protocol and filtering on synced ADO repositories.

To repro issue:
- Sync ADO repository with Sourcegraph instance
- Connect VS Code to instance and open chat
- Enhanced Context will show the repository not found on the instance, and `/_git/` will be the malformed portion of the url
(Screenshot of issue attached)

To verify fix:
- Sync ADO repository with Sourcegraph instance
- Connect VS Code to instance and open chat
- Enhanced Context will now show embeddings and search (if available) without repository not found errors

<img width="1639" alt="Screenshot 2023-12-11 at 11 25 25 AM" src="https://github.com/sourcegraph/cody/assets/11511020/a38b161c-ca1a-4a07-b97c-cbc720b6a969">
