### PR TITLE
VS Code: remove redundant cancellation logic from the click handler

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -89,13 +89,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     enableNewChatUI,
     userInfo,
 }) => {
-    const [abortMessageInProgressInternal, setAbortMessageInProgress] = useState<() => void>(() => () => undefined)
-
     const abortMessageInProgress = useCallback(() => {
-        abortMessageInProgressInternal()
         vscodeAPI.postMessage({ command: 'abort' })
-        setAbortMessageInProgress(() => () => undefined)
-    }, [abortMessageInProgressInternal, vscodeAPI])
+    }, [vscodeAPI])
 
     const addEnhancedContext = useEnhancedContextEnabled()
 


### PR DESCRIPTION
## Context

- Removes redundant logic from the abort streaming click handler. @abeatrix, let me know if I misunderstood the code here.

## Test plan

1. CI
2. Tested manually that the "stop generating" chat feature works as expected.