### PR TITLE
Remove "bin/" from search ignore and just rank low unless typed

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,9 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Folders named 'bin/' are no longer filtered out from chat `@`-mentions but instead ranked lower. [pull/2472](https://github.com/sourcegraph/cody/pull/2472)
+- Files ignored in `.cody/ignore` (if the internal experiment is enabled) will no longer show up in chat `@`-mentions. [pull/2472](https://github.com/sourcegraph/cody/pull/2472)
+
 ## [1.0.5]
 
 ### Added

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -14,10 +14,15 @@ const findWorkspaceFiles = async (cancellationToken: vscode.CancellationToken): 
     // TODO(toolmantim): Add support for the search.exclude option, e.g.
     // Object.keys(vscode.workspace.getConfiguration().get('search.exclude',
     // {}))
-    const fileExcludesPattern = '**/{*.env,.git,out/,dist/,bin/,snap,node_modules,__pycache__}**'
+    const fileExcludesPattern = '**/{*.env,.git,out/,dist/,snap,node_modules,__pycache__}**'
     // TODO(toolmantim): Check this performs with remote workspaces (do we need a UI spinner etc?)
     return vscode.workspace.findFiles('', fileExcludesPattern, undefined, cancellationToken)
 }
+
+// Some matches we don't want to ignore because they might be valid code (for example `bin/` in Dart)
+// but could also be junk (`bin/` in .NET). If a file path contains a segment matching any of these
+// items it will be ranked low unless the users query contains the exact segment.
+const lowScoringPathSegments = ['bin']
 
 // This is expensive for large repos (e.g. Chromium), so we only do it max once
 // every 10 seconds. It also handily supports a cancellation callback to use
@@ -67,10 +72,24 @@ export async function getFileContextFiles(
         threshold: -100000,
     })
 
+    // Apply a penalty for segments that are in the low scoring list.
+    const adjustedResults = [...results].map(result => {
+        const segments = result.obj.uri.fsPath.split(path.sep)
+        for (const lowScoringPathSegment of lowScoringPathSegments) {
+            if (segments.includes(lowScoringPathSegment) && !query.includes(lowScoringPathSegment)) {
+                return {
+                    ...result,
+                    score: result.score - 100000,
+                }
+            }
+        }
+        return result
+    })
+
     // fuzzysort can return results in different order for the same query if
     // they have the same score :( So we do this hacky post-limit sorting (first
-    // by score, then by path) to ensure the order stays the same
-    const sortedResults = [...results].sort((a, b) => {
+    // by score, then by path) to ensure the order stays the same.
+    const sortedResults = adjustedResults.sort((a, b) => {
         return (
             b.score - a.score ||
             new Intl.Collator(undefined, { numeric: true }).compare(a.obj.uri.fsPath, b.obj.uri.fsPath)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/2401 by removing `bin/` from the ignore list and instead just penalizing it unless you have typed `bin` in the query specifically.

https://github.com/sourcegraph/cody/assets/1078012/2ad0ef3b-b2f9-45bd-bfc0-54fd77811511


## Test plan

- Run `pnpm test:unit` and ensure the new tests pass
- Open a project with a file in a folder named `bin` and ensure the file shows up in search results, near the bottom unless you've explicitly typed "bin"


