### PR TITLE
Autocomplete: change Anthropic temperature to 0.2

### DIFF
--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -154,7 +154,6 @@ export class AnthropicProvider extends Provider {
         const requestParams: CodeCompletionsParams = {
             ...partialRequestParams,
             messages: this.createPrompt(snippets).messages,
-            temperature: 0.5,
         }
 
         await generateCompletions({


### PR DESCRIPTION
## Context

- Changes the temperature for the Antrothic provider from 0.5 to 0.2. From my memories, 0.2 performed in a more predictable way, which resulted in a higher CAR and better completion quality. That's why we ended up setting it to 0.2 for Fireworks.
- Discussed briefly in https://github.com/sourcegraph/cody/pull/2425#discussion_r1429960244

## Test plan

TODO
