### PR TITLE
VS Code: Release 1.0.3

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,7 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Fixes an issue where the prompt text was logged when not intended. [pulls/2444](https://github.com/sourcegraph/cody/pull/2444)
+- Logging improvements for accuracy .[pulls/2444](https://github.com/sourcegraph/cody/pull/2444)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,9 +16,9 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Logging improvements for accuracy .[pulls/2444](https://github.com/sourcegraph/cody/pull/2444)
-
 ### Changed
+
+- Logging improvements for accuracy. [pulls/2444](https://github.com/sourcegraph/cody/pull/2444)
 
 ## [1.0.2]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+### Changed
+
+## [1.0.3]
+
+### Added
+
+### Fixed
+
 - Fixes an issue where the prompt text was logged when not intended. [pulls/2444](https://github.com/sourcegraph/cody/pull/2444)
 
 ### Changed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Mainly for pushing out #2444 quickly.

## Test plan

- Just a version inc, CI will check

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
