### PR TITLE
[WIP] Ensure pressing Up to re-send chat messages includes same context files

### DIFF
--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -45,11 +45,15 @@ export interface ChatMetadata {
 
 export interface UserLocalHistory {
     chat: ChatHistory
-    input: string[]
+    input: ChatInputHistory[]
 }
 
 export interface ChatHistory {
     [chatID: string]: TranscriptJSON
+}
+
+export interface ChatInputHistory {
+    inputText: string
 }
 
 export interface OldChatHistory {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,7 +1,7 @@
 // Add anything else here that needs to be used outside of this repository.
 
 export { ChatContextStatus } from './chat/context'
-export { ChatButton, ChatMessage, ChatError } from './chat/transcript/messages'
+export { ChatButton, ChatInputHistory, ChatMessage, ChatError } from './chat/transcript/messages'
 export { RateLimitError, ContextWindowLimitError } from './sourcegraph-api/errors'
 export { renderCodyMarkdown } from './chat/markdown'
 export { basename, pluralize, isDefined, dedupeWith } from './common'

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import {
     ChatButton,
     ChatContextStatus,
+    ChatInputHistory,
     ChatMessage,
     ChatModelProvider,
     CodyPrompt,
@@ -29,8 +30,8 @@ interface ChatProps extends ChatClassNames {
     contextStatus?: ChatContextStatus | null
     formInput: string
     setFormInput: (input: string) => void
-    inputHistory: string[]
-    setInputHistory: (history: string[]) => void
+    inputHistory: ChatInputHistory[]
+    setInputHistory: (history: ChatInputHistory[]) => void
     onSubmit: (text: string, submitType: ChatSubmitType, userContextFiles?: Map<string, ContextFile>) => void
     contextStatusComponent?: React.FunctionComponent<any>
     contextStatusComponentProps?: any
@@ -317,7 +318,8 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             const rowsCount = (inputValue.match(/\n/g)?.length || 0) + 1
             setInputRows(rowsCount > 25 ? 25 : rowsCount)
             setFormInput(inputValue)
-            if (inputValue !== inputHistory[historyIndex]) {
+
+            if (inputValue !== inputHistory[historyIndex]?.inputText) {
                 setHistoryIndex(inputHistory.length)
             }
         },
@@ -334,7 +336,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             setChatContextFiles(new Map())
             setSelectedChatContext(0)
             setHistoryIndex(inputHistory.length + 1)
-            setInputHistory([...inputHistory, input])
+            setInputHistory([...inputHistory, { inputText: input }])
             setDisplayCommands(null)
             setSelectedChatCommand(-1)
         },
@@ -477,16 +479,16 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 return
             }
 
-            if (formInput === inputHistory[historyIndex] || !formInput) {
+            if (formInput === inputHistory[historyIndex]?.inputText || !formInput) {
                 if (event.key === 'ArrowUp' && caretPosition === 0) {
                     const newIndex = historyIndex - 1 < 0 ? inputHistory.length - 1 : historyIndex - 1
                     setHistoryIndex(newIndex)
-                    setFormInput(inputHistory[newIndex])
+                    setFormInput(inputHistory[newIndex]?.inputText)
                 } else if (event.key === 'ArrowDown' && caretPosition === formInput.length) {
                     if (historyIndex + 1 < inputHistory.length) {
                         const newIndex = historyIndex + 1
                         setHistoryIndex(newIndex)
-                        setFormInput(inputHistory[newIndex])
+                        setFormInput(inputHistory[newIndex]?.inputText)
                     }
                 }
             }

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -1,5 +1,5 @@
 import { TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/transcript'
-import { UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatInputHistory, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { localStorage } from '../../services/LocalStorageProvider'
 import { AuthStatus } from '../protocol'
@@ -14,7 +14,11 @@ export class ChatHistoryManager {
         return chatHistory?.chat ? chatHistory.chat[sessionID] : null
     }
 
-    public async saveChat(authStatus: AuthStatus, chat: TranscriptJSON, input?: string): Promise<UserLocalHistory> {
+    public async saveChat(
+        authStatus: AuthStatus,
+        chat: TranscriptJSON,
+        input?: ChatInputHistory
+    ): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory(authStatus)
         history.chat[chat.id] = chat
         if (input) {
@@ -29,13 +33,13 @@ export class ChatHistoryManager {
     }
 
     // HumanInputHistory is the history list when user presses "up" in the chat input box
-    public async saveHumanInputHistory(authStatus: AuthStatus, input: string): Promise<UserLocalHistory> {
+    public async saveHumanInputHistory(authStatus: AuthStatus, input: ChatInputHistory): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory(authStatus)
         history.input.push(input)
         await localStorage.setChatHistory(authStatus, history)
         return history
     }
-    public getHumanInputHistory(authStatus: AuthStatus): string[] {
+    public getHumanInputHistory(authStatus: AuthStatus): ChatInputHistory[] {
         const history = localStorage.getChatHistory(authStatus)
         if (!history) {
             return []

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { ChatModelProvider, ContextFile } from '@sourcegraph/cody-shared'
 import { CodyPrompt, CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
-import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatInputHistory, ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 import { ChatSubmitType } from '@sourcegraph/cody-ui/src/Chat'
 
@@ -70,7 +70,7 @@ export class ChatPanelProvider extends MessageProvider {
                 break
             case 'submit':
                 return this.onHumanMessageSubmitted(
-                    message.text,
+                    message.input,
                     message.submitType,
                     message.contextFiles,
                     message.addEnhancedContext
@@ -140,21 +140,23 @@ export class ChatPanelProvider extends MessageProvider {
     }
 
     private async onHumanMessageSubmitted(
-        text: string,
+        input: ChatInputHistory,
         submitType: ChatSubmitType,
         contextFiles?: ContextFile[],
         addEnhancedContext = true
     ): Promise<void> {
-        logDebug('ChatPanelProvider:onHumanMessageSubmitted', 'chat', { verbose: { text, submitType } })
+        logDebug('ChatPanelProvider:onHumanMessageSubmitted', 'chat', {
+            verbose: { text: input.inputText, submitType },
+        })
 
-        await chatHistory.saveHumanInputHistory(this.authProvider.getAuthStatus(), text)
+        await chatHistory.saveHumanInputHistory(this.authProvider.getAuthStatus(), input)
 
         if (submitType === 'suggestion') {
             const args = { requestID: this.currentRequestID }
             telemetryService.log('CodyVSCodeExtension:chatPredictions:used', args, { hasV2Event: true })
         }
 
-        return this.executeRecipe('chat-question', text, 'chat', contextFiles, addEnhancedContext)
+        return this.executeRecipe('chat-question', input.inputText, 'chat', contextFiles, addEnhancedContext)
     }
 
     /**

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { ContextFile } from '@sourcegraph/cody-shared'
 import { CodyPrompt, CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
-import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatInputHistory, ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import { ChatSubmitType } from '@sourcegraph/cody-ui/src/Chat'
 
@@ -61,7 +61,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
                 void this.contextProvider.localEmbeddings?.start()
 
                 return this.onHumanMessageSubmitted(
-                    message.text,
+                    message.input,
                     message.submitType,
                     message.contextFiles,
                     message.addEnhancedContext
@@ -69,7 +69,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
             case 'edit':
                 this.transcript.removeLastInteraction()
                 // TODO: This should replay the submitted context files and/or enhanced context fetching
-                await this.onHumanMessageSubmitted(message.text, 'user')
+                await this.onHumanMessageSubmitted(message.input, 'user')
                 telemetryService.log('CodyVSCodeExtension:editChatButton:clicked', undefined, { hasV2Event: true })
                 telemetryRecorder.recordEvent('cody.editChatButton', 'clicked')
                 break
@@ -187,7 +187,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
     }
 
     private async onHumanMessageSubmitted(
-        text: string,
+        input: ChatInputHistory,
         submitType: ChatSubmitType,
         contextFiles?: ContextFile[],
         addEnhancedContext = true
@@ -196,14 +196,14 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
             verbose: { text, submitType, addEnhancedContext },
         })
 
-        await chatHistory.saveHumanInputHistory(this.authProvider.getAuthStatus(), text)
+        await chatHistory.saveHumanInputHistory(this.authProvider.getAuthStatus(), input)
 
         if (submitType === 'suggestion') {
             const args = { requestID: this.currentRequestID }
             telemetryService.log('CodyVSCodeExtension:chatPredictions:used', args, { hasV2Event: true })
         }
 
-        return this.executeRecipe('chat-question', text, 'chat', contextFiles, addEnhancedContext)
+        return this.executeRecipe('chat-question', input.inputText, 'chat', contextFiles, addEnhancedContext)
     }
 
     /**

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -13,7 +13,7 @@ import {
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { InteractionJSON } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
-import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatEventSource, ChatInputHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Typewriter } from '@sourcegraph/cody-shared/src/chat/typewriter'
 import { reformatBotMessageForChat } from '@sourcegraph/cody-shared/src/chat/viewHelpers'
 import { ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
@@ -453,7 +453,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
         this.postViewTranscript()
     }
 
-    public async saveSession(humanInput?: string): Promise<void> {
+    public async saveSession(humanInput?: ChatInputHistory): Promise<void> {
         const allHistory = await this.history.saveChat(
             this.authProvider.getAuthStatus(),
             this.chatModel.toTranscriptJSON(),
@@ -561,7 +561,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             ? createDisplayTextWithFileLinks(userContextFiles, text)
             : createDisplayTextWithFileSelection(text, this.editor.getActiveTextEditorSelection())
         this.chatModel.addHumanMessage({ text }, displayText)
-        await this.saveSession(text)
+        await this.saveSession({ inputText: text })
         // trigger the context progress indicator
         this.postViewTranscript({ speaker: 'assistant' })
         await this.generateAssistantResponse(requestID, userContextFiles, addEnhancedContext, contextSummary => {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -2,7 +2,7 @@ import { ActiveTextEditorSelectionRange, ChatModelProvider, ContextFile } from '
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { CodyPrompt, CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
-import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatInputHistory, ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { EnhancedContextContextT } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
 import { ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
@@ -27,7 +27,7 @@ export type WebviewMessage =
       } // new event log internal API (use createWebviewTelemetryService wrapper)
     | {
           command: 'submit'
-          text: string
+          input: ChatInputHistory
           submitType: ChatSubmitType
           addEnhancedContext?: boolean
           contextFiles?: ContextFile[]

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -6,7 +6,7 @@ import { ChatModelProvider, ContextFile } from '@sourcegraph/cody-shared'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { CodyPrompt } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { trailingNonAlphaNumericRegex } from '@sourcegraph/cody-shared/src/chat/prompts/utils'
-import { ChatHistory, ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatHistory, ChatInputHistory, ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { EnhancedContextContextT } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
@@ -42,7 +42,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     })
 
     const [formInput, setFormInput] = useState('')
-    const [inputHistory, setInputHistory] = useState<string[] | []>([])
+    const [inputHistory, setInputHistory] = useState<ChatInputHistory[] | []>([])
     const [userHistory, setUserHistory] = useState<ChatHistory | null>(null)
 
     const [contextStatus, setContextStatus] = useState<ChatContextStatus | null>(null)

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import { ChatModelProvider, ContextFile } from '@sourcegraph/cody-shared'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { CodyPrompt } from '@sourcegraph/cody-shared/src/chat/prompts'
-import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatInputHistory, ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import { TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
 import {
@@ -46,8 +46,8 @@ interface ChatboxProps {
     contextStatus: ChatContextStatus | null
     formInput: string
     setFormInput: (input: string) => void
-    inputHistory: string[]
-    setInputHistory: (history: string[]) => void
+    inputHistory: ChatInputHistory[]
+    setInputHistory: (history: ChatInputHistory[]) => void
     vscodeAPI: VSCodeWrapper
     telemetryService: TelemetryService
     suggestions?: string[]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
+import { ChatInputHistory, ChatMessage } from '@sourcegraph/cody-shared'
 import { Client, createClient, Transcript } from '@sourcegraph/cody-shared/src/chat/client'
-import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { ErrorLike, isErrorLike } from '@sourcegraph/cody-shared/src/common'
 import type { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { CodySvg } from '@sourcegraph/cody-ui/src/utils/icons'
@@ -69,7 +69,7 @@ export const App: React.FunctionComponent = () => {
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
     const [formInput, setFormInput] = useState('')
-    const [inputHistory, setInputHistory] = useState<string[] | []>([])
+    const [inputHistory, setInputHistory] = useState<ChatInputHistory[] | []>([])
 
     const [client, setClient] = useState<Client | null | ErrorLike>()
     useEffect(() => {


### PR DESCRIPTION
I started trying to fix https://github.com/sourcegraph/cody/issues/2195 but I'm not sure if I'm taking the right approach...

Currently the input history is just a `string[]` so we don't retain the `Map<string, ContextFile>` which maps input strings to context files for previous chat inputs. I considered just capturing these in a new state array/map so we could look a map for a previous history, however it seems you can reuse history after closing and re-opening a chat window, so to work correctly this needs to persist.

So I started changing `inputHistory: string[]` to `inputHistory: ChatInputHistory[]` so we could track both the input string and the `Map<string, ContextFile>` for context files, but it's touching a lot of code and I have some other concerns so I wanted some validation this is the right direction. In particular:

- Since this history is persisted, I think changing the shape of this object would become incompatible with earlier chats and we'd have to handle opening chats that had a `string[]` history
- Some of these changes are outside of `vscode/` and I'm not sure if they will break other clients
- I started changing the signature of `onHumanMessageSubmitted` to accept `ChatInputHistory` instead of just `string`, but this method is already accepting a `contextFiles?: ContextFile[]` which feels a little odd (maybe this is fine because there can be context files not tied to the chat input text?)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
