### PR TITLE
Automate VS Code release GitHub changelog

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -3,6 +3,9 @@ name: vscode-insiders-release
 on:
   schedule:
     - cron: '0 15 * * *' # daily at 1500 UTC
+  push:
+    tags:
+      - vscode-v* # automatically create a new insider build with a release
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
           VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
+      - run: pnpm -C vscode run github-changelog
       - name: create release
         id: create_release
         uses: actions/create-release@v1
@@ -55,6 +56,7 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Cody for VS Code ${{ env.EXT_VERSION }}
           draft: false
+          body_path: vscode/GITHUB_CHANGELOG.md
       - name: upload release asset
         uses: actions/upload-release-asset@v1
         env:

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -4,3 +4,4 @@ out/
 dist/
 .vscode-test-web/
 resources/wasm/
+GITHUB_CHANGELOG.md

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -35,7 +35,8 @@
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:unit": "vitest",
     "vscode:prepublish": "pnpm -s run build",
-    "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts"
+    "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
+    "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
   "categories": [
     "Programming Languages",

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /**
  * A script to create the GitHub release changelog format from the current
  * CHANGELOG.md.

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -50,18 +50,18 @@ function extractSection(changelog: string, version: string): { changes: Change[]
     for (const line of lines) {
         if (found) {
             if (line.startsWith('## ')) {
-                const versionMatches = /^## \[(\d+\.\d+\.\d+)]$/.exec(line)
-                if (!versionMatches) {
+                const versionMatches = /^## \[(?<dottedVersion>\d+\.\d+\.\d+)]$/.exec(line)
+                if (!versionMatches?.groups) {
                     throw new Error(`Malformed version line: ${line}`)
                 }
-                previousVersion = versionMatches[1]
+                previousVersion = versionMatches.groups?.dottedVersion
                 break
             }
 
             if (line.startsWith('- ')) {
                 const change = line.slice(2)
 
-                const linkRegex = /\[(pull|pulls|issue|issues).*]\((.*)\)/
+                const linkRegex = /\[(pull|pulls|issue|issues).*]\((?<link>.*)\)/
                 const firstLink = linkRegex.exec(change)
 
                 let text = change.slice(0, firstLink?.index ?? -1).trim()
@@ -70,7 +70,7 @@ function extractSection(changelog: string, version: string): { changes: Change[]
                     text = text.slice(0, -1)
                 }
 
-                const link = firstLink?.[2] ?? undefined
+                const link = firstLink?.groups?.link ?? undefined
 
                 changes.push({ text, link })
             }
@@ -83,14 +83,14 @@ function extractSection(changelog: string, version: string): { changes: Change[]
 }
 
 function extractRepoAndNumberFromLink(link: string): { owner: string; repo: string; number: string } | undefined {
-    const matches = /https:\/\/github\.com\/([^/]+)\/([^/]+)\/(pull|issues)\/(\d+)/.exec(link)
-    if (!matches) {
+    const matches = /https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/(pull|issues)\/(?<number>\d+)/.exec(link)
+    if (!matches?.groups) {
         throw new Error(`Malformed link: ${link}`)
     }
     return {
-        owner: matches[1],
-        repo: matches[2],
-        number: matches[4],
+        owner: matches.groups.owner,
+        repo: matches.groups.repo,
+        number: matches.groups.number,
     }
 }
 

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -1,0 +1,167 @@
+/**
+ * A script to create the GitHub release changelog format from the current
+ * CHANGELOG.md.
+ *
+ * Example:
+ *
+ * ✨ See the [What’s new in v0.18](https://about.sourcegraph.com/blog/cody-vscode-0-18-release) blog post for what’s new in this release since v0.16 ✨
+ *
+ * ## v0.18.6 Changes
+ *
+ * - Context: Incomplete embeddings indexing status can seen in the status bar. On macOS and Linux, indexing can be resumed by clicking there. However Windows users will still see an OS error 5 (access denied) when retrying indexing by @dominiccooney in https://github.com/sourcegraph/cody/pull/2265
+ * - ...
+ *
+ * **Full Changelog**: https://github.com/sourcegraph/cody/compare/vscode-v0.18.5...vscode-v0.18.6
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+import dedent from 'dedent'
+
+interface Change {
+    text: string
+    link?: string
+}
+
+// Given a section in the changelog that looks like this:
+//
+// some other content...
+// ## [1.0.2]
+//
+// ### Added
+//
+// ### Fixed
+//
+// - Chat: Honor the cody.codebase setting for manually setting the remote codebase context. [pulls/2415](https://github.com/sourcegraph/cody/pull/2415)
+//
+// ### Changed
+//
+// ## [1.0.1]
+// some other content...
+//
+// Extract a list of changes and the previous version number
+function extractSection(changelog: string, version: string): { changes: Change[]; previousVersion: string } {
+    let previousVersion = ''
+
+    const lines = changelog.split('\n')
+    const changes = []
+    let found = false
+    for (const line of lines) {
+        if (found) {
+            if (line.startsWith('## ')) {
+                const versionMatches = /^## \[(\d+\.\d+\.\d+)]$/.exec(line)
+                if (!versionMatches) {
+                    throw new Error(`Malformed version line: ${line}`)
+                }
+                previousVersion = versionMatches[1]
+                break
+            }
+
+            if (line.startsWith('- ')) {
+                const change = line.slice(2)
+
+                const linkRegex = /\[(pull|pulls|issue|issues).*]\((.*)\)/
+                const firstLink = linkRegex.exec(change)
+
+                let text = change.slice(0, firstLink?.index ?? -1).trim()
+                // Remove eventual trailing dot in the text
+                if (text.endsWith('.')) {
+                    text = text.slice(0, -1)
+                }
+
+                const link = firstLink?.[2] ?? undefined
+
+                changes.push({ text, link })
+            }
+        } else if (line.startsWith(`## [${version}]`)) {
+            found = true
+        }
+    }
+
+    return { changes, previousVersion }
+}
+
+function extractRepoAndNumberFromLink(link: string): { owner: string; repo: string; number: string } | undefined {
+    const matches = /https:\/\/github\.com\/([^/]+)\/([^/]+)\/(pull|issues)\/(\d+)/.exec(link)
+    if (!matches) {
+        throw new Error(`Malformed link: ${link}`)
+    }
+    return {
+        owner: matches[1],
+        repo: matches[2],
+        number: matches[4],
+    }
+}
+
+async function main(): Promise<void> {
+    let output = ''
+
+    const packageJSONPath = path.join(__dirname, '../package.json')
+    const packageJSONBody = await fs.promises.readFile(packageJSONPath, 'utf-8')
+    const packageJSON = JSON.parse(packageJSONBody)
+    const currentVersion: string = packageJSON.version
+
+    const changelogPath = path.join(__dirname, '../CHANGELOG.md')
+    const changelogBody = await fs.promises.readFile(changelogPath, 'utf-8')
+
+    const { changes, previousVersion } = extractSection(changelogBody, currentVersion)
+
+    const minor = currentVersion.split('.').slice(0, 2).join('.')
+
+    let intro = dedent`
+        ✨ See the [What’s new in v${minor}](https://about.sourcegraph.com/blog/cody-vscode-${minor.replace(
+            '.',
+            '-'
+        )}-release) blog post for what’s new in this release since v${minor} ✨
+
+        ## v${currentVersion} Changes
+    `
+    if (minor === '1.0') {
+        intro = dedent`
+            #### [Cody is now generally available](https://sourcegraph.com/blog/cody-is-generally-available) 🎉
+
+            Cody for VS Code now includes embeddings generation without needing the Cody desktop app, introduces a new Search Context engine for higher quality chat responses, and includes a range of improvements to all the built-in commands.
+
+            Until February you can upgrade to Cody Pro for free. To upgrade your account, head to your [Account Page](http://sourcegraph.com/cody/manage), or see our [Pricing Plans](https://sourcegraph.com/pricing) and [Documentation](https://sourcegraph.com/docs/cody/usage-and-pricing) for details.
+
+            👉 For the full announcement, read the [Cody v1.0.0 blog post](https://sourcegraph.com/blog/cody-is-generally-available)
+
+            A finally a big thank you to you, our beta testers, for using Cody in beta, giving feedback, and helping shape Cody v1.0 💖
+
+            ## v${currentVersion} Changes
+        `
+    }
+
+    output += intro + '\n\n'
+
+    for (const change of changes) {
+        let author: string | undefined
+        if (change.link) {
+            const data = extractRepoAndNumberFromLink(change.link)
+            if (data) {
+                const { owner, repo, number } = data
+
+                const apiUrl = `https://api.github.com/repos/${owner}/${repo}/issues/${number}`
+
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore: Fetch is available in node :shrug:
+                const json = await fetch(apiUrl).then(res => res.json())
+                if (json?.user?.login) {
+                    author = json.user.login
+                }
+            }
+        }
+
+        output += `- ${change.text}${author ? ` by @${author}` : ''}${change.link ? ` in ${change.link}` : ''}\n`
+    }
+
+    const outro = dedent`
+      **Full Changelog**: https://github.com/sourcegraph/cody/compare/vscode-v${previousVersion}...vscode-v${currentVersion}
+    `
+    output += '\n' + outro + '\n'
+
+    await fs.promises.writeFile(path.join(__dirname, '../GITHUB_CHANGELOG.md'), output)
+}
+
+main().catch(console.error)

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -109,29 +109,11 @@ async function main(): Promise<void> {
 
     const minor = currentVersion.split('.').slice(0, 2).join('.')
 
-    let intro = dedent`
-        ✨ See the [What’s new in v${minor}](https://about.sourcegraph.com/blog/cody-vscode-${minor.replace(
-            '.',
-            '-'
-        )}-release) blog post for what’s new in this release since v${minor} ✨
+    const intro = dedent`
+        ✨ See the [What’s new in v${minor}](https://about.sourcegraph.com/blog/cody-vscode-${minor}.0-release) blog post for what’s new in this release since v${minor} ✨
 
         ## v${currentVersion} Changes
     `
-    if (minor === '1.0') {
-        intro = dedent`
-            #### [Cody is now generally available](https://sourcegraph.com/blog/cody-is-generally-available) 🎉
-
-            Cody for VS Code now includes embeddings generation without needing the Cody desktop app, introduces a new Search Context engine for higher quality chat responses, and includes a range of improvements to all the built-in commands.
-
-            Until February you can upgrade to Cody Pro for free. To upgrade your account, head to your [Account Page](http://sourcegraph.com/cody/manage), or see our [Pricing Plans](https://sourcegraph.com/pricing) and [Documentation](https://sourcegraph.com/docs/cody/usage-and-pricing) for details.
-
-            👉 For the full announcement, read the [Cody v1.0.0 blog post](https://sourcegraph.com/blog/cody-is-generally-available)
-
-            A finally a big thank you to you, our beta testers, for using Cody in beta, giving feedback, and helping shape Cody v1.0 💖
-
-            ## v${currentVersion} Changes
-        `
-    }
 
     output += intro + '\n\n'
 


### PR DESCRIPTION
We already have a pretty stable release pipeline, however one thing that has been very tedious and we often forgot about was to update the GitHub release changelog.

This PR adds a new script that computes the GitHub release body from the `CHANGELOG.md`. 

It also makes it so that we always create a new insider build when we do a stable release (something that also went out of sync before).

## Test plan

- `pnpm -C vscode run github-changelog`
- `cat vscode/GITHUB_CHANGELOG.md`

<img width="648" alt="Screenshot 2023-12-19 at 16 27 47" src="https://github.com/sourcegraph/cody/assets/458591/17cbb1c8-4d95-4547-9e99-eb961b87e45d">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
