### PR TITLE
Pass URIs for some context snippets

### DIFF
--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@mdi/js": "^7.2.96",
     "@sourcegraph/cody-shared": "workspace:*",
-    "classnames": "^2.3.2"
+    "classnames": "^2.3.2",
+    "vscode-uri": "^3.0.7"
   }
 }

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 
+import { URI } from 'vscode-uri'
+
 import { ActiveTextEditorSelectionRange, ContextFile } from '@sourcegraph/cody-shared'
 
 import { TranscriptAction } from '../actions/TranscriptAction'
 
 export interface FileLinkProps {
+    uri?: URI
     path: string
     repoName?: string
     revision?: string
@@ -62,6 +65,7 @@ export const EnhancedContext: React.FunctionComponent<{
                 verb: '',
                 object: (
                     <FileLink
+                        uri={file.uri}
                         path={file.fileName}
                         repoName={file.repoName}
                         revision={file.revision}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       classnames:
         specifier: ^2.3.2
         version: 2.3.2
+      vscode-uri:
+        specifier: ^3.0.7
+        version: 3.0.7
 
   slack:
     dependencies:

--- a/vscode/src/chat/chat-view/ChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/ChatPanelProvider.ts
@@ -123,7 +123,7 @@ export class ChatPanelProvider extends MessageProvider {
                 void openExternalLinks(message.value)
                 break
             case 'openFile':
-                await openFilePath(message.filePath, this.webviewPanel?.viewColumn, message.range)
+                await openFilePath(message.filePath, undefined, this.webviewPanel?.viewColumn, message.range)
                 break
             case 'openLocalFileWithRange':
                 await openLocalFileWithRange(message.filePath, message.range)

--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -17,7 +17,7 @@ import { SymfRunner } from '../../local-context/symf'
 import { repositoryRemoteUrl } from '../../repository/repositoryHelpers'
 import { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 
-interface CodebaseIdentifiers {
+export interface CodebaseIdentifiers {
     local: string
     remote?: string
     remoteRepoId?: string

--- a/vscode/src/chat/chat-view/SidebarChatProvider.ts
+++ b/vscode/src/chat/chat-view/SidebarChatProvider.ts
@@ -145,7 +145,7 @@ export class SidebarChatProvider extends MessageProvider implements vscode.Webvi
                 void openExternalLinks(message.value)
                 break
             case 'openFile':
-                await openFilePath(message.filePath, this.webviewPanel?.viewColumn)
+                await openFilePath(message.filePath, undefined, this.webviewPanel?.viewColumn)
                 break
             case 'openLocalFileWithRange':
                 await openLocalFileWithRange(message.filePath, message.range)

--- a/vscode/src/chat/chat-view/chat-helpers.test.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.test.ts
@@ -11,7 +11,9 @@ import * as vscode from '../../testutils/mocks'
 import {
     contextItemsToContextFiles,
     contextMessageToContextItem,
+    fragmentToRange,
     getChatPanelTitle,
+    rangeToFragment,
     stripContextWrapper,
 } from './chat-helpers'
 import { ContextItem } from './SimpleChatModel'
@@ -124,5 +126,27 @@ describe('getChatPanelTitle', () => {
         const title = 'Explain the relationship...'
         const result = getChatPanelTitle(title)
         expect(result).toEqual('Explain the relationship....')
+    })
+})
+
+describe('range-fragment conversion', () => {
+    test('converts a valid range to a string fragment', () => {
+        const range = { start: { line: 10, character: 5 }, end: { line: 20, character: 15 } }
+        const result = rangeToFragment(range)
+        expect(result).toEqual('L10-20')
+    })
+    test('converts a valid fragment to a range', () => {
+        const fragment = 'L10-20'
+        const expectedRange = {
+            start: {
+                line: 10,
+                character: 0,
+            },
+            end: {
+                line: 20,
+                character: 0,
+            },
+        }
+        expect(fragmentToRange(fragment)).toEqual(expectedRange)
     })
 })

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -1,19 +1,138 @@
+import path from 'path'
+
 import * as vscode from 'vscode'
 
 import { ActiveTextEditorSelectionRange } from '@sourcegraph/cody-shared'
 import { ContextFile, ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { EmbeddingsSearchResult } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
+import { CodebaseIdentifiers } from './CodebaseStatusProvider'
 import { ContextItem } from './SimpleChatModel'
 
 export const relativeFileUrlScheme = 'cody-file-relative'
-export const embeddingsUrlScheme = 'cody-embeddings'
+export const embeddingsUrlScheme = 'cody-remote-embeddings'
 
-export function relativeFileUrl(fileName: string, range?: vscode.Range): vscode.Uri {
+/**
+ * Returns a URI for a snippet returned from the remote embeddings endpoint
+ */
+export function remoteEmbeddingSnippetUri(codebase: CodebaseIdentifiers, result: EmbeddingsSearchResult): vscode.Uri {
+    return vscode.Uri.from({
+        scheme: embeddingsUrlScheme,
+        authority: codebase.remote,
+        path: '/' + result.fileName,
+        fragment: `L${result.startLine}-${result.endLine}`,
+        query: `local=${encodeURIComponent(codebase.local)}`,
+    })
+}
+
+/**
+ * Return a URI for a local file that's relative to a workspace folder.
+ */
+export function relativeFileUri(
+    absParentDir: string,
+    relPath: string,
+    range?: ActiveTextEditorSelectionRange
+): vscode.Uri {
+    return vscode.Uri.from({
+        scheme: relativeFileUrlScheme,
+        authority: absParentDir.endsWith('/') ? absParentDir.slice(0, -1) : absParentDir,
+        path: relPath.startsWith('/') ? relPath : '/' + relPath,
+        fragment: range && rangeToFragment(range),
+    })
+}
+
+/**
+ * Returns a URI for a file from a legacy ContextFile instance
+ */
+export function legacyContextFileUri(fileName: string, range?: vscode.Range): vscode.Uri {
     return vscode.Uri.from({
         scheme: relativeFileUrlScheme,
         path: fileName,
-        fragment: range && `L${range.start.line}-${range.end.line}`,
+        fragment: range && rangeToFragment(range),
     })
+}
+
+export function rangeToFragment(range: ActiveTextEditorSelectionRange): string {
+    return `L${range.start.line}-${range.end.line}`
+}
+
+export function fragmentToRange(fragment: string): ActiveTextEditorSelectionRange | undefined {
+    const match = fragment.match(/^L(\d+)-(\d+)$/)
+    if (!match) {
+        return undefined
+    }
+    return {
+        start: {
+            line: parseInt(match[1], 10),
+            character: 0,
+        },
+        end: {
+            line: parseInt(match[2], 10),
+            character: 0,
+        },
+    }
+}
+
+export async function openUri(
+    uri: vscode.Uri,
+    range?: ActiveTextEditorSelectionRange,
+    currentViewColumn?: vscode.ViewColumn
+): Promise<void> {
+    switch (uri.scheme) {
+        case embeddingsUrlScheme: {
+            const localCodebaseDir = new URLSearchParams(uri.query).get('local')
+            if (!localCodebaseDir) {
+                throw new Error(`Failed to open embeddings: missing local codebase dir from uri ${uri}`)
+            }
+            const relpath = uri.path.startsWith('/') ? uri.path.slice(1) : uri.path
+            await openFile(path.join(localCodebaseDir, relpath), range, currentViewColumn)
+            break
+        }
+        case relativeFileUrlScheme: {
+            let containerDir = uri.authority || ''
+            const relPath = uri.path.startsWith('/') ? uri.path.slice(1) : uri.path
+
+            if (containerDir === '') {
+                for (const workspaceFolder of vscode.workspace.workspaceFolders || []) {
+                    const absPath = path.join(workspaceFolder.uri.fsPath, relPath)
+                    try {
+                        await vscode.workspace.fs.stat(vscode.Uri.file(absPath))
+                        containerDir = workspaceFolder.uri.fsPath
+                        break
+                    } catch {
+                        continue
+                    }
+                }
+            }
+            if (!range) {
+                range = uri.fragment ? fragmentToRange(uri.fragment) : undefined
+            }
+
+            const absPath = path.join(containerDir, relPath)
+            await openFile(absPath, range, currentViewColumn)
+            break
+        }
+        case 'file':
+            await openFile(uri.fsPath, fragmentToRange(uri.fragment), currentViewColumn)
+            break
+        default:
+            throw new Error(`Failed to open uri ${uri}: unsupported scheme "${uri.scheme}"`)
+    }
+}
+
+export async function openFile(
+    absPath: string,
+    range?: ActiveTextEditorSelectionRange,
+    currentViewColumn?: vscode.ViewColumn
+): Promise<void> {
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(absPath))
+
+    let viewColumn = vscode.ViewColumn.Beside
+    if (currentViewColumn) {
+        viewColumn = currentViewColumn - 1 || currentViewColumn + 1
+    }
+    const selection = range ? new vscode.Range(range.start.line, 0, range.end.line, 0) : range
+    await vscode.window.showTextDocument(doc, { selection, viewColumn, preserveFocus: true, preview: true })
 }
 
 // The approximate inverse of CodebaseContext.makeContextMessageWithResponse
@@ -33,7 +152,7 @@ export function contextMessageToContextItem(contextMessage: ContextMessage): Con
         text: contextText,
         uri:
             contextMessage.file.uri ||
-            relativeFileUrl(contextMessage.file.fileName, activeEditorSelectionRangeToRange(range)),
+            legacyContextFileUri(contextMessage.file.fileName, activeEditorSelectionRangeToRange(range)),
         range: range && new vscode.Range(range.start.line, range.start.character, range.end.line, range.end.character),
     }
 }
@@ -76,6 +195,7 @@ export function contextItemsToContextFiles(items: ContextItem[]): ContextFile[] 
             relFsPath = relFsPath.slice(1)
         }
         contextFiles.push({
+            uri: item.uri,
             fileName: relFsPath,
             source: 'embeddings',
             range: rangeToActiveTextEditorSelectionRange(item.range),

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -1,3 +1,5 @@
+import { URI } from 'vscode-uri'
+
 import { ActiveTextEditorSelectionRange, ChatModelProvider, ContextFile } from '@sourcegraph/cody-shared'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { CodyPrompt, CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
@@ -47,6 +49,7 @@ export type WebviewMessage =
           command: 'openFile'
           filePath: string
           range?: ActiveTextEditorSelectionRange
+          uri?: URI
       }
     | {
           command: 'openLocalFileWithRange'

--- a/vscode/src/services/utils/workspace-action.ts
+++ b/vscode/src/services/utils/workspace-action.ts
@@ -1,6 +1,9 @@
 import * as vscode from 'vscode'
+import { URI } from 'vscode-uri'
 
 import { ActiveTextEditorSelectionRange } from '@sourcegraph/cody-shared'
+
+import { openUri } from '../../chat/chat-view/chat-helpers'
 
 let workspaceRootUri = vscode.workspace.workspaceFolders?.[0]?.uri
 let serverEndpoint = ''
@@ -19,12 +22,17 @@ export function workspaceActionsOnConfigChange(workspaceUri: vscode.Uri | null, 
  */
 export async function openFilePath(
     filePath: string,
+    uri?: URI,
     currentViewColumn?: vscode.ViewColumn,
     range?: ActiveTextEditorSelectionRange
 ): Promise<void> {
-    void vscode.commands.executeCommand('vscode.open', filePath)
     if (!workspaceRootUri) {
         throw new Error('Failed to open file: missing workspace')
+    }
+
+    if (uri) {
+        await openUri(uri, range, currentViewColumn)
+        return
     }
 
     try {

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -6,7 +6,7 @@ import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 import styles from './FileLink.module.css'
 
-export const FileLink: React.FunctionComponent<FileLinkProps> = ({ path, range, source }) => {
+export const FileLink: React.FunctionComponent<FileLinkProps> = ({ uri, path, range, source }) => {
     const pathWithRange = range?.end.line ? `${path}:${range?.start.line + 1}-${range?.end.line - 1}` : path
 
     return (
@@ -15,7 +15,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({ path, range, 
             type="button"
             title={source ? `${pathWithRange} included via ${source}` : pathWithRange}
             onClick={() => {
-                getVSCodeAPI().postMessage({ command: 'openFile', filePath: path, range })
+                getVSCodeAPI().postMessage({ command: 'openFile', filePath: path, uri, range })
             }}
         >
             {`@${pathWithRange}`}


### PR DESCRIPTION
Previously, we used the relative file name to indicate the source file of all context snippets. This causes problems, because:
* The user may have more than one workspace folder open, in which case we don't know how to resolve a relative file name, because we lose track of which workspace folder it came from
* Context from remote sources (e.g., remote embeddings) isn't attached to a local file, and we may need to treat these differently when trying to open the file

Add a URI field to keep better track of the true location of a context item. Adds creator functions for 2 URI schemes: `cody-file-relative://` and `cody-embeddings://`.

Also add an `openUri` function that handles opening these URIs and is more forgiving for `file://` URIs (will attempt to match a relative file URI with an open workspace folder).

## Test plan

1. Open at least 2 workspace folders
2. Open a file from the 2nd workspace folder
3. Create a new chat and ask a question
4. Attempt to open the context files—these should open properly, whereas before, nothing occurred

See screen recordings for examples.

Before: https://github.com/sourcegraph/cody/assets/1646931/4ae6b2a1-ce00-4d3a-86bd-25effae6495c
After: https://github.com/sourcegraph/cody/assets/1646931/2d72e149-0f0f-4704-9b2b-3fab699a5b3e