### PR TITLE
Remove serverEndpoint from config object

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -53,7 +53,6 @@ const clientInfo: ClientInfo = {
         serverEndpoint: dotcom,
         customHeaders: {},
         autocompleteAdvancedProvider: 'anthropic',
-        autocompleteAdvancedAccessToken: '',
         debug: false,
         verboseDebug: false,
     },

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -54,7 +54,6 @@ const clientInfo: ClientInfo = {
         customHeaders: {},
         autocompleteAdvancedProvider: 'anthropic',
         autocompleteAdvancedAccessToken: '',
-        autocompleteAdvancedServerEndpoint: '',
         debug: false,
         verboseDebug: false,
     },

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -154,8 +154,6 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return true
             case 'cody.autocomplete.advanced.provider':
                 return connectionConfig?.autocompleteAdvancedProvider ?? null
-            case 'cody.autocomplete.advanced.serverEndpoint':
-                return connectionConfig?.autocompleteAdvancedServerEndpoint ?? null
             case 'cody.autocomplete.advanced.model':
                 return connectionConfig?.autocompleteAdvancedModel ?? null
             case 'cody.autocomplete.advanced.accessToken':

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -156,8 +156,6 @@ const configuration: vscode.WorkspaceConfiguration = {
                 return connectionConfig?.autocompleteAdvancedProvider ?? null
             case 'cody.autocomplete.advanced.model':
                 return connectionConfig?.autocompleteAdvancedModel ?? null
-            case 'cody.autocomplete.advanced.accessToken':
-                return connectionConfig?.autocompleteAdvancedAccessToken ?? null
             case 'cody.advanced.agent.running':
                 return true
             case 'cody.debug.enable':

--- a/cli/src/client/context.ts
+++ b/cli/src/client/context.ts
@@ -23,8 +23,9 @@ export async function createCodebaseContext(
         repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, codebase, repoId) : null
 
     const codebaseContext = new CodebaseContext(
-        { useContext: contextType, serverEndpoint, experimentalLocalSymbols: false },
+        { useContext: contextType, experimentalLocalSymbols: false },
         codebase,
+        () => serverEndpoint,
         embeddingsSearch,
         null,
         null,

--- a/lib/shared/src/chat/client.ts
+++ b/lib/shared/src/chat/client.ts
@@ -90,7 +90,15 @@ export async function createClient({
         const embeddingsSearch = repoId
             ? new SourcegraphEmbeddingsSearchClient(graphqlClient, config.codebase || repoId, repoId, undefined, true)
             : null
-        const codebaseContext = new CodebaseContext(config, config.codebase, embeddingsSearch, null, null, null)
+        const codebaseContext = new CodebaseContext(
+            config,
+            config.codebase,
+            () => config.serverEndpoint,
+            embeddingsSearch,
+            null,
+            null,
+            null
+        )
 
         const intentDetector = new SourcegraphIntentDetectorClient(graphqlClient, completionsClient)
 

--- a/lib/shared/src/chat/transcript/transcript.test.ts
+++ b/lib/shared/src/chat/transcript/transcript.test.ts
@@ -74,10 +74,10 @@ describe('Transcript', () => {
                 codebaseContext: new CodebaseContext(
                     {
                         useContext: 'embeddings',
-                        serverEndpoint: 'https://example.com',
                         experimentalLocalSymbols: false,
                     },
                     'dummy-codebase',
+                    () => 'https://example.com',
                     embeddings,
                     null,
                     null,
@@ -117,10 +117,10 @@ describe('Transcript', () => {
                 codebaseContext: new CodebaseContext(
                     {
                         useContext: 'embeddings',
-                        serverEndpoint: 'https://example.com',
                         experimentalLocalSymbols: false,
                     },
                     'dummy-codebase',
+                    () => 'https://example.com',
                     embeddings,
                     null,
                     null,
@@ -155,8 +155,9 @@ describe('Transcript', () => {
         })
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
-            { useContext: 'embeddings', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+            { useContext: 'embeddings', experimentalLocalSymbols: false },
             'dummy-codebase',
+            () => 'https://example.com',
             embeddings,
             null,
             null,
@@ -247,8 +248,9 @@ describe('Transcript', () => {
             isEditorContextRequired: () => true,
         })
         const codebaseContext = new CodebaseContext(
-            { useContext: 'embeddings', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+            { useContext: 'embeddings', experimentalLocalSymbols: false },
             'dummy-codebase',
+            () => 'https://example.com',
             embeddings,
             null,
             null,
@@ -329,8 +331,9 @@ describe('Transcript', () => {
         })
         const intentDetector = new MockIntentDetector({ isCodebaseContextRequired: async () => Promise.resolve(true) })
         const codebaseContext = new CodebaseContext(
-            { useContext: 'embeddings', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+            { useContext: 'embeddings', experimentalLocalSymbols: false },
             'dummy-codebase',
+            () => 'https://example.com',
             embeddings,
             null,
             null,

--- a/lib/shared/src/chat/useClient.ts
+++ b/lib/shared/src/chat/useClient.ts
@@ -295,6 +295,7 @@ export const useClient = ({
             const codebaseContext = new CodebaseContext(
                 config,
                 undefined,
+                () => config.serverEndpoint,
                 null,
                 null,
                 null,

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -13,7 +13,6 @@ export const CONTEXT_SELECTION_ID: Record<ConfigurationUseContext, number> = {
 
 // Should we share VS Code specific config via cody-shared?
 export interface Configuration {
-    serverEndpoint: string
     proxy?: string | null
     codebase?: string
     debugEnable: boolean
@@ -33,7 +32,6 @@ export interface Configuration {
     autocomplete: boolean
     autocompleteLanguages: Record<string, boolean>
     autocompleteAdvancedProvider: 'anthropic' | 'fireworks' | 'unstable-openai' | null
-    autocompleteAdvancedServerEndpoint: string | null
     autocompleteAdvancedModel: string | null
     autocompleteAdvancedAccessToken: string | null
     autocompleteCompleteSuggestWidgetSelection?: boolean
@@ -74,6 +72,7 @@ export interface AutocompleteTimeouts {
 }
 
 export interface ConfigurationWithAccessToken extends Configuration {
+    serverEndpoint: string
     /** The access token, which is stored in the secret storage (not configuration). */
     accessToken: string | null
 }

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -33,7 +33,6 @@ export interface Configuration {
     autocompleteLanguages: Record<string, boolean>
     autocompleteAdvancedProvider: 'anthropic' | 'fireworks' | 'unstable-openai' | null
     autocompleteAdvancedModel: string | null
-    autocompleteAdvancedAccessToken: string | null
     autocompleteCompleteSuggestWidgetSelection?: boolean
     autocompleteFormatOnAccept?: boolean
 

--- a/lib/shared/src/test/mocks.ts
+++ b/lib/shared/src/test/mocks.ts
@@ -150,8 +150,9 @@ export function newRecipeContext(args?: Partial<RecipeContext>): RecipeContext {
         codebaseContext:
             args.codebaseContext ||
             new CodebaseContext(
-                { useContext: 'none', serverEndpoint: 'https://example.com', experimentalLocalSymbols: false },
+                { useContext: 'none', experimentalLocalSymbols: false },
                 'dummy-codebase',
+                () => 'https://example.com',
                 defaultEmbeddingsClient,
                 null,
                 null,

--- a/slack/src/services/codebase-context.ts
+++ b/slack/src/services/codebase-context.ts
@@ -32,8 +32,9 @@ export async function createCodebaseContext(
         repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(sourcegraphClient, codebase, repoId) : null
 
     const codebaseContext = new CodebaseContext(
-        { useContext: contextType, serverEndpoint, experimentalLocalSymbols: false },
+        { useContext: contextType, experimentalLocalSymbols: false },
         codebase,
+        () => serverEndpoint,
         embeddingsSearch,
         null,
         null,

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,9 +8,11 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Fixed config parsing to ensure we read the right remote server endpoint everywhere. [pulls/2456](https://github.com/sourcegraph/cody/pull/2456)
+
 ### Changed
 
-- Autocomplete: Accepting a full line completion will not immedialty start another completion request on the same line. [pulls/2446](https://github.com/sourcegraph/cody/pull/2446)
+- Autocomplete: Accepting a full line completion will not immediately start another completion request on the same line. [pulls/2446](https://github.com/sourcegraph/cody/pull/2446)
 
 ## [1.0.3]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -922,15 +922,7 @@
             "fireworks",
             "unstable-openai"
           ],
-          "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
-        },
-        "cody.autocomplete.advanced.serverEndpoint": {
-          "type": "string",
-          "markdownDescription": "The server endpoint used for code autocomplete. This is only supported with a provider other than `anthropic`."
-        },
-        "cody.autocomplete.advanced.accessToken": {
-          "type": "string",
-          "markdownDescription": "The access token used for code autocomplete. This is only supported with a provider other than `anthropic`."
+          "markdownDescription": "The provider used for code autocomplete. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
         "cody.autocomplete.advanced.model": {
           "type": "string",

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -26,7 +26,7 @@ import { telemetryRecorder } from '../services/telemetry-v2'
 
 import { SidebarChatWebview } from './chat-view/SidebarChatProvider'
 import { GraphContextProvider } from './GraphContextProvider'
-import { ConfigurationSubsetForWebview, LocalEnv } from './protocol'
+import { AuthStatus, ConfigurationSubsetForWebview, LocalEnv } from './protocol'
 
 export type Config = Pick<
     ConfigurationWithAccessToken,
@@ -146,6 +146,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
 
         const codebaseContext = await getCodebaseContext(
             this.config,
+            this.authProvider.getAuthStatus(),
             this.rgPath,
             this.symf,
             this.editor,
@@ -191,6 +192,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
             // Update codebase context
             const codebaseContext = await getCodebaseContext(
                 newConfig,
+                this.authProvider.getAuthStatus(),
                 this.rgPath,
                 this.symf,
                 this.editor,
@@ -309,6 +311,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
  */
 async function getCodebaseContext(
     config: Config,
+    authStatus: AuthStatus,
     rgPath: string | null,
     symf: IndexedKeywordContextFetcher | undefined,
     editor: Editor,
@@ -348,6 +351,7 @@ async function getCodebaseContext(
     return new CodebaseContext(
         config,
         codebase,
+        () => authStatus.endpoint ?? '',
         // Use embeddings search if there are no local embeddings.
         (!(await hasLocalEmbeddings) && embeddingsSearch) || null,
         rgPath ? platform.createFilenameContextFetcher?.(rgPath, editor, chatClient) ?? null : null,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -549,6 +549,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             const properties = {
                 requestID,
                 chatModel: this.chatModel.modelID,
+                // 🚨 SECURITY: included only for DotCom users.
                 promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? text : undefined,
                 contextSummary,
             }

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -5,7 +5,7 @@ import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { EnhancedContextContextT } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
 import { ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { SearchPanelFile } from '@sourcegraph/cody-shared/src/local-context'
 import { CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import type { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
@@ -116,7 +116,8 @@ export type ExtensionMessage =
 /**
  * The subset of configuration that is visible to the webview.
  */
-export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debugEnable' | 'serverEndpoint'> {}
+export interface ConfigurationSubsetForWebview
+    extends Pick<ConfigurationWithAccessToken, 'debugEnable' | 'serverEndpoint'> {}
 
 /**
  * URLs for the Sourcegraph instance and app.

--- a/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/analytics.test.ts
@@ -89,8 +89,6 @@ describe('[getInlineCompletions] completion event', () => {
                 "items": [
                   {
                     "charCount": 30,
-                    "insertText": "console.log(bar)
-              return false}",
                     "lineCount": 2,
                     "lineTruncatedCount": 0,
                     "nodeTypes": {
@@ -144,7 +142,6 @@ describe('[getInlineCompletions] completion event', () => {
                 "items": [
                   {
                     "charCount": 5,
-                    "insertText": "\\"foo\\"",
                     "lineCount": 1,
                     "lineTruncatedCount": undefined,
                     "nodeTypes": {

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -54,6 +54,7 @@ export function params(
         triggerKind = TriggerKind.Automatic,
         selectedCompletionInfo,
         takeSuggestWidgetSelectionIntoAccount,
+        isDotComUser = false,
         ...params
     }: Params = {}
 ): InlineCompletionsParams {
@@ -107,6 +108,7 @@ export function params(
             position,
             prefix: docContext.prefix,
         }),
+        isDotComUser,
         ...params,
     }
 }

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -36,6 +36,7 @@ export interface InlineCompletionsParams {
     contextMixer: ContextMixer
 
     // UI state
+    isDotComUser: boolean
     lastCandidate?: LastInlineCompletionCandidate
     debounceInterval?: { singleLine: number; multiLine: number }
     setIsLoading?: (isLoading: boolean) => void
@@ -182,6 +183,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         dynamicMultilineCompletions,
         hotStreak,
         lastAcceptedCompletionItem,
+        isDotComUser,
     } = params
 
     tracer?.({ params: { document, position, triggerKind, selectedCompletionInfo } })
@@ -331,7 +333,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
         tracer ? createCompletionProviderTracer(tracer) : undefined
     )
 
-    CompletionLogger.loaded(logId, reqContext, completions, source)
+    CompletionLogger.loaded(logId, reqContext, completions, source, isDotComUser)
 
     return {
         logId,

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -358,6 +358,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     dynamicMultilineCompletions: this.config.dynamicMultilineCompletions,
                     hotStreak: this.config.hotStreak,
                     lastAcceptedCompletionItem: this.lastAcceptedCompletionItem,
+                    isDotComUser: this.config.isDotComUser,
                 })
 
                 // Avoid any further work if the completion is invalidated already.
@@ -500,7 +501,8 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
             completion.logId,
             completion.requestParams.document,
             completion.analyticsItem,
-            completion.trackedRange
+            completion.trackedRange,
+            this.config.isDotComUser
         )
     }
 
@@ -546,7 +548,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         if (!completion) {
             return
         }
-        CompletionLogger.suggested(completion.logId, completion.analyticsItem)
+        CompletionLogger.suggested(completion.logId)
     }
 
     /**
@@ -558,7 +560,12 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
         completion: Pick<AutocompleteItem, 'logId' | 'analyticsItem'>,
         acceptedLength: number
     ): void {
-        CompletionLogger.partiallyAccept(completion.logId, completion.analyticsItem, acceptedLength)
+        CompletionLogger.partiallyAccept(
+            completion.logId,
+            completion.analyticsItem,
+            acceptedLength,
+            this.config.isDotComUser
+        )
     }
 
     public async manuallyTriggerCompletion(): Promise<void> {

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -53,16 +53,16 @@ describe('logger', () => {
         CompletionLogger.reset_testOnly()
     })
 
-    it('logs a suggestion life cycle', () => {
+    it('logs a suggestion life cycle', async () => {
         const item = { id: completionItemId, insertText: 'foo' }
         const id = CompletionLogger.create(defaultArgs)
         expect(typeof id).toBe('string')
 
         CompletionLogger.start(id)
         CompletionLogger.networkRequestStarted(id, defaultContextSummary)
-        CompletionLogger.loaded(id, defaultRequestParams, [item], InlineCompletionsResultSource.Network)
-        CompletionLogger.suggested(id, item)
-        CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0))
+        CompletionLogger.loaded(id, defaultRequestParams, [item], InlineCompletionsResultSource.Network, false)
+        CompletionLogger.suggested(id)
+        CompletionLogger.accepted(id, document, item, range(0, 0, 0, 0), false)
 
         const shared = {
             id: expect.any(String),
@@ -85,7 +85,6 @@ describe('logger', () => {
                 {
                     charCount: 3,
                     lineCount: 1,
-                    insertText: 'foo',
                     lineTruncatedCount: undefined,
                     nodeTypes: undefined,
                     parseErrorCount: undefined,
@@ -136,14 +135,14 @@ describe('logger', () => {
         })
     })
 
-    it('reuses the completion ID for the same completion', () => {
+    it('reuses the completion ID for the same completion', async () => {
         const item = { id: completionItemId, insertText: 'foo' }
 
         const id1 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id1)
         CompletionLogger.networkRequestStarted(id1, defaultContextSummary)
-        CompletionLogger.loaded(id1, defaultRequestParams, [item], InlineCompletionsResultSource.Network)
-        CompletionLogger.suggested(id1, item)
+        CompletionLogger.loaded(id1, defaultRequestParams, [item], InlineCompletionsResultSource.Network, false)
+        CompletionLogger.suggested(id1)
 
         const loggerItem = CompletionLogger.getCompletionEvent(id1)
         const completionId = loggerItem?.params.id
@@ -152,9 +151,9 @@ describe('logger', () => {
         const id2 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id2)
         CompletionLogger.networkRequestStarted(id2, defaultContextSummary)
-        CompletionLogger.loaded(id2, defaultRequestParams, [item], InlineCompletionsResultSource.Cache)
-        CompletionLogger.suggested(id2, item)
-        CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0))
+        CompletionLogger.loaded(id2, defaultRequestParams, [item], InlineCompletionsResultSource.Cache, false)
+        CompletionLogger.suggested(id2)
+        CompletionLogger.accepted(id2, document, item, range(0, 0, 0, 0), false)
 
         const loggerItem2 = CompletionLogger.getCompletionEvent(id2)
         expect(loggerItem2?.params.id).toBe(completionId)
@@ -192,8 +191,8 @@ describe('logger', () => {
         const id3 = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id3)
         CompletionLogger.networkRequestStarted(id3, defaultContextSummary)
-        CompletionLogger.loaded(id3, defaultRequestParams, [item], InlineCompletionsResultSource.Cache)
-        CompletionLogger.suggested(id3, item)
+        CompletionLogger.loaded(id3, defaultRequestParams, [item], InlineCompletionsResultSource.Cache, false)
+        CompletionLogger.suggested(id3)
 
         const loggerItem3 = CompletionLogger.getCompletionEvent(id3)
         expect(loggerItem3?.params.id).not.toBe(completionId)
@@ -204,7 +203,7 @@ describe('logger', () => {
 
         const id = CompletionLogger.create(defaultArgs)
         CompletionLogger.start(id)
-        CompletionLogger.partiallyAccept(id, item, 5)
+        CompletionLogger.partiallyAccept(id, item, 5, false)
 
         expect(logSpy).toHaveBeenCalledWith(
             'CodyVSCodeExtension:completion:partiallyAccepted',
@@ -216,7 +215,7 @@ describe('logger', () => {
         )
         expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'partiallyAccepted', expect.anything())
 
-        CompletionLogger.partiallyAccept(id, item, 10)
+        CompletionLogger.partiallyAccept(id, item, 10, false)
 
         expect(logSpy).toHaveBeenCalledWith(
             'CodyVSCodeExtension:completion:partiallyAccepted',
@@ -228,8 +227,8 @@ describe('logger', () => {
         )
         expect(recordSpy).toHaveBeenCalledWith('cody.completion', 'partiallyAccepted', expect.anything())
 
-        CompletionLogger.partiallyAccept(id, item, 5)
-        CompletionLogger.partiallyAccept(id, item, 8)
+        CompletionLogger.partiallyAccept(id, item, 5, false)
+        CompletionLogger.partiallyAccept(id, item, 8, false)
         expect(logSpy).toHaveBeenCalledTimes(2)
     })
 })

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -53,7 +53,7 @@ describe('logger', () => {
         CompletionLogger.reset_testOnly()
     })
 
-    it('logs a suggestion life cycle', async () => {
+    it('logs a suggestion life cycle', () => {
         const item = { id: completionItemId, insertText: 'foo' }
         const id = CompletionLogger.create(defaultArgs)
         expect(typeof id).toBe('string')
@@ -135,7 +135,7 @@ describe('logger', () => {
         })
     })
 
-    it('reuses the completion ID for the same completion', async () => {
+    it('reuses the completion ID for the same completion', () => {
         const item = { id: completionItemId, insertText: 'foo' }
 
         const id1 = CompletionLogger.create(defaultArgs)

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -2,7 +2,6 @@ import { LRUCache } from 'lru-cache'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import { isNetworkError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 import { BillingCategory, BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
 import { KnownString, TelemetryEventParameters } from '@sourcegraph/telemetry'
@@ -466,7 +465,8 @@ export function loaded(
     id: CompletionLogID,
     params: RequestParams,
     items: InlineCompletionItemWithAnalytics[],
-    source: InlineCompletionsResultSource
+    source: InlineCompletionsResultSource,
+    isDotComUser: boolean
 ): void {
     const event = activeSuggestionRequests.get(id)
     if (!event) {
@@ -486,7 +486,6 @@ export function loaded(
     }
 
     if (event.items.length === 0) {
-        const isDotComUser = isDotComServer()
         event.items = items.map(item => completionItemToItemInfo(item, isDotComUser))
     }
 }
@@ -497,7 +496,7 @@ export function loaded(
 //
 // For statistics logging we start a timeout matching the READ_TIMEOUT_MS so we can increment the
 // suggested completion count as soon as we count it as such.
-export function suggested(id: CompletionLogID, completion: InlineCompletionItemWithAnalytics): void {
+export function suggested(id: CompletionLogID): void {
     const event = activeSuggestionRequests.get(id)
     if (!event) {
         return
@@ -535,7 +534,8 @@ export function accepted(
     id: CompletionLogID,
     document: vscode.TextDocument,
     completion: InlineCompletionItemWithAnalytics,
-    trackedRange: vscode.Range | undefined
+    trackedRange: vscode.Range | undefined,
+    isDotComUser: boolean
 ): void {
     const completionEvent = activeSuggestionRequests.get(id)
     if (!completionEvent || completionEvent.acceptedAt) {
@@ -590,7 +590,7 @@ export function accepted(
     logSuggestionEvents()
     logCompletionAcceptedEvent({
         ...getSharedParams(completionEvent),
-        acceptedItem: completionItemToItemInfo(completion),
+        acceptedItem: completionItemToItemInfo(completion, isDotComUser),
     })
     statistics.logAccepted()
 
@@ -612,7 +612,8 @@ export function accepted(
 export function partiallyAccept(
     id: CompletionLogID,
     completion: InlineCompletionItemWithAnalytics,
-    acceptedLength: number
+    acceptedLength: number,
+    isDotComUser: boolean
 ): void {
     const completionEvent = activeSuggestionRequests.get(id)
     // Only log partial acceptances if the completion was not yet fully accepted
@@ -632,7 +633,7 @@ export function partiallyAccept(
 
     logCompletionPartiallyAcceptedEvent({
         ...getSharedParams(completionEvent),
-        acceptedItem: completionItemToItemInfo(completion),
+        acceptedItem: completionItemToItemInfo(completion, isDotComUser),
         acceptedLength,
         acceptedLengthDelta,
     })
@@ -773,7 +774,7 @@ function getSharedParams(event: CompletionBookkeepingEvent): SharedEventPayload 
     }
 }
 
-function completionItemToItemInfo(item: InlineCompletionItemWithAnalytics, isDotComUser = false): CompletionItemInfo {
+function completionItemToItemInfo(item: InlineCompletionItemWithAnalytics, isDotComUser: boolean): CompletionItemInfo {
     const { lineCount, charCount } = lineAndCharCount(item)
 
     const completionItemInfo: CompletionItemInfo = {
@@ -821,10 +822,4 @@ function getOtherCompletionProvider(): string[] {
 function isRunningInsideAgent(): boolean {
     const config = getConfiguration(vscode.workspace.getConfiguration())
     return !!config.isRunningInsideAgent
-}
-
-// 🚨 SECURITY: this helper ensures we log additional data only for DotCom users.
-function isDotComServer(): boolean {
-    const config = getConfiguration(vscode.workspace.getConfiguration())
-    return isDotCom(config.serverEndpoint)
 }

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import {
     CodyLLMSiteConfiguration,
     GraphQLAPIClientConfig,
@@ -13,7 +12,6 @@ import { CodeCompletionsClient } from '../client'
 import { createProviderConfig } from './create-provider'
 
 const DEFAULT_VSCODE_SETTINGS: Configuration = {
-    serverEndpoint: DOTCOM_URL.href,
     proxy: null,
     codebase: '',
     customHeaders: {},
@@ -35,7 +33,6 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     debugFilter: null,
     telemetryLevel: 'all',
     autocompleteAdvancedProvider: null,
-    autocompleteAdvancedServerEndpoint: null,
     autocompleteAdvancedModel: null,
     autocompleteAdvancedAccessToken: null,
     autocompleteCompleteSuggestWidgetSelection: false,
@@ -138,7 +135,6 @@ describe('createProviderConfig', () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({
                     autocompleteAdvancedProvider: 'unstable-openai',
-                    autocompleteAdvancedServerEndpoint: 'https://unstable-openai.com',
                 }),
                 dummyCodeCompletionsClient,
                 { provider: 'azure-open-ai', completionModel: 'gpt-35-turbo-test' }

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -34,7 +34,6 @@ const DEFAULT_VSCODE_SETTINGS: Configuration = {
     telemetryLevel: 'all',
     autocompleteAdvancedProvider: null,
     autocompleteAdvancedModel: null,
-    autocompleteAdvancedAccessToken: null,
     autocompleteCompleteSuggestWidgetSelection: false,
     autocompleteExperimentalSyntacticPostProcessing: false,
     autocompleteExperimentalGraphContext: null,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -36,7 +36,6 @@ describe('getConfiguration', () => {
             telemetryLevel: 'all',
             autocompleteAdvancedProvider: null,
             autocompleteAdvancedModel: null,
-            autocompleteAdvancedAccessToken: null,
             autocompleteCompleteSuggestWidgetSelection: true,
             autocompleteFormatOnAccept: true,
             autocompleteExperimentalSyntacticPostProcessing: true,
@@ -101,12 +100,8 @@ describe('getConfiguration', () => {
                         return 'My name is Jeff.'
                     case 'cody.autocomplete.advanced.provider':
                         return 'unstable-openai'
-                    case 'cody.autocomplete.advanced.serverEndpoint':
-                        return 'https://example.com/llm'
                     case 'cody.autocomplete.advanced.model':
                         return 'starcoder-32b'
-                    case 'cody.autocomplete.advanced.accessToken':
-                        return 'foobar'
                     case 'cody.autocomplete.advanced.timeout.multiline':
                         return undefined
                     case 'cody.autocomplete.advanced.timeout.singleline':
@@ -161,7 +156,6 @@ describe('getConfiguration', () => {
             telemetryLevel: 'off',
             autocompleteAdvancedProvider: 'unstable-openai',
             autocompleteAdvancedModel: 'starcoder-32b',
-            autocompleteAdvancedAccessToken: 'foobar',
             autocompleteCompleteSuggestWidgetSelection: false,
             autocompleteFormatOnAccept: true,
             autocompleteExperimentalSyntacticPostProcessing: true,

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
 import { getConfiguration } from './configuration'
 
@@ -12,7 +11,6 @@ describe('getConfiguration', () => {
             get: <T>(_key: string, defaultValue?: T): typeof defaultValue | undefined => defaultValue,
         }
         expect(getConfiguration(config)).toEqual({
-            serverEndpoint: DOTCOM_URL.href,
             proxy: null,
             codebase: '',
             customHeaders: {},
@@ -37,7 +35,6 @@ describe('getConfiguration', () => {
             debugFilter: null,
             telemetryLevel: 'all',
             autocompleteAdvancedProvider: null,
-            autocompleteAdvancedServerEndpoint: null,
             autocompleteAdvancedModel: null,
             autocompleteAdvancedAccessToken: null,
             autocompleteCompleteSuggestWidgetSelection: true,
@@ -136,7 +133,6 @@ describe('getConfiguration', () => {
             },
         }
         expect(getConfiguration(config)).toEqual({
-            serverEndpoint: 'http://example.com',
             proxy: 'socks5://127.0.0.1:9999',
             codebase: 'my/codebase',
             useContext: 'keyword',
@@ -164,7 +160,6 @@ describe('getConfiguration', () => {
             debugFilter: /.*/,
             telemetryLevel: 'off',
             autocompleteAdvancedProvider: 'unstable-openai',
-            autocompleteAdvancedServerEndpoint: 'https://example.com/llm',
             autocompleteAdvancedModel: 'starcoder-32b',
             autocompleteAdvancedAccessToken: 'foobar',
             autocompleteCompleteSuggestWidgetSelection: false,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -85,7 +85,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         editorTitleCommandIcon: config.get(CONFIG_KEY.editorTitleCommandIcon, true),
         autocompleteAdvancedProvider,
         autocompleteAdvancedModel: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedModel, null),
-        autocompleteAdvancedAccessToken: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedAccessToken, null),
         autocompleteCompleteSuggestWidgetSelection: config.get(
             CONFIG_KEY.autocompleteCompleteSuggestWidgetSelection,
             true

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -68,9 +68,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
     }
 
     return {
-        // NOTE: serverEndpoint is now stored in Local Storage instead but we will still keep supporting the one in confg
-        // to use as fallback for users who do not have access to local storage
-        serverEndpoint: sanitizeServerEndpoint(config.get(CONFIG_KEY.serverEndpoint, '')),
         proxy: config.get<string | null>(CONFIG_KEY.proxy, null),
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
         customHeaders: config.get<object>(CONFIG_KEY.customHeaders, {}) as Record<string, string>,
@@ -87,10 +84,6 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         commandCodeLenses: config.get(CONFIG_KEY.commandCodeLenses, false),
         editorTitleCommandIcon: config.get(CONFIG_KEY.editorTitleCommandIcon, true),
         autocompleteAdvancedProvider,
-        autocompleteAdvancedServerEndpoint: config.get<string | null>(
-            CONFIG_KEY.autocompleteAdvancedServerEndpoint,
-            null
-        ),
         autocompleteAdvancedModel: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedModel, null),
         autocompleteAdvancedAccessToken: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedAccessToken, null),
         autocompleteCompleteSuggestWidgetSelection: config.get(
@@ -156,27 +149,12 @@ function sanitizeCodebase(codebase: string | undefined): string {
     return codebase.replace(protocolRegexp, '').trim().replace(trailingSlashRegexp, '')
 }
 
-function sanitizeServerEndpoint(serverEndpoint: string): string {
-    if (!serverEndpoint) {
-        // TODO(philipp-spiess): Find out why the config is not loaded properly in the integration
-        // tests.
-        const isTesting = process.env.CODY_TESTING === 'true'
-        if (isTesting) {
-            return 'http://localhost:49300/'
-        }
-
-        return DOTCOM_URL.href
-    }
-    const trailingSlashRegexp = /\/$/
-    return serverEndpoint.trim().replace(trailingSlashRegexp, '')
-}
-
 export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => {
     const config = getConfiguration()
-    // Migrate endpoints to local storage
-    config.serverEndpoint = localStorage?.getEndpoint() || config.serverEndpoint
+    const isTesting = process.env.CODY_TESTING === 'true'
+    const serverEndpoint = localStorage?.getEndpoint() || (isTesting ? 'http://localhost:49300/' : DOTCOM_URL.href)
     const accessToken = (await getAccessToken()) || null
-    return { ...config, accessToken }
+    return { ...config, accessToken, serverEndpoint }
 }
 
 function checkValidEnumValues(configName: string, value: string | null): void {

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { Recipe } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
-import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { Configuration, ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import type { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/browserClient'
 import type { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
@@ -32,8 +32,8 @@ export interface PlatformContext {
     createCompletionsClient:
         | Constructor<typeof SourcegraphBrowserCompletionsClient>
         | Constructor<typeof SourcegraphNodeCompletionsClient>
-    createSentryService?: (config: Pick<Configuration, 'serverEndpoint'>) => SentryService
-    createOpenTelemetryService?: (config: Pick<Configuration, 'serverEndpoint'>) => OpenTelemetryService
+    createSentryService?: (config: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>) => SentryService
+    createOpenTelemetryService?: (config: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>) => OpenTelemetryService
     recipes: Recipe[]
     onConfigurationChange?: (configuration: Configuration) => void
 }

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -78,6 +78,7 @@ export async function configureExternalServices(
     const codebaseContext = new CodebaseContext(
         initialConfig,
         initialConfig.codebase,
+        () => initialConfig.serverEndpoint,
         embeddingsSearch,
         rgPath ? platform.createFilenameContextFetcher?.(rgPath, editor, chatClient) ?? null : null,
         null,

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -213,7 +213,6 @@ export interface ExtensionConfiguration {
 
     autocompleteAdvancedProvider?: string
     autocompleteAdvancedModel?: string | null
-    autocompleteAdvancedAccessToken?: string | null
     debug?: boolean
     verboseDebug?: boolean
     codebase?: string

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -212,7 +212,6 @@ export interface ExtensionConfiguration {
     anonymousUserID?: string
 
     autocompleteAdvancedProvider?: string
-    autocompleteAdvancedServerEndpoint?: string | null
     autocompleteAdvancedModel?: string | null
     autocompleteAdvancedAccessToken?: string | null
     debug?: boolean

--- a/vscode/src/services/OpenTelemetryService.node.ts
+++ b/vscode/src/services/OpenTelemetryService.node.ts
@@ -4,7 +4,7 @@ import { Resource } from '@opentelemetry/resources'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
-import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
 import { version } from '../version'
@@ -16,11 +16,11 @@ export class OpenTelemetryService {
     // be run in parallel
     private reconfigurePromiseMutex: Promise<void> = Promise.resolve()
 
-    constructor(protected config: Pick<Configuration, 'serverEndpoint'>) {
+    constructor(protected config: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>) {
         this.reconfigurePromiseMutex = this.reconfigurePromiseMutex.then(() => this.reconfigure())
     }
 
-    public onConfigurationChange(newConfig: Pick<Configuration, 'serverEndpoint'>): void {
+    public onConfigurationChange(newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>): void {
         this.config = newConfig
         this.reconfigurePromiseMutex = this.reconfigurePromiseMutex.then(() => this.reconfigure())
     }

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -1,7 +1,7 @@
 import type { init as browserInit } from '@sentry/browser'
 import type { init as nodeInit } from '@sentry/node'
 
-import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import {
     isAbortError,
@@ -18,11 +18,13 @@ export const SENTRY_DSN = 'https://f565373301c9c7ef18448a1c60dfde8d@o19358.inges
 export type SentryOptions = NonNullable<Parameters<typeof nodeInit | typeof browserInit>[0]>
 
 export abstract class SentryService {
-    constructor(protected config: Pick<Configuration, 'serverEndpoint' | 'isRunningInsideAgent' | 'agentIDE'>) {
+    constructor(
+        protected config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'isRunningInsideAgent' | 'agentIDE'>
+    ) {
         this.prepareReconfigure()
     }
 
-    public onConfigurationChange(newConfig: Pick<Configuration, 'serverEndpoint'>): void {
+    public onConfigurationChange(newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint'>): void {
         this.config = newConfig
         this.prepareReconfigure()
     }

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -28,9 +28,7 @@ import { createWebviewTelemetryService } from './utils/telemetry'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const [config, setConfig] = useState<(Pick<Configuration, 'debugEnable' | 'serverEndpoint'> & LocalEnv) | null>(
-        null
-    )
+    const [config, setConfig] = useState<(Pick<Configuration, 'debugEnable'> & LocalEnv) | null>(null)
     const [endpoint, setEndpoint] = useState<string | null>(null)
     const [view, setView] = useState<View | undefined>()
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)


### PR DESCRIPTION
This refactors the `Config` object to no longer expose a `serverEndpoint`. The `serverEndpoint` should be retrieved only from local storage as part of the authenticated user. When going through this legacy code part, the server endpoint would always be set to the dotcom instance URL instead.

This caused some parts to behave like you were on dotcom even when inside an enterprise version.

## Test plan

- I tested it by evaluating analytics logs and switching accounts
- Video is large so uploading it on Google Drive instead: https://drive.google.com/file/d/1dpn-C1IczJ9CQ0zX6evMyzKpHpq8lIvS/view?usp=sharing


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
