### PR TITLE
Fix logging issue

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Fixes an issue where the prompt text was logged when not intended. [pulls/2444](https://github.com/sourcegraph/cody/pull/2444)
+
 ### Changed
 
 ## [1.0.2]

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -544,10 +544,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 return
             }
 
+            const authStatus = this.authProvider.getAuthStatus()
+
             const properties = {
                 requestID,
                 chatModel: this.chatModel.modelID,
-                promptText: text,
+                promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? text : undefined,
                 contextSummary,
             }
             telemetryService.log('CodyVSCodeExtension:recipe:chat-question:executed', properties, {


### PR DESCRIPTION
Fixes an issue where the prompt text was added when not intended.

## Test plan


### Dotcom

<img width="1167" alt="Screenshot 2023-12-20 at 12 41 43" src="https://github.com/sourcegraph/cody/assets/458591/91784b05-32ee-44c5-9f11-b5165004be84">


### Enterprise
<img width="1167" alt="Screenshot 2023-12-20 at 12 42 55" src="https://github.com/sourcegraph/cody/assets/458591/6482c2ae-6cdf-479d-90c1-f827efc84f9c">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
