### PR TITLE
VS Code: call the error callback only once per request

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -738,6 +738,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 },
                 onError: error => {
                     this.cancelInProgressCompletion()
+                    typewriter.close()
                     typewriter.stop()
                     callbacks.error(lastContent, error)
                 },


### PR DESCRIPTION
## Context

- Close the upstream in the typewriter to avoid raising an error and potentially crashing the agent.
- Trigger error once per completion request to avoid uncaught errors like `ECONNRESET` being bubbled upstream after the request is aborted.
- [Slack thread.](https://sourcegraph.slack.com/archives/C059N5FRYG3/p1703180240925439)

## Test plan

1. Start a new chat in VS Code.
2. Cancel token sampling in the middle of response streaming.
3. Observe no uncaught errors in the Cody output channels.
