### PR TITLE
VS Code: remove redundant abort controller

### DIFF
--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -14,9 +14,6 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
     public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
         const log = this.logger?.startCompletion(params, this.completionsEndpoint)
 
-        const abortController = new AbortController()
-        const abortSignal = abortController.signal
-
         const requestFn = this.completionsEndpoint.startsWith('https://') ? https.request : http.request
 
         // Keep track if we have send any message to the completion callbacks
@@ -157,10 +154,6 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
 
         request.write(JSON.stringify(params))
         request.end()
-
-        abortSignal.addEventListener('abort', () => {
-            request.destroy()
-        })
 
         return () => request.destroy()
     }


### PR DESCRIPTION
## Context

- Removes redundant `abortSignal` from the completions `stream` function. It's not exposed to the outside world, so it cannot affect the execution flow of the request. @abeatrix, let me know if I misunderstood the code here.

## Test plan

1. CI
2. Tested manually that the "stop generating" chat feature works as expected.
