### PR TITLE
Only open renovate PRs manually

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>sourcegraph/renovate-config"]
+  "$schema": "http://json.schemastore.org/renovate",
+  "extends": ["github>sourcegraph/renovate-config"],
+  "semanticCommits": "disabled",
+  "rebaseWhen": "never",
+  "prBodyNotes": ["Test plan: CI should pass with updated dependencies."],
+  "dependencyDashboardApproval": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "rangeStrategy": "bump"
+    }
+  ]
 }


### PR DESCRIPTION
Basically copying @olafurpg here: https://github.com/sourcegraph/bfg-private/pull/44 in an attempt to reduce noise from Renovate. I think this will make it so that PRs are only created if we manually trigger it.

## Test plan

Guess we land it and see if it works? Only a dev tool with no customer impact though.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
