### PR TITLE
RFC: Detect and close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days.'
+          stale-pr-message: 'This PR is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days.'
+          days-before-stale: 60
+          days-before-close: 5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,3 +13,5 @@ jobs:
           stale-pr-message: 'This PR is marked as stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed automatically in 5 days.'
           days-before-stale: 60
           days-before-close: 5
+          exempt-issue-labels: 'neverstale'
+          exempt-pr-labels: 'neverstale'


### PR DESCRIPTION
This PR adds the stale action to automatically detect and close stale issues and PRs. 

I configured it so that issues will be marked as stale after 60 days of no activity and will be closed within 5 days unless manually interfered.

I’m personally up for even more aggressive timeouts, e.g. 30 days are enough, just because of how fast we move here but I’m happy to settle on something larger.

## Test plan

We see if issues close huh

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
