### PR TITLE
OpenAI provider requires use of topP parameter

### DIFF
--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -128,7 +128,7 @@ ${OPENING_CODE_TAG}${infillBlock}`
         const requestParams: CodeCompletionsParams = {
             ...partialRequestParams,
             messages: [{ speaker: 'human', text: this.createPrompt(snippets) }],
-            topK: 0.5,
+            topP: 0.5,
         }
 
         await generateCompletions({


### PR DESCRIPTION
Closes #2524

Regression introduced by accident [here](https://github.com/sourcegraph/cody/pull/2426/files#diff-9ed150d2122201c9bf34be216ad0ceb4d367cbc653ff240cc8408d29bf19c131R131) where a different parameter for completion request is used.

## Test plan

Tested manually

<img width="943" alt="Screenshot 2023-12-29 at 9 18 24 PM" src="https://github.com/sourcegraph/cody/assets/153410/e34950bf-dcd0-4fd6-b5e2-02246cecad85">

