### PR TITLE
Autocomplete: Do not trigger a completion if a single-line completion was accepted

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Autocomplete: Accepting a full line completion will not immedialty start another completion request on the same line. [pulls/2446](https://github.com/sourcegraph/cody/pull/2446)
+
 ## [1.0.2]
 
 ### Added

--- a/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
@@ -7,7 +7,7 @@ import { completion } from '../test-helpers'
 import { getInlineCompletions, params, V } from './helpers'
 
 describe('[getInlineCompletions] no request when accepting', () => {
-    // In VS Code, accepting a completion will immediatly start a new completion request. If the
+    // In VS Code, accepting a completion will immediately start a new completion request. If the
     // user, however, accepted a single line completion, chances are that the current line is
     // finished (ie. the LLM already gave the best guess at completing the line).
     //

--- a/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
@@ -1,0 +1,109 @@
+import dedent from 'dedent'
+import { describe, expect, it } from 'vitest'
+
+import { TriggerKind } from '../get-inline-completions'
+import { completion } from '../test-helpers'
+
+import { getInlineCompletions, params, V } from './helpers'
+
+describe('[getInlineCompletions] no request when accepting', () => {
+    // In VS Code, accepting a completion will immediatly start a new completion request. If the
+    // user, however, accepted a single line completion, chances are that the current line is
+    // finished (ie. the LLM already gave the best guess at completing the line).
+    //
+    // Thus, this results in a request that almost always has zero results but still incurs network
+    // and inference costs.
+    it('should not make a request after accepting a completion', async () => {
+        const initialRequestParams = params(
+            dedent`
+                function test() {
+                    console.l█
+                }
+            `,
+            [completion`├og = 123┤`]
+        )
+        const item = await getInlineCompletions(initialRequestParams)
+        expect(
+            await getInlineCompletions(
+                params(
+                    dedent`
+                        function test() {
+                            console.log = 123█
+                        }
+                    `,
+                    [],
+                    {
+                        lastAcceptedCompletionItem: {
+                            requestParams: initialRequestParams,
+                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                            analyticsItem: item!.items[0]!,
+                        },
+                    }
+                )
+            )
+        ).toEqual<V>(null)
+    })
+
+    it('should make the request when manually invoked', async () => {
+        const initialRequestParams = params(
+            dedent`
+                function test() {
+                    console.l█
+                }
+            `,
+            [completion`├og = 123┤`]
+        )
+        const item = await getInlineCompletions(initialRequestParams)
+        expect(
+            await getInlineCompletions(
+                params(
+                    dedent`
+                        function test() {
+                            console.log = 123█
+                        }
+                    `,
+                    [],
+                    {
+                        triggerKind: TriggerKind.Manual,
+                        lastAcceptedCompletionItem: {
+                            requestParams: initialRequestParams,
+                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                            analyticsItem: item!.items[0]!,
+                        },
+                    }
+                )
+            )
+        ).not.toEqual<V>(null)
+    })
+
+    it('should make the request when the accepted completion was multi-line', async () => {
+        const initialRequestParams = params(
+            dedent`
+                function test() {
+                    █
+                }
+            `,
+            [completion`├console.log = 123┤`]
+        )
+        const item = await getInlineCompletions(initialRequestParams)
+        expect(
+            await getInlineCompletions(
+                params(
+                    dedent`
+                        function test() {
+                            console.log = 123█
+                        }
+                    `,
+                    [],
+                    {
+                        lastAcceptedCompletionItem: {
+                            requestParams: initialRequestParams,
+                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                            analyticsItem: item!.items[0]!,
+                        },
+                    }
+                )
+            )
+        ).not.toEqual<V>(null)
+    })
+})

--- a/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
@@ -1,10 +1,35 @@
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
+import { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+
 import { TriggerKind } from '../get-inline-completions'
 import { completion } from '../test-helpers'
 
 import { getInlineCompletions, params, V } from './helpers'
+
+// Simulate the VS Code behavior where accepting a completion will immediately start a new
+// completion request.
+async function getInlineCompletionAfterAccepting(
+    initialCode: string,
+    completion: CompletionResponse,
+    acceptedCode: string,
+    triggerKind: TriggerKind = TriggerKind.Automatic
+): ReturnType<typeof getInlineCompletions> {
+    const initialRequestParams = params(initialCode, [completion])
+    const item = await getInlineCompletions(initialRequestParams)
+
+    return getInlineCompletions(
+        params(acceptedCode, [], {
+            triggerKind,
+            lastAcceptedCompletionItem: {
+                requestParams: initialRequestParams,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                analyticsItem: item!.items[0]!,
+            },
+        })
+    )
+}
 
 describe('[getInlineCompletions] no request when accepting', () => {
     // In VS Code, accepting a completion will immediately start a new completion request. If the
@@ -13,97 +38,56 @@ describe('[getInlineCompletions] no request when accepting', () => {
     //
     // Thus, this results in a request that almost always has zero results but still incurs network
     // and inference costs.
-    it('should not make a request after accepting a completion', async () => {
-        const initialRequestParams = params(
-            dedent`
-                function test() {
-                    console.l█
-                }
-            `,
-            [completion`├og = 123┤`]
-        )
-        const item = await getInlineCompletions(initialRequestParams)
+    it('should not make a request after accepting a completion', async () =>
         expect(
-            await getInlineCompletions(
-                params(
-                    dedent`
-                        function test() {
-                            console.log = 123█
-                        }
-                    `,
-                    [],
-                    {
-                        lastAcceptedCompletionItem: {
-                            requestParams: initialRequestParams,
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                            analyticsItem: item!.items[0]!,
-                        },
+            await getInlineCompletionAfterAccepting(
+                dedent`
+                    function test() {
+                        console.l█
                     }
-                )
+                `,
+                completion`├og = 123┤`,
+                dedent`
+                    function test() {
+                        console.log = 123█
+                    }
+                `
             )
-        ).toEqual<V>(null)
-    })
+        ).toEqual<V>(null))
 
-    it('should make the request when manually invoked', async () => {
-        const initialRequestParams = params(
-            dedent`
-                function test() {
-                    console.l█
-                }
-            `,
-            [completion`├og = 123┤`]
-        )
-        const item = await getInlineCompletions(initialRequestParams)
+    it('should make the request when manually invoked', async () =>
         expect(
-            await getInlineCompletions(
-                params(
-                    dedent`
-                        function test() {
-                            console.log = 123█
-                        }
-                    `,
-                    [],
-                    {
-                        triggerKind: TriggerKind.Manual,
-                        lastAcceptedCompletionItem: {
-                            requestParams: initialRequestParams,
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                            analyticsItem: item!.items[0]!,
-                        },
+            await getInlineCompletionAfterAccepting(
+                dedent`
+                    function test() {
+                        console.l█
                     }
-                )
+                `,
+                completion`├og = 123┤`,
+                dedent`
+                    function test() {
+                        console.log = 123█
+                    }
+                `,
+                TriggerKind.Manual
             )
-        ).not.toEqual<V>(null)
-    })
+        ).not.toEqual<V>(null))
 
-    it('should make the request when the accepted completion was multi-line', async () => {
-        const initialRequestParams = params(
-            dedent`
+    it('should make the request when the accepted completion was multi-line', async () =>
+        expect(
+            await getInlineCompletionAfterAccepting(
+                dedent`
                 function test() {
                     █
                 }
             `,
-            [completion`├console.log = 123┤`]
-        )
-        const item = await getInlineCompletions(initialRequestParams)
-        expect(
-            await getInlineCompletions(
-                params(
-                    dedent`
-                        function test() {
-                            console.log = 123█
-                        }
-                    `,
-                    [],
-                    {
-                        lastAcceptedCompletionItem: {
-                            requestParams: initialRequestParams,
-                            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                            analyticsItem: item!.items[0]!,
-                        },
-                    }
-                )
+                completion`├console.log = 123┤`,
+                dedent`
+                function test() {
+                    console.log = 123█
+                }
+            `,
+                TriggerKind.Manual
             )
-        ).not.toEqual<V>(null)
-    })
+        ).not.toEqual<V>(null))
 })

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -152,6 +152,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
     /** Accessible for testing only. */
     protected lastCandidate: LastInlineCompletionCandidate | undefined
 
+    private lastAcceptedCompletionItem: Pick<AutocompleteItem, 'requestParams' | 'analyticsItem'> | undefined
+
     private disposables: vscode.Disposable[] = []
 
     private isProbablyNewInstall = true
@@ -355,6 +357,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     completionIntent,
                     dynamicMultilineCompletions: this.config.dynamicMultilineCompletions,
                     hotStreak: this.config.hotStreak,
+                    lastAcceptedCompletionItem: this.lastAcceptedCompletionItem,
                 })
 
                 // Avoid any further work if the completion is invalidated already.
@@ -490,6 +493,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         this.requestManager.removeFromCache(completion.requestParams)
 
         this.handleFirstCompletionOnboardingNotices(completion.requestParams)
+
+        this.lastAcceptedCompletionItem = completion
 
         CompletionLogger.accepted(
             completion.logId,


### PR DESCRIPTION
This is a small optimization that should cut down a bit on unnecessary LLM request:

In VS Code, if you accept a completion, this changes the document and thus issue a new completion request. Makes sense! The thing is: we always complete full lines so the chance that you do want a follow-up completion is _very_ slim. In some cases the ending `)` or `;` helps to guard against this but not in all cases. 

This PR adds a special logic now to detect this case and not issue a completion (so accepting a completion via `tab` won't issue a new request but any further keystroke (like `enter`) will).

## Test plan

- Added tests
- 

https://github.com/sourcegraph/cody/assets/458591/83d9c044-a886-4e72-90bf-d2c1486f260e



<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
