### PR TITLE
Fix double agent messages with rate limit errors

### DIFF
--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -77,24 +77,24 @@
             "encoding": "base64",
             "mimeType": "application/json",
             "size": 139,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp\",\"pcklYalFxZn5eUpWSkamZgZGBvFGBkbGuoZGukZm8aZ6RrrGpsYWKamWxqZGieZKtbW1AAAAAP//AwCoWRY+SQAAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp\",\"pcklYalFxZn5eUpWSkamZsZmJvFGBkYmugaGugbG8aZ6RrrmlolJBgaGiWZppkZKtbW1AAAAAP//AwDYKpmXSQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:22.000Z",
+              "expires": "2025-01-03T16:21:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e32c2479-95e6-40dc-97c9-7a42f7e70303"
+              "value": "8dc31992-f2b4-4c95-ba28-5530e167e035"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:22.000Z",
+              "expires": "2024-01-03T16:51:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "uhts2BH3DyZ6__bmVejZE5GbLjquipkuHQdCX8hBzdg-1703613802-1-AZsEUL6N5CwDxSaow0//oUlyQW6aIl8HT1Oa1HhHwTjRFXuvw50gUfZ+aa6tSxFohmmsZfZC9zkKfifPJJRwVp8="
+              "value": "DQEiVWR07g5vD17lRwJIHAV_5NmgMr5j6Y0rOgDK1P8-1704298891-1-Adg/6my/Ad1pTs4AkL9yNnrap+13Ezya+wgP9vRS4na08yMkdgOYItfgChBIugDRYz6aylfrt1yeXegpLCjxWxg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -103,13 +103,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "BrBua471n.zl_FWhxJll8z6nT00RWm2yyLV8iQWaYr4-1703613802279-0-604800000"
+              "value": "mBMRZjoTqgIAka1rjdyia_anvmoFnd84eE5T9Tp38Mo-1704298891154-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:22 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
             },
             {
               "name": "content-type",
@@ -138,17 +138,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e32c2479-95e6-40dc-97c9-7a42f7e70303; Expires=Thu, 26 Dec 2024 18:03:22 GMT; Secure"
+              "value": "sourcegraphDeviceId=8dc31992-f2b4-4c95-ba28-5530e167e035; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=uhts2BH3DyZ6__bmVejZE5GbLjquipkuHQdCX8hBzdg-1703613802-1-AZsEUL6N5CwDxSaow0//oUlyQW6aIl8HT1Oa1HhHwTjRFXuvw50gUfZ+aa6tSxFohmmsZfZC9zkKfifPJJRwVp8=; path=/; expires=Tue, 26-Dec-23 18:33:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=DQEiVWR07g5vD17lRwJIHAV_5NmgMr5j6Y0rOgDK1P8-1704298891-1-Adg/6my/Ad1pTs4AkL9yNnrap+13Ezya+wgP9vRS4na08yMkdgOYItfgChBIugDRYz6aylfrt1yeXegpLCjxWxg=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=BrBua471n.zl_FWhxJll8z6nT00RWm2yyLV8iQWaYr4-1703613802279-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=mBMRZjoTqgIAka1rjdyia_anvmoFnd84eE5T9Tp38Mo-1704298891154-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -164,15 +164,15 @@
             },
             {
               "name": "x-trace",
-              "value": "a116d2a0da0994bc2aa2d74b2eb47ed2"
+              "value": "483df82c01dc5fc6f2230bdb16d76b51"
             },
             {
               "name": "x-trace-span",
-              "value": "37a422d6e1584bfc"
+              "value": "4933c1ab05e5d4c1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a116d2a0da0994bc2aa2d74b2eb47ed2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/483df82c01dc5fc6f2230bdb16d76b51"
             },
             {
               "name": "x-xss-protection",
@@ -196,7 +196,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d772d4a3524-WAW"
+              "value": "83fc9344bac6bfad-WAW"
             },
             {
               "name": "content-encoding",
@@ -209,8 +209,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:21.909Z",
-        "time": 283,
+        "startedDateTime": "2024-01-03T16:21:30.898Z",
+        "time": 238,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -218,7 +218,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 283
+          "wait": 238
         }
       },
       {
@@ -286,29 +286,29 @@
           "url": "https://sourcegraph.com/.api/graphql?Repository"
         },
         "response": {
-          "bodySize": 158,
+          "bodySize": 148,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 158,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8=\",\"AwD/h5WCVAAAAA==\"]"
+            "size": 148,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:22.000Z",
+              "expires": "2025-01-03T16:21:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "502c93af-acf3-4d26-ba20-2a1628bd7d70"
+              "value": "4df446eb-42b6-4154-a16a-f0249202c3d2"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:22.000Z",
+              "expires": "2024-01-03T16:51:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": ".uMpotU9nsoGSrES4NOYF08phsrnm5CiNJamB4sKbmo-1703613802-1-AdUlCTTueWtope87jYUqP4BTLwXIDr+pcknqm2wq+ObN2bOlWPrclpYbUSE7pz8LK+pEbQI+BXUQrOYcumIgsDI="
+              "value": "yaNKJ.NbjPyXEKUIi2aZ2z8MoF8tsibir0WC4iOHppw-1704298891-1-ARLWtx7kQ2Z+wy68XmG0qvOUwLQnEc+c3oBW16Bn0zcd4RDRzZy5zpPrDp1JqosupD7+lwu5ae7TjL9w5QhWqUQ="
             },
             {
               "domain": ".sourcegraph.com",
@@ -317,13 +317,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "X2fxaTc8doojX2ct8vhbRvQV.9L6VqhltZvD5esL290-1703613802772-0-604800000"
+              "value": "QWLlGVa.dTd7zzBaCn28XgcwtMTQGXNC2AFcBY.K.pc-1704298891604-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:22 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
             },
             {
               "name": "content-type",
@@ -352,17 +352,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=502c93af-acf3-4d26-ba20-2a1628bd7d70; Expires=Thu, 26 Dec 2024 18:03:22 GMT; Secure"
+              "value": "sourcegraphDeviceId=4df446eb-42b6-4154-a16a-f0249202c3d2; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=.uMpotU9nsoGSrES4NOYF08phsrnm5CiNJamB4sKbmo-1703613802-1-AdUlCTTueWtope87jYUqP4BTLwXIDr+pcknqm2wq+ObN2bOlWPrclpYbUSE7pz8LK+pEbQI+BXUQrOYcumIgsDI=; path=/; expires=Tue, 26-Dec-23 18:33:22 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=yaNKJ.NbjPyXEKUIi2aZ2z8MoF8tsibir0WC4iOHppw-1704298891-1-ARLWtx7kQ2Z+wy68XmG0qvOUwLQnEc+c3oBW16Bn0zcd4RDRzZy5zpPrDp1JqosupD7+lwu5ae7TjL9w5QhWqUQ=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=X2fxaTc8doojX2ct8vhbRvQV.9L6VqhltZvD5esL290-1703613802772-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=QWLlGVa.dTd7zzBaCn28XgcwtMTQGXNC2AFcBY.K.pc-1704298891604-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -378,15 +378,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e89c2cee723a15152efb91aae7264a1b"
+              "value": "b294a5ffdc842ba0c105b11513e76201"
             },
             {
               "name": "x-trace-span",
-              "value": "f72af4c113fa6697"
+              "value": "d314e5e8b28ed3d9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e89c2cee723a15152efb91aae7264a1b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b294a5ffdc842ba0c105b11513e76201"
             },
             {
               "name": "x-xss-protection",
@@ -410,7 +410,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7a5c8f34b0-WAW"
+              "value": "83fc93475fff34fe-WAW"
             },
             {
               "name": "content-encoding",
@@ -423,8 +423,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:22.441Z",
-        "time": 244,
+        "startedDateTime": "2024-01-03T16:21:31.352Z",
+        "time": 233,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -432,7 +432,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 244
+          "wait": 233
         }
       },
       {
@@ -500,29 +500,29 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
         },
         "response": {
-          "bodySize": 222,
+          "bodySize": 212,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 222,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaR\",\"wfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8=\",\"AwBhzrhaoAAAAA==\"]"
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:22.000Z",
+              "expires": "2025-01-03T16:21:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d5e42eab-848b-42cd-bc15-a119a11e41ad"
+              "value": "ca434d8e-9dc0-4610-a141-53d099c937ac"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
+              "expires": "2024-01-03T16:51:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "LABRwLCf6fiEMjiLLAuJ6bt4YBqHXFjidjrLkrvYbfw-1703613803-1-AfkdBW1TcDNz0ejIDvnclUAhn6zhzOnUuP9b6FqOxDhLus4dBQSgdq+jxJnASKapi1I2mns+yQRkyIN3oLLxVEk="
+              "value": "iSPyJq7p3ZmRmAowZwj6.aEuYcmxKs5Ry6hP1WhqP9o-1704298891-1-AcDu6gkBYs45F63shQywz4DVRVDq1jtX9vqwYl3xEUKC52H7+qK5VkCEprUA/qVYP8QqKBngVGYNtjKGPYEqejw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -531,13 +531,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "VZdCZ0C4qnDvh46pFyVOi9pFlgYgNodrvrTYYlgz8Oo-1703613803047-0-604800000"
+              "value": "skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
             },
             {
               "name": "content-type",
@@ -566,17 +566,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d5e42eab-848b-42cd-bc15-a119a11e41ad; Expires=Thu, 26 Dec 2024 18:03:22 GMT; Secure"
+              "value": "sourcegraphDeviceId=ca434d8e-9dc0-4610-a141-53d099c937ac; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=LABRwLCf6fiEMjiLLAuJ6bt4YBqHXFjidjrLkrvYbfw-1703613803-1-AfkdBW1TcDNz0ejIDvnclUAhn6zhzOnUuP9b6FqOxDhLus4dBQSgdq+jxJnASKapi1I2mns+yQRkyIN3oLLxVEk=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=iSPyJq7p3ZmRmAowZwj6.aEuYcmxKs5Ry6hP1WhqP9o-1704298891-1-AcDu6gkBYs45F63shQywz4DVRVDq1jtX9vqwYl3xEUKC52H7+qK5VkCEprUA/qVYP8QqKBngVGYNtjKGPYEqejw=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=VZdCZ0C4qnDvh46pFyVOi9pFlgYgNodrvrTYYlgz8Oo-1703613803047-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -592,15 +592,15 @@
             },
             {
               "name": "x-trace",
-              "value": "efcf856bef47f01e0111f85075045df3"
+              "value": "d77b46a41789ce29c1bef11b11c95743"
             },
             {
               "name": "x-trace-span",
-              "value": "e16be3f0090b8db3"
+              "value": "2cea555ab9fe1998"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/efcf856bef47f01e0111f85075045df3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d77b46a41789ce29c1bef11b11c95743"
             },
             {
               "name": "x-xss-protection",
@@ -624,7 +624,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7c0e663510-WAW"
+              "value": "83fc9348ef753572-WAW"
             },
             {
               "name": "content-encoding",
@@ -637,8 +637,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:22.701Z",
-        "time": 258,
+        "startedDateTime": "2024-01-03T16:21:31.594Z",
+        "time": 212,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -646,7 +646,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 258
+          "wait": 212
         }
       },
       {
@@ -723,20 +723,20 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:22.000Z",
+              "expires": "2025-01-03T16:21:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "07fa14db-ca2a-4b0b-b9e4-35d974573ca3"
+              "value": "d8c6c7dd-945f-4b1b-aa4c-f045c1b4d1b5"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
+              "expires": "2024-01-03T16:51:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "tlXMvO1MXU43hs6vv0T49VC6D2qyoYUaAAHcENgipmA-1703613803-1-AWTnrDkQLxDk5KwyBoTeHOP5BhioLSBcr1NbjTXrVUeFPJN9Mg1lxdtE9Y4QdSsOHUllQGXekssi1P4Aoo3PtBk="
+              "value": "ZnJc6wpO9ekBTL7GUBErys1hrDCfhwUGxptp_eaMAA0-1704298891-1-AZZya4Ex+IAQMqz48CC2CooH1srSYaiB2VQ0tKk5lpPzIWIv/IlHUnlHmFl9U6LsrIvktC7KLc5XD2zNOjpAoTg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -745,13 +745,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "v00oZD0e4A.Gw61JLLuublVVVEDNRadHBgDa5L7JUd4-1703613803045-0-604800000"
+              "value": "skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
             },
             {
               "name": "content-type",
@@ -780,17 +780,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=07fa14db-ca2a-4b0b-b9e4-35d974573ca3; Expires=Thu, 26 Dec 2024 18:03:22 GMT; Secure"
+              "value": "sourcegraphDeviceId=d8c6c7dd-945f-4b1b-aa4c-f045c1b4d1b5; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=tlXMvO1MXU43hs6vv0T49VC6D2qyoYUaAAHcENgipmA-1703613803-1-AWTnrDkQLxDk5KwyBoTeHOP5BhioLSBcr1NbjTXrVUeFPJN9Mg1lxdtE9Y4QdSsOHUllQGXekssi1P4Aoo3PtBk=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ZnJc6wpO9ekBTL7GUBErys1hrDCfhwUGxptp_eaMAA0-1704298891-1-AZZya4Ex+IAQMqz48CC2CooH1srSYaiB2VQ0tKk5lpPzIWIv/IlHUnlHmFl9U6LsrIvktC7KLc5XD2zNOjpAoTg=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=v00oZD0e4A.Gw61JLLuublVVVEDNRadHBgDa5L7JUd4-1703613803045-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -806,15 +806,15 @@
             },
             {
               "name": "x-trace",
-              "value": "4399c68ff245386efdf6d1ee8f959d60"
+              "value": "1147d60a37380342b52e4cc6318e895a"
             },
             {
               "name": "x-trace-span",
-              "value": "fea973590c09cf01"
+              "value": "49a69c3d244f5f8e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4399c68ff245386efdf6d1ee8f959d60"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1147d60a37380342b52e4cc6318e895a"
             },
             {
               "name": "x-xss-protection",
@@ -838,7 +838,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7c097f3bc9-WAW"
+              "value": "83fc9348eba43479-WAW"
             },
             {
               "name": "content-encoding",
@@ -851,8 +851,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:22.707Z",
-        "time": 254,
+        "startedDateTime": "2024-01-03T16:21:31.597Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -860,7 +860,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 254
+          "wait": 210
         }
       },
       {
@@ -937,20 +937,20 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:22.000Z",
+              "expires": "2025-01-03T16:21:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "a5bcd897-c27d-4710-93ee-f604ea382661"
+              "value": "51d7b782-aa37-413a-a0d6-d47b3827293f"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
+              "expires": "2024-01-03T16:51:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "5X4XnObqY3_9YopxBizN5mEjqcS9t81bjAQjANz8c5Q-1703613803-1-Aa9UU+A+CvccD4znykZ2drBZlQ7Qfg6b06WECEOwnEYPfkMWOrnEofqThjIXRDco9zrP83ETI3jXZx0H6qfNg5w="
+              "value": "ag7mU1fUQ9mz0bdKacnJqlqzEdyQSBssbiAYXMyS9TY-1704298891-1-ARTzpK8jclpEAuK9FUBqU3ys/kk6woAfSAEsmNL4jEb2b3Ik9HUNpqIO2Pzjn/F8QbxMai2SdlSBLF9yojQn8Gs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -959,13 +959,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "uUcM.Tc2OlumDSDcUpZriOu6_UIJ7rei31tWXOlb5ZA-1703613803057-0-604800000"
+              "value": "za1ZJXvC4TW4.3UxZ9K0Ki32RB2HBj_SWcShfeaeWSU-1704298891827-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
             },
             {
               "name": "content-type",
@@ -994,17 +994,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a5bcd897-c27d-4710-93ee-f604ea382661; Expires=Thu, 26 Dec 2024 18:03:22 GMT; Secure"
+              "value": "sourcegraphDeviceId=51d7b782-aa37-413a-a0d6-d47b3827293f; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=5X4XnObqY3_9YopxBizN5mEjqcS9t81bjAQjANz8c5Q-1703613803-1-Aa9UU+A+CvccD4znykZ2drBZlQ7Qfg6b06WECEOwnEYPfkMWOrnEofqThjIXRDco9zrP83ETI3jXZx0H6qfNg5w=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ag7mU1fUQ9mz0bdKacnJqlqzEdyQSBssbiAYXMyS9TY-1704298891-1-ARTzpK8jclpEAuK9FUBqU3ys/kk6woAfSAEsmNL4jEb2b3Ik9HUNpqIO2Pzjn/F8QbxMai2SdlSBLF9yojQn8Gs=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=uUcM.Tc2OlumDSDcUpZriOu6_UIJ7rei31tWXOlb5ZA-1703613803057-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=za1ZJXvC4TW4.3UxZ9K0Ki32RB2HBj_SWcShfeaeWSU-1704298891827-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1020,15 +1020,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5f4895e9038054feb1601b8b9ad9df53"
+              "value": "3d03de286523582ba189b76dc0343ef5"
             },
             {
               "name": "x-trace-span",
-              "value": "66e6bf2c2d7953da"
+              "value": "5d80e5a1f73d3e74"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5f4895e9038054feb1601b8b9ad9df53"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3d03de286523582ba189b76dc0343ef5"
             },
             {
               "name": "x-xss-protection",
@@ -1052,7 +1052,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7c1ecd34d0-WAW"
+              "value": "83fc9348f94834f8-WAW"
             },
             {
               "name": "content-encoding",
@@ -1065,8 +1065,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:22.705Z",
-        "time": 264,
+        "startedDateTime": "2024-01-03T16:21:31.596Z",
+        "time": 211,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1074,7 +1074,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 264
+          "wait": 211
         }
       },
       {
@@ -1142,29 +1142,29 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
         },
         "response": {
-          "bodySize": 307,
+          "bodySize": 304,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 307,
-            "text": "[\"H4sIAAAAAAAAAyyOsWrDMBRFf6Xc2dgNpIUIQrtk\",\"amJCSULXF+nFVi1b5kkKGOOl/9b/KiLd7j3D4cwwFAlqhk4iPMRzYMnXGihcvmqnv/10OOnn+tRsUaClcGGxN8tm15N1UFESFzA2jI6mmnqGwtH6KE8fqbP8+9MRCtCdIsn5cw+FNsYxqKp6sFA2NrbpmgKL9kPkIZba91WqVi+rzet683bfrlFAezMdxe8Gujo2UDdygQuMYnuS6T9mBj8GxpxQdjnBdfTeZJy9WJZl+QMAAP//AwDQJ9BE9wAAAA==\"]"
+            "size": 304,
+            "text": "[\"H4sIAAAAAAAAAyyOsWrDMBRFf6Xc2dgNpIUIQrtkamJCSULXF+nFVi1b5kkKGOOl/9b/KiLd7j3D4cwwFAlqhk4iPMRzYMnXGihcvmqnv/10OOnn+tRsUaClcGGxN8tm15N1UFESFzA2jI6mmnqGwtH6KE8fqbP8+9MRCtCdIsn5cw+FNsYxqKp6sFA2NrbpmgKL9kPkIZba91WqVi+rzet683bfrlFAezMdxe8Gujo2UDdygQuMYnuS6T9mBj8GxpxQdjnBdfTeZJy9WJZl+QMAAP//AwDQJ9BE9wAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:23.000Z",
+              "expires": "2025-01-03T16:21:31.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "60a30d8d-1396-4c5f-9dac-8d3c367f3572"
+              "value": "60f18308-2db4-4f15-8116-e73c313f984f"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
+              "expires": "2024-01-03T16:51:32.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "2P8WSXjfTH10iS4s8F7aH_TjTDieVdnSqE4Z0D7LINc-1703613803-1-AR+jhdB7lq0YOQP7u5ZgVvF8R7JsXQUIcuqcaHy0v3OnwhFT1hsGi0BG6CtC5q55CbNf03yP/UlEGTqtrwDacqI="
+              "value": "h7p969sGHDS6bePDcYUCxX_dcDTWnX58ZA.bDyd0vjs-1704298892-1-AS4B4uEXSmek51Yt4aBhmWhomVINTDPlOsamZp+1oZ+RkzzzI2wBZJirOEtDalR7qmo0+LR/pJQHxO9VhfRLh8A="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1173,13 +1173,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "oJyarRVc9Ljbs8JBsE_Pl7JNI4LtjMz246ZNiVTikOo-1703613803309-0-604800000"
+              "value": "SzwGZDY8A7NVnOfCkurNXTdWyTIywzFzRZ2L_DEYcnU-1704298892074-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
             },
             {
               "name": "content-type",
@@ -1208,17 +1208,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=60a30d8d-1396-4c5f-9dac-8d3c367f3572; Expires=Thu, 26 Dec 2024 18:03:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=60f18308-2db4-4f15-8116-e73c313f984f; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=2P8WSXjfTH10iS4s8F7aH_TjTDieVdnSqE4Z0D7LINc-1703613803-1-AR+jhdB7lq0YOQP7u5ZgVvF8R7JsXQUIcuqcaHy0v3OnwhFT1hsGi0BG6CtC5q55CbNf03yP/UlEGTqtrwDacqI=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=h7p969sGHDS6bePDcYUCxX_dcDTWnX58ZA.bDyd0vjs-1704298892-1-AS4B4uEXSmek51Yt4aBhmWhomVINTDPlOsamZp+1oZ+RkzzzI2wBZJirOEtDalR7qmo0+LR/pJQHxO9VhfRLh8A=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=oJyarRVc9Ljbs8JBsE_Pl7JNI4LtjMz246ZNiVTikOo-1703613803309-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=SzwGZDY8A7NVnOfCkurNXTdWyTIywzFzRZ2L_DEYcnU-1704298892074-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1234,15 +1234,15 @@
             },
             {
               "name": "x-trace",
-              "value": "ddb97c30db0c319601750f5ce6e60a19"
+              "value": "84052aad647fb4ca9fe16434a18df8ec"
             },
             {
               "name": "x-trace-span",
-              "value": "86efba758b404a9f"
+              "value": "6bb98c52c799eeca"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ddb97c30db0c319601750f5ce6e60a19"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/84052aad647fb4ca9fe16434a18df8ec"
             },
             {
               "name": "x-xss-protection",
@@ -1266,7 +1266,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7dab750030-WAW"
+              "value": "83fc934a7e9a34bc-WAW"
             },
             {
               "name": "content-encoding",
@@ -1279,8 +1279,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:22.981Z",
-        "time": 240,
+        "startedDateTime": "2024-01-03T16:21:31.837Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1288,7 +1288,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 240
+          "wait": 218
         }
       },
       {
@@ -1356,29 +1356,29 @@
           "url": "https://sourcegraph.com/.api/graphql?Repository"
         },
         "response": {
-          "bodySize": 123,
+          "bodySize": 120,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 123,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA==\"]"
+            "size": 120,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:23.000Z",
+              "expires": "2025-01-03T16:21:32.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c69e0739-b36e-4e80-866b-0a8a134796e6"
+              "value": "4f1fefea-89d9-4cb3-912c-6de8635f3cea"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
+              "expires": "2024-01-03T16:51:32.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "wr_MZeJG_R1Kxs3SUrBta.rK2vCr9EcQqvG.c2UZufs-1703613803-1-AfxwNE6VPbUhszGmQHqc3oFH/wF0wck0Ay47jU1PpWuiVWvz6KUFTUOdshhRWgJ/2EiHADuEg6+Xhq3Htm5C2mQ="
+              "value": "_iIQJtzT3yTNrBN7GFIHPhN0xY7p8XBKWEkaY0hTpEM-1704298892-1-AYIMh0KTqDGIeXm1KVHd7SCrYgHe1TojmZYQ999S4897oLVRS0c8999Mlp948vogw/8lQ8p/A3KT99GGMt2MX00="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1387,13 +1387,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "hsssj50xBM8pjQ.Gjc5uDJ9QWfbTO61UIxOH19GL6n8-1703613803576-0-604800000"
+              "value": "8Nf51mMTa82X01ClWb2zLnwEP6pAOwrRx8p4z2gK2Xg-1704298892298-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
             },
             {
               "name": "content-type",
@@ -1422,17 +1422,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c69e0739-b36e-4e80-866b-0a8a134796e6; Expires=Thu, 26 Dec 2024 18:03:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=4f1fefea-89d9-4cb3-912c-6de8635f3cea; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=wr_MZeJG_R1Kxs3SUrBta.rK2vCr9EcQqvG.c2UZufs-1703613803-1-AfxwNE6VPbUhszGmQHqc3oFH/wF0wck0Ay47jU1PpWuiVWvz6KUFTUOdshhRWgJ/2EiHADuEg6+Xhq3Htm5C2mQ=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=_iIQJtzT3yTNrBN7GFIHPhN0xY7p8XBKWEkaY0hTpEM-1704298892-1-AYIMh0KTqDGIeXm1KVHd7SCrYgHe1TojmZYQ999S4897oLVRS0c8999Mlp948vogw/8lQ8p/A3KT99GGMt2MX00=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=hsssj50xBM8pjQ.Gjc5uDJ9QWfbTO61UIxOH19GL6n8-1703613803576-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=8Nf51mMTa82X01ClWb2zLnwEP6pAOwrRx8p4z2gK2Xg-1704298892298-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1448,15 +1448,15 @@
             },
             {
               "name": "x-trace",
-              "value": "0d58acf7a03799b65ab8cddfe72b3d91"
+              "value": "7fbbe6025ea006366e22045b058b2044"
             },
             {
               "name": "x-trace-span",
-              "value": "a5f452aa4fa2a402"
+              "value": "2af19bcc4b9f82a1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0d58acf7a03799b65ab8cddfe72b3d91"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7fbbe6025ea006366e22045b058b2044"
             },
             {
               "name": "x-xss-protection",
@@ -1480,7 +1480,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7f48b2502a-WAW"
+              "value": "83fc934bd987bff3-WAW"
             },
             {
               "name": "content-encoding",
@@ -1493,8 +1493,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:23.235Z",
-        "time": 253,
+        "startedDateTime": "2024-01-03T16:21:32.066Z",
+        "time": 213,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1502,7 +1502,221 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 253
+          "wait": 213
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 335,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 440,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 440,
+            "text": "[\"H4sIAAAAAAAAA5RSS24CMQy9S9b4AnOAXqLqwpN4EpdMPHUcIELcvRpRVQh1oKz9nt/HPruAhm44OzpgbmgU3gitKb1ljNUN72dXcCY3OC+hAzYTL/OSyQhCLzizh7ll48yF4GfEUqrbuXUjuWHCXOmy+10kCxUvgaLikrZhlWNpC9SmB+pABcdMYRs+ZhlhwUhQj2w+ASphhZpEzTd74MdLMcVqV/eMxaD2YniCxDFljsm4xEf8+2LWjXQyyOIxw8ynW+Om7X/scYr33D+lFxX4JBsV+bb2pzqm6J8H8wkNZvF7MKr2SguB63ozUPLdZy4RZIJF6cDSKih9NaqP73IN90KkQBO2bFANdX0xhdRH5QBVmvqnH0eoPkGhI+ypH0XDS3E3tDftG2WaybQDnRZRuwN+XC7fAAAA//8DAKhp1z2eAwAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2b4f00ad-479f-4bbb-a6ee-a8086d408dcf"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "cdHIqQ3q0xSrUPuHp3Z2ZiJGZGuKl7AD_jbrDFETR4M-1704298892-1-ARhdCcjaU1cbVJ+I1Q0vUiMizyswK4mkyaNrnt6ErnNtEzETN1JuqUTW3Ka65AWOHoOWGFD3E22edzphAMUsnFA="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "gzFoZyLgMSEA5sQzKTWgGZCcmmblP1nigsNApq5us1A-1704298892323-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2b4f00ad-479f-4bbb-a6ee-a8086d408dcf; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=cdHIqQ3q0xSrUPuHp3Z2ZiJGZGuKl7AD_jbrDFETR4M-1704298892-1-ARhdCcjaU1cbVJ+I1Q0vUiMizyswK4mkyaNrnt6ErnNtEzETN1JuqUTW3Ka65AWOHoOWGFD3E22edzphAMUsnFA=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=gzFoZyLgMSEA5sQzKTWgGZCcmmblP1nigsNApq5us1A-1704298892323-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4cad2a4386e49975a194a112bfbe0a36"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "ee5d334af561224e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4cad2a4386e49975a194a112bfbe0a36"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc934bd9afc01e-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:32.065Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
         }
       },
       {
@@ -1578,20 +1792,20 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:23.000Z",
+              "expires": "2025-01-03T16:21:32.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0b091d00-f204-45d1-a9f5-8251c46e44ac"
+              "value": "de5cdbd5-6000-403d-9b8a-eb4c48e341b4"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
+              "expires": "2024-01-03T16:51:32.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "qqk437v96MxB977QiQ_dQpyaskjibP33az8DQsUYePA-1703613803-1-Ab0LpDbTAKo5G/RYlnVtn6inNeOj9jAWjMzSd8LBiQoeIV309YS8FeUWas6yJIu4nVfZP1r8ljA6ONwCr1RVjVU="
+              "value": "xPpi0SUT5h054zqbl.LKZ0HrbjTZRyta3wN9WlLiLrs-1704298892-1-AeIjPf/Xh4tcG2kZKydepUVd1i2b1t4zChoHWeihgkFoPbjbrVBAbzvK5udi5bE7XITDrF2Q1F7yf5nOhgzFNe8="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1600,13 +1814,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "qEfwYD0sk4MU1keuMLU6t6.aM1UCCwR0u8lotgOoGY8-1703613803578-0-604800000"
+              "value": "RdfyQTFVcllfnD7h2XsMEUi7MUfrIn3yFaxOCsjFR2k-1704298892329-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
             },
             {
               "name": "content-type",
@@ -1635,17 +1849,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0b091d00-f204-45d1-a9f5-8251c46e44ac; Expires=Thu, 26 Dec 2024 18:03:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=de5cdbd5-6000-403d-9b8a-eb4c48e341b4; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=qqk437v96MxB977QiQ_dQpyaskjibP33az8DQsUYePA-1703613803-1-Ab0LpDbTAKo5G/RYlnVtn6inNeOj9jAWjMzSd8LBiQoeIV309YS8FeUWas6yJIu4nVfZP1r8ljA6ONwCr1RVjVU=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=xPpi0SUT5h054zqbl.LKZ0HrbjTZRyta3wN9WlLiLrs-1704298892-1-AeIjPf/Xh4tcG2kZKydepUVd1i2b1t4zChoHWeihgkFoPbjbrVBAbzvK5udi5bE7XITDrF2Q1F7yf5nOhgzFNe8=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=qEfwYD0sk4MU1keuMLU6t6.aM1UCCwR0u8lotgOoGY8-1703613803578-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=RdfyQTFVcllfnD7h2XsMEUi7MUfrIn3yFaxOCsjFR2k-1704298892329-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1661,15 +1875,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3b7092eab7cdc7f123b55c095d182c77"
+              "value": "1b91fb5097598636086e1139a03f0f5e"
             },
             {
               "name": "x-trace-span",
-              "value": "dc57fd17b50a0953"
+              "value": "45fc9a78b92419c6"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3b7092eab7cdc7f123b55c095d182c77"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1b91fb5097598636086e1139a03f0f5e"
             },
             {
               "name": "x-xss-protection",
@@ -1693,7 +1907,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d7f4eecbf47-WAW"
+              "value": "83fc934bd8aaffbc-WAW"
             }
           ],
           "headersSize": 1286,
@@ -1702,8 +1916,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:23.238Z",
-        "time": 252,
+        "startedDateTime": "2024-01-03T16:21:32.069Z",
+        "time": 241,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1711,430 +1925,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 252
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 335,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 448,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 448,
-            "text": "[\"H4sIAAAAAAAAA6xSSW7DMAz8i87hB/yAfKLogZZpSY0sqiSV2Ajy9yJIlzRBnRboWZqFM3N0Axq67uhoj7mh0bAltCa0zRjUdU9HV3Ai1znPwwLYjD1PNZMRDEvBKXmYWraUUyF4f0pc1G3cmZFcN2JWOm0+ifrMPVQMBHpI5iOgECpoZDHfbAV5b8FzMZoNMnvMMKWZhi+4SbtD+4gGE/sdGKn9RcoEfSrhZ4imUFoFbbKnBahgn6/dPFYYaMSWDdRQPA8kEJde0oOLqvD6h+8aSc++QMgvPqcSgEeoQvvETUHotZGuV1BMUO1SdcJioEsxnCGmEHMK0VZD4krlfFsQrPE/wgHlJv5XfFUYXsh6wXS9z5vMlFB8hEIH2NFyYFnp0CjTRCYL0FxZ7A9FfCy3H8Ptbi8qz6fTGwAAAP//AwD1+CotngMAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "de1484f7-d9fa-4530-a517-cd60bd66210d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:23.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "WCg_eTV2IHBmyI6m2asY8op27z8dSBl7HaTFgV2e254-1703613803-1-Absrp4NJOSyXolWK1beua2RE6DVWN9S5aIy+gqi9Cdzos5XVl+j+vhqpLYZW2Ix+VoKiJqDp8XXGpwsDEULiF/c="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "XUrRNkdeD8cIK6BDEyA2SEKI8e8KWaGV3Y_DHn1MhAk-1703613803582-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:23 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=de1484f7-d9fa-4530-a517-cd60bd66210d; Expires=Thu, 26 Dec 2024 18:03:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=WCg_eTV2IHBmyI6m2asY8op27z8dSBl7HaTFgV2e254-1703613803-1-Absrp4NJOSyXolWK1beua2RE6DVWN9S5aIy+gqi9Cdzos5XVl+j+vhqpLYZW2Ix+VoKiJqDp8XXGpwsDEULiF/c=; path=/; expires=Tue, 26-Dec-23 18:33:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=XUrRNkdeD8cIK6BDEyA2SEKI8e8KWaGV3Y_DHn1MhAk-1703613803582-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "348f3a36442cc931455f69494d2b586a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "09c99238e9816e77"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/348f3a36442cc931455f69494d2b586a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d7f4cae70c3-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:23.236Z",
-        "time": 256,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 256
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:24.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "72bc5fc6-6ea5-4387-aa25-2a8090c5d254"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:24.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "lGCyMLWZTmqoa3xnr.Nm5cPPz.JJmzkNIlX5vqvNPCg-1703613804-1-AUFdRYAgMeCvhAjYowxEHLwbnpiW2x0YaIYNe/m5ghVhfdDaeIrgCHHh6Edmh85XuM7RwWtFKbHl3IkdfO0N+jY="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "SHx7QRYP4A6Nn1v7yfjQ.34zVTDNlnS.BGVcwJE8Y5o-1703613804266-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:24 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=72bc5fc6-6ea5-4387-aa25-2a8090c5d254; Expires=Thu, 26 Dec 2024 18:03:24 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=lGCyMLWZTmqoa3xnr.Nm5cPPz.JJmzkNIlX5vqvNPCg-1703613804-1-AUFdRYAgMeCvhAjYowxEHLwbnpiW2x0YaIYNe/m5ghVhfdDaeIrgCHHh6Edmh85XuM7RwWtFKbHl3IkdfO0N+jY=; path=/; expires=Tue, 26-Dec-23 18:33:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=SHx7QRYP4A6Nn1v7yfjQ.34zVTDNlnS.BGVcwJE8Y5o-1703613804266-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4b9c741ecbef3d8578fdf76fb625be7b"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "475b6d0c86585dcd"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4b9c741ecbef3d8578fdf76fb625be7b"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d839d54f2e4-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:23.781Z",
-        "time": 397,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 397
+          "wait": 241
         }
       },
       {
@@ -2210,20 +2001,20 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:24.000Z",
+              "expires": "2025-01-03T16:21:32.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "9dedf2b3-58fb-4805-98a0-d02dea1935e6"
+              "value": "1988b49f-f42a-4c2b-8440-74881be63aed"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:24.000Z",
+              "expires": "2024-01-03T16:51:32.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "UomqilXdPUp.WJrUHaXICgaeP1gN32SsGK_3KWO9DJw-1703613804-1-AUoucBGjWQ1B4SsT5TZ8vM7dLq1Dw0VA+TAozfYxNebzB7X53R49udaJA7GtwcBvEnwmizIPRsb8He6FZ/uCYTE="
+              "value": "umC0BWCyOEr1NOz7fe9MYo3L3yaC32zhzZRBve05mQU-1704298892-1-AbkJbZ4YYaUYq+55gErIw92fXmQ59sst2Rx+dYLW2lu/7j2JOovllPzc/BjehOgAtqVuteoeaZBJDrG74fEl6vY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2232,13 +2023,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3dIQj8Gb1Vtg28o9BIzLO3m4HTqlJBM8aAK5uqBFCl8-1703613804268-0-604800000"
+              "value": "CGnt51Bk_SuqnozdgP94BzV_y3QozDqZ_RKQno4Ffr4-1704298892794-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:24 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
             },
             {
               "name": "content-type",
@@ -2267,17 +2058,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=9dedf2b3-58fb-4805-98a0-d02dea1935e6; Expires=Thu, 26 Dec 2024 18:03:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=1988b49f-f42a-4c2b-8440-74881be63aed; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=UomqilXdPUp.WJrUHaXICgaeP1gN32SsGK_3KWO9DJw-1703613804-1-AUoucBGjWQ1B4SsT5TZ8vM7dLq1Dw0VA+TAozfYxNebzB7X53R49udaJA7GtwcBvEnwmizIPRsb8He6FZ/uCYTE=; path=/; expires=Tue, 26-Dec-23 18:33:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=umC0BWCyOEr1NOz7fe9MYo3L3yaC32zhzZRBve05mQU-1704298892-1-AbkJbZ4YYaUYq+55gErIw92fXmQ59sst2Rx+dYLW2lu/7j2JOovllPzc/BjehOgAtqVuteoeaZBJDrG74fEl6vY=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=3dIQj8Gb1Vtg28o9BIzLO3m4HTqlJBM8aAK5uqBFCl8-1703613804268-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=CGnt51Bk_SuqnozdgP94BzV_y3QozDqZ_RKQno4Ffr4-1704298892794-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2293,15 +2084,15 @@
             },
             {
               "name": "x-trace",
-              "value": "75eca33abbad37b4887db05bb38d4d58"
+              "value": "77502a98050536bc319b12a3f96afd4f"
             },
             {
               "name": "x-trace-span",
-              "value": "13b0b445287f6090"
+              "value": "645c8de7aaf88eca"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/75eca33abbad37b4887db05bb38d4d58"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/77502a98050536bc319b12a3f96afd4f"
             },
             {
               "name": "x-xss-protection",
@@ -2325,7 +2116,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d839c90bfc3-WAW"
+              "value": "83fc934eea4634e6-WAW"
             }
           ],
           "headersSize": 1286,
@@ -2334,8 +2125,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:23.785Z",
-        "time": 394,
+        "startedDateTime": "2024-01-03T16:21:32.551Z",
+        "time": 224,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2343,7 +2134,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 394
+          "wait": 224
         }
       },
       {
@@ -2419,20 +2210,20 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:24.000Z",
+              "expires": "2025-01-03T16:21:32.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d3840397-8485-4526-96a1-27980a3186d1"
+              "value": "9c24c044-5367-4e50-9511-8071474ff9b6"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:24.000Z",
+              "expires": "2024-01-03T16:51:32.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "RmB2rEj7LGeuum7xNHmiGCpn0bkQv.yw6_YUE4zBaQg-1703613804-1-AZ9cbpIGbzv/onlhHRzMYDPv+jaeRgGGEtn7bjsAYVl+y7Od7HZF8IDRkwb3R+Dt7rG5HFxW6gYUFL5c1MQjIOU="
+              "value": "gpHXRQ.achJQgG_43BvjwmGQ1dwMa8gSXmFGS.j0LCo-1704298892-1-AewNWx9uWJeFvlVEULsBzG8eYsxPsyT1AyiJuY8SDNhL6S3I3q1EA+L2zeTE/w+sKb5mJC5Wdo0c3nV/sLBnG5s="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2441,13 +2232,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "wEK4g4IDMD2ytOnKxoG_vEQpfq593xIBr1hjOEkpGQo-1703613804274-0-604800000"
+              "value": "jgFHyRTuIW2Y8ZUipsHJCcMKRG0qQkwiZ7I1u_AqBos-1704298892798-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:24 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
             },
             {
               "name": "content-type",
@@ -2476,17 +2267,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d3840397-8485-4526-96a1-27980a3186d1; Expires=Thu, 26 Dec 2024 18:03:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=9c24c044-5367-4e50-9511-8071474ff9b6; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=RmB2rEj7LGeuum7xNHmiGCpn0bkQv.yw6_YUE4zBaQg-1703613804-1-AZ9cbpIGbzv/onlhHRzMYDPv+jaeRgGGEtn7bjsAYVl+y7Od7HZF8IDRkwb3R+Dt7rG5HFxW6gYUFL5c1MQjIOU=; path=/; expires=Tue, 26-Dec-23 18:33:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=gpHXRQ.achJQgG_43BvjwmGQ1dwMa8gSXmFGS.j0LCo-1704298892-1-AewNWx9uWJeFvlVEULsBzG8eYsxPsyT1AyiJuY8SDNhL6S3I3q1EA+L2zeTE/w+sKb5mJC5Wdo0c3nV/sLBnG5s=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=wEK4g4IDMD2ytOnKxoG_vEQpfq593xIBr1hjOEkpGQo-1703613804274-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=jgFHyRTuIW2Y8ZUipsHJCcMKRG0qQkwiZ7I1u_AqBos-1704298892798-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2502,15 +2293,15 @@
             },
             {
               "name": "x-trace",
-              "value": "378f8a7191a4528f3ebe441c8315ffe2"
+              "value": "8d6b484bca7356cf584ce983ef1d2afd"
             },
             {
               "name": "x-trace-span",
-              "value": "604a1fcf30467cd1"
+              "value": "8bfd51ef180877e8"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/378f8a7191a4528f3ebe441c8315ffe2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8d6b484bca7356cf584ce983ef1d2afd"
             },
             {
               "name": "x-xss-protection",
@@ -2534,7 +2325,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d839f8834e0-WAW"
+              "value": "83fc934eeb137728-WAW"
             }
           ],
           "headersSize": 1286,
@@ -2543,8 +2334,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:23.783Z",
-        "time": 401,
+        "startedDateTime": "2024-01-03T16:21:32.550Z",
+        "time": 230,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2552,7 +2343,216 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 401
+          "wait": 230
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:32.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "e10a665e-e2c4-4b80-9125-fe38e6252175"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:32.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ny6tIIawD4OSClva8UhF5y2j01oCF3Ihot1QdrM7WY8-1704298892-1-AZgVvhyUmvj/hlUd8drorEOwo9grj0lcvmgMENl0nSzITJpW+fd/s8WJ6rZthIIn5KS2PsBnQu2GFAmVV2X8sf0="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Gt5XTbXHDCD9DYBmWX0X89hSHHd_uZJQfI8e.ya915g-1704298892799-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=e10a665e-e2c4-4b80-9125-fe38e6252175; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ny6tIIawD4OSClva8UhF5y2j01oCF3Ihot1QdrM7WY8-1704298892-1-AZgVvhyUmvj/hlUd8drorEOwo9grj0lcvmgMENl0nSzITJpW+fd/s8WJ6rZthIIn5KS2PsBnQu2GFAmVV2X8sf0=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=Gt5XTbXHDCD9DYBmWX0X89hSHHd_uZJQfI8e.ya915g-1704298892799-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "44660068b5edb6dbf77c6d06da419dc3"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c6554c83d7fd150b"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/44660068b5edb6dbf77c6d06da419dc3"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc934eedc8fc7b-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:32.549Z",
+        "time": 231,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 231
         }
       },
       {
@@ -2628,20 +2628,20 @@
           },
           "cookies": [
             {
-              "expires": "2024-12-26T18:03:24.000Z",
+              "expires": "2025-01-03T16:21:33.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "225f25c8-e3d5-4524-b93b-41e688dc84f2"
+              "value": "b5b058fc-2178-4895-ad51-c052786930aa"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:24.000Z",
+              "expires": "2024-01-03T16:51:33.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "BTeA_B6ezmvkrQwmltJX.X1hllAMU7QmnuGcjMZFZus-1703613804-1-AUOpXnsoRoZEjLBHwX7hqxoqBumUrmOIowfIESR5Q+xbUBc6fWwKEMhtIZvRZ+OHmf4tD7aZFUqNgdbUTwW8U1M="
+              "value": "WQ8oM.tBnK44uf7o99K84cl3GrAwDuZGf61rwW.Zsno-1704298893-1-ATVPs8xBd3EOLZvOZdbLRNllesdFb2XIs3N0dO0DuSsDIvPrBao/nv5nNmCT6unG+W8z6cxvPSX8w2wUaV7LfYg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2650,13 +2650,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "rXmOcaOwVqIRDEjrtlTqepCYgkJZJMVY3TdMCybrRTs-1703613804803-0-604800000"
+              "value": "kFvdVZtH47jcaDH6Wwl1EMgh_875H8mI9snJWIX38ss-1704298893315-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:24 GMT"
+              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
             },
             {
               "name": "content-type",
@@ -2685,17 +2685,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=225f25c8-e3d5-4524-b93b-41e688dc84f2; Expires=Thu, 26 Dec 2024 18:03:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=b5b058fc-2178-4895-ad51-c052786930aa; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=BTeA_B6ezmvkrQwmltJX.X1hllAMU7QmnuGcjMZFZus-1703613804-1-AUOpXnsoRoZEjLBHwX7hqxoqBumUrmOIowfIESR5Q+xbUBc6fWwKEMhtIZvRZ+OHmf4tD7aZFUqNgdbUTwW8U1M=; path=/; expires=Tue, 26-Dec-23 18:33:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=WQ8oM.tBnK44uf7o99K84cl3GrAwDuZGf61rwW.Zsno-1704298893-1-ATVPs8xBd3EOLZvOZdbLRNllesdFb2XIs3N0dO0DuSsDIvPrBao/nv5nNmCT6unG+W8z6cxvPSX8w2wUaV7LfYg=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=rXmOcaOwVqIRDEjrtlTqepCYgkJZJMVY3TdMCybrRTs-1703613804803-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=kFvdVZtH47jcaDH6Wwl1EMgh_875H8mI9snJWIX38ss-1704298893315-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2711,15 +2711,15 @@
             },
             {
               "name": "x-trace",
-              "value": "1568a5330d6cf4b68e7766229f1e1913"
+              "value": "0ee2489d30e15cb1476daccaf9f43210"
             },
             {
               "name": "x-trace-span",
-              "value": "e8d2bd1b9fbc4bce"
+              "value": "e96b1018159e937c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1568a5330d6cf4b68e7766229f1e1913"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0ee2489d30e15cb1476daccaf9f43210"
             },
             {
               "name": "x-xss-protection",
@@ -2743,7 +2743,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "83bb3d8708b070b7-WAW"
+              "value": "83fc93523f593536-WAW"
             }
           ],
           "headersSize": 1286,
@@ -2752,8 +2752,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2023-12-26T18:03:24.460Z",
-        "time": 257,
+        "startedDateTime": "2024-01-03T16:21:33.081Z",
+        "time": 214,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2761,7 +2761,4816 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 257
+          "wait": 214
+        }
+      },
+      {
+        "_id": "376c77f6f6da3ec20db639d4790073be",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1184,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1184"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "b210095b-4fed-43f8-a3a1-806323b846b0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "yI2EzwXAhbhq_d05Gn_44v5ljvip83UHvytdHlLEICA-1704298893-1-AeyKNKey6nVsbZOj/9M5dDkw9yGLir1B1oNC9gF9bZweFBf5/dFfwvGHlRCFE+e2we8tnI3UBmLs1/fuTQ/z/3o="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "SJ6mysNYUJdvfWiHNBAF3K5_FaqrXKJULvwJVHdP5GU-1704298893360-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=b210095b-4fed-43f8-a3a1-806323b846b0; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=yI2EzwXAhbhq_d05Gn_44v5ljvip83UHvytdHlLEICA-1704298893-1-AeyKNKey6nVsbZOj/9M5dDkw9yGLir1B1oNC9gF9bZweFBf5/dFfwvGHlRCFE+e2we8tnI3UBmLs1/fuTQ/z/3o=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=SJ6mysNYUJdvfWiHNBAF3K5_FaqrXKJULvwJVHdP5GU-1704298893360-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "6d26910c478d0ead4b54a312f28bd9b2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5f1f578f43f3aa2d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6d26910c478d0ead4b54a312f28bd9b2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc935238db347c-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.079Z",
+        "time": 260,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 260
+        }
+      },
+      {
+        "_id": "8192ad19598e6814fcd3050df70a8e5d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "0e2aa6b7-defd-4330-afc8-17b68d46baff"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "5G.29GyQcXqSegYrkGuxl9m4hzLihSANsFUc_FIuiXI-1704298893-1-ATevc64Ak20K/875FopWQ2RpPtAdgyemmlrvXz0wz1WwVjd6uhFFtpI87zpgkAK+XgAJ3aZ8nw3joKeeMNr/TDw="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "qHR.orl5qAMbC.z6WBHb9sduShIZ_x9QabTL_9u4lM4-1704298893552-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=0e2aa6b7-defd-4330-afc8-17b68d46baff; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=5G.29GyQcXqSegYrkGuxl9m4hzLihSANsFUc_FIuiXI-1704298893-1-ATevc64Ak20K/875FopWQ2RpPtAdgyemmlrvXz0wz1WwVjd6uhFFtpI87zpgkAK+XgAJ3aZ8nw3joKeeMNr/TDw=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=qHR.orl5qAMbC.z6WBHb9sduShIZ_x9QabTL_9u4lM4-1704298893552-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d1be0cad5d064b404e6cc4c6bd1a2488"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "fd59ac30fd7e516e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d1be0cad5d064b404e6cc4c6bd1a2488"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93539d41fbce-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.305Z",
+        "time": 227,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 227
+        }
+      },
+      {
+        "_id": "a0ad203278c23856d665c25dd6c1b28a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 474,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "474"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:33.073Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "fb2110f6-c8b4-42bd-b5c1-9c446db64e61"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "eO66Q3tH8FADrdJ1qybjC6usF0zuBjvD4D2pgHa.Cek-1704298893-1-Ab5usQ2tnuE6KnNn29UA6Offgz5kS0rzmyedqpZLpK5LpezUA5dVSuDAffBLMsGwZ4hv3rCZgD7hVHyaPiYqzW0="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "NGVQtSL1WB8gx83TZPaXn8AI4qDslb38S523E56wzDE-1704298893566-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=fb2110f6-c8b4-42bd-b5c1-9c446db64e61; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=eO66Q3tH8FADrdJ1qybjC6usF0zuBjvD4D2pgHa.Cek-1704298893-1-Ab5usQ2tnuE6KnNn29UA6Offgz5kS0rzmyedqpZLpK5LpezUA5dVSuDAffBLMsGwZ4hv3rCZgD7hVHyaPiYqzW0=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=NGVQtSL1WB8gx83TZPaXn8AI4qDslb38S523E56wzDE-1704298893566-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "823642c2c4f50a79dfccd8054c34e1d0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "7790dfbe7315cc14"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/823642c2c4f50a79dfccd8054c34e1d0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93539abd3528-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.303Z",
+        "time": 244,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 244
+        }
+      },
+      {
+        "_id": "d9c51bc7f5683994e3e65be926827058",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 477,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "477"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:33.304Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 115,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:33.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ea7380b7-41a9-4c24-925d-230e50e9dd60"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:33.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "U9svv3N0YfSRYrRXn.Fc22PpFc28eC3xqHjVX3lwC_8-1704298893-1-AXy4VxwjG5C2NaDNzQP0HuPen5nuRqMydK/oIDKvfb0aCexRuWnR0KdSKJ9GwkWEYkYfaaW4cOrZVJYHNL4AP/o="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "nHuMZ9OsA1pT5WLlT.SNtW82logracgHIKlPYlBgDfo-1704298893576-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ea7380b7-41a9-4c24-925d-230e50e9dd60; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=U9svv3N0YfSRYrRXn.Fc22PpFc28eC3xqHjVX3lwC_8-1704298893-1-AXy4VxwjG5C2NaDNzQP0HuPen5nuRqMydK/oIDKvfb0aCexRuWnR0KdSKJ9GwkWEYkYfaaW4cOrZVJYHNL4AP/o=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=nHuMZ9OsA1pT5WLlT.SNtW82logracgHIKlPYlBgDfo-1704298893576-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "60d0785408a2f42b6d9fdde40f17bcd6"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "6aa2dc5f7b139c63"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/60d0785408a2f42b6d9fdde40f17bcd6"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93539a63f2c8-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.305Z",
+        "time": 255,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 255
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "069403cb-6310-4376-b7c3-359c04a3d324"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "w.noDPLqDSLJ6XEbUkWNRk0LElsQrC7X2lI7KQGFJkM-1704298894-1-Ad2sogL2dhEJqVFrTxKuzgO3rAePxxYN3WKPa7cXk0hDZDNrP8YeCRhMZLu2xA8cA+ol2SiTeiHKnWrf4+pdsB0="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "44tDnrDBzS0u97bCTJhFzwuttli85rconty2xR_6_lI-1704298894129-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=069403cb-6310-4376-b7c3-359c04a3d324; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=w.noDPLqDSLJ6XEbUkWNRk0LElsQrC7X2lI7KQGFJkM-1704298894-1-Ad2sogL2dhEJqVFrTxKuzgO3rAePxxYN3WKPa7cXk0hDZDNrP8YeCRhMZLu2xA8cA+ol2SiTeiHKnWrf4+pdsB0=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=44tDnrDBzS0u97bCTJhFzwuttli85rconty2xR_6_lI-1704298894129-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "dfebc21664c8d79805d84a6ec30e37df"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "dd7a1aad06c588d0"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dfebc21664c8d79805d84a6ec30e37df"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93575db15019-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.899Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "d41336af-0a0c-4369-af90-6c63a412c19f"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "YkSB64d7QzdaI6vRAnMlvw64TBMEUcV3zqw2znZa1h8-1704298894-1-AXt2UsOASlL9voTPe5RgwCXsugGbl30ckMGmOd1ZVgo8Gpx6mDJ5F+YYrxMCi1HagKlgFiUgrRa+Pifh0u9JFnM="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "05oy55r0knMtvic9borZ_x8NTpVDeWdI1ESI3AtuqrE-1704298894139-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=d41336af-0a0c-4369-af90-6c63a412c19f; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=YkSB64d7QzdaI6vRAnMlvw64TBMEUcV3zqw2znZa1h8-1704298894-1-AXt2UsOASlL9voTPe5RgwCXsugGbl30ckMGmOd1ZVgo8Gpx6mDJ5F+YYrxMCi1HagKlgFiUgrRa+Pifh0u9JFnM=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=05oy55r0knMtvic9borZ_x8NTpVDeWdI1ESI3AtuqrE-1704298894139-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "932cef7d9d6e70276c0a849223abc27e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "5449a9530ffaff59"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/932cef7d9d6e70276c0a849223abc27e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93575bf5bfc3-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.897Z",
+        "time": 225,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 225
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "e5bb4fb4-ac4d-4b3b-b7bb-ba0a77d0500d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "AHjmC0gTJT5ufKbMDUdBESS8NBtrrNnFOmUEKhaQhm0-1704298894-1-AQ894nAfjabmY68sedCO62f6yTjmeZRHhDW6FCCf2G2KQ6v5EI44hxLVnGUiH76XuIqcmpuTDlQYFDXt/z3TyaM="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XhspBy9DUuiEvPHDfgfOnu7I0ZL8TwUYKOAcggaXdC8-1704298894149-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=e5bb4fb4-ac4d-4b3b-b7bb-ba0a77d0500d; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=AHjmC0gTJT5ufKbMDUdBESS8NBtrrNnFOmUEKhaQhm0-1704298894-1-AQ894nAfjabmY68sedCO62f6yTjmeZRHhDW6FCCf2G2KQ6v5EI44hxLVnGUiH76XuIqcmpuTDlQYFDXt/z3TyaM=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=XhspBy9DUuiEvPHDfgfOnu7I0ZL8TwUYKOAcggaXdC8-1704298894149-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "41224bf4030f70c62316915aa7ffccb8"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "af49eb7bb33d30b8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/41224bf4030f70c62316915aa7ffccb8"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93575eb1cc8f-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.897Z",
+        "time": 232,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 232
+        }
+      },
+      {
+        "_id": "fdfcc7f2c502f374d01b3e1824ad5539",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 477,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "477"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:33.892Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ec774367-81a4-482d-ab38-b10e032bc456"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "SNZAkZp2J3lLO79GZ6bqxbIE7q5CumhduUhaMCJo1mM-1704298894-1-AXP4v9Cnyigg3pr3KZ50hwsbppz+KPfXtzOK5Jr6VgyxMAWWsfXdS8xJ3QgB+zqMwn7Y7PhuYYB8KrSASRE3Rgk="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "1plC34s0lNAYMpk9LP3BfvnPQ5UjFsHPQWXiwzsqtJA-1704298894157-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ec774367-81a4-482d-ab38-b10e032bc456; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=SNZAkZp2J3lLO79GZ6bqxbIE7q5CumhduUhaMCJo1mM-1704298894-1-AXP4v9Cnyigg3pr3KZ50hwsbppz+KPfXtzOK5Jr6VgyxMAWWsfXdS8xJ3QgB+zqMwn7Y7PhuYYB8KrSASRE3Rgk=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=1plC34s0lNAYMpk9LP3BfvnPQ5UjFsHPQWXiwzsqtJA-1704298894157-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "eb1c43b0d71af17ba1e91d41cdd4cb32"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3186e21b1f41c0ad"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/eb1c43b0d71af17ba1e91d41cdd4cb32"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93575974bfe4-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.894Z",
+        "time": 245,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 245
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "c6d0b807-4c48-450e-a5ff-a28c07cfba08"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "kzigPvr.4_uwT4zB1guS31Ofivut.f.uXnL7JsvJCqI-1704298894-1-AX6tyapva6QGGO9ax40OPSUpOTMTBqdYF8Ffo5xCkBV3PgGk8S5dndzgeclT14Bg/Ok5tn/X0DE4Slhty6puYeo="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "dhueYJ1XnIfAcGMbuc3cAW_XRRg0__rFRD_Qj.iIOeY-1704298894187-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=c6d0b807-4c48-450e-a5ff-a28c07cfba08; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=kzigPvr.4_uwT4zB1guS31Ofivut.f.uXnL7JsvJCqI-1704298894-1-AX6tyapva6QGGO9ax40OPSUpOTMTBqdYF8Ffo5xCkBV3PgGk8S5dndzgeclT14Bg/Ok5tn/X0DE4Slhty6puYeo=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=dhueYJ1XnIfAcGMbuc3cAW_XRRg0__rFRD_Qj.iIOeY-1704298894187-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "89732910a58196ea16edb70c998a9356"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a0aafd524f1cf3e5"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/89732910a58196ea16edb70c998a9356"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93575aa0bf8d-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:33.898Z",
+        "time": 269,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 269
+        }
+      },
+      {
+        "_id": "7449140909c921a511332d4c1de94c1f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 182,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "182"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6f4f1919-0df3-4ef6-8e25-7109b532191d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:34.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "yZEgpTSXZt8tgty2Ci22OpgsjRpl0P847hzciF5JdCU-1704298894-1-AStd6XzMiCaJLU1L1OJNc3Qu+JY3yyqjqlasgGii2H3jcvs9BzQ7PKBt2frF36l+QH66zHda1Ek8zuoqgFnYGbo="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "tDk3aKNfmul8NuxndJd4qnCpEdxAHHOlkp9yHN2i00E-1704298894596-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6f4f1919-0df3-4ef6-8e25-7109b532191d; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=yZEgpTSXZt8tgty2Ci22OpgsjRpl0P847hzciF5JdCU-1704298894-1-AStd6XzMiCaJLU1L1OJNc3Qu+JY3yyqjqlasgGii2H3jcvs9BzQ7PKBt2frF36l+QH66zHda1Ek8zuoqgFnYGbo=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=tDk3aKNfmul8NuxndJd4qnCpEdxAHHOlkp9yHN2i00E-1704298894596-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8f0919196c2a1f8b0f3a17e3acf58d5e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e9de1c9a25dc1a24"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8f0919196c2a1f8b0f3a17e3acf58d5e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc935a39f5353a-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:34.367Z",
+        "time": 210,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 210
+        }
+      },
+      {
+        "_id": "8a049c80771d508a499a55e49d24b525",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1273,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip;q=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1273"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 333,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"timeoutMs\":15000,\"maxTokensToSample\":256,\"stopSequences\":[\"\\n\\nHuman:\",\"</CODE5711>\"],\"temperature\":0.5,\"topK\":0,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in <CODE5711> tags. You only response with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.\"},{\"speaker\":\"assistant\",\"text\":\"I am a code completion AI with exceptional context-awareness designed to auto-complete nested code blocks with high-quality code that seamlessly integrates with surrounding code.\"},{\"speaker\":\"human\",\"text\":\"Below is the code from file path src/sum.ts. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: \\n```\\nexport function sum(a: number, b: number): number {\\n   <CODE5711></CODE5711> \\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"<CODE5711>export function sum(a: number, b: number): number {\"}],\"stream\":true}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/code"
+        },
+        "response": {
+          "bodySize": 619,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 619,
+            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:34.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ae1c7e1e-658a-4bff-b5ec-58fad6422108"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:35.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "M.EUlM9UT97pPNxZaJV0sTLBGpcsZ8ZVI7GOhuqM2oM-1704298895-1-AfIYZ0EYUUFj6IbUpMpyxV/RR2reU/k6XlbzhsZcs5VFQFdKhTC3FC6PqvzhdDVTPIWA2hU5kNruChF8al+94Lw="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "GatHzGn8WRArlSTsxCIff.4BPc3AvbrH6jjjLlVY5JY-1704298895845-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:35 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ae1c7e1e-658a-4bff-b5ec-58fad6422108; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=M.EUlM9UT97pPNxZaJV0sTLBGpcsZ8ZVI7GOhuqM2oM-1704298895-1-AfIYZ0EYUUFj6IbUpMpyxV/RR2reU/k6XlbzhsZcs5VFQFdKhTC3FC6PqvzhdDVTPIWA2hU5kNruChF8al+94Lw=; path=/; expires=Wed, 03-Jan-24 16:51:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=GatHzGn8WRArlSTsxCIff.4BPc3AvbrH6jjjLlVY5JY-1704298895845-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c810a6b7a9d2eeb6bb3c2b3783200b74"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "2f11c8b6b05179c8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c810a6b7a9d2eeb6bb3c2b3783200b74"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc935baafa35b4-WAW"
+            }
+          ],
+          "headersSize": 1289,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:34.587Z",
+        "time": 1239,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1239
+        }
+      },
+      {
+        "_id": "de15dd5a1d2440a81de0322eceb1d59a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2030,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "2030"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"anthropic\\\",\\\"providerModel\\\":\\\"claude-instant-1.2\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"fa1afd4f-9ed8-4e2d-92e7-bf7f9d961339\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"local-mixed\\\",\\\"duration\\\":1.0849169492721558,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "f75b0263-87d4-4368-8019-523ac267e7d0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "c6MewJuZR8ly_nPy9txvwH3gM32uOEFmfFgq0qsHK70-1704298896-1-AagTPwmLnTJQ1TFPtuMHp4Sv2nzbmZEH/26ECYUW6qjULakOoaLjDEO4Un8BpYQxdFiqa36HKyVGDieg8aeDMOw="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "LTm8Q4NwVKnWNgfK442vIxedCgYR3Qmh6m0g6gHi9IQ-1704298896183-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=f75b0263-87d4-4368-8019-523ac267e7d0; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=c6MewJuZR8ly_nPy9txvwH3gM32uOEFmfFgq0qsHK70-1704298896-1-AagTPwmLnTJQ1TFPtuMHp4Sv2nzbmZEH/26ECYUW6qjULakOoaLjDEO4Un8BpYQxdFiqa36HKyVGDieg8aeDMOw=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=LTm8Q4NwVKnWNgfK442vIxedCgYR3Qmh6m0g6gHi9IQ-1704298896183-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4ca5cc0e72ecc4fb56ec03d014eb68b4"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c7297b7462cdd51e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4ca5cc0e72ecc4fb56ec03d014eb68b4"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9363dcdb35d6-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:35.895Z",
+        "time": 268,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 268
+        }
+      },
+      {
+        "_id": "eb9eb798a8d1611b980687fe88d488ca",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1226,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1226"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "8b3030b3-1926-44b6-9f77-c5490b7d22dc"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "WeA8fjQxrsYRax6W.NpeSWJQmaBnK2iJv7.LPc5L7Us-1704298896-1-AQk1ecjcJUzH3wNorMEoKGZKcauOmvpcd2pHKB5Gg++V+YCI0uZ7CzkEvmGZgBxe3Rq/ROuCEs/LliQaTVfWw3A="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "xOXQFQgkGhi7wU8HMCACcwlqfWXnSAhZIXIt3mxPNkU-1704298896499-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=8b3030b3-1926-44b6-9f77-c5490b7d22dc; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=WeA8fjQxrsYRax6W.NpeSWJQmaBnK2iJv7.LPc5L7Us-1704298896-1-AQk1ecjcJUzH3wNorMEoKGZKcauOmvpcd2pHKB5Gg++V+YCI0uZ7CzkEvmGZgBxe3Rq/ROuCEs/LliQaTVfWw3A=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=xOXQFQgkGhi7wU8HMCACcwlqfWXnSAhZIXIt3mxPNkU-1704298896499-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "7e904ef5465b84e375413f20c781cf9f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "f400bd86840f217d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7e904ef5465b84e375413f20c781cf9f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9363c88c3566-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:35.894Z",
+        "time": 676,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 676
+        }
+      },
+      {
+        "_id": "2045fa645bf1bb8bc4c29fdbe40533b2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 496,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "496"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:35.892Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 122,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 122,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "c8de4a24-6922-4f16-99ec-2ac22f0676e0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "FJeo7LH0tCBcPpz2iT5DJ_YfaCuQXY0Z6SXjccu7k58-1704298896-1-AYxASx/PZp1SFASvt2uDy0YTm2SwBxaYd+BsR9Xyer9gVN8WrOv1t8VbjEKmaFsxql8Y3qwSXtxSFEAP0cIBa2U="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "vydBsUgOlTfJeM.GGQxavRWv4bTjFxxU8qJAA0A9keU-1704298896507-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=c8de4a24-6922-4f16-99ec-2ac22f0676e0; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=FJeo7LH0tCBcPpz2iT5DJ_YfaCuQXY0Z6SXjccu7k58-1704298896-1-AYxASx/PZp1SFASvt2uDy0YTm2SwBxaYd+BsR9Xyer9gVN8WrOv1t8VbjEKmaFsxql8Y3qwSXtxSFEAP0cIBa2U=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=vydBsUgOlTfJeM.GGQxavRWv4bTjFxxU8qJAA0A9keU-1704298896507-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d9f3c3413a21155726ccab74be0a32c7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "8f13cd8922d29b0f"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d9f3c3413a21155726ccab74be0a32c7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9363c93834e0-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:35.896Z",
+        "time": 674,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 674
+        }
+      },
+      {
+        "_id": "df5a9eb392a5c64b9d4b8c9e4770f874",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1698,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1698"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"interactionID\":\"fa1afd4f-9ed8-4e2d-92e7-bf7f9d961339\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":1.0849169492721558},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"anthropic\",\"providerModel\":\"claude-instant-1.2\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"fa1afd4f-9ed8-4e2d-92e7-bf7f9d961339\",\"contextSummary\":{\"strategy\":\"local-mixed\",\"duration\":1.0849169492721558,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}}},\"timestamp\":\"2024-01-03T16:21:35.893Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 122,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 122,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "d288d5e2-320f-49f8-a108-78950f47e255"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "oMt41Cy87.SKGtAk2mVuSFRlLgLhlEL1jSCvXMptyQs-1704298896-1-AY3iY9ZtWGgWyq7ob9QClFkFSCdtHkzQqglgiF/gLr/cQ5kQL7Ub/Eea/feEzSoO69+dZVnAtFcsMffi5FjId+I="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "1qQMlo0R6j1jTsghNYjvXIXo_TmJTLqr4K357NAeOoU-1704298896584-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=d288d5e2-320f-49f8-a108-78950f47e255; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=oMt41Cy87.SKGtAk2mVuSFRlLgLhlEL1jSCvXMptyQs-1704298896-1-AY3iY9ZtWGgWyq7ob9QClFkFSCdtHkzQqglgiF/gLr/cQ5kQL7Ub/Eea/feEzSoO69+dZVnAtFcsMffi5FjId+I=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=1qQMlo0R6j1jTsghNYjvXIXo_TmJTLqr4K357NAeOoU-1704298896584-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c29c1a5c6d339e582eaaf2710787e2cc"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "990ac3e16b889000"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c29c1a5c6d339e582eaaf2710787e2cc"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9363ca0835b1-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:35.896Z",
+        "time": 674,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 674
+        }
+      },
+      {
+        "_id": "fb5ccae70488a1172b9b76428acf169e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 545,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "545"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery LegacyEmbeddingsSearch($repo: ID!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {\\n\\tembeddingsSearch(repo: $repo, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {\\n\\t\\tcodeResults {\\n\\t\\t\\tfileName\\n\\t\\t\\tstartLine\\n\\t\\t\\tendLine\\n\\t\\t\\tcontent\\n\\t\\t}\\n\\t\\ttextResults {\\n\\t\\t\\tfileName\\n\\t\\t\\tstartLine\\n\\t\\t\\tendLine\\n\\t\\t\\tcontent\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{\"repo\":\"UmVwb3NpdG9yeTo2MTMyNTMyOA==\",\"query\":\"Hello!\",\"codeResultsCount\":12,\"textResultsCount\":3}}"
+          },
+          "queryString": [
+            {
+              "name": "LegacyEmbeddingsSearch",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LegacyEmbeddingsSearch"
+        },
+        "response": {
+          "bodySize": 2554,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 2554,
+            "text": "[\"H4sIAAAAAAAA/8RX247cuBH9lYqMwB5vq9WXGXs=\",\"0ovBxp71wgPYa8OXOAtrsE2JJYkYilTIUl9gDLDfkLcAAYLkKd/lL8gnBEV1z6h7Lrt5imG03WSxTtWpU0X2l0gKEtHsS4R1hlIqU/r3KFxe8VpuJb5D32ry0ezzl6hQGn8UNUazaOF5M/EuTzy6hcrRJ89aqt46u1AS3XtVN1oVCuWQfDSIPAlHr5TBaPbkeBChkd2Xp6NBlFtDaCiaRZepiS4HtwERekpwgkmhVm0TS8ytE2TdkDduQDx90oc43oE4uB+jUCtqHfpkad2Fb0SOiTISV8OKar2LMuqBjCd9kLQdjab5775/c/rhp7cvgI+GJUxNt8UroIUpT9IITRptdwEANhYoZH/1eqdGEpBXwnmkkzT6+OGH+DiNILnHuiJqYvxLqxYnafTn+OOz+NTWjSCVaUwj2AR+kkZnL05Qlvgr7oyo8SSNFgqXjXW042GpJFUnElkScfgyAGUUKaFjnwuNJ+Ph6G7/pEhjt/UStbZwauW620p6e32mkn2quuVse3DXuL+8Pd8rz740tMqSVgWd55Wg5IMTxudONXRGWA/Jr3Y1MZlMe6qYTJ70ZcFhHKTmHgkGHFs3GklZ4xNtyxLvEPlkOulDTY/2oS5/HUvbXOg4HFtRIu3SaCtk7Nd1cQNvPO6nNh7fSO0yNbc0MDPoK+FQXrPoMFcN+oSYTS0Ib4AdHvawDp/+dqh+sZRpWjrdJHdaCTrrLdys3XG/oY+n+5hbtUy3WrmF2v1krcRMeLxiuEbvRYn+Jrmjoz65o+N99PNbM871Jl2t0HDChE7kQTs3Ke3P3aMb6W3/fD6/7smD7r8Hv4nt7eS8CdznlQt7E/hy0CGdD26FwgnGyvgGc7IuIHYzOff+7pE82bla/qhqnlXQOv3oIc9DP0uSwhryw9LaUqNolB/mtk5y7yffFaJWen1y9vz1N281rr55bY3luk+ebHZ+bI2izZJUvtFifeKXonl48G1qUjNz1hJ86bKKY9/mOXof51ZbNwNXZuLR4RTG02N4MoEEnh79ns91xkvhjDLljvFkOoLx+A8w2jeWwpTodm1HYzic8N8928w6eW37QMjsKJO37saTGTzIUR5KcbXvUWNOKK/OF+NiWhx9GyqWGh6s24SZ17gjagYdUwPwwvjYo1PF9gi3xyA1jcNbDz48e/4amH1g9h8OoLbGhiv5241KzgcRt9X9b5Sl0BdUOduWlU9ES3YzYHFYy3su9HFfPQ8e8EWE8Kx3nDPoZoKqS/AuP0mjrbA8WSdK3JeWt63LsXSiqWLhPZJPMm3LZMHKkBhbk1nh+BUW96Lm1048GU2mbLSO+ynE5FfDUhXXL4jUvOeEYOkUKVMC+wVhZLhIYam0hu1hoApBK4PwyLrwBQ0ph1C0JsyQAyisg7Vth/BSEZDIgCyIPMeGgr1vyxI9mw4Z+fHjr3//N7x1NibV+HC49RxEwO7H/fjxlrvMdZF//eVfO+xC69FvQJyzrZE72WwGKsejTGFdvRePH4C3oAqOHgyiZMuyVRJBUVjMhQEhJQjmo0ZDIDK76JGytu1Dh4AyEDm8LeCfNn4qu0AH4YOPlw7XvVgY2iOCALJWZ8KBLUBoQmcEqcVe2MLDErXmfy1V7LYJO+DbvOLVjn9mQwCzqxGW1kkQxAiqxntDbX2XYhp9cIofF7usC4LT1nnrwqOurplrskAbW9FVoJcbo5p1wB1sqs3uJRai1QQXuA6SBl9ZR3lLnPv8TUhpDvM0nYM1UIv8zftQ1/kzTdfrn5SRdumhG7PwSpl2NbzzQbPT6IVa3d/fo73+/kGtQo//H9pa+IuYbMwh7/eyrQ==\",\"kSomdeksfyqqWJgu1OE7+OgxNNfXX/7mIY2e+Yuu18hyPrs1LNQKFA3AOsBVo4UyoVKNs5nG+q4GLtTqqvECOvu/vX23ErMNdq7/84+//hNqNO2gOyrMrTF2Ah9AtobaLrYKyoMMu6ZihYWetEUvEmEAnbMuCOdaeruSg/lpR8Ec5sOe2KyD+akjfbV8h9buTlNob8GpsiLItcov2AkHqghrDxt20+htx69PozBAbQF/et9dJhx2d6neRsudMpc2T5aY/S+3F3zCDHBFaDz37CNcNegUDz2hD7jwAZnLvY1NeS6AQ0N6DdboNfDb0kiUm7GOnOHW+nv0F2SbARhL8LmLcyhxcf5o2znXawdMfTfZlpjF/DyWsBBOCUO+R08Q5Eu7xAU6/glJDhslQeICtW3Q+Z1x9nOlykqvoZ/ZzwzQS3sDEhIIP3y2zth8O7xQdUO3YLceYQLcgVb6GccTw7vWwLwxTQ2uNbAUlFcziYvZErN5qChVuGkBzn2WdL+xKutpNh2NRkxbaGCOLXN26dEN2fHZFZ2D4Jqzmr8SrcmrK55fXJfwE2bMCjzvXBzMQWLWcqOaQpWtE1e38rvWmG1vXJMR9Kk8LMWai82Fs0WhciW05sur4dcySi4WX69hlX+GogwD+Pzy8vK/AQAA//+tBIeePRIAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "cc78db0c-e0f6-4bbf-a8ce-66421f8e6c8e"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "HTgnNgWPMfJhPZfvjnGWGKQCynKqMLxRnyGk7E.0la8-1704298896-1-Afpwaa5tkEoSBgQwfRR91ARv7ISiCvJLHhXgJB16jaKFRhdbvWpYeK0EpCwjUq08BUrcTkQdG1ZR8TVAktW9P4A="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "jsZNIExFH4AK_t5I7kRNQiVfp2GPLM33oBdMU1EAewQ-1704298896695-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=cc78db0c-e0f6-4bbf-a8ce-66421f8e6c8e; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=HTgnNgWPMfJhPZfvjnGWGKQCynKqMLxRnyGk7E.0la8-1704298896-1-Afpwaa5tkEoSBgQwfRR91ARv7ISiCvJLHhXgJB16jaKFRhdbvWpYeK0EpCwjUq08BUrcTkQdG1ZR8TVAktW9P4A=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=jsZNIExFH4AK_t5I7kRNQiVfp2GPLM33oBdMU1EAewQ-1704298896695-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "b84187e48895d8a79cf6646fe5504d3e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "45f0bd6d42f966c8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b84187e48895d8a79cf6646fe5504d3e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93655d15f2cc-WAW"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:36.137Z",
+        "time": 540,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 540
+        }
+      },
+      {
+        "_id": "dd061dc14aab25a042520650837ae4a2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 524,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "524"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:36.683Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 115,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "69e2ec10-c542-471e-9b4a-0961c86341a8"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:36.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XHCGeSZcWX7ioK.1fxLG0ogb8kV1m23dfDFtP6O5LZY-1704298896-1-AZF/mmO5h4BNhO6oOMnhjGimID+zhq0Fkwfvw4jmqUwJgzAkBQddoARSCLqGyvhdN1mderk+cpFTNvLsdw3dQ3Q="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Fx14W9Dn9sr2zSAsY7ntskDf8MFTEy5mPG5W2WVPpB8-1704298896948-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=69e2ec10-c542-471e-9b4a-0961c86341a8; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=XHCGeSZcWX7ioK.1fxLG0ogb8kV1m23dfDFtP6O5LZY-1704298896-1-AZF/mmO5h4BNhO6oOMnhjGimID+zhq0Fkwfvw4jmqUwJgzAkBQddoARSCLqGyvhdN1mderk+cpFTNvLsdw3dQ3Q=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=Fx14W9Dn9sr2zSAsY7ntskDf8MFTEy5mPG5W2WVPpB8-1704298896948-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e598a96f98ff6dad1286fa56961e46df"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "7f9e6c125f5d4c35"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e598a96f98ff6dad1286fa56961e46df"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9368b93ecca3-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:36.688Z",
+        "time": 242,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 242
+        }
+      },
+      {
+        "_id": "5d38dae5bd0498aa351bb3cbc23ff21e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 477,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "477"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:36.818Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 115,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "8465edba-7e26-468f-a4ff-543fd1879e29"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:37.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "mMwMbwUA5IMSRPhKyb1fiYHJ8Fv0u_qdr18Oh1mK2qM-1704298897-1-AeAPWGN0RanMa/d2DnpnT5IycWM4RL/2IIz+Klx8PVohrogIv3nK5Q+k3gjRP0s1AysVusErBI6yRkyzqYu1rJE="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Oab6qK0_BHwZSdkMra25hc9bJ3NU50ZSn9LOpvfMo40-1704298897081-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:37 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=8465edba-7e26-468f-a4ff-543fd1879e29; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=mMwMbwUA5IMSRPhKyb1fiYHJ8Fv0u_qdr18Oh1mK2qM-1704298897-1-AeAPWGN0RanMa/d2DnpnT5IycWM4RL/2IIz+Klx8PVohrogIv3nK5Q+k3gjRP0s1AysVusErBI6yRkyzqYu1rJE=; path=/; expires=Wed, 03-Jan-24 16:51:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=Oab6qK0_BHwZSdkMra25hc9bJ3NU50ZSn9LOpvfMo40-1704298897081-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e6236129739c67886aaee798ae65a93a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "cfc7ff525eea84e8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e6236129739c67886aaee798ae65a93a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93698f45347c-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:36.821Z",
+        "time": 242,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 242
+        }
+      },
+      {
+        "_id": "a511620fa04208be0b3f5a247d516a54",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 5808,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip;q=0"
+            },
+            {
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 261,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/e2e-inspector/src/index.css`:\\n```css\\n@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Nunito&display=swap');\\n\\n:root {\\n    --success-color: rgba(43 138 62 / 75%);\\n    --warning-color: rgba(230 119 0 / 75%);\\n    --danger-color: rgba(201 42 42 / 75%);\\n    --border-color: #adb5bd;\\n    --border-color-2: #ced4da;\\n    --selected-color: #f1f3f5;\\n}\\n\\nbody {\\n    font-family: Nunito, sans-serif;\\n}\\n\\ncode,\\npre {\\n    font-family: 'IBM Plex Mono', monospace;\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/fixtures.ts`:\\n```ts\\n        },\\n    ],\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/cli/src/client/interactions.ts`:\\n```ts\\n            []\\n        )\\n    )\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/stream"
+        },
+        "response": {
+          "bodySize": 232,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 232,
+            "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:36.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "b94df24e-8208-41f9-97eb-e8e2ff7807e6"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:39.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": ".6ZMv0W94ju2x.6VVVOdSpydv49ppiNeWqChjAncdR0-1704298899-1-ASE/Rkha1wmTQ1A98mpPKKzHMsE14DelMh8qx5cJBXoTV0Z5OnKHWtxpvrdbZOsA6/bztOD6uJjBlGRf1DNAua0="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "bGfXXUk79r97JEzZCdH4uBGxRORa5q5CWMCElp8iNFE-1704298899201-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:39 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=b94df24e-8208-41f9-97eb-e8e2ff7807e6; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=.6ZMv0W94ju2x.6VVVOdSpydv49ppiNeWqChjAncdR0-1704298899-1-ASE/Rkha1wmTQ1A98mpPKKzHMsE14DelMh8qx5cJBXoTV0Z5OnKHWtxpvrdbZOsA6/bztOD6uJjBlGRf1DNAua0=; path=/; expires=Wed, 03-Jan-24 16:51:39 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=bGfXXUk79r97JEzZCdH4uBGxRORa5q5CWMCElp8iNFE-1704298899201-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c0a57668e49e85db4372b783b13b8b6b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "072f172d05ccb534"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c0a57668e49e85db4372b783b13b8b6b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9368bd813539-WAW"
+            }
+          ],
+          "headersSize": 1289,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:36.687Z",
+        "time": 2495,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2495
+        }
+      },
+      {
+        "_id": "0e534a092994acb0376ac67425d4ba42",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 584,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "584"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery LegacyEmbeddingsSearch($repo: ID!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {\\n\\tembeddingsSearch(repo: $repo, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {\\n\\t\\tcodeResults {\\n\\t\\t\\tfileName\\n\\t\\t\\tstartLine\\n\\t\\t\\tendLine\\n\\t\\t\\tcontent\\n\\t\\t}\\n\\t\\ttextResults {\\n\\t\\t\\tfileName\\n\\t\\t\\tstartLine\\n\\t\\t\\tendLine\\n\\t\\t\\tcontent\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{\"repo\":\"UmVwb3NpdG9yeTo2MTMyNTMyOA==\",\"query\":\"Generate simple hello world function in java!\",\"codeResultsCount\":12,\"textResultsCount\":3}}"
+          },
+          "queryString": [
+            {
+              "name": "LegacyEmbeddingsSearch",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LegacyEmbeddingsSearch"
+        },
+        "response": {
+          "bodySize": 5896,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 5896,
+            "text": "[\"H4sIAAAAAAAA/+x7bW8bSXL/V6nj7YGkl+TI8g==\",\"7t4eF8QfOtne1cFeCSv5fAfTf6s5Uxx21NM9291DitAKyKsgL/LqEOTVAUECBMjn2k+QjxBUd88TSdGS7WTvRYjFmpzph+rq6l/9qrp000mYZZ3xTQezGSYJl6k5R6bjBT2LVYI/oCmENZ3xm5vOnAv8nmXYGXeWhl5GFo2N5vzaFhpNtFL6yuQsxugl43L0d2zJOoOOsUzbF1xiZ3ww6KBM/PfHB4NOrKRFaTvjThTBxYIb4AYYGJblAoGmg8JgAlwCXluUhisJXFpMNbP0neY3o6mcyryYCR5DLJgxQNPDzVQCAOSaL5lF96zXh5tbau1e+B7GMstjWCqeQEZtzq3mMn3zFphOTZ+GmdrztbGYjVRhR7nm0grZm3a+QyHUAFZKi2Ta6X/jh72dytup7NwOHqIvLhO8Hi1sJvYo7LCpsGlxcPAk/tXT0+OLP589A+rqHuFU+lf0BAST6WTaQTntlG9JxtACWdJ8Wr/J0DKIF0wbtJNp59XF8+HX0w5Ee1ovrM2H+GPBl5Np50/DV0fDY5XlzPKZwGkHguCTaefk2QSTFN8znGQZTqadJcdVrrRtjbDiiV1MElzyGIfuxwC45JYzMTQxEzh5PDq4e3zLrUD/yu0gHKtk7V9FjXdNTUWbqvKPZ2XHduPm47J/Y3vuMA2j48hqxKHh1qKOfixQr4fOwJ3ZDOmkRjnTKK0ZWXO3oXz5VdNQ8JoUCPNCxu7IrBbMmld5r18ekFhJY0G7cw6T8mkU0f9/qpW3ZKLAMUDXfek2jX0qowiG9/hQ0015DJepQJL8j0xzNhO4KRp7t0S9fieUTN8tQ5t3ZCAwaUvjZb7r89PDZSWo0XMWI1zhVVszDe0EzRiHGx+vkByvag1sL+mnpmrIJsZOuGrjGhJ1V2rVHVQ7Rf9otIWWrl+QNEzvx1tkWQYTePzAJXjUPZI8Y2JL8qbAuoit0gGGP1BRfrKnKk2V9wrJ5tQB2WdMNzS5c+saKrm5/WQmzSUtlhs6gScyQWmdt6pl4XPouQW0pPNb4PYOJiALIb4pT4DWagUT6PVh4mFk96r2fxprLqdTAkdCpb2uR8LX5Mp+1e1/cwdGrXBGiGyiozwfWXPdxqAnXzxpoNCTr1oOfior9aRoX6OIVYYv0RiW4u/Xp+c9Zcoj1C+/tGFg1erzkumrRK0kTOAyjAbWY/mv4JyEgpXmlkYh0YHJxL2EFRcCWGFVrIhlWATBJRrXAKXlGquNNDBXGtaqcAzjQoEuJLxxoxyrLGMyMW97sf82jlWyHjHXbxSemVGGsugThwG7IBBZzxTTCZiF0jYubPAYJmfSm/Vk2ikbDctGleuu2vrfnzVMQBmYTCbQTZhecdmF/wfdn//pP7owhu6RsBVYe2dUD7E55PEdLRoPBm4lO+Sm9Q85bVUp8NFWZ5gV1io5AKVB83Rhh7Hg8RUwuV4tUCMRvbUqtNsyp/Q/qwJiJsGZGTCQuCJiYoH+k2uwPENYcbv4W1Nl9H5VkhYKcn/3V+l3d6nUKeu50pApjWB57g3aah5fmQEY9Bb45lu07ky4E4IJfFvwBDeMOBy0vhvhTaJi87ZH9M6Mo8ioQsdEv/MFWXlEbyPq1R9N5WXLx+w+r/vY8f0oEHeQ8h4K9HUTe2ruo1meo24TjAoDw9tu37+retHUd/mRClU/wG20JjhjmmXmTscfZgkifoq50KLuLZnYQzU+3azOgb3epf2Gc2vxqId7ug/fiEBfUpR2UxkfQBobzDaVjCK9Xt8NsC3vg8aNIqBjitI2RnvwII8eTSU8qkdqrhQeRR+61vILHehA73Zt1kPE/SiQSA==\",\"VFzQAilWGEryJvvg4qvH/ytw8Ymg4nkh411A8X8YUYr4EVBQT0dqfv+UYbpPBTkfN9RxHWO19FeHXe2pPtYa70a4h+JSHWlfoLEn1a8ddvdAFW3CiOCzyCyYxsRBCZHJSGPMczTRnF8X+RZSHB580cCKw8NWXDMEoqguqJgh5FoteYKJp6Q8qN6FEiH1QkFKihI1szgAlLFQIcPpqd1nN2c/nL48u3h3cXp2cnw+Ovn+/OKHV8cXJ6ffn9+2iOQ9WsKfXr4Ay1IzclJmhbEwV0KoFbFBg20JY6ZxXgix9tRROcYokFB2NJVDOJViXUrsabpGkyvpxrlD/NNXF2evLvYL3mrTEPmpcpET0XxlF6irV1BIgcaQfGtgGiGn4EDNncClcpMyiBjSQFLZcnPcgCxJOK2aidIVMr0GNlOFdaO4mHGtCmqIyciv3S83bO7OuabyYuFy1hq4gbjQGqUVa9IPtSczHMNNaY3OjM+CVE6h7QEb0YHfNfrV3LJxmWC8j9XIm0bX2yo1eY+ul7tT5hpZokgvc359plWWWwrGSeFkbLQvTMLRCek91SzLSHpmDDeWSQurhXLZfgl4naO2pKM5v6ZGqLXSxqmZy3obaVSzUIVIgF5cgbGYD2frIf1L9poLFuLHOb8udTjDOYVEQbOVPjltvSpsXtjNwVGaQvt4qciTejcyZuMFOrMDXqd13GlZLbhFl8sv7dB1CftOBmG6YFCgTxBUx0ljppah8VyrbGdz4HNvixrBicYtqY5sWiKSfe7hSiHNQeYSpWiHXAoucdh4HMiTYDItWIpmRL+3UPDrr5p3EY+/bILgXZR817UJfTovC2F5LpyynozBP4TPgZe3KJufW0BhWn7+3nOdPn16nwmmnfaLy8Drbvul9UcRXJw+PR3DU7QYW7i8nU4liTWdyptLyBkhpXQ5IyesueI5CJXy2Pd3xLDrLn08hMTkh/LuAJhZy/iO7F6Znv+xoF0aw3G1cRVFM2/ewgTevN3sxC1mBibAVoxbSNGeuL2vRzAn0qC2F3hte+3V5z4c3dZVgmT4l7uVSEvvcWmBwwQOvgEevAI8fvwN8M8/7+/bQD6HHoffwCFMJnDQv7vhnjHo8/O//ON2g8vB9rM3u8epT8Ydq6wm+ue/HoeA4LXm1t1h9O40MKiT8Ls+zmJKFTz5SBVsi7V95PaehnsI+0mFc2c0SPTxhO3x75qJaEffNi9Of1mHyZLk0zhM5q7sfVbUObv1HUzhoQ7041xnPcTDfGauMcakytm3vSeZhJvvJJVKexqXa1xyVZg2kbWKkChjts1SA+qWmcgRnFRulMUx5i5ZQJ1L1lndMZRp6XKkQclAvSNOuMbYOm8uHF0I3DkIvnMfdkcMbtmWwgTa6RlRg8ZAcaGN0veJGs5+eHb87OnJ99/uZ96bzXbFC/7ygtisk03BAkXu6EhtLU2a1OhKmtWYI0U91QilLr0BlYqUGKMxTK8foqAZhkjm4Qp6fvrixenr9ypos9nfgoL+h/Nijw8fN4neF0/at3ieWZS37zRwt7oAvfHPfe7voRmAew9cfj7lBAnOWSH82+YkD51jY7idabudqdGfti9Fdvm93HkN2tAsJ6jZfwvypJWpCJywBqN3eeWDnjeTAroQhJULJJg2K3RXsdkaHAMNYac7o40EQMD/GaNTpzxue+F94c61BfJ8zXDcFGmKxl3jkTdK/bFe+XE0MnctWA8SgsAjITajZHeUZgjzQgggeu1wvIrI/dGuhPcH+WZRZEyeyLyw5V3eRgt3neV1Rl4GpX23YEIUMZfMu5lJqPrpHDktuTVXg7jllg==\",\"gduVDDjl9QlKu0vNjF0hMFihEEMuyWVhAmmBxgw8H7QoBGQ+EZEo2bV+JG5HFK1s1G74sU1dCWJRZ+Srx9D9XllMRnASbr+9FA5lJG1NKXVz/7ipBiihyCGwT8VU+RG/P6OyzKSKWbcm1TgnHakG0rn+roOHatIQJtwq164pZSlgNY/PpLx3ClqPryMs42eh1JXjVbY9x4YiKJLZjOLDDW0QODgE5wyaUr3gxo5rBrxXRMGNy1tRP1PH/3WCKFALpdfUrKJVblkbKmrJX0mUs/iKpfgHs2NHyrIEdxMPgs8005xINYWVdI6ACaKsazBoi7x1Oe8Vqza2x2tiu6wowFZtmg0UGu+ApJ2DeFiqhmgdxvEdZ3TnQAk3uWDr50HJjoOXhP25s6vL/QWcjQrUqCr12Jk0aaLx4W+baMwzJ9EjYIY4PvF5t/9d/6PrkuKNNn7+0Mb/aLa5ATa3qE9qyS7Q2EGg8FuPU7QXmkkTa57bAawYt6+k5QJuwwyjiFgMkargAS9On54GGuOrbsn+nJE4VKAIxHBXtkuOijqZglvsdctKme6gdof1TQQdg5EX8hmLF72d8vYbbd0yXdNdC65yNT6j0iw5usBr+8yBy2tuF+clTvX6Y6BYjJvAAZeKJztvlU5zlFAVNtev/IaN1FXPb8uoKuutvz1XIkFt+psZmoxx+Qe2ZK80h0nY49ErzUc50wZ7l5/dvHfMNwdvR4XmI6t84XKvf1uXX19uzWgrNVSJoXIKLhO1GpmFWpGungam2GvIWKk3qMRr0YNjh9pNO5ChXaikblZPOKoTmhNnMGHiei++HMDBAH47qHIft43cm8YUrx3mRP9/4crVKsCsguTPotatYfn4B9d18p6OdZZuZK543us+u84F4xKO6bDtz9JVKbY7zaxz+3bQIWXsr6hfMXFlF1oV6cJEzTK1UZbsqQ1vXWD/+tdOZDhqdK+ZEM9SMDqeTDtVUY9VmqU4SpVKBbKcG1fb06j1GZKRWxPNhEqjpRmSqEMlXXUVl+mwIfUwwXh4eHD4ZOjKl5pLGFpzPUr5vC5Gn8r3lupVZXruNopLhF7wzRvVev2qWg++4xYsmzkX6SJ7z0c94eShWurRo5//+p909oeuXGpeVWO5uZtyP3pU6m6mveQ///2/t7RLvtSESbRWhUxaqykpsFXged6GPGYARpVkUaLPIKQFT1yqfx1q4FiSACuvqxrZAaeUtSq62tMnLtPRLoHLWrqFWhIHXQbKmmpcN2ShqQ0SL7VKiRnTxDyYsKjJpy43xGbG0Vf61xNDlXv6a4p44Xyb079jXKHUm7xG4ur3XPXeXlFLijLtXGiepqjbWmcWjl3I7/4+wPkZx61CW+Z3oLG2RtXgoHG7VsZr2wWaag6Xp25Jl8QSLokbZyw+PXf7enkkbP38tQNQ43ji4VfwgsvienQnk2gddPRIs/+M/27jjDfhqT7eS56gcuZ7JtgasoLItVAqByI9xl8BbP/Vgj/sDdhe5/4PMBJUUZZ/0bwe+VD0WOHMcIvRmVZJEdvfHB64um1/N+XQIujB4wsrUsKRUWP2aOPvKpx4NZi8MuhPr7tkp70GLocJ5nYBbmhPC51FyzXkHH3usWT5PqVYJ1/LK7Gy/pfGNL5ychwil3bOxkcvg0CpXXHrwCPAQilDduzE+/kf/tLevU6r2JUJ42uNQxzjDbtyWq4CeVyVIMNLlMV96pAHsFrweAELZh5i9ce7jf54n83vRldJfMWyBjg67kjL2Q2xTlmVRoJxlNfDVqlBfRU/7RyZq2rzg3KnnYBHZQj3X//6l38DUoZxNcizdXOnSA==\",\"KuWNwN+clXFf50yrmcDMTDvOrag5/PHcbdxe8EpwHpBZg1pJiAtjVeYXXq6l3CGHugW3gwo4Q3LGJUXK27+Q/K/seK7iIgTsuSJg4EyAwbjQ3K6BG1OgKXHuzbGfvjKb3u/Rsv49SnsjL/iwlLV/T1CrrW8fqj3ZZi51ef0vwFpKKN7gKU4sOjkMNJNpgI2gSnfl6/uVpj1oXpsUkggJ7eCgvLKpErG0kR4jMqU/HdKwbdzw4OMouiy2Aaf0tR8KL780utTcrZRrN6iUi54VXCT16fyE5yNcVfjxQu5jUCbRuLTK/wmD0pCjdnTQY0LCnYHUptC5fXt7e/vfAQAA//+7npP6pTsAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:39.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "41db6941-01e5-46c8-9ece-eb0febc9c5d1"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:39.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "UpyIi4uM3DoIggHVYSWhFEKYgdpOXgI6xoKMd_D64E4-1704298899-1-AVhoIZ/1TOF9ifq3ufaKkNdFnoJR3vqOIuTN6co2qv1debdNyTsQAfTEMOTi2CGrAsdsRzRDopqKJZ1CzIULWn8="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "olM49GgpcTkooH4uDWQyUpm6rINURmOWzftblTKskfQ-1704298899715-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:39 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=41db6941-01e5-46c8-9ece-eb0febc9c5d1; Expires=Fri, 03 Jan 2025 16:21:39 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=UpyIi4uM3DoIggHVYSWhFEKYgdpOXgI6xoKMd_D64E4-1704298899-1-AVhoIZ/1TOF9ifq3ufaKkNdFnoJR3vqOIuTN6co2qv1debdNyTsQAfTEMOTi2CGrAsdsRzRDopqKJZ1CzIULWn8=; path=/; expires=Wed, 03-Jan-24 16:51:39 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=olM49GgpcTkooH4uDWQyUpm6rINURmOWzftblTKskfQ-1704298899715-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "655ac2babdcd5130ab071a9e35207730"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "15858622e5739fed"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/655ac2babdcd5130ab071a9e35207730"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc93786cd6772e-WAW"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:39.195Z",
+        "time": 557,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 557
+        }
+      },
+      {
+        "_id": "4c110131880710a943dee57f6d125cd6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 524,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "524"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:39.755Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 115,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:39.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "c617b8f6-b14e-4c2a-b716-de649148419f"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:40.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ELbjmS2kRmJOEJAQa05RgsWFhyAdhv2ZtP1geKSbagY-1704298900-1-AT6bDDHKrAbRGG//xW+tvGOqaY6kcQs9zh3sVPk3VIGdjAHuWu290sRKqb98vGva2EvH814bvynfkvu7l6xmkZY="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "CACQsgflfGbhQ8_ue6ftY06wgq2p7vCgnnc2Av3Dn.w-1704298900012-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=c617b8f6-b14e-4c2a-b716-de649148419f; Expires=Fri, 03 Jan 2025 16:21:39 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ELbjmS2kRmJOEJAQa05RgsWFhyAdhv2ZtP1geKSbagY-1704298900-1-AT6bDDHKrAbRGG//xW+tvGOqaY6kcQs9zh3sVPk3VIGdjAHuWu290sRKqb98vGva2EvH814bvynfkvu7l6xmkZY=; path=/; expires=Wed, 03-Jan-24 16:51:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=CACQsgflfGbhQ8_ue6ftY06wgq2p7vCgnnc2Av3Dn.w-1704298900012-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "43ecc8e2575265be12aea57e5b5dda6f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "193f5b008b608267"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/43ecc8e2575265be12aea57e5b5dda6f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc937bffddfbd2-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:39.761Z",
+        "time": 232,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 232
+        }
+      },
+      {
+        "_id": "040e40f17249803ef11aca01e7a7a32c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 16068,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept-encoding",
+              "value": "gzip;q=0"
+            },
+            {
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 261,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/commands.md`:\\n## Cody Commands\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-explain.gif\\\">\\n\\nCody has a range of commands for explaining code, generating unit tests, adding documentation, and more.\\n\\nTo get started: select code in your editor, right click, and choose a command from the \\\"Cody\\\" menu.\\n\\nYou can also use the [Cody: Commands Menu](command:cody.action.commands.menu) which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.\\n\\n**✨ Pro-tips for using Cody commands**\\n<br>• You can build your own [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands) with custom prompts, output into chat or perform code edits, and more.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/explain.md`:\\n## Explain Code\\n\\n<video autoPlay muted loop playsInline>\\n    <source\\n        type=\\\"video/mp4\\\"\\n        src=\\\"https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/cody-explain-code-aug2023.mp4\\\"\\n    />\\n</video>\\n\\nUse Cody to get an in-depth explanation of any piece of code in any programming language.\\n\\nTo get started: select code in your editor, right click, and choose \\\"Cody → Explain Code\\\".\\n\\nYou can also run this command from the [Cody: Commands Menu](command:cody.action.commands.menu), which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.\\n\\n**✨ Pro-tips for understanding code with Cody**\\n<br>• Cody can also explain errors too, with the \\\"Ask Cody to Explain\\\" option in the 💡 menus, or by right clicking on any items in the \\\"Problems\\\" tab of VS Code.\\n<br>• You can define your own custom code explain commands to suit, such as prompt that requests an explanation focused on potential security issues, using [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands).\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/integration/commands.test.ts`:\\n```ts\\nimport * as assert from 'assert'\\n\\nimport * as vscode from 'vscode'\\n\\nimport { afterIntegrationTest, beforeIntegrationTest, getTranscript, waitUntil } from './helpers'\\n\\n// TODO update tests to work with new simple chat\\n\\nsuite('Commands', function () {\\n    this.beforeEach(beforeIntegrationTest)\\n    this.afterEach(afterIntegrationTest)\\n\\n    async function getTextEditorWithSelection(): Promise<void> {\\n        // Open Main.java\\n        assert.ok(vscode.workspace.workspaceFolders)\\n        const mainJavaUri = vscode.Uri.parse(`${vscode.workspace.workspaceFolders[0].uri.toString()}/Main.java`)\\n        const textEditor = await vscode.window.showTextDocument(mainJavaUri)\\n\\n        // Select the \\\"main\\\" method\\n        textEditor.selection = new vscode.Selection(5, 0, 7, 0)\\n    }\\n\\n    // regex for /^hello from the assistant$/\\n    const assistantRegex = /^hello from the assistant$/\\n\\n    test.skip('Explain Code', async () => {\\n        await getTextEditorWithSelection()\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/templates.ts`:\\n```ts\\nconst instruction_prompt = `Follow these rules when answering my questions:\\n- Your response should based on the shared context only.\\n- Do not suggest anything that would break any shared code.\\n- All generated code must be full workable code.\\n\\n<questions>{humanInput}</questions>\\n`\\nconst prevent_hallucinations =\\n    \\\"Answer the questions only if you know the answer or can make a well-informed guess, else tell me you don't know it.\\\"\\n\\nexport const answers = {\\n    terminal: 'Noted. I will answer your next question based on this terminal output with other code you shared.',\\n    selection: 'Noted. I will refer to this code you selected in the editor to answer your question.',\\n    file: 'Noted. I will refer to this codebase file you are looking at to answer you next question for the code in the <selected> tags.',\\n    fileList:\\n        'Noted. I will refer to this list of files from the {fileName} directory of your codebase to answer your next question.',\\n    packageJson: 'Noted. I will use the right libraries/framework already setup in your codebase for your questions.',\\n}\\n\\nexport const prompts = {\\n    instruction: instruction_prompt,\\n}\\n\\nexport const rules = {\\n    hallucination: prevent_hallucinations,\\n}\\n\\nexport const displayFileName = `/n\\n    File: `\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/documentable-node.ts`:\\n```ts\\n\\nconst name = 'test'\\nexport { name }\\n// |\\n\\n// ------------------------------------\\n\\nconst name = 'test'\\nexport { name }\\n//         |\\n\\n// ------------------------------------\\n\\nconst name = 'test'\\nexport default name\\n//        |\\n\\n// ------------------------------------\\n\\nexport default function testFunc() {}\\n//                |\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/fixup.ts`:\\n```ts\\n<${PROMPT_TOPICS.INSTRUCTIONS}>\\n{instruction}\\n</${PROMPT_TOPICS.INSTRUCTIONS}>`\\n\\n    public static readonly addPrompt = `\\n- You are an AI programming assistant who is an expert in adding new code by following instructions.\\n- You should think step-by-step to plan your code before generating the final output.\\n- You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.\\n- Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.\\n- You will be provided with code that is above the users' cursor, enclosed in <${PROMPT_TOPICS.PRECEDING}></${PROMPT_TOPICS.PRECEDING}> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.\\n- You will be provided with code that is below the users' cursor, enclosed in <${PROMPT_TOPICS.FOLLOWING}></${PROMPT_TOPICS.FOLLOWING}> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/get-inline-completions-tests/languages.test.ts`:\\n```ts\\n                        System.out.println(\\\\\\\\\\\"Multiple of 3: \\\\\\\\\\\" + i);\\n                    } else {\\n                        System.out.println(\\\\\\\\\\\"ODD \\\\\\\\\\\" + i);\\n                    }\\\"\\n            `)\\n    })\\n\\n    // TODO: Detect `}/nelse/n{` pattern for else skip logic\\n    test('works with csharp', async () => {\\n        const requests: CompletionParameters[] = []\\n        const items = await getInlineCompletionsInsertText(\\n            params(\\n                dedent`\\n                    for (int i = 0; i < 11; i++) {\\n                        if (i % 2 == 0)\\n                        {\\n                            █\\n                `,\\n                [\\n                    completion`\\n                            ├Console.WriteLine(i);\\n                        }\\n                        else if (i % 3 == 0)\\n                        {\\n                            Console.WriteLine(\\\"Multiple of 3: \\\" + i);\\n                        }\\n                        else\\n                        {\\n                            Console.WriteLine(\\\"ODD \\\" + i);\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/fixup.ts`:\\n```ts\\n- You will be provided with instructions on what to generate, enclosed in <${PROMPT_TOPICS.INSTRUCTIONS}></${PROMPT_TOPICS.INSTRUCTIONS}> XML tags. You must follow these instructions carefully and to the letter.\\n- Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.\\n- Do not provide any additional commentary about the code you added. Only respond with the generated code.\\n\\nThe user is currently in the file: {fileName}\\n\\nProvide your generated code using the following instructions:\\n<${PROMPT_TOPICS.INSTRUCTIONS}>\\n{instruction}\\n</${PROMPT_TOPICS.INSTRUCTIONS}>`\\n\\n    public static readonly fixPrompt = `\\n- You are an AI programming assistant who is an expert in fixing errors within code.\\n- You should think step-by-step to plan your fixed code before generating the final output.\\n- You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.\\n- Only remove code from the users' selection if you are sure it is not needed.\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/documentable-node.ts`:\\n```ts\\nfunction wrapper() {\\n    console.log('wrapper')\\n    function test() {\\n        //      |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction testFunc() {\\n    //        |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction testParameter(val) {\\n    //                 |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction arrowWrapper() {\\n    const arrow = (value: string) => {\\n        //  |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nconst arrowFunc = (value: string) => {\\n    //  |\\n}\\n\\n// ------------------------------------\\n\\nclass Agent {\\n    //   |\\n}\\n\\n// ------------------------------------\\n\\nclass AgentConstructor {\\n    constructor() {\\n    //   |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction signature()\\n//           |\\n\\n// ------------------------------------\\n\\ninterface TestInterface {\\n    //          |\\n}\\n\\n// ------------------------------------\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/intents.ts`:\\n```ts\\nfunction wrapper() {\\n    console.log('wrapper')\\n    function test() {\\n        //          |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction testParams() {\\n    //             |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction testParameter(val) {\\n    //                 |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction arrowWrapper() {\\n    const arrow = (value: string) => {\\n        //                           |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nclass Agent {\\n    //      |\\n}\\n\\n// ------------------------------------\\n\\nfunction signature()\\n//                |\\n\\n// ------------------------------------\\n\\n// comment\\n//       |\\n\\n// ------------------------------------\\n\\n/**\\n * comment\\n //      |\\n */\\n\\n// ------------------------------------\\n\\nfunction functionName() {}\\n//                  |\\n\\n// ------------------------------------\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/webviews/App.tsx`:\\n```tsx\\n\\nfunction getWelcomeMessageByOS(os: string): string {\\n    const welcomeMessageMarkdown = `Welcome to Cody! Start writing code and Cody will autocomplete lines and entire functions for you.\\n\\nTo run [Cody Commands](command:cody.action.commands.menu) use the keyboard shortcut <span class=\\\"keyboard-shortcut\\\"><span>${\\n        os === 'darwin' ? '⌥' : 'Alt'\\n    }</span><span>C</span></span>, the <span class=\\\"cody-icons\\\">A</span> button, or right-click anywhere in your code.\\n\\nYou can start a new chat at any time with <span class=\\\"keyboard-shortcut\\\"><span>${\\n        os === 'darwin' ? '⌥' : 'Alt'\\n    }</span><span>/</span></span> or using the <span class=\\\"cody-icons\\\">H</span> button.\\n\\nFor more tips and tricks, see the [Getting Started Guide](command:cody.welcome) and [docs](https://sourcegraph.com/docs/cody).\\n`\\n    return welcomeMessageMarkdown\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/parents.ts`:\\n```ts\\nexport function whatsUp() {\\n    const result = {\\n    //    |\\n        value:  'value'\\n    }\\n}\\n\\n// ------------------------------------\\n\\nexport function singleLineVariable() {\\n    const a_very_long_variable_name = 'value'\\n    //                            |\\n}\\n\\n// ------------------------------------\\n\\ninterface kek {\\n    //        |\\n    value: string\\n}\\n\\n// ------------------------------------\\n\\nexport function pek() {\\n    //                |\\n    const data: kek = {\\n        value: 'wow',\\n    }\\n    return data\\n}\\n\\nexport const hmmm = 1\\n\\n// ------------------------------------\\n\\nclass Animal {\\n    //       |\\n    constructor() {}\\n}\\n\\n// ------------------------------------\\n\\nexport class Doggo extends Animal {\\n    public bark() {\\n        //        |\\n        return {}\\n    }\\n}\\n\\n// ------------------------------------\\n\\nexport function inconsistentIndentation() {\\n    if (Doggo) {\\n        const value = null; const arrow = () => {\\n        //                                      |\\n            console.log('Hello World!');\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/Main.java`:\\n```java\\n// This is a sample file used in extension integration tests.\\n\\npublic class Main {\\n    private Main() {}\\n\\n    public static void main(String[] args) {\\n\\tSystem.out.println(\\\"Hello, world\\\");\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Generate simple hello world function in java!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
+          },
+          "queryString": [],
+          "url": "https://sourcegraph.com/.api/completions/stream"
+        },
+        "response": {
+          "bodySize": 6971,
+          "content": {
+            "mimeType": "text/event-stream",
+            "size": 6971,
+            "text": "event: completion\ndata: {\"completion\":\" Here\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[]\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n   \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\");\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:39.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "89ff63ac-3044-4847-9026-e4bc06f629ae"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "2_wE.5_ByTatLsVbSeoZe.wpOsBMXIwQWJL7wXVBEkQ-1704298903-1-AeXFntLzHt+tG6DRTjbHqSDULeSaMpbkmdGv5SGcc2qKeuyagFKoNMWAfHPZyvqg4MAs9eI5Jj7yOVmpthVSxw4="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Dr4bhizDbMnCpvCkTo2X1xPLbr5l1Fv9pkW79CsHKT4-1704298903896-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/event-stream"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=89ff63ac-3044-4847-9026-e4bc06f629ae; Expires=Fri, 03 Jan 2025 16:21:39 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=2_wE.5_ByTatLsVbSeoZe.wpOsBMXIwQWJL7wXVBEkQ-1704298903-1-AeXFntLzHt+tG6DRTjbHqSDULeSaMpbkmdGv5SGcc2qKeuyagFKoNMWAfHPZyvqg4MAs9eI5Jj7yOVmpthVSxw4=; path=/; expires=Wed, 03-Jan-24 16:51:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=Dr4bhizDbMnCpvCkTo2X1xPLbr5l1Fv9pkW79CsHKT4-1704298903896-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8782c6b0963ac9adfd23b050dac17256"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e6808b9379ef67f0"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8782c6b0963ac9adfd23b050dac17256"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc937bbf383539-WAW"
+            }
+          ],
+          "headersSize": 1289,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:39.760Z",
+        "time": 4799,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4799
+        }
+      },
+      {
+        "_id": "4513df7f1ecd2925ab87523d3ebb9370",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 549,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "549"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.chatResponse.new\",\"action\":\"hasCode\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"lineCount\",\"value\":7},{\"key\":\"charCount\",\"value\":111},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:44.564Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-03T16:21:44.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "c01caf81-28b9-4684-96ae-9ad7ffb62ac4"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-03T16:51:44.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "9z.BlHmmwAmDxAc4yzcKzvto7cqV3kovJFI4neHyTpc-1704298904-1-AT21S+Ko2Lx6Oyf9o44/CsKHFY4QXa4P6j/EHaCVIo7wuVafE3bOggiIGB/xZH9Fs8PI3jxO8bQLhBD27rU5K3I="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "rHjgq1ZsBoajXjl2l3RpS_EVIOLXqDuJ_N12_.IwoAE-1704298904820-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 03 Jan 2024 16:21:44 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=c01caf81-28b9-4684-96ae-9ad7ffb62ac4; Expires=Fri, 03 Jan 2025 16:21:44 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=9z.BlHmmwAmDxAc4yzcKzvto7cqV3kovJFI4neHyTpc-1704298904-1-AT21S+Ko2Lx6Oyf9o44/CsKHFY4QXa4P6j/EHaCVIo7wuVafE3bOggiIGB/xZH9Fs8PI3jxO8bQLhBD27rU5K3I=; path=/; expires=Wed, 03-Jan-24 16:51:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=rHjgq1ZsBoajXjl2l3RpS_EVIOLXqDuJ_N12_.IwoAE-1704298904820-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3a568c67a8a16f3359d487d4e658e5c3"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "7129c0371dce1964"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3a568c67a8a16f3359d487d4e658e5c3"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "83fc9399f93bfbe2-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-03T16:21:44.565Z",
+        "time": 235,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 235
         }
       },
       {
@@ -3825,1255 +8634,6 @@
         }
       },
       {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "0476ba1f-cb05-4de2-8823-b3902920ccee"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "FjZUeZo2zc13ws8DsrdCuZXpTLdw5mOqLqv3pq4qfwM-1703613805-1-AU1wZvVmPh3mkhKKPH97cUPhvdPj14sspWyxn3dNZhV1um4mUa0RnA+v7xNuY5PQW3mvIJWon2VIdfTqlHJGS5o="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Vqki_UTLBNS9Fl0lTmIput5k_p6x53oDYKzmwHVfNVI-1703613805719-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0476ba1f-cb05-4de2-8823-b3902920ccee; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=FjZUeZo2zc13ws8DsrdCuZXpTLdw5mOqLqv3pq4qfwM-1703613805-1-AU1wZvVmPh3mkhKKPH97cUPhvdPj14sspWyxn3dNZhV1um4mUa0RnA+v7xNuY5PQW3mvIJWon2VIdfTqlHJGS5o=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=Vqki_UTLBNS9Fl0lTmIput5k_p6x53oDYKzmwHVfNVI-1703613805719-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "660e8063ca2d7dc7ee75cc9a6409a5c6"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "52ba479fceadfb98"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/660e8063ca2d7dc7ee75cc9a6409a5c6"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8cbaed3516-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.357Z",
-        "time": 271,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 271
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7bd5dbeb-0ed5-463d-96a5-d1d96764663b"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gUP3kS93MS5OjecagsndeG6ZC7hbwcG8kPvs5WZz_oI-1703613805-1-AaXdFw21tN6Tx/E7a51ihoCVN/wtR1mMl+G8r72c3T1BC/8fhV3WoSAKiquEHkCwT8VDvTLExltJXCcPfYVKUIo="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "_npSDuLLXKZLnNwGDxDnpvocdofPTm07DVWk51mgjpo-1703613805723-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7bd5dbeb-0ed5-463d-96a5-d1d96764663b; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=gUP3kS93MS5OjecagsndeG6ZC7hbwcG8kPvs5WZz_oI-1703613805-1-AaXdFw21tN6Tx/E7a51ihoCVN/wtR1mMl+G8r72c3T1BC/8fhV3WoSAKiquEHkCwT8VDvTLExltJXCcPfYVKUIo=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=_npSDuLLXKZLnNwGDxDnpvocdofPTm07DVWk51mgjpo-1703613805723-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d324714c681d4b42b37ac739e988f353"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "1883741a162ce525"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d324714c681d4b42b37ac739e988f353"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8cb996f2cc-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.355Z",
-        "time": 279,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 279
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "26061b9b-c6b8-44a7-89b6-f37611b6fbaf"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "fDqR_KVOkzbIxE9a5irNRsD5ezLyu2lPugkrnwqaGCA-1703613805-1-AeWB2Gffsh3f83OscI7/b+mfzjZRG5AbUzJze6KHD8iSf5XusdH2sQZenb2lQrcj+SWgxDg2Fl50RoGcg2dISqw="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "310JU9TuheuxdezaHavXjJm3x.PaQ7sM.JIkwUwimvA-1703613805736-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=26061b9b-c6b8-44a7-89b6-f37611b6fbaf; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=fDqR_KVOkzbIxE9a5irNRsD5ezLyu2lPugkrnwqaGCA-1703613805-1-AeWB2Gffsh3f83OscI7/b+mfzjZRG5AbUzJze6KHD8iSf5XusdH2sQZenb2lQrcj+SWgxDg2Fl50RoGcg2dISqw=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=310JU9TuheuxdezaHavXjJm3x.PaQ7sM.JIkwUwimvA-1703613805736-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6e80d4ebe8847e1b99eec11d4d0aa839"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "3f6d755f7f9d73e4"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6e80d4ebe8847e1b99eec11d4d0aa839"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8cac16bf92-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.354Z",
-        "time": 292,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 292
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "28b3d4ef-94e1-48c4-8d6a-2594e3f3fa4d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "YvfMfgW2q_SWkBgXflrP.snuiuuyFtpt31OkPs2veVE-1703613805-1-AT8fOMoJlUgY/7DowoVDQ3r6sYnYQUXPyhFCSb4IfUtbCKHoSzSSYfa9IRTBivqZxZAlVkh8AUuuqpjq43KOfKI="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "s4yipxeJ.VpZ7t0vG9LeRlu1q1TxagLMYE9Odb.Aa_I-1703613805749-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=28b3d4ef-94e1-48c4-8d6a-2594e3f3fa4d; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=YvfMfgW2q_SWkBgXflrP.snuiuuyFtpt31OkPs2veVE-1703613805-1-AT8fOMoJlUgY/7DowoVDQ3r6sYnYQUXPyhFCSb4IfUtbCKHoSzSSYfa9IRTBivqZxZAlVkh8AUuuqpjq43KOfKI=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=s4yipxeJ.VpZ7t0vG9LeRlu1q1TxagLMYE9Odb.Aa_I-1703613805749-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8e9f71a9898b4328c5e1783a3007db04"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "76cb7970a57a3938"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8e9f71a9898b4328c5e1783a3007db04"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8cbf7efc8b-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.356Z",
-        "time": 304,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 304
-        }
-      },
-      {
-        "_id": "7449140909c921a511332d4c1de94c1f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 182,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "182"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-user-latency\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:26.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2c584833-33b1-4267-bf46-e6b52e78ab60"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:26.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "TkirVTfQykbGlulnO05mIPs9TiOhCSgDFptqSnOQhX4-1703613806-1-ATLMmFzhA2EIOkbRm1qYfcZKpU5So/r6WnOcKj3eHt5PqcbYGW01hpvKTRi7OhCOgTruYzAvF6Ec71LbLnODV4A="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "3u4PX6uoTJALiUMoCG1SFpRb9_wiRmi_E8VrnnwLMkE-1703613806204-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:26 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2c584833-33b1-4267-bf46-e6b52e78ab60; Expires=Thu, 26 Dec 2024 18:03:26 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=TkirVTfQykbGlulnO05mIPs9TiOhCSgDFptqSnOQhX4-1703613806-1-ATLMmFzhA2EIOkbRm1qYfcZKpU5So/r6WnOcKj3eHt5PqcbYGW01hpvKTRi7OhCOgTruYzAvF6Ec71LbLnODV4A=; path=/; expires=Tue, 26-Dec-23 18:33:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=3u4PX6uoTJALiUMoCG1SFpRb9_wiRmi_E8VrnnwLMkE-1703613806204-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "82b14a105ff32a8c4eea4713cb86aed6"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c3afe620b077e7a2"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/82b14a105ff32a8c4eea4713cb86aed6"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8fb83efbc6-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.874Z",
-        "time": 240,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 240
-        }
-      },
-      {
-        "_id": "8a049c80771d508a499a55e49d24b525",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1273,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip;q=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1273"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 333,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"timeoutMs\":15000,\"maxTokensToSample\":256,\"stopSequences\":[\"\\n\\nHuman:\",\"</CODE5711>\"],\"temperature\":0.5,\"topK\":0,\"messages\":[{\"speaker\":\"human\",\"text\":\"You are a code completion AI designed to take the surrounding code and shared context into account in order to predict and suggest high-quality code to complete the code enclosed in <CODE5711> tags. You only response with code that works and fits seamlessly with surrounding code if any or use best practice and nothing else.\"},{\"speaker\":\"assistant\",\"text\":\"I am a code completion AI with exceptional context-awareness designed to auto-complete nested code blocks with high-quality code that seamlessly integrates with surrounding code.\"},{\"speaker\":\"human\",\"text\":\"Below is the code from file path src/sum.ts. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code: \\n```\\nexport function sum(a: number, b: number): number {\\n   <CODE5711></CODE5711> \\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"<CODE5711>export function sum(a: number, b: number): number {\"}],\"stream\":true}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/code"
-        },
-        "response": {
-          "bodySize": 619,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 619,
-            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:26.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b306df5a-2c39-4232-98a7-e223cd086485"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "CiHYljovR5cln.ZtFYpyT3icwDQ0_CKg9ypmJSx6Mh0-1703613807-1-ATmvEL/0hdYiKCIQg5aLQCq9wFWzLW8R17ao3b3qN3ANDFhwGDgaYJudeDrcS3ESCaTUFPSgLE5l6hujbinvTqo="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "P.6DX4t32Fi6RCdJpIuGc.xu0auICrpPhuN4PajxDOA-1703613807357-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "keep-alive"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b306df5a-2c39-4232-98a7-e223cd086485; Expires=Thu, 26 Dec 2024 18:03:26 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=CiHYljovR5cln.ZtFYpyT3icwDQ0_CKg9ypmJSx6Mh0-1703613807-1-ATmvEL/0hdYiKCIQg5aLQCq9wFWzLW8R17ao3b3qN3ANDFhwGDgaYJudeDrcS3ESCaTUFPSgLE5l6hujbinvTqo=; path=/; expires=Tue, 26-Dec-23 18:33:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=P.6DX4t32Fi6RCdJpIuGc.xu0auICrpPhuN4PajxDOA-1703613807357-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d6dc7d9d8ff6c4461be692bb98bedd87"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "8bb0f552f8925b81"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d6dc7d9d8ff6c4461be692bb98bedd87"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d915f085037-WAW"
-            }
-          ],
-          "headersSize": 1289,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:26.125Z",
-        "time": 1222,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1222
-        }
-      },
-      {
         "_id": "655f4a5576ce322849772678587446b2",
         "_order": 0,
         "cache": {},
@@ -6131,220 +9691,6 @@
           "send": 0,
           "ssl": -1,
           "wait": 261
-        }
-      },
-      {
-        "_id": "fb5ccae70488a1172b9b76428acf169e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 545,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "545"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 345,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery LegacyEmbeddingsSearch($repo: ID!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {\\n\\tembeddingsSearch(repo: $repo, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {\\n\\t\\tcodeResults {\\n\\t\\t\\tfileName\\n\\t\\t\\tstartLine\\n\\t\\t\\tendLine\\n\\t\\t\\tcontent\\n\\t\\t}\\n\\t\\ttextResults {\\n\\t\\t\\tfileName\\n\\t\\t\\tstartLine\\n\\t\\t\\tendLine\\n\\t\\t\\tcontent\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{\"repo\":\"UmVwb3NpdG9yeTo2MTMyNTMyOA==\",\"query\":\"Hello!\",\"codeResultsCount\":12,\"textResultsCount\":3}}"
-          },
-          "queryString": [
-            {
-              "name": "LegacyEmbeddingsSearch",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LegacyEmbeddingsSearch"
-        },
-        "response": {
-          "bodySize": 2262,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 2262,
-            "text": "[\"H4sIAAAAAAAA/8RX4W7byBF+lSnvR8+BKMqyz/Y=\",\"CRAK15dDAgRNECeXHo7Backdkgsvd9ndoSghMHDP0H8FChTtrz5XnqCPUMxSsijbctJf/SObs7vzzXwz3yz5KZKCRDT7FGGdoZTKlP4ahcsrtuVW4lv0rSYfzX75FBVK459EjdEsWnpeTLzLE49uqXL0yWVL1Rtnl0qiu1Z1o1WhUI7JR6PIk3D0ShmMZmcXowiN7B/OJ6Mot4bQUDSLblMT3Y4OAeWVoPATLxV2/X8V6gadfwByPD0doBxPz74e5i4fcog/KexeEtaPIJydDxHOvh8ifDyIQOgpwSkmhVq1TSwxt06QdWNeeABy/t2Qq/O9JI6exijUilqHPumsu/GNyDFRRuJqXFGt91Eme1QNQdJ2MjnJf/fD66t3P795Dnw0mDA1/RJbQAtTztMITRptVwEANjtQyKF1t1IjCcgr4TzSPI3ev/sxvkgjSJ7YXRE1Mf6lVct5Gv05fn8ZX9m6EaQyjWkEm8DnafTy+RxliV9wZ0SN8zTidmqsoz0PnZJUzSVyL8ThYQTKKFJCxz4XGufH48lh/6RIY7/0ArW2cGXlul9KBmtDppL7VPXmbHtwf/PQvD0/KM/91tAqS1q109E7J4zPnWqI23tMfrXfE9PpyaArpvsC4jCOUvNECwYcWzcaSVnjE23LEg80+fRkOoQ6+e4+1O2XsbTNhY7DsRUl0nZGWyFjv66Lh8o9HqZ2fPwgtdvUfGESDTLbYjokp3CJzifaN7FWZUW7/+K75UfSP9tL//uvC4cL6ivhUO6K6jBXTZhcwngtCB+AnQ7H4un510GJEg31KFoluBS6FYSxaMlumMDEkxOE5TouFcXalg9ZPx3OsuPTi69Pc9i3yjQtXW04v6oEvRwYHrbxxXC2XZzcx9wK52Qrm9BlH0cRe3v66uuEvqHK2basfDKkYlzLJ8br8TCEb77hsYBwOTiemq2eVV2Cd/k8jXjs+VmSeLJOlDgurS01ikb5cW7rxNvW5Vg60VSx8B7JJ5m2ZbL0MYcaW5NZ4fhyjwdR890TTyfTE9603qtmTH41LlWxm+epueaEoHOKlCmB/YIwMow16JTWsD0MVCFoZRC+tS48oCHlEIrW5KyZIyisg7Vtx/BCEZDIgCyIPMeGwn7fliV63jpm5GfPPv/93/DG2ZhU48Ph1nMQAXsY97NnW+4y10f++bd/7bELrUe/AXHOtkbuZbMRM8ejTGFdfS8ePwJvQRUcPRhEyTvLVkkERcGYCwNCShDMR42GQGR2OSBlbdvfOwSUgcjxYwH/vPFT2SU6CD98vHS4HsTC0B4RBJC1OhMObAFCEzojSC3vhS08dKg1/7VUsdsmrIBv84qtPf/MhgBmVyN01kkQxAiqxidDbX2fYhq9c4pH/T7rguCqdd66cMXWNXNNFmizV/QVGOTGqGYdcEebarN7iYVoNcENrkNLg6+so7wlzn3xOqS0gEWaLsAaqEX++jrUdXGpaWf/oIy0nQ/qn57BK2Xa1fjgwN8TeqFWT+t7ck/fP6pV0Pj/QdbC38RkYw75vpZtjVQxqZ2z/Kuo4sZ0oQ5/gPceg7g+//Y3D2l06W96rZHlfPZrWKgVKBqBdYCrRgtlQqUaZzON9SEBF2p1J7yAzv4fl++2xWyDvev//OOv/4QaTTvqjwrzaIx9g48gW0Ntl9sOykMb9qLiDguatMUgEmEAnbMuNM6u9fZbDhZXPQULWIwHzWYdLK4c6TvzgV47nKbQ3oLjdwbItcpv2AkHqvgrBDbsptGbnl+fRmGA2gJ+uu4vEw7bo8acHqPlYJtLmycdZv/L7QUfMANcERrPmv0WVw06xUNP6A==\",\"Iy58QOZyb2NTngvg0JBegzV6DYq9SZSbsY6c4Xb3D+hvyDYjMJbglz7OscTlx2+3ytnZjpj6frJ1mMWZ8ChhKZwShvyAntCQL2zHr2L8Qk8OGyVB4hK15U/JvXH2a6XKSq9hmNmvDDBIewMSEgivoVtnvH07vFD1Q7dgtx5hCqxAK/2M44nhbWtg0ZimBtca6ATl1UzictZhtggVpQo3EuDcZ0n/xltZT7OTyWTCtAUBc2yZs51HN2bHL+/oHAXXnNXilWhNXt3x/HxXwg+YMSvwx97F0QIkZi0L1RSqbJ24u5XftsZstbEjI/Sn8tCJNRebC2eLQuVKaM2XV8PfWSi5WHy9Bit/FKAMA/jj7e3tfwMAAP//uOaAUZQQAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:28.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "f4d614fe-6890-4b88-9240-4c7495ff861b"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:28.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "iFadiQ3Ni0lgHzU5ps1hAE1S6j0be0PZ2QLVyeApbXo-1703613808-1-AUvfheAjyJ9Z+ksiCrjjquNmGaApYjG7WjZ4mt6RXKOB4cwI9mvDvwpfb/BoFiZJlOjBd/ENgtFCj14oot+Y+LA="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "22sGSu0qSun0_V5O6yldw65C.May0l_UfZU.80eJNjI-1703613808669-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:28 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f4d614fe-6890-4b88-9240-4c7495ff861b; Expires=Thu, 26 Dec 2024 18:03:28 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=iFadiQ3Ni0lgHzU5ps1hAE1S6j0be0PZ2QLVyeApbXo-1703613808-1-AUvfheAjyJ9Z+ksiCrjjquNmGaApYjG7WjZ4mt6RXKOB4cwI9mvDvwpfb/BoFiZJlOjBd/ENgtFCj14oot+Y+LA=; path=/; expires=Tue, 26-Dec-23 18:33:28 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=22sGSu0qSun0_V5O6yldw65C.May0l_UfZU.80eJNjI-1703613808669-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "5a33abe1ecd0b48bbe4a2a9eeb962642"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "404d0d2f6938e1a0"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5a33abe1ecd0b48bbe4a2a9eeb962642"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d9ccf3e70c1-WAW"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:27.957Z",
-        "time": 624,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 624
         }
       },
       {

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -72,29 +72,29 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteProductVersion"
         },
         "response": {
-          "bodySize": 139,
+          "bodySize": 142,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 139,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZuYGhvFGBkYmugaGugam8aZ6RrpGxiamqSkWacnGRiZKtbW1AAAAAP//\",\"AwC7GWWbSQAAAA==\"]"
+            "size": 142,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp\",\"pcklYalFxZn5eUpWSkamZuYGhvFGBkYmugaGugam8aZ6RrpGxiamqSkWacnGRiZKtbW1AAAAAP//\",\"AwC7GWWbSQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:16.000Z",
+              "expires": "2025-01-05T09:16:39.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "83de075a-6894-487d-8929-151e9b79d072"
+              "value": "9215309b-94b2-4099-968f-4419f99ac061"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:16.000Z",
+              "expires": "2024-01-05T09:46:39.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XoOUdJx.wr6dKfVVk_q0RNKDFGdTKzJ0DPtc5j.fGAk-1704442816-1-AXCYNDukNdbE00tg1KE4k8Jh0cvlSVyeM4O8gnV4GmRtslCGnVTzzfTnCxPblXTWlDiryx4qFscXr92LBxYySj4="
+              "value": "LlAWL5uxmLgoUMJLV2Dfr_PyYPqRatqg736mt0lKCns-1704446199-1-AWo1FaUuqUzqXCSPf0d1Xl7H6dUaCWcH8bjOOAt6r1ArkKpkfFAQqou1Dwg3sy+RcQcTWroyl8mXTs9wYFFDoYI="
             },
             {
               "domain": ".sourcegraph.com",
@@ -103,13 +103,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Zd2HHU_IXoCD6A6kgiLFmQblmK_A51J9GMySCfnM2fk-1704442816458-0-604800000"
+              "value": "AO.U.sLX2_HQDH9VOHxGzbgm_y.Im6UapPnOx2z4u6M-1704446199818-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:16 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:39 GMT"
             },
             {
               "name": "content-type",
@@ -122,18 +122,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "347"
             },
             {
               "name": "access-control-allow-credentials",
@@ -150,17 +138,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=83de075a-6894-487d-8929-151e9b79d072; Expires=Sun, 05 Jan 2025 08:20:16 GMT; Secure"
+              "value": "sourcegraphDeviceId=9215309b-94b2-4099-968f-4419f99ac061; Expires=Sun, 05 Jan 2025 09:16:39 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=XoOUdJx.wr6dKfVVk_q0RNKDFGdTKzJ0DPtc5j.fGAk-1704442816-1-AXCYNDukNdbE00tg1KE4k8Jh0cvlSVyeM4O8gnV4GmRtslCGnVTzzfTnCxPblXTWlDiryx4qFscXr92LBxYySj4=; path=/; expires=Fri, 05-Jan-24 08:50:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=LlAWL5uxmLgoUMJLV2Dfr_PyYPqRatqg736mt0lKCns-1704446199-1-AWo1FaUuqUzqXCSPf0d1Xl7H6dUaCWcH8bjOOAt6r1ArkKpkfFAQqou1Dwg3sy+RcQcTWroyl8mXTs9wYFFDoYI=; path=/; expires=Fri, 05-Jan-24 09:46:39 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Zd2HHU_IXoCD6A6kgiLFmQblmK_A51J9GMySCfnM2fk-1704442816458-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=AO.U.sLX2_HQDH9VOHxGzbgm_y.Im6UapPnOx2z4u6M-1704446199818-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -176,15 +164,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5655b33e9c6cae7ac41361707f9c1f24"
+              "value": "b865c4854b11922573657d3d9ec456b7"
             },
             {
               "name": "x-trace-span",
-              "value": "086a9571d3cf55be"
+              "value": "d63ce5946782cda4"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5655b33e9c6cae7ac41361707f9c1f24"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b865c4854b11922573657d3d9ec456b7"
             },
             {
               "name": "x-xss-protection",
@@ -208,21 +196,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d11df613540-WAW"
+              "value": "840a9fabdc76fc8f-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:16.190Z",
-        "time": 226,
+        "startedDateTime": "2024-01-05T09:16:39.584Z",
+        "time": 225,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -230,7 +218,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 226
+          "wait": 225
         }
       },
       {
@@ -307,20 +295,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:16.000Z",
+              "expires": "2025-01-05T09:16:40.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d9fc37b1-fd68-4496-bdf6-77c33963f667"
+              "value": "e71856db-63b8-4157-9fb5-e2a513667161"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:16.000Z",
+              "expires": "2024-01-05T09:46:40.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "GWn2ilBCDdAR4rdKiwo7drhWTboeLIjSBKBdzfPOJTo-1704442816-1-AZetxLUhBTaGmBQuuGlQJR9VAr/mZ9teCZa9m+ZfA1ii0g5vxhTHdsOG/5CxXt28CrdwXQjKbpxkIMmcW2kd7BM="
+              "value": "MU_gnDGDWar2wDPPbKRzUkkwLdb8KbAzGmJsE6BFRZk-1704446200-1-AQHmHEFxGvW23lHosFYd0crx5m3RBcQxt22FKqZj7HRJCLA+44Iz8iAfT2LiB/4uxfDdmHf/hYcAqP+2VTNKiVc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -329,13 +317,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ESbavwfmWFlxryr0I4OL_KosjMcThUfoFOqhADJ07jw-1704442816894-0-604800000"
+              "value": "T4pECiX9spR6MmQSNLA5FTEW464tGPmAl2uSXxB8VU8-1704446200267-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:16 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
             },
             {
               "name": "content-type",
@@ -348,18 +336,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -376,17 +352,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d9fc37b1-fd68-4496-bdf6-77c33963f667; Expires=Sun, 05 Jan 2025 08:20:16 GMT; Secure"
+              "value": "sourcegraphDeviceId=e71856db-63b8-4157-9fb5-e2a513667161; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=GWn2ilBCDdAR4rdKiwo7drhWTboeLIjSBKBdzfPOJTo-1704442816-1-AZetxLUhBTaGmBQuuGlQJR9VAr/mZ9teCZa9m+ZfA1ii0g5vxhTHdsOG/5CxXt28CrdwXQjKbpxkIMmcW2kd7BM=; path=/; expires=Fri, 05-Jan-24 08:50:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=MU_gnDGDWar2wDPPbKRzUkkwLdb8KbAzGmJsE6BFRZk-1704446200-1-AQHmHEFxGvW23lHosFYd0crx5m3RBcQxt22FKqZj7HRJCLA+44Iz8iAfT2LiB/4uxfDdmHf/hYcAqP+2VTNKiVc=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=ESbavwfmWFlxryr0I4OL_KosjMcThUfoFOqhADJ07jw-1704442816894-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=T4pECiX9spR6MmQSNLA5FTEW464tGPmAl2uSXxB8VU8-1704446200267-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -402,15 +378,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5c948bf7b1dc98f642c89146c720c174"
+              "value": "048320349c7aab55598b80170ae34e71"
             },
             {
               "name": "x-trace-span",
-              "value": "e0b51c4a74670eb7"
+              "value": "025356699bcc62a5"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5c948bf7b1dc98f642c89146c720c174"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/048320349c7aab55598b80170ae34e71"
             },
             {
               "name": "x-xss-protection",
@@ -434,21 +410,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d149b643bbd-WAW"
+              "value": "840a9fae9ce934c1-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:16.642Z",
-        "time": 210,
+        "startedDateTime": "2024-01-05T09:16:40.028Z",
+        "time": 229,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -456,459 +432,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 210
-        }
-      },
-      {
-        "_id": "26f7093bcc1d125e7768f46a33e590e8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 318,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "318"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:17.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "288027bd-21b0-42ad-9bf2-f89a04f245e3"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "TWfA1oabX1Lo3EWwtAIWbEXGJx5wSH5cyHFudjz5bw8-1704442817-1-AW4pSSEjbYMYWzKQyuDQ7nAkURJvw4aB22PPY2fq2HGgvGBZa0YVWntL8DhxXBFPfiszQk+8h8Txm6tAlxZlEbs="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "zKSKbaeD_SWEwzpaD9guOL1cRWRpKb.H6IYePGo1yI8-1704442817116-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=288027bd-21b0-42ad-9bf2-f89a04f245e3; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=TWfA1oabX1Lo3EWwtAIWbEXGJx5wSH5cyHFudjz5bw8-1704442817-1-AW4pSSEjbYMYWzKQyuDQ7nAkURJvw4aB22PPY2fq2HGgvGBZa0YVWntL8DhxXBFPfiszQk+8h8Txm6tAlxZlEbs=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=zKSKbaeD_SWEwzpaD9guOL1cRWRpKb.H6IYePGo1yI8-1704442817116-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4e603ef75db0dd706178fe85585ecb8c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "bd8afbb4e867d7e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4e603ef75db0dd706178fe85585ecb8c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d160813bf35-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1425,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:16.866Z",
-        "time": 210,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 210
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 131,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 131,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:17.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2fb789b0-d81e-4480-a1da-dea6a92876bf"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "rFkpP9zab.dyFTJb3qlu5fEOcxuDOScuirlkXGZetYc-1704442817-1-AVyMsXQj4r+3N9PRPKZaO+NFjVN9KpD5rAueOCf/ID82OMjw7MUzeqJ7D7gGB6NfFvNMg7NJG9KtZDrTk0OigQE="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "h3JjoqjeGNepFSU6e1V1dsH9uN5W8M8NIjHs.HWpDUg-1704442817118-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2fb789b0-d81e-4480-a1da-dea6a92876bf; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=rFkpP9zab.dyFTJb3qlu5fEOcxuDOScuirlkXGZetYc-1704442817-1-AVyMsXQj4r+3N9PRPKZaO+NFjVN9KpD5rAueOCf/ID82OMjw7MUzeqJ7D7gGB6NfFvNMg7NJG9KtZDrTk0OigQE=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=h3JjoqjeGNepFSU6e1V1dsH9uN5W8M8NIjHs.HWpDUg-1704442817118-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "f7e9bf2ea3204391ebd5da3521cdc019"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e3f0244f97590567"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f7e9bf2ea3204391ebd5da3521cdc019"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d16088cfc7f-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1425,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:16.868Z",
-        "time": 209,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 209
+          "wait": 229
         }
       },
       {
@@ -985,20 +509,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:17.000Z",
+              "expires": "2025-01-05T09:16:40.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "f7bd13b3-ed32-423f-9508-05b0ab66ade7"
+              "value": "ac09ef7f-695e-4951-9158-168d9b8f4f94"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
+              "expires": "2024-01-05T09:46:40.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "smDEdLOfauiUNxHy729pYi5PLTPZh4xjXnZZDeKIXPA-1704442817-1-AWo/HVDzfEA2GVPJcBVAXRXM+R216PYd0WiDJs9/he++fN0xP8qB5hBLYNeF/3gWxLaM+jYt/VWCbRbvtWTFsTU="
+              "value": "GhgTUxHe7mNSRFH2hCG.qmZ5rmQ0Y.HfZfu3crtii2s-1704446200-1-AcH3yJUftl77ZkdC8lhGA8gtAMPnHUm6rAZl/iY/vNYkn2xmmaMYNcVSeoeF4JumO7+prvJy480DEy0iGvkLSIg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1007,13 +531,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "1_CuFJicaxENKYXGaP2MKFtyIJQe53tpTqm6XQ5vJkk-1704442817119-0-604800000"
+              "value": "nomYLdTDgtozAF8iuocoHwEHnmqGajdpjC7VvELKTrI-1704446200484-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
             },
             {
               "name": "content-type",
@@ -1026,18 +550,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1054,17 +566,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f7bd13b3-ed32-423f-9508-05b0ab66ade7; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=ac09ef7f-695e-4951-9158-168d9b8f4f94; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=smDEdLOfauiUNxHy729pYi5PLTPZh4xjXnZZDeKIXPA-1704442817-1-AWo/HVDzfEA2GVPJcBVAXRXM+R216PYd0WiDJs9/he++fN0xP8qB5hBLYNeF/3gWxLaM+jYt/VWCbRbvtWTFsTU=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=GhgTUxHe7mNSRFH2hCG.qmZ5rmQ0Y.HfZfu3crtii2s-1704446200-1-AcH3yJUftl77ZkdC8lhGA8gtAMPnHUm6rAZl/iY/vNYkn2xmmaMYNcVSeoeF4JumO7+prvJy480DEy0iGvkLSIg=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=1_CuFJicaxENKYXGaP2MKFtyIJQe53tpTqm6XQ5vJkk-1704442817119-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=nomYLdTDgtozAF8iuocoHwEHnmqGajdpjC7VvELKTrI-1704446200484-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1080,15 +592,15 @@
             },
             {
               "name": "x-trace",
-              "value": "8ff510b8b27aab48431b4bbc2a20dea1"
+              "value": "1594037ee1c7257b6b9559a4172d84e4"
             },
             {
               "name": "x-trace-span",
-              "value": "778248f2788b59e9"
+              "value": "fe1c52881b2980f3"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8ff510b8b27aab48431b4bbc2a20dea1"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1594037ee1c7257b6b9559a4172d84e4"
             },
             {
               "name": "x-xss-protection",
@@ -1112,21 +624,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d160f2170bf-WAW"
+              "value": "840a9fb01df335a6-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:16.864Z",
-        "time": 213,
+        "startedDateTime": "2024-01-05T09:16:40.269Z",
+        "time": 207,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1134,7 +646,435 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 213
+          "wait": 207
+        }
+      },
+      {
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 155,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "155"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 134,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 134,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmV\",\"Pj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:40.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1165786e-4957-4819-8e24-1a299c631830"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:40.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "M1cQI52jR5qRa.n8o2HEPwCRHJsAhD3FrNlfo6mXF5k-1704446200-1-Aea6JD9h+1oGAKPHTwqOzXZ70eQTpCnccqYej0zjt0P0lntrZwxiLCzVZVMUdQynbPi/FMhA1tj3Ksf4ypSYwQA="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "m6WoT_onFG91YUxod9J8XFz.4dkBHAiE.eilvORLbLI-1704446200486-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1165786e-4957-4819-8e24-1a299c631830; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=M1cQI52jR5qRa.n8o2HEPwCRHJsAhD3FrNlfo6mXF5k-1704446200-1-Aea6JD9h+1oGAKPHTwqOzXZ70eQTpCnccqYej0zjt0P0lntrZwxiLCzVZVMUdQynbPi/FMhA1tj3Ksf4ypSYwQA=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=m6WoT_onFG91YUxod9J8XFz.4dkBHAiE.eilvORLbLI-1704446200486-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "60c4e1d9498ecb4c4d9df3875b729701"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "57e389e782dc2d5e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/60c4e1d9498ecb4c4d9df3875b729701"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb01b8934f1-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:40.274Z",
+        "time": 203,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 203
+        }
+      },
+      {
+        "_id": "26f7093bcc1d125e7768f46a33e590e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 318,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "318"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:40.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "5a6dc51d-4573-42e4-9348-2663218b8106"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:40.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "JQP78FDD_oywqOA0jdAPkSJJdI5yXe6g6oSWgleZpw4-1704446200-1-AUV2Ik0TIBu9DCALQHZaFj5HB/uUcbEfVC1wX3NMGjn950JPvOPlcwVM4rk8HneAlWGcSMDd0Ed9Icsukettb0Y="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "EW59Dj6JsYfSLd0l5XJ6AcdfImdPE89p0Fc3AgBDIbE-1704446200490-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=5a6dc51d-4573-42e4-9348-2663218b8106; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=JQP78FDD_oywqOA0jdAPkSJJdI5yXe6g6oSWgleZpw4-1704446200-1-AUV2Ik0TIBu9DCALQHZaFj5HB/uUcbEfVC1wX3NMGjn950JPvOPlcwVM4rk8HneAlWGcSMDd0Ed9Icsukettb0Y=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=EW59Dj6JsYfSLd0l5XJ6AcdfImdPE89p0Fc3AgBDIbE-1704446200490-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "67d5cc894a1c705a28a3861834e34bf3"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "efc4bb7f79f4e448"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/67d5cc894a1c705a28a3861834e34bf3"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb01bb7504f-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:40.272Z",
+        "time": 207,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 207
         }
       },
       {
@@ -1211,20 +1151,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:17.000Z",
+              "expires": "2025-01-05T09:16:40.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "f2d256af-ec3a-4b49-836a-5a816938677a"
+              "value": "99ffda4a-a3c3-4167-904d-25476381bdce"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
+              "expires": "2024-01-05T09:46:40.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "VVHPI8APWRPLxtv1xHXWbbcW7UbOfmnSRQ6QzzxR4_c-1704442817-1-AXi6uPSy8k+yyYORNhN6QdCV8vZrDfetW6aB8rnU9gZru3xr5wP7bjiXpK18+f2wp+BerrL5UtnvFYDm6aBwD4M="
+              "value": "VWFX6.03KQpwRtX3DtnXj0l3mBB3LFGYA4IKMXsE0C4-1704446200-1-AT3++y0GQUGXQGvRR6DkOEgJ5vMUBu1m0RodojqsrSxujSrt3KA1VPMznlVvUNH6L7NNaE9m1wVLBX5VcHp/5xs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1233,13 +1173,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Bw0crT0MDMWFjfLcp2S0ZjomUG66GhCQ7in467_nYhk-1704442817349-0-604800000"
+              "value": "9ELR8xIhA1MBTpMRh1bzKlVc.wGMWre2zZogUo5neZg-1704446200704-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
             },
             {
               "name": "content-type",
@@ -1252,18 +1192,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1280,17 +1208,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f2d256af-ec3a-4b49-836a-5a816938677a; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=99ffda4a-a3c3-4167-904d-25476381bdce; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=VVHPI8APWRPLxtv1xHXWbbcW7UbOfmnSRQ6QzzxR4_c-1704442817-1-AXi6uPSy8k+yyYORNhN6QdCV8vZrDfetW6aB8rnU9gZru3xr5wP7bjiXpK18+f2wp+BerrL5UtnvFYDm6aBwD4M=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=VWFX6.03KQpwRtX3DtnXj0l3mBB3LFGYA4IKMXsE0C4-1704446200-1-AT3++y0GQUGXQGvRR6DkOEgJ5vMUBu1m0RodojqsrSxujSrt3KA1VPMznlVvUNH6L7NNaE9m1wVLBX5VcHp/5xs=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Bw0crT0MDMWFjfLcp2S0ZjomUG66GhCQ7in467_nYhk-1704442817349-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=9ELR8xIhA1MBTpMRh1bzKlVc.wGMWre2zZogUo5neZg-1704446200704-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1306,15 +1234,15 @@
             },
             {
               "name": "x-trace",
-              "value": "73a2277e894a6f2fdbae7f2edfe7dd45"
+              "value": "e9dae8151062d1c9baa2a2d8fce2c3d6"
             },
             {
               "name": "x-trace-span",
-              "value": "aec1171e0310c19c"
+              "value": "c712c77235484fd9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/73a2277e894a6f2fdbae7f2edfe7dd45"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e9dae8151062d1c9baa2a2d8fce2c3d6"
             },
             {
               "name": "x-xss-protection",
@@ -1338,21 +1266,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d1759223500-WAW"
+              "value": "840a9fb16eaffc73-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:17.082Z",
-        "time": 225,
+        "startedDateTime": "2024-01-05T09:16:40.483Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1360,7 +1288,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 225
+          "wait": 210
         }
       },
       {
@@ -1436,20 +1364,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:17.000Z",
+              "expires": "2025-01-05T09:16:40.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "cf48c4b6-5a05-4850-b428-309075b2cead"
+              "value": "3c1a3132-92d7-4459-a06c-88c968fc793a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
+              "expires": "2024-01-05T09:46:40.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "eC2OiLtbwdLtCdeg5vaS0V34jXLylO9ezrNsU7j2_Ac-1704442817-1-ATmyTQKQTOq5K9NAUtt32TrbDBuNv/O5lclmM9RPW8czIKaGNzikyWEOwI1IPi9dOsItsgj3KUkhYOnCOx7/QDM="
+              "value": "Okdk8amlqW7KCIokbNLGof1WeDsqIrbB3qpA3PDjUZI-1704446200-1-Adzwq3OzaL2LMlgt+Sgnw6ohnS5uQ2R1blT9K8P9p8fMSgg+G4n0TC/sVvBtwwyRYsI1fsszfHll27UCXLGEqGY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1458,13 +1386,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "EWQhGz7scf1taY2iFmaPcNqCakoZk_lVSzpIaoQdRJc-1704442817558-0-604800000"
+              "value": "eyoQ6CWYraS4.c0iq1gjltt0g5.wCAuBEDbmg7MPxYk-1704446200921-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
             },
             {
               "name": "content-type",
@@ -1479,18 +1407,6 @@
               "value": "close"
             },
             {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
-            },
-            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -1505,17 +1421,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cf48c4b6-5a05-4850-b428-309075b2cead; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=3c1a3132-92d7-4459-a06c-88c968fc793a; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=eC2OiLtbwdLtCdeg5vaS0V34jXLylO9ezrNsU7j2_Ac-1704442817-1-ATmyTQKQTOq5K9NAUtt32TrbDBuNv/O5lclmM9RPW8czIKaGNzikyWEOwI1IPi9dOsItsgj3KUkhYOnCOx7/QDM=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=Okdk8amlqW7KCIokbNLGof1WeDsqIrbB3qpA3PDjUZI-1704446200-1-Adzwq3OzaL2LMlgt+Sgnw6ohnS5uQ2R1blT9K8P9p8fMSgg+G4n0TC/sVvBtwwyRYsI1fsszfHll27UCXLGEqGY=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=EWQhGz7scf1taY2iFmaPcNqCakoZk_lVSzpIaoQdRJc-1704442817558-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=eyoQ6CWYraS4.c0iq1gjltt0g5.wCAuBEDbmg7MPxYk-1704446200921-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1531,15 +1447,15 @@
             },
             {
               "name": "x-trace",
-              "value": "7fcfaedb1450d67f5479758f86234405"
+              "value": "9a5a0f95b1eb80548d8b5943a54f45f3"
             },
             {
               "name": "x-trace-span",
-              "value": "6de8ebd605b335a6"
+              "value": "78ad52919b0f54ac"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7fcfaedb1450d67f5479758f86234405"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9a5a0f95b1eb80548d8b5943a54f45f3"
             },
             {
               "name": "x-xss-protection",
@@ -1563,17 +1479,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d18dbf2bfc8-WAW"
+              "value": "840a9fb2cce8bf8f-WAW"
             }
           ],
-          "headersSize": 1393,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:17.319Z",
-        "time": 197,
+        "startedDateTime": "2024-01-05T09:16:40.705Z",
+        "time": 205,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1581,233 +1497,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 197
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 335,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 448,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 448,
-            "text": "[\"H4sIAAAAAAAAA6xSQW7DMAz7i8/VB/KAfmLYQbEV26tjZZLcNij69yErtrUd2mDAziIpiuLJBTR03cnRHktDo7AltCa0LRjVdS8nV3Ek1znNsbYJtMmeZqCKfaHgNm7hkesGLErnzTfcc5gBm7HncSpkBCboc42PKUaFRjKZgY4Ti/0gTdov7Un4OeBmuedqdDQo7LHAmI/X3lfZYa44Zg9jK5ZLrove5yhz1ccH9YV7mDAS6CGbT4BCqKCJxXwzXUnPJzQY2e/ASO0ZuJqg2sVUxmqgczU8QsoxlRyTPc2dJ6qeA0XBKf3loyHr0gIQ8rMvuUbgASahfeamIPTeSFevvFWkAVsxUENZLAmkuZccVqsAb2S9YL5+xx1UCcUnqHSAHc0HlvAfzkC5if97dl+F7Id4X8cL+fV8/gAAAP//AwDAhjmfngMAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:17.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "01575acf-e887-40c3-8413-3c0bb207dbb1"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "60KoEfxPUwS68EJnLAGx0qeHaU6qkpUojpmwThCTfcE-1704442817-1-AQD93FJQlnY6jmsBOTxe3nIMtiwQN8a4P94bnCB+FvE9i+1n+lb9bU/RbqU0SMkwncYtayb8v5gYhA0IlqRhy4M="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "z52rIZKtas9fVgoC9R9pxEsdqQU32RSgsf3azBECf94-1704442817567-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=01575acf-e887-40c3-8413-3c0bb207dbb1; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=60KoEfxPUwS68EJnLAGx0qeHaU6qkpUojpmwThCTfcE-1704442817-1-AQD93FJQlnY6jmsBOTxe3nIMtiwQN8a4P94bnCB+FvE9i+1n+lb9bU/RbqU0SMkwncYtayb8v5gYhA0IlqRhy4M=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=z52rIZKtas9fVgoC9R9pxEsdqQU32RSgsf3azBECf94-1704442817567-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "055553985536c7ccca60ab19cbd9a704"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "69185542bd51a026"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/055553985536c7ccca60ab19cbd9a704"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d18cad1357c-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1425,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:17.318Z",
-        "time": 207,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 207
+          "wait": 205
         }
       },
       {
@@ -1875,29 +1565,29 @@
           "url": "https://sourcegraph.com/.api/graphql?Repository"
         },
         "response": {
-          "bodySize": 120,
+          "bodySize": 123,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 120,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA==\"]"
+            "size": 123,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:17.000Z",
+              "expires": "2025-01-05T09:16:40.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "a0591581-a566-4ecc-ad40-2555dd1b7d26"
+              "value": "def03440-3f42-4574-81e9-5dda0a21ecdf"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:17.000Z",
+              "expires": "2024-01-05T09:46:40.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "wh1.BO1NM_hxuS0fpI_cdqRHLWZDlQBRbOdMeD6hYmU-1704442817-1-AZSL2RA0UoG2rhmNx3sn3V3WOzoo6y6o/4P9/Cxm4Bty132V0MGRLMTy6Px0013FDouASFN9IVCYPBaPRbzP2j0="
+              "value": "s6BcFtyDl5UPqwV0DKUbBj3sGXdleIHfsTA0Oxd9O8k-1704446200-1-ASUm+rjL605pGbE8Bf4wqXddFSUSuMWopAcp/gk/HA3VTyZ225p+Yx16LFvYOMw/ZJNMLfsD4Pb11Lp+s/Jn1pQ="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1906,13 +1596,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XBRxoJhwt49HMkZmvoYk4FHCaKBojd5erTDRiJ9YdDc-1704442817570-0-604800000"
+              "value": "wHmJoHdGQY9DwvdsrJcLMDEt6dBo6P15TPlx7xr5dIA-1704446200924-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
             },
             {
               "name": "content-type",
@@ -1925,18 +1615,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1953,17 +1631,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a0591581-a566-4ecc-ad40-2555dd1b7d26; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=def03440-3f42-4574-81e9-5dda0a21ecdf; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=wh1.BO1NM_hxuS0fpI_cdqRHLWZDlQBRbOdMeD6hYmU-1704442817-1-AZSL2RA0UoG2rhmNx3sn3V3WOzoo6y6o/4P9/Cxm4Bty132V0MGRLMTy6Px0013FDouASFN9IVCYPBaPRbzP2j0=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=s6BcFtyDl5UPqwV0DKUbBj3sGXdleIHfsTA0Oxd9O8k-1704446200-1-ASUm+rjL605pGbE8Bf4wqXddFSUSuMWopAcp/gk/HA3VTyZ225p+Yx16LFvYOMw/ZJNMLfsD4Pb11Lp+s/Jn1pQ=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=XBRxoJhwt49HMkZmvoYk4FHCaKBojd5erTDRiJ9YdDc-1704442817570-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=wHmJoHdGQY9DwvdsrJcLMDEt6dBo6P15TPlx7xr5dIA-1704446200924-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1979,15 +1657,15 @@
             },
             {
               "name": "x-trace",
-              "value": "17271d54af8511f3412759a6b9f3ebd6"
+              "value": "76bd0675e8d871106e36e76b47e800be"
             },
             {
               "name": "x-trace-span",
-              "value": "74e329376a772334"
+              "value": "54b1036fe5187806"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/17271d54af8511f3412759a6b9f3ebd6"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/76bd0675e8d871106e36e76b47e800be"
             },
             {
               "name": "x-xss-protection",
@@ -2011,20 +1689,20 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d18d983fbda-WAW"
+              "value": "840a9fb2cbffffb8-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:17.317Z",
+        "startedDateTime": "2024-01-05T09:16:40.703Z",
         "time": 210,
         "timings": {
           "blocked": -1,
@@ -2034,6 +1712,429 @@
           "send": 0,
           "ssl": -1,
           "wait": 210
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 335,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 440,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 440,
+            "text": "[\"H4sIAAAAAAAAA5RSS24CMQy9S9b4AnMALlF14Uk8SUomTm0HGCHuXk1VtYgWKGu/n+13cgEN3XBytMfS0ShsCa0LbQtGdcPLyVWcyQ3OqNBMJgvQsbGY27iVQm4w6XTefAO5UfUcKAq29IOasOglTHOsvYF22dMCVHEsFG7DPYcFfEKDmf0OjNQegLEbe55bISMIWVcDEPKLL7lG4Ama0D5zVxB676Sm9xSrCarBp2LGaqBLNTxCyjGVHJPlGp9JZIL+Scoago4GhT0WmPPx8mBXX7jNHqd4zf3TugnDG9komKs+4RNowl4M1FDWHgikZZQcQLmLf1SL/+vdjKSE4hNUOsCOlgPLnU3HwiM0jAR6yOYToBAqaGIx3+834lfQpeKcPcy9WC65EnyNMld9fOyrfV7P5w8AAAD//wMAAJL01p4DAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:40.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "bc0e2445-adce-4a57-8988-23e4d7bafae8"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:40.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "LgyZ0pfDNA8Tnlo4CYtQh_QDJjydfI7QOXWMtX_oCc4-1704446200-1-AYbYMRsaeQojVh7w63EF9Xoh9ljH68V/yykW7auA2rsPotXnCgMn0HouZ0IHtZi6zFg0t3yVnH885L00rH1bOKo="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "MdMj.QafXRs41_PUa3IyqP5u1nxRhr.lJ93PgQMqU2E-1704446200934-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:40 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=bc0e2445-adce-4a57-8988-23e4d7bafae8; Expires=Sun, 05 Jan 2025 09:16:40 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=LgyZ0pfDNA8Tnlo4CYtQh_QDJjydfI7QOXWMtX_oCc4-1704446200-1-AYbYMRsaeQojVh7w63EF9Xoh9ljH68V/yykW7auA2rsPotXnCgMn0HouZ0IHtZi6zFg0t3yVnH885L00rH1bOKo=; path=/; expires=Fri, 05-Jan-24 09:46:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=MdMj.QafXRs41_PUa3IyqP5u1nxRhr.lJ93PgQMqU2E-1704446200934-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "33a9dd97fc1ce1ca34e328cdaaf7af6b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "07736ea2f2ead57f"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/33a9dd97fc1ce1ca34e328cdaaf7af6b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb2ccc1fc8f-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:40.701Z",
+        "time": 237,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 237
+        }
+      },
+      {
+        "_id": "f183d7475b363dc45d23134c3118a915",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 180,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "180"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:41.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "fef8d208-37ee-4b84-84fb-99a926a9d1a2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:41.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "SqyGzurKJTxz9RLwqTlEaDP7Sqzm2zSnu_TQICcv8ho-1704446201-1-AZQAE7VGUSQ5crHl5CMtg6jY6E1BS3iUyTut2tnveInu8vQUIL7BSdoGraDzddWg8y4zd070AnTUq4+1/45x5BE="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "TlmDN67amNHiM2KDbyCBFhMAxak3C8Bcfn1aXC6e05k-1704446201386-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:41 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=fef8d208-37ee-4b84-84fb-99a926a9d1a2; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=SqyGzurKJTxz9RLwqTlEaDP7Sqzm2zSnu_TQICcv8ho-1704446201-1-AZQAE7VGUSQ5crHl5CMtg6jY6E1BS3iUyTut2tnveInu8vQUIL7BSdoGraDzddWg8y4zd070AnTUq4+1/45x5BE=; path=/; expires=Fri, 05-Jan-24 09:46:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=TlmDN67amNHiM2KDbyCBFhMAxak3C8Bcfn1aXC6e05k-1704446201386-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "fe0f8e8f219033dcfcf1d3397cb9bb1f"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "92aa91ffb8e3caf9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fe0f8e8f219033dcfcf1d3397cb9bb1f"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb5bbcfbf35-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:41.169Z",
+        "time": 206,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 206
         }
       },
       {
@@ -2109,20 +2210,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:17.000Z",
+              "expires": "2025-01-05T09:16:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6774cbf4-8de5-4890-bd55-fe6bd64c0b11"
+              "value": "f8d3e7a7-2fc6-4ee8-8bd2-aec1ae9a2caa"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
+              "expires": "2024-01-05T09:46:41.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HUElRe8SWEYXNgtMTa5Ks3bmn0yDiU5Xzsw_MbrSQBU-1704442818-1-ARXOmnEs6wN88aYbAJ6dl0hof779/Lw+ujf/ZyrEKct308Jehd3G2tgF8B0/30HA2GLKEkXfnjcWu2l+VjtdU5k="
+              "value": "PKlFWLUXxr3yElKD1sMsbmx.oTTlHnHzl4_uQJVO7xY-1704446201-1-AUjeNcfyDIpQm6WTidYicKFEovAiF9k6CA4nGiKdWcihZKXFjl8e2HrsFLtgpNWRuUjSPKH+t6iVVFDqg/xvhAc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2131,13 +2232,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000"
+              "value": "uZmO4dkfbqTTrL79u9ZBXLmbZ.6XdULYq8fulMr4z5E-1704446201389-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:41 GMT"
             },
             {
               "name": "content-type",
@@ -2150,18 +2251,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2178,17 +2267,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6774cbf4-8de5-4890-bd55-fe6bd64c0b11; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=f8d3e7a7-2fc6-4ee8-8bd2-aec1ae9a2caa; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HUElRe8SWEYXNgtMTa5Ks3bmn0yDiU5Xzsw_MbrSQBU-1704442818-1-ARXOmnEs6wN88aYbAJ6dl0hof779/Lw+ujf/ZyrEKct308Jehd3G2tgF8B0/30HA2GLKEkXfnjcWu2l+VjtdU5k=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=PKlFWLUXxr3yElKD1sMsbmx.oTTlHnHzl4_uQJVO7xY-1704446201-1-AUjeNcfyDIpQm6WTidYicKFEovAiF9k6CA4nGiKdWcihZKXFjl8e2HrsFLtgpNWRuUjSPKH+t6iVVFDqg/xvhAc=; path=/; expires=Fri, 05-Jan-24 09:46:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=uZmO4dkfbqTTrL79u9ZBXLmbZ.6XdULYq8fulMr4z5E-1704446201389-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2204,15 +2293,15 @@
             },
             {
               "name": "x-trace",
-              "value": "ab530ae635d77989d594ccf65fd82864"
+              "value": "bd3e19e7b25d5baedcd723ac21b7826c"
             },
             {
               "name": "x-trace-span",
-              "value": "fc21b0bd65fe2669"
+              "value": "caa90d56d4a674ee"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ab530ae635d77989d594ccf65fd82864"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/bd3e19e7b25d5baedcd723ac21b7826c"
             },
             {
               "name": "x-xss-protection",
@@ -2236,16 +2325,16 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d1b98a7bf4e-WAW"
+              "value": "840a9fb5a8cdfc8f-WAW"
             }
           ],
-          "headersSize": 1393,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:17.756Z",
+        "startedDateTime": "2024-01-05T09:16:41.167Z",
         "time": 217,
         "timings": {
           "blocked": -1,
@@ -2330,20 +2419,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:17.000Z",
+              "expires": "2025-01-05T09:16:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1bce8d84-c861-44a6-807e-5fe7a3171f99"
+              "value": "310ed116-81d6-44d3-bb66-59748cc975f2"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
+              "expires": "2024-01-05T09:46:41.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "tPlYFmTtJN_g_eN3nngOmppGtx0eykdkFgxiOYGZfdo-1704442818-1-AfK0OpfqQXc4FSJR1uSaNY4IvMbzemwsz9rsC1X68FtC3PBMpwMiZPj1l49tsIcr2js6YAxgO1RwPgDJP+jp4lM="
+              "value": "fmynAaA43Qx1Og_D.0e8amTtCMz8BnoHOgPHEHb5vvo-1704446201-1-AY++jgQ1fXjh1txf4BiNWLlTdlH8buiWdqk9v3vmr/9XUrhAkSz0puYCmShTdHh4cGh/m07qjw7TT6Zysbb/v4M="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2352,13 +2441,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000"
+              "value": "uZmO4dkfbqTTrL79u9ZBXLmbZ.6XdULYq8fulMr4z5E-1704446201389-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:41 GMT"
             },
             {
               "name": "content-type",
@@ -2373,18 +2462,6 @@
               "value": "close"
             },
             {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
-            },
-            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -2399,17 +2476,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1bce8d84-c861-44a6-807e-5fe7a3171f99; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+              "value": "sourcegraphDeviceId=310ed116-81d6-44d3-bb66-59748cc975f2; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=tPlYFmTtJN_g_eN3nngOmppGtx0eykdkFgxiOYGZfdo-1704442818-1-AfK0OpfqQXc4FSJR1uSaNY4IvMbzemwsz9rsC1X68FtC3PBMpwMiZPj1l49tsIcr2js6YAxgO1RwPgDJP+jp4lM=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=fmynAaA43Qx1Og_D.0e8amTtCMz8BnoHOgPHEHb5vvo-1704446201-1-AY++jgQ1fXjh1txf4BiNWLlTdlH8buiWdqk9v3vmr/9XUrhAkSz0puYCmShTdHh4cGh/m07qjw7TT6Zysbb/v4M=; path=/; expires=Fri, 05-Jan-24 09:46:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=uZmO4dkfbqTTrL79u9ZBXLmbZ.6XdULYq8fulMr4z5E-1704446201389-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2425,15 +2502,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3482625ad321da8d38414dc43bc21cb0"
+              "value": "9e4eb6b22a801fb7a5cb6ffd5b751d0e"
             },
             {
               "name": "x-trace-span",
-              "value": "46f563220aa010e8"
+              "value": "5a2ca19c2b4a5b98"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3482625ad321da8d38414dc43bc21cb0"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9e4eb6b22a801fb7a5cb6ffd5b751d0e"
             },
             {
               "name": "x-xss-protection",
@@ -2457,1121 +2534,16 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d1b9978c014-WAW"
+              "value": "840a9fb5bf0f35be-WAW"
             }
           ],
-          "headersSize": 1393,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:17.758Z",
-        "time": 215,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 215
-        }
-      },
-      {
-        "_id": "f183d7475b363dc45d23134c3118a915",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 180,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "180"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:17.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1fd29b1d-ac1e-4ca9-a9b2-9756c2735aa0"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ty348dISeoKAsGo5B6LH0MNbjmox5ZUFV5OBjuwpItg-1704442818-1-AfBQeRMtAmXTQXiC2Jn3gqc1QaqlqKCLwaHOS+T/W4jMkcw4sGOqZyVOqUq9fpISPjcaDNgKYxhVNcevQmYjVQY="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vmM9yXmmM5Io2saBBB2DtfF_BFXuQtP2MEGOwrwqN5c-1704442818018-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1fd29b1d-ac1e-4ca9-a9b2-9756c2735aa0; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ty348dISeoKAsGo5B6LH0MNbjmox5ZUFV5OBjuwpItg-1704442818-1-AfBQeRMtAmXTQXiC2Jn3gqc1QaqlqKCLwaHOS+T/W4jMkcw4sGOqZyVOqUq9fpISPjcaDNgKYxhVNcevQmYjVQY=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=vmM9yXmmM5Io2saBBB2DtfF_BFXuQtP2MEGOwrwqN5c-1704442818018-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8a06e8e4987e8b0218569e4176655bd2"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "0f01d6a747a4f5c4"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a06e8e4987e8b0218569e4176655bd2"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d1b9aabbf3a-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:17.759Z",
-        "time": 216,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 216
-        }
-      },
-      {
-        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 160,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "160"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "94bdfd8d-ced6-4afc-997a-7fc25f489bcc"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "S0iudDpmtdRmek6XeHqjl.9zJ1SkK6OqzvQujtuZw78-1704442818-1-AXdPbBc9+kcZlk7EpGQGdk8Vjcrwsg7s+LWN571xrrfa7OADHyfz8X7ushmo1kk2qGMmJ35z2dzMbqCkDDOJgjc="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "0z181oBSRhsroi2aaPzgWPZvq2KA1Mp.s1DqWkGcDMI-1704442818700-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=94bdfd8d-ced6-4afc-997a-7fc25f489bcc; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=S0iudDpmtdRmek6XeHqjl.9zJ1SkK6OqzvQujtuZw78-1704442818-1-AXdPbBc9+kcZlk7EpGQGdk8Vjcrwsg7s+LWN571xrrfa7OADHyfz8X7ushmo1kk2qGMmJ35z2dzMbqCkDDOJgjc=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=0z181oBSRhsroi2aaPzgWPZvq2KA1Mp.s1DqWkGcDMI-1704442818700-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "5469b350cafc627bc841a06cadc9a774"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "24ae01eb581a5a22"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5469b350cafc627bc841a06cadc9a774"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d1fee33bf74-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:18.447Z",
-        "time": 211,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 211
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "40688ea4-646d-4029-a229-31cae2a099d1"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "JEjH2GQiu7U401Ojpe6vrdtpiBimOnl1oBbux1XIkC4-1704442818-1-AWv9Qddbk159htInTpOejj8Iuh6gcsfpJ4qqG167mOwRqAgcOszDQH4zWaARA4UkrlWbaSKb7So6YrDDWp48jhw="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "yrg5yuKuzynfjgtZwVqImx0JNs.C86hsV4ROVTIRZGI-1704442818702-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=40688ea4-646d-4029-a229-31cae2a099d1; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=JEjH2GQiu7U401Ojpe6vrdtpiBimOnl1oBbux1XIkC4-1704442818-1-AWv9Qddbk159htInTpOejj8Iuh6gcsfpJ4qqG167mOwRqAgcOszDQH4zWaARA4UkrlWbaSKb7So6YrDDWp48jhw=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=yrg5yuKuzynfjgtZwVqImx0JNs.C86hsV4ROVTIRZGI-1704442818702-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "640b8f63be349bacebb00ea34a4775a4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7fd811214f7aa456"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/640b8f63be349bacebb00ea34a4775a4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d1fe823c019-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:18.449Z",
-        "time": 209,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 209
-        }
-      },
-      {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "14f4641e-0c05-448f-bcc2-434b629d2103"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "13LQvfuq8AUEL_wTW0w0AC1._5rKcsj7bL_HcWzsYYA-1704442818-1-AdAkjR8rddIUnS1N+wjv3VhTbhYPv01uQ4lhjev6hacK2e4NLCPa8hBJjfklZ7TiMiZZuOI9u5KZ7ysDiZ9Mtp8="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ehmjEaUp6RFaOU2_vfe0WwyPZ7oBBnxdH8ohYNsZRsg-1704442818705-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=14f4641e-0c05-448f-bcc2-434b629d2103; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=13LQvfuq8AUEL_wTW0w0AC1._5rKcsj7bL_HcWzsYYA-1704442818-1-AdAkjR8rddIUnS1N+wjv3VhTbhYPv01uQ4lhjev6hacK2e4NLCPa8hBJjfklZ7TiMiZZuOI9u5KZ7ysDiZ9Mtp8=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=ehmjEaUp6RFaOU2_vfe0WwyPZ7oBBnxdH8ohYNsZRsg-1704442818705-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "89763fc8827dc54433d3d3558e5b46c0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "a246dd1b9f21bfab"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/89763fc8827dc54433d3d3558e5b46c0"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d1ffd79c008-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:18.452Z",
-        "time": 210,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 210
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:18.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6267d119-583f-46e7-8117-496463145355"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "izku26brNLUIC66DHFfxt1KafWBQ.rmgACWRitd0eNQ-1704442818-1-AYZ0LjCW1VoaS9O7YJbMhfM82VhOq0Psv3Xwl/BWSEwWnXuzy4zNVCft3CbVfjr9bXLpvmGH6U2LyuV9dF09SW4="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "aC6FbybCh3UCR418nzdcvhVFO7CzXqkGC_pkCFITIWk-1704442818710-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6267d119-583f-46e7-8117-496463145355; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=izku26brNLUIC66DHFfxt1KafWBQ.rmgACWRitd0eNQ-1704442818-1-AYZ0LjCW1VoaS9O7YJbMhfM82VhOq0Psv3Xwl/BWSEwWnXuzy4zNVCft3CbVfjr9bXLpvmGH6U2LyuV9dF09SW4=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=aC6FbybCh3UCR418nzdcvhVFO7CzXqkGC_pkCFITIWk-1704442818710-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "772086011081a2d593abae07b165fd16"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "b2bb73e7d2408015"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/772086011081a2d593abae07b165fd16"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d1fe825c019-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:18.451Z",
+        "startedDateTime": "2024-01-05T09:16:41.168Z",
         "time": 216,
         "timings": {
           "blocked": -1,
@@ -3656,20 +2628,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:18.000Z",
+              "expires": "2025-01-05T09:16:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "35578159-04ef-4620-9d39-68f0161ec017"
+              "value": "b00462a3-f7c8-4c16-8109-d47e2b3b5b94"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
+              "expires": "2024-01-05T09:46:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XYauyC5SK9WiXLg9c_gBJYo1fKV82e1mWHf.5P3mpr0-1704442818-1-ATs8qHOKQmlYpiaJmYoPpukn1lg7c/55TspG2ghjefZpAEC/UC1X7iEMy7wH8cGre68kpx7LhMorduTAnOP9Cfs="
+              "value": "zl1S.f_vBfVlgtcxzT5LNXHuw9Bc9DVdVw0I62gDW5g-1704446202-1-AYeWWW464S9Nz1YU7xDFJp05akrffDRfvOuxjktZ3JT/DGuHwWSpwhCHSXQUt2L6naWANOhj+FCoR5lTtS5k518="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3678,13 +2650,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "g2dkiUOR0IWu9.isfmq2T7PHvlat.j5eqigCZJJUJec-1704442818711-0-604800000"
+              "value": "bg7ssbQp1cQRBIYu6f2Wd5MLW1EHUUfLxVZrjqi5TS4-1704446202051-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
             },
             {
               "name": "content-type",
@@ -3697,18 +2669,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3725,17 +2685,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=35578159-04ef-4620-9d39-68f0161ec017; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
+              "value": "sourcegraphDeviceId=b00462a3-f7c8-4c16-8109-d47e2b3b5b94; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=XYauyC5SK9WiXLg9c_gBJYo1fKV82e1mWHf.5P3mpr0-1704442818-1-ATs8qHOKQmlYpiaJmYoPpukn1lg7c/55TspG2ghjefZpAEC/UC1X7iEMy7wH8cGre68kpx7LhMorduTAnOP9Cfs=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=zl1S.f_vBfVlgtcxzT5LNXHuw9Bc9DVdVw0I62gDW5g-1704446202-1-AYeWWW464S9Nz1YU7xDFJp05akrffDRfvOuxjktZ3JT/DGuHwWSpwhCHSXQUt2L6naWANOhj+FCoR5lTtS5k518=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=g2dkiUOR0IWu9.isfmq2T7PHvlat.j5eqigCZJJUJec-1704442818711-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=bg7ssbQp1cQRBIYu6f2Wd5MLW1EHUUfLxVZrjqi5TS4-1704446202051-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3751,15 +2711,15 @@
             },
             {
               "name": "x-trace",
-              "value": "0aa23972a99c19b839b99f8b52536a62"
+              "value": "69ee14f38f97cd7e2aa3d0d9c4e12ecb"
             },
             {
               "name": "x-trace-span",
-              "value": "1ec2dab3257304bf"
+              "value": "f43dcd2aba5174f6"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0aa23972a99c19b839b99f8b52536a62"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/69ee14f38f97cd7e2aa3d0d9c4e12ecb"
             },
             {
               "name": "x-xss-protection",
@@ -3783,17 +2743,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d1fedb6ffc0-WAW"
+              "value": "840a9fb9dae134d4-WAW"
             }
           ],
-          "headersSize": 1393,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:18.450Z",
-        "time": 218,
+        "startedDateTime": "2024-01-05T09:16:41.836Z",
+        "time": 205,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3801,11 +2761,847 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 218
+          "wait": 205
         }
       },
       {
-        "_id": "501141f683aafdd826d483e7a19d6aa3",
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:41.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6e03ec28-2811-4aed-8e8a-646c07f1044d"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "uj5Pu7Fj9Z1l4f8Y5e2jfocx7EOs02eKb__bSwCJsZI-1704446202-1-AchKnuwDPHlMe12nkfiRbFjyCi/8+nzIhhLvloPyA1gRQO0AJjRo5orlaokyOhG9yctajoI7HSR7SqSQ1Qx5N60="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "58jsSj3tGkgRzyWgvHxOSQkydfDaqzVc1txGnERZMus-1704446202053-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6e03ec28-2811-4aed-8e8a-646c07f1044d; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=uj5Pu7Fj9Z1l4f8Y5e2jfocx7EOs02eKb__bSwCJsZI-1704446202-1-AchKnuwDPHlMe12nkfiRbFjyCi/8+nzIhhLvloPyA1gRQO0AJjRo5orlaokyOhG9yctajoI7HSR7SqSQ1Qx5N60=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=58jsSj3tGkgRzyWgvHxOSQkydfDaqzVc1txGnERZMus-1704446202053-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "f8cf620c55f848bf3a3f28d8687ebd17"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a787fb16bb9f1784"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f8cf620c55f848bf3a3f28d8687ebd17"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb9e80f772a-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:41.836Z",
+        "time": 206,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 206
+        }
+      },
+      {
+        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 160,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "160"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:41.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "9fa26d72-1cd6-40bf-85d6-f38bf2548699"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "JJSSMXRYkbDk4tcZMfmjYL9WN77R_O87DPT6FarlaTs-1704446202-1-Afs+t41t+awXeofebWtq6z64JSTfRHc2b/Xow6V1Ht6QmMhABJagJkXde+OaigQVjS2NVMhwqzBtxko1aGzMvfI="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XfbPxiqdqxW5ZKrOmwWstLu7vBKhkitVYxsm590kxJ8-1704446202059-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=9fa26d72-1cd6-40bf-85d6-f38bf2548699; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=JJSSMXRYkbDk4tcZMfmjYL9WN77R_O87DPT6FarlaTs-1704446202-1-Afs+t41t+awXeofebWtq6z64JSTfRHc2b/Xow6V1Ht6QmMhABJagJkXde+OaigQVjS2NVMhwqzBtxko1aGzMvfI=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=XfbPxiqdqxW5ZKrOmwWstLu7vBKhkitVYxsm590kxJ8-1704446202059-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "b74ae451ac7aa3084663932351e7ef99"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "de6c5a20ed8c3be0"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b74ae451ac7aa3084663932351e7ef99"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb9da1835cc-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:41.834Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:41.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ec3aba3b-b161-4d40-95df-351a1afe364f"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "6Qw8O9mkdK02vzfqPtWRnc20TnetelCwEyOwHf48188-1704446202-1-Af6kKoGO/A78A4K12jX20L86pRWRWrzgqDMJsKUXnOU3dOeHE4DLStvfyDrcIOFqdmFJ/EF1RgIH73VJJSS6Y9M="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "fYJUC.7v5BN3koKGBb1U8X8cOzzFKa0W47i_8jJ25uk-1704446202061-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ec3aba3b-b161-4d40-95df-351a1afe364f; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=6Qw8O9mkdK02vzfqPtWRnc20TnetelCwEyOwHf48188-1704446202-1-Af6kKoGO/A78A4K12jX20L86pRWRWrzgqDMJsKUXnOU3dOeHE4DLStvfyDrcIOFqdmFJ/EF1RgIH73VJJSS6Y9M=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=fYJUC.7v5BN3koKGBb1U8X8cOzzFKa0W47i_8jJ25uk-1704446202061-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4c6cd4c7d9b5c0c892d5282bdfbc6cc4"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c9c7d0cc137beded"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4c6cd4c7d9b5c0c892d5282bdfbc6cc4"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb9e8a90043-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:41.837Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:41.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "868ab507-6bee-40f6-9821-cd8a8ec3b8f7"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:42.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "LY2w27ftaQAgl8TSb0S_ou_YBlr6V.1JdXwUsEMDux0-1704446202-1-AemTrVG2sRSIPGxJt0wRWVPzPy+u4/6+Kv/8R+dZBz7bf0NqJqx0JOX3qlKwz6eedK3TsTETccgMHmK6q626iqo="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "fYJUC.7v5BN3koKGBb1U8X8cOzzFKa0W47i_8jJ25uk-1704446202061-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=868ab507-6bee-40f6-9821-cd8a8ec3b8f7; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=LY2w27ftaQAgl8TSb0S_ou_YBlr6V.1JdXwUsEMDux0-1704446202-1-AemTrVG2sRSIPGxJt0wRWVPzPy+u4/6+Kv/8R+dZBz7bf0NqJqx0JOX3qlKwz6eedK3TsTETccgMHmK6q626iqo=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=fYJUC.7v5BN3koKGBb1U8X8cOzzFKa0W47i_8jJ25uk-1704446202061-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "47e45731da83bf5d4f67c677fda5d563"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "b00ab2dd20b89fb3"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/47e45731da83bf5d4f67c677fda5d563"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fb9ec7d5012-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:41.838Z",
+        "time": 212,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 212
+        }
+      },
+      {
+        "_id": "552eab3ba1f3de6582d35e91e1ee7950",
         "_order": 0,
         "cache": {},
         "request": {
@@ -3858,7 +3654,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"16e4a31f-b58d-4f62-b0f5-cf6f56b42589\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -3877,20 +3673,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:18.000Z",
+              "expires": "2025-01-05T09:16:41.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6fdab9de-93f4-4fd6-a3df-0c3fdd9b5626"
+              "value": "35ddbd3a-61de-4436-8ba3-167fb4d2fb21"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
+              "expires": "2024-01-05T09:46:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "gLkuGe4_2ynjElccythMgkVvdTMIFR0wItSJRhSuYUs-1704442818-1-AXJOy6J7E/786EAJaM8zYb9Wj//gWCImJN1pG4nBKL0pJlwYZTBYOWfSk5sRWB4mnUR5y5N4KV72GSHwtESTe80="
+              "value": "Mld7J1K.jD1JM6Nf.Y_D.jIEFw5mgPFPEvNbGsDAbJM-1704446202-1-AdjHnHdSlbGOsXnww0oEHcpT9T5A92xLIf4TgRkHW53YQJoHWdlyc7JJ6TPr0YrhTVTKXfBgGrk4uVTiQgHPB50="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3899,13 +3695,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "d.qUHyW410JwJughC4265YAInJIYXY7NkIof5BKon1g-1704442818726-0-604800000"
+              "value": "mDmNKEu5mhCYHlYSIC9_ciZQUM9ghC451.QRnX5CJzw-1704446202078-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
             },
             {
               "name": "content-type",
@@ -3918,18 +3714,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3946,17 +3730,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6fdab9de-93f4-4fd6-a3df-0c3fdd9b5626; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
+              "value": "sourcegraphDeviceId=35ddbd3a-61de-4436-8ba3-167fb4d2fb21; Expires=Sun, 05 Jan 2025 09:16:41 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=gLkuGe4_2ynjElccythMgkVvdTMIFR0wItSJRhSuYUs-1704442818-1-AXJOy6J7E/786EAJaM8zYb9Wj//gWCImJN1pG4nBKL0pJlwYZTBYOWfSk5sRWB4mnUR5y5N4KV72GSHwtESTe80=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=Mld7J1K.jD1JM6Nf.Y_D.jIEFw5mgPFPEvNbGsDAbJM-1704446202-1-AdjHnHdSlbGOsXnww0oEHcpT9T5A92xLIf4TgRkHW53YQJoHWdlyc7JJ6TPr0YrhTVTKXfBgGrk4uVTiQgHPB50=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=d.qUHyW410JwJughC4265YAInJIYXY7NkIof5BKon1g-1704442818726-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=mDmNKEu5mhCYHlYSIC9_ciZQUM9ghC451.QRnX5CJzw-1704446202078-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3972,15 +3756,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c5fda37732d84ed4136f41b7c24984d7"
+              "value": "c13d88812a8f9009e7e1d252fdf5a7c7"
             },
             {
               "name": "x-trace-span",
-              "value": "6b27700f2499b694"
+              "value": "cd9fcba685a93e9f"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c5fda37732d84ed4136f41b7c24984d7"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c13d88812a8f9009e7e1d252fdf5a7c7"
             },
             {
               "name": "x-xss-protection",
@@ -4004,17 +3788,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d1fe95e7730-WAW"
+              "value": "840a9fb9dc79501f-WAW"
             }
           ],
-          "headersSize": 1393,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:18.444Z",
-        "time": 242,
+        "startedDateTime": "2024-01-05T09:16:41.831Z",
+        "time": 236,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4022,11 +3806,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 242
+          "wait": 236
         }
       },
       {
-        "_id": "5c802486f7d3cc4353253e4635acde23",
+        "_id": "45cd6466fee0e94e44e66e0d336cf8bd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -4079,7 +3863,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:18.441Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:41.828Z\"}]}}"
           },
           "queryString": [
             {
@@ -4090,29 +3874,29 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 115,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:18.000Z",
+              "expires": "2025-01-05T09:16:42.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7b425b89-16a3-4f41-9a13-01a8aee014a5"
+              "value": "593ebf94-a3eb-49d2-86af-d21956a82df7"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:18.000Z",
+              "expires": "2024-01-05T09:46:42.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "AxAlwL6lIhDdiwG1UNH7.ZEYoppZL3hnRm7HaWdtL1Y-1704442818-1-AQBRo23Ex1f5eufwoh+WDS6aVRDruzrS9Pbx7ZGlaTnci97lBZNSziMwPu33ZRyJlUMTWIIDbVucFDEjthQPI18="
+              "value": "C0qLFNbRLSeb_etNLe88enKfDguRIHknRoGDYjs9z5Y-1704446202-1-AS63IFFxHlv4W9H8c+WMuyGghg5hSpikBYmHekUQDA88E3fVWR+cCS9t2aj6hKVSuMRKz9SZBN9I/NZh42qY5ZM="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4121,13 +3905,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "DriZMnn1dmtUsQFPyY5fKZHTJmf49VosoAumHOt9SQI-1704442818946-0-604800000"
+              "value": "YYb2WVxMqDccaPgCZNUPrtYQxl8.731ovVviKxV3_Kg-1704446202281-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:42 GMT"
             },
             {
               "name": "content-type",
@@ -4142,18 +3926,6 @@
               "value": "close"
             },
             {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "344"
-            },
-            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -4168,17 +3940,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7b425b89-16a3-4f41-9a13-01a8aee014a5; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
+              "value": "sourcegraphDeviceId=593ebf94-a3eb-49d2-86af-d21956a82df7; Expires=Sun, 05 Jan 2025 09:16:42 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=AxAlwL6lIhDdiwG1UNH7.ZEYoppZL3hnRm7HaWdtL1Y-1704442818-1-AQBRo23Ex1f5eufwoh+WDS6aVRDruzrS9Pbx7ZGlaTnci97lBZNSziMwPu33ZRyJlUMTWIIDbVucFDEjthQPI18=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=C0qLFNbRLSeb_etNLe88enKfDguRIHknRoGDYjs9z5Y-1704446202-1-AS63IFFxHlv4W9H8c+WMuyGghg5hSpikBYmHekUQDA88E3fVWR+cCS9t2aj6hKVSuMRKz9SZBN9I/NZh42qY5ZM=; path=/; expires=Fri, 05-Jan-24 09:46:42 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=DriZMnn1dmtUsQFPyY5fKZHTJmf49VosoAumHOt9SQI-1704442818946-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=YYb2WVxMqDccaPgCZNUPrtYQxl8.731ovVviKxV3_Kg-1704446202281-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4194,15 +3966,15 @@
             },
             {
               "name": "x-trace",
-              "value": "6d94b145cdaa36c3dcc77429eb10c7ed"
+              "value": "1854d4d1235278a2d31374b12d3fcccc"
             },
             {
               "name": "x-trace-span",
-              "value": "aafa2816411c97c9"
+              "value": "09f805d62317ffb9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6d94b145cdaa36c3dcc77429eb10c7ed"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1854d4d1235278a2d31374b12d3fcccc"
             },
             {
               "name": "x-xss-protection",
@@ -4226,21 +3998,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d215deebf4e-WAW"
+              "value": "840a9fbb3ec3bff0-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:18.685Z",
-        "time": 218,
+        "startedDateTime": "2024-01-05T09:16:42.046Z",
+        "time": 225,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4248,232 +4020,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 218
+          "wait": 225
         }
       },
       {
-        "_id": "f5b753070f506f2f8efbe8b3b36ee4a3",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1184,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1184"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:20.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "dfa22658-86a0-4162-8d76-0909edba82fc"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:20.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "5QRKl0upQUj9cngnQOg9o2YFgrn8qQ5PPaiWU4kavEg-1704442820-1-AdooBqPwCrvPbwjYA7DhJt0Kwq0VNWMC4kgU29Eep65iErFBayfgIwG66txkyQE7I1aYa/eCqOIBVXIA3kDU7HU="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "M2Jp2fT5VSekPyHoIO.djqNnl_Zh8hwgcx7jW_XTrAI-1704442820614-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:20 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "343"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=dfa22658-86a0-4162-8d76-0909edba82fc; Expires=Sun, 05 Jan 2025 08:20:20 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=5QRKl0upQUj9cngnQOg9o2YFgrn8qQ5PPaiWU4kavEg-1704442820-1-AdooBqPwCrvPbwjYA7DhJt0Kwq0VNWMC4kgU29Eep65iErFBayfgIwG66txkyQE7I1aYa/eCqOIBVXIA3kDU7HU=; path=/; expires=Fri, 05-Jan-24 08:50:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=M2Jp2fT5VSekPyHoIO.djqNnl_Zh8hwgcx7jW_XTrAI-1704442820614-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "75209c3b199439055f104461884302aa"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "3b1dbf97b3ffee78"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/75209c3b199439055f104461884302aa"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d2bbe2770c2-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:20.336Z",
-        "time": 234,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 234
-        }
-      },
-      {
-        "_id": "db3120835c70b59b5f9cfff4ecec6cf4",
+        "_id": "5941e5b78431c1c9ef812ddcd2acbd77",
         "_order": 0,
         "cache": {},
         "request": {
@@ -4526,7 +4077,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:20.332Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:43.659Z\"}]}}"
           },
           "queryString": [
             {
@@ -4537,29 +4088,29 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 119,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 119,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:20.000Z",
+              "expires": "2025-01-05T09:16:43.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "9689c554-f9af-4ce4-afb4-d6834522c149"
+              "value": "43056a55-182e-46e7-a0da-d1d3b5900dac"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:20.000Z",
+              "expires": "2024-01-05T09:46:43.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "fWIZIqyzDzf7MfOl7NZ5fnJWKgU81A3RMhr8C8UZ.8w-1704442820-1-AUR6ne/9RmTKdpL93/EcgZlkk0i7HPqF5YURk7zaztUZjbhLv+RpvswjBp1fsL1sInbxfJSa+VMzD3X++Ll+e6Q="
+              "value": "aFYK5_9KNMFzKwT2LA00I1SfQDJP2WB1rbLmNKyW3vo-1704446203-1-ATuBBE+OapzpBmrRIqanJSR1jShw/zUOgOp7ULVvDTMEyqMvJTglPjZEWsEmmBc/f9gKT1Il0JTqIS5MO4Csxrw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4568,13 +4119,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8Yp4gMBOgNK7xmf01ggMFa6SmaWSpeqZvk3QJHHyydY-1704442820615-0-604800000"
+              "value": "EghtGFDACJ1S7qgh64NXAYxrT12mgOXdzLmYHq2EK8U-1704446203907-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:20 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:43 GMT"
             },
             {
               "name": "content-type",
@@ -4587,18 +4138,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "343"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4615,17 +4154,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=9689c554-f9af-4ce4-afb4-d6834522c149; Expires=Sun, 05 Jan 2025 08:20:20 GMT; Secure"
+              "value": "sourcegraphDeviceId=43056a55-182e-46e7-a0da-d1d3b5900dac; Expires=Sun, 05 Jan 2025 09:16:43 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=fWIZIqyzDzf7MfOl7NZ5fnJWKgU81A3RMhr8C8UZ.8w-1704442820-1-AUR6ne/9RmTKdpL93/EcgZlkk0i7HPqF5YURk7zaztUZjbhLv+RpvswjBp1fsL1sInbxfJSa+VMzD3X++Ll+e6Q=; path=/; expires=Fri, 05-Jan-24 08:50:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=aFYK5_9KNMFzKwT2LA00I1SfQDJP2WB1rbLmNKyW3vo-1704446203-1-ATuBBE+OapzpBmrRIqanJSR1jShw/zUOgOp7ULVvDTMEyqMvJTglPjZEWsEmmBc/f9gKT1Il0JTqIS5MO4Csxrw=; path=/; expires=Fri, 05-Jan-24 09:46:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=8Yp4gMBOgNK7xmf01ggMFa6SmaWSpeqZvk3QJHHyydY-1704442820615-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=EghtGFDACJ1S7qgh64NXAYxrT12mgOXdzLmYHq2EK8U-1704446203907-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4641,15 +4180,15 @@
             },
             {
               "name": "x-trace",
-              "value": "1d5067223809101b3fd5f922374becb0"
+              "value": "97c2fa9a5ceba964445ff53d0bc84a5f"
             },
             {
               "name": "x-trace-span",
-              "value": "d97c57f0c662cdf9"
+              "value": "117cc824ce6469a1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1d5067223809101b3fd5f922374becb0"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/97c2fa9a5ceba964445ff53d0bc84a5f"
             },
             {
               "name": "x-xss-protection",
@@ -4673,21 +4212,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d2bb8bbbfcd-WAW"
+              "value": "840a9fc54ad7bff3-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:20.337Z",
-        "time": 235,
+        "startedDateTime": "2024-01-05T09:16:43.664Z",
+        "time": 232,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4695,11 +4234,220 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 235
+          "wait": 232
         }
       },
       {
-        "_id": "fd5fcdff6c39e8c32664df5b4799519c",
+        "_id": "ecb60d909173c0270cd132f1e7a05fbe",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1184,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1184"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"16e4a31f-b58d-4f62-b0f5-cf6f56b42589\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:43.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "a94e8649-ff69-4c7a-805a-aabd5f878996"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:43.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "6qiiaAWYHGeZ.aPXmYxS4zBkwuHgezNcupPcwzjTDWA-1704446203-1-AQ4I2A8JbNZOT85/az/yg1t6eqEDatEoixmqOuPt/4oz8bCMMAcUschBBeb0n3Xq8NV6qRBWm+2GTdWmcDl5bWc="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "glObcusJ4wH1.xgoIxOhd401UXbHr6HLUWO.uL1QrfY-1704446203915-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:43 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=a94e8649-ff69-4c7a-805a-aabd5f878996; Expires=Sun, 05 Jan 2025 09:16:43 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=6qiiaAWYHGeZ.aPXmYxS4zBkwuHgezNcupPcwzjTDWA-1704446203-1-AQ4I2A8JbNZOT85/az/yg1t6eqEDatEoixmqOuPt/4oz8bCMMAcUschBBeb0n3Xq8NV6qRBWm+2GTdWmcDl5bWc=; path=/; expires=Fri, 05-Jan-24 09:46:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=glObcusJ4wH1.xgoIxOhd401UXbHr6HLUWO.uL1QrfY-1704446203915-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8bcf0f082a59b6606e5d11d243664487"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0a050bcd8231dcf8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8bcf0f082a59b6606e5d11d243664487"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fc54a38500c-WAW"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:43.663Z",
+        "time": 241,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 241
+        }
+      },
+      {
+        "_id": "e6a505a5ca81b66c2c1cd34dd687cf6c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -4752,7 +4500,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:21.022Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:44.349Z\"}]}}"
           },
           "queryString": [
             {
@@ -4772,20 +4520,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:21.000Z",
+              "expires": "2025-01-05T09:16:44.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "f2cb6149-00f0-44f0-b496-bc8f24f4b514"
+              "value": "79108111-cc76-49bc-a0c4-24f5c021a1e3"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:21.000Z",
+              "expires": "2024-01-05T09:46:44.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "TOxgAS0PTf29feZuxCKIXThCqk_5arff1BuvgPslPXI-1704442821-1-ASof8ps8aNlgcgVKAwBoYR38n4SZDH8LlTc3BSPmGRSlv93sBSxif9wIfmqWCM32o52gvzIlkp6AK3vEc2WX0n0="
+              "value": "70Mvaxx7A49ztYJCyS0wizaH0qnCNbdttavVQ6C6Jww-1704446204-1-AWEwFedlk/RbaEteNFZHWb8SD7sVUPbmG5Se7pIyqVe449CEZbGnRRz2dEAh84ObT+bfyFWUVEpZ7mH4FEuqxaY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4794,13 +4542,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "B49bhb8f.NGZJ96gRJGdS4O2NkXJ9d_Yq0v0UBHp1EM-1704442821295-0-604800000"
+              "value": "beuZyDPzXn2xLnzHpf_7GR2t7XZi.vhHBfrr7jHwtwQ-1704446204584-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:21 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:44 GMT"
             },
             {
               "name": "content-type",
@@ -4813,18 +4561,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "342"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4841,17 +4577,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f2cb6149-00f0-44f0-b496-bc8f24f4b514; Expires=Sun, 05 Jan 2025 08:20:21 GMT; Secure"
+              "value": "sourcegraphDeviceId=79108111-cc76-49bc-a0c4-24f5c021a1e3; Expires=Sun, 05 Jan 2025 09:16:44 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=TOxgAS0PTf29feZuxCKIXThCqk_5arff1BuvgPslPXI-1704442821-1-ASof8ps8aNlgcgVKAwBoYR38n4SZDH8LlTc3BSPmGRSlv93sBSxif9wIfmqWCM32o52gvzIlkp6AK3vEc2WX0n0=; path=/; expires=Fri, 05-Jan-24 08:50:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=70Mvaxx7A49ztYJCyS0wizaH0qnCNbdttavVQ6C6Jww-1704446204-1-AWEwFedlk/RbaEteNFZHWb8SD7sVUPbmG5Se7pIyqVe449CEZbGnRRz2dEAh84ObT+bfyFWUVEpZ7mH4FEuqxaY=; path=/; expires=Fri, 05-Jan-24 09:46:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=B49bhb8f.NGZJ96gRJGdS4O2NkXJ9d_Yq0v0UBHp1EM-1704442821295-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=beuZyDPzXn2xLnzHpf_7GR2t7XZi.vhHBfrr7jHwtwQ-1704446204584-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4867,15 +4603,15 @@
             },
             {
               "name": "x-trace",
-              "value": "da9984ea930359dbb06663b94cf5fb9d"
+              "value": "4886aeeaec6c7cd36e7a2a9a26eb108d"
             },
             {
               "name": "x-trace-span",
-              "value": "04423cf74415fda5"
+              "value": "255243593aaeb01c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/da9984ea930359dbb06663b94cf5fb9d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4886aeeaec6c7cd36e7a2a9a26eb108d"
             },
             {
               "name": "x-xss-protection",
@@ -4899,21 +4635,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d300ef134fc-WAW"
+              "value": "840a9fc99b00bf1f-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1425,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:21.024Z",
-        "time": 229,
+        "startedDateTime": "2024-01-05T09:16:44.352Z",
+        "time": 222,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4921,7 +4657,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 229
+          "wait": 222
         }
       },
       {
@@ -4997,20 +4733,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:21.000Z",
+              "expires": "2025-01-05T09:16:44.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "55d9e334-a02c-4cc2-8ac8-d1c1847e5b1a"
+              "value": "93f55d0c-c4da-4228-8931-925e3d55f3dc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:21.000Z",
+              "expires": "2024-01-05T09:46:44.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "BlW5G55fOOCH6544QQ2GkU6r6KjkrHEXNVuoNcl11K4-1704442821-1-AUHYl88qGzegAU3scwTD7ZDTEs4nzZR8dVyQrNGjFtkR6ekQMLgL5o1/7a8zNbQM05i/yJb383t6IF7az+XVYeY="
+              "value": "KkM8tD8LQUr4xpntc944_8gTDICOykqUzdRbD6TRZ5I-1704446204-1-AY54UuULy+tkCSaz7VAwsE4q/LMdB0VG4fPpRnxklCCV6qDUD2Bbcg44iyGR/cb1aGhJW9NieP0dAhWR26AhfYs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5019,13 +4755,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ooJzuLumAeFng3vSu34fiTsioCPsiqvDjf1zpZ8HoLk-1704442821748-0-604800000"
+              "value": "rm9LJ7voql_Ej_vACwpgK0sGAICEiLxahtNLPLt4Bvs-1704446204984-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:21 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:44 GMT"
             },
             {
               "name": "content-type",
@@ -5038,18 +4774,6 @@
             {
               "name": "connection",
               "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "342"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5066,17 +4790,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=55d9e334-a02c-4cc2-8ac8-d1c1847e5b1a; Expires=Sun, 05 Jan 2025 08:20:21 GMT; Secure"
+              "value": "sourcegraphDeviceId=93f55d0c-c4da-4228-8931-925e3d55f3dc; Expires=Sun, 05 Jan 2025 09:16:44 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=BlW5G55fOOCH6544QQ2GkU6r6KjkrHEXNVuoNcl11K4-1704442821-1-AUHYl88qGzegAU3scwTD7ZDTEs4nzZR8dVyQrNGjFtkR6ekQMLgL5o1/7a8zNbQM05i/yJb383t6IF7az+XVYeY=; path=/; expires=Fri, 05-Jan-24 08:50:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=KkM8tD8LQUr4xpntc944_8gTDICOykqUzdRbD6TRZ5I-1704446204-1-AY54UuULy+tkCSaz7VAwsE4q/LMdB0VG4fPpRnxklCCV6qDUD2Bbcg44iyGR/cb1aGhJW9NieP0dAhWR26AhfYs=; path=/; expires=Fri, 05-Jan-24 09:46:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=ooJzuLumAeFng3vSu34fiTsioCPsiqvDjf1zpZ8HoLk-1704442821748-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=rm9LJ7voql_Ej_vACwpgK0sGAICEiLxahtNLPLt4Bvs-1704446204984-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5092,15 +4816,15 @@
             },
             {
               "name": "x-trace",
-              "value": "213c794a996307855f6b51092f5b082c"
+              "value": "6e1f0e6bc0a54eb899bf79022a6ea50b"
             },
             {
               "name": "x-trace-span",
-              "value": "e1c247535520d5e1"
+              "value": "54e5269ecd6c9be6"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/213c794a996307855f6b51092f5b082c"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6e1f0e6bc0a54eb899bf79022a6ea50b"
             },
             {
               "name": "x-xss-protection",
@@ -5124,17 +4848,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d32ebb6352d-WAW"
+              "value": "840a9fcc3c66bf79-WAW"
             }
           ],
-          "headersSize": 1393,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:21.453Z",
-        "time": 252,
+        "startedDateTime": "2024-01-05T09:16:44.774Z",
+        "time": 199,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5142,7 +4866,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 252
+          "wait": 199
         }
       },
       {
@@ -5213,20 +4937,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:21.000Z",
+              "expires": "2025-01-05T09:16:45.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e85e24b4-4ab6-406a-bdc7-4c06d75d1106"
+              "value": "b2f1dd0a-3dfc-46f8-bca2-908941143bff"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:23.000Z",
+              "expires": "2024-01-05T09:46:46.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "0MKwvRwCQ0236VV62jmwbNOcSlgqY.C.N5P1uBxaVtc-1704442823-1-AZzwAyFdVCoaGO4VyI1qgsIyU90H3K4rX98avsjnO5rwREL0KYWzAEJrxzQe5f6xSh7UKnNKEtX+u+IbPXq31mw="
+              "value": "moWIcA5cvxz3DISWrtOhmDHB5i64aE3ZZAObH4acGVQ-1704446206-1-ATnEb0kH/4bxNLpPHbe9hS4TlSNYC/7siPWA8FGa+Yb2d9jv8NcGU8YnAXBvTaCTDy17/PlhAJYG0ZMXNT9qNu4="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5235,13 +4959,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "kNzgEdrQBlkkkDdi0GuAlSUSQjulbl0FaZSx6SGXuJ8-1704442823148-0-604800000"
+              "value": "pWV82sU0S4.SP22Rdt2IMmW48aTy7oiFZgoCWA91uP0-1704446206546-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:46 GMT"
             },
             {
               "name": "content-type",
@@ -5254,18 +4978,6 @@
             {
               "name": "connection",
               "value": "keep-alive"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "341"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5282,17 +4994,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e85e24b4-4ab6-406a-bdc7-4c06d75d1106; Expires=Sun, 05 Jan 2025 08:20:21 GMT; Secure"
+              "value": "sourcegraphDeviceId=b2f1dd0a-3dfc-46f8-bca2-908941143bff; Expires=Sun, 05 Jan 2025 09:16:45 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=0MKwvRwCQ0236VV62jmwbNOcSlgqY.C.N5P1uBxaVtc-1704442823-1-AZzwAyFdVCoaGO4VyI1qgsIyU90H3K4rX98avsjnO5rwREL0KYWzAEJrxzQe5f6xSh7UKnNKEtX+u+IbPXq31mw=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=moWIcA5cvxz3DISWrtOhmDHB5i64aE3ZZAObH4acGVQ-1704446206-1-ATnEb0kH/4bxNLpPHbe9hS4TlSNYC/7siPWA8FGa+Yb2d9jv8NcGU8YnAXBvTaCTDy17/PlhAJYG0ZMXNT9qNu4=; path=/; expires=Fri, 05-Jan-24 09:46:46 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=kNzgEdrQBlkkkDdi0GuAlSUSQjulbl0FaZSx6SGXuJ8-1704442823148-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=pWV82sU0S4.SP22Rdt2IMmW48aTy7oiFZgoCWA91uP0-1704446206546-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5308,15 +5020,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f243707e3d43e7ddc2140ff6e5c54017"
+              "value": "afbf85f3f8957e859c93b7dd5be31a7f"
             },
             {
               "name": "x-trace-span",
-              "value": "0361b5494a7de6b4"
+              "value": "166e81ba3640ff27"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f243707e3d43e7ddc2140ff6e5c54017"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/afbf85f3f8957e859c93b7dd5be31a7f"
             },
             {
               "name": "x-xss-protection",
@@ -5340,17 +5052,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d345b36fc63-WAW"
+              "value": "840a9fcd8eb2ffc0-WAW"
             }
           ],
-          "headersSize": 1396,
+          "headersSize": 1289,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:21.712Z",
-        "time": 1509,
+        "startedDateTime": "2024-01-05T09:16:44.982Z",
+        "time": 1554,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5358,458 +5070,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1509
+          "wait": 1554
         }
       },
       {
-        "_id": "ec449ff29bc7d399b19b885c81c5c731",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1696,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1696"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 345,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"interactionID\":\"f385caed-70c3-43b4-b940-5d7327ec8ef7\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":0.687624990940094},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"anthropic\",\"providerModel\":\"claude-instant-1.2\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"f385caed-70c3-43b4-b940-5d7327ec8ef7\",\"contextSummary\":{\"strategy\":\"local-mixed\",\"duration\":0.687624990940094,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}}},\"timestamp\":\"2024-01-05T08:20:23.255Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7d61d76b-876e-4b81-a5a6-4d347ab5641d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:23.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "R_0zFZCJVUk1Yc.MPuuY96p2eBhrADID7yoR5DiG3pQ-1704442823-1-ARg9baonmybyfQkNQpZopB0CsR/sp/7R06T0hl4YocXdgkgUkO+w7MPS8rIM2cprU4xlcV9bPvFI0HPME1IKK/w="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Du.4fsgYqbtDNB5aJwssbLr2QzDvXO2UdR1znZaDG7w-1704442823533-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "340"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7d61d76b-876e-4b81-a5a6-4d347ab5641d; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=R_0zFZCJVUk1Yc.MPuuY96p2eBhrADID7yoR5DiG3pQ-1704442823-1-ARg9baonmybyfQkNQpZopB0CsR/sp/7R06T0hl4YocXdgkgUkO+w7MPS8rIM2cprU4xlcV9bPvFI0HPME1IKK/w=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=Du.4fsgYqbtDNB5aJwssbLr2QzDvXO2UdR1znZaDG7w-1704442823533-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "9d4e0e4b0c5e44f9880ad96c8ccfc5b4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "00c03711692b7b05"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9d4e0e4b0c5e44f9880ad96c8ccfc5b4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d3e0bad35ae-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1425,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:23.259Z",
-        "time": 236,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 236
-        }
-      },
-      {
-        "_id": "a61f9ee0b93db1eca63e63f464134a67",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1226,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1226"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T08:20:23.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "711863eb-5464-4c46-895b-4c5461423795"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:23.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vrFNPWOUglf2twgXTeIFJDa2MYRgtHWV_VudzUjoF6k-1704442823-1-Abf6ezSyNDNTvdFB7BgIql+ObNXjkWwqsW6Ygi5+3fm+kyaWPZyeBrt1v0PUUYxxIl/cGKvTE+Sq0cY7LdGH/WY="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "4ehlcjAYRaoHgWG.6FyACKZTM1Lgul4xtyiYDbKF0Pg-1704442823539-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "cf-rate-limit-rule-id",
-              "value": "93c64da34dda4e9089a4aff7b686e50b"
-            },
-            {
-              "name": "cf-rate-limit-action",
-              "value": "simulate"
-            },
-            {
-              "name": "retry-after",
-              "value": "340"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=711863eb-5464-4c46-895b-4c5461423795; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=vrFNPWOUglf2twgXTeIFJDa2MYRgtHWV_VudzUjoF6k-1704442823-1-Abf6ezSyNDNTvdFB7BgIql+ObNXjkWwqsW6Ygi5+3fm+kyaWPZyeBrt1v0PUUYxxIl/cGKvTE+Sq0cY7LdGH/WY=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=4ehlcjAYRaoHgWG.6FyACKZTM1Lgul4xtyiYDbKF0Pg-1704442823539-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "88e7b6aece22f917b131eb7f1382aaf9"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "9b0f0557be2f316b"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/88e7b6aece22f917b131eb7f1382aaf9"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840a4d3e0baac012-WAW"
-            }
-          ],
-          "headersSize": 1393,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T08:20:23.256Z",
-        "time": 239,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 239
-        }
-      },
-      {
-        "_id": "f04aa5e380c4dbe7d64c31b9a6d05f49",
+        "_id": "bfd3070fe9a2ff0f3054ec8427b7637d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -5862,7 +5127,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:23.255Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:47.455Z\"}]}}"
           },
           "queryString": [
             {
@@ -5882,20 +5147,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:23.000Z",
+              "expires": "2025-01-05T09:16:47.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2ae8b36f-1daa-47eb-957f-fd1760639e86"
+              "value": "7b8af6e2-a19a-4046-9910-aacf8a1d09c1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:23.000Z",
+              "expires": "2024-01-05T09:46:47.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "GZartLClsgqZqURFKPHbCZBjjJXj083k7KMzsj_Z7E4-1704442823-1-AW2elo2203e9UJqLZqMzNR7otjOD3+aLqD2E5OZJVCkJEyhzMIu9o1B6KoOKGetQIYYRA7DL2m+Y9jIbATVN4z8="
+              "value": "OiIzx8tO_gRLYBf8UyutnyYt7sOeaTA424ZBMFZWqjA-1704446207-1-AWXT64G4Xjl0P4TBwHWzDzVWjWUpDXSYrgAA0sA+EN2h7CyYR35aPSZ+Cl0R6T26cdl46MbS57NN9rm6Ff58b2o="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5904,13 +5169,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000"
+              "value": "fGMzAa5oKMgFDklZ2INOiOaNewyLJCpOxl3Evsx5KU0-1704446207706-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:47 GMT"
             },
             {
               "name": "content-type",
@@ -5934,7 +5199,7 @@
             },
             {
               "name": "retry-after",
-              "value": "340"
+              "value": "600"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5951,17 +5216,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2ae8b36f-1daa-47eb-957f-fd1760639e86; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=7b8af6e2-a19a-4046-9910-aacf8a1d09c1; Expires=Sun, 05 Jan 2025 09:16:47 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=GZartLClsgqZqURFKPHbCZBjjJXj083k7KMzsj_Z7E4-1704442823-1-AW2elo2203e9UJqLZqMzNR7otjOD3+aLqD2E5OZJVCkJEyhzMIu9o1B6KoOKGetQIYYRA7DL2m+Y9jIbATVN4z8=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=OiIzx8tO_gRLYBf8UyutnyYt7sOeaTA424ZBMFZWqjA-1704446207-1-AWXT64G4Xjl0P4TBwHWzDzVWjWUpDXSYrgAA0sA+EN2h7CyYR35aPSZ+Cl0R6T26cdl46MbS57NN9rm6Ff58b2o=; path=/; expires=Fri, 05-Jan-24 09:46:47 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=fGMzAa5oKMgFDklZ2INOiOaNewyLJCpOxl3Evsx5KU0-1704446207706-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5977,15 +5242,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b68c07eb6cc7bdd6ec4f7e8405d83677"
+              "value": "51b59cc3873760e81c86e9902ac07688"
             },
             {
               "name": "x-trace-span",
-              "value": "7a64aab8358d4673"
+              "value": "3b7256da7b802dc7"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b68c07eb6cc7bdd6ec4f7e8405d83677"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/51b59cc3873760e81c86e9902ac07688"
             },
             {
               "name": "x-xss-protection",
@@ -6009,7 +5274,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d3e0a6f3524-WAW"
+              "value": "840a9fdd1c643578-WAW"
             },
             {
               "name": "content-encoding",
@@ -6022,8 +5287,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:23.259Z",
-        "time": 241,
+        "startedDateTime": "2024-01-05T09:16:47.459Z",
+        "time": 240,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6031,15 +5296,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 241
+          "wait": 240
         }
       },
       {
-        "_id": "301ea02d32e7fa81522fd24d2df31a8e",
+        "_id": "53f073e00e92f2ec49730ac00d845102",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2029,
+          "bodySize": 1698,
           "cookies": [],
           "headers": [
             {
@@ -6065,7 +5330,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "2029"
+              "value": "1698"
             },
             {
               "_fromType": "array",
@@ -6082,45 +5347,46 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"anthropic\\\",\\\"providerModel\\\":\\\"claude-instant-1.2\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"f385caed-70c3-43b4-b940-5d7327ec8ef7\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"local-mixed\\\",\\\"duration\\\":0.687624990940094,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"interactionID\":\"630ab563-e036-4e78-bfc8-d4772a31afef\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":0.7270829975605011},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"anthropic\",\"providerModel\":\"claude-instant-1.2\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"630ab563-e036-4e78-bfc8-d4772a31afef\",\"contextSummary\":{\"strategy\":\"local-mixed\",\"duration\":0.7270829975605011,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}}},\"timestamp\":\"2024-01-05T09:16:47.456Z\"}]}}"
           },
           "queryString": [
             {
-              "name": "LogEventMutation",
+              "name": "RecordTelemetryEvents",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 26,
+          "bodySize": 119,
           "content": {
+            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:23.000Z",
+              "expires": "2025-01-05T09:16:47.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8df0a05f-df23-4c2f-880a-0b744b1bab19"
+              "value": "6021515f-a43d-40e7-8ccb-8e5a816d94d1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:23.000Z",
+              "expires": "2024-01-05T09:46:47.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3Tkoee21QEAXEaGuvi.FehWeYSKWHF_I1vvEpZnEaJA-1704442823-1-ASz6hGgYMni4afrKsab03U+T2FfqdBupD7N1kOc2F93VtuF7EJe5eTCcSEUfrJNV+rhdkV0er2fecOfHIoK3rYw="
+              "value": "nYKxetkMETVW2IKa83DAgGadR_p.2GzrxMFRocrtnLo-1704446207-1-ASu+CtDPnQ5i5pNata8tdpHdQzxiKz44iQQ+m8Uq7H0YhOglOBvaYyCyn7MWiXMxuLMqFpZjZIEr+3mgRGxPTtI="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6129,21 +5395,21 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000"
+              "value": "GjPoInzIjrdrmkCDoR0ZBBLbCvWdDMkQFXtWALCKDmQ-1704446207709-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:47 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "content-length",
-              "value": "26"
+              "name": "transfer-encoding",
+              "value": "chunked"
             },
             {
               "name": "connection",
@@ -6159,7 +5425,7 @@
             },
             {
               "name": "retry-after",
-              "value": "340"
+              "value": "600"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6176,17 +5442,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8df0a05f-df23-4c2f-880a-0b744b1bab19; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=6021515f-a43d-40e7-8ccb-8e5a816d94d1; Expires=Sun, 05 Jan 2025 09:16:47 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3Tkoee21QEAXEaGuvi.FehWeYSKWHF_I1vvEpZnEaJA-1704442823-1-ASz6hGgYMni4afrKsab03U+T2FfqdBupD7N1kOc2F93VtuF7EJe5eTCcSEUfrJNV+rhdkV0er2fecOfHIoK3rYw=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=nYKxetkMETVW2IKa83DAgGadR_p.2GzrxMFRocrtnLo-1704446207-1-ASu+CtDPnQ5i5pNata8tdpHdQzxiKz44iQQ+m8Uq7H0YhOglOBvaYyCyn7MWiXMxuLMqFpZjZIEr+3mgRGxPTtI=; path=/; expires=Fri, 05-Jan-24 09:46:47 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=GjPoInzIjrdrmkCDoR0ZBBLbCvWdDMkQFXtWALCKDmQ-1704446207709-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6202,15 +5468,15 @@
             },
             {
               "name": "x-trace",
-              "value": "fa3bb6c7dfe6b740cf2c5c2cd406fab9"
+              "value": "1adcc52c4273953d34514fe6c561506a"
             },
             {
               "name": "x-trace-span",
-              "value": "cdcf81e8d77e7118"
+              "value": "091dc30c2f37c087"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fa3bb6c7dfe6b740cf2c5c2cd406fab9"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1adcc52c4273953d34514fe6c561506a"
             },
             {
               "name": "x-xss-protection",
@@ -6234,7 +5500,232 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d3e08c870c1-WAW"
+              "value": "840a9fdd2c653527-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:47.460Z",
+        "time": 239,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 239
+        }
+      },
+      {
+        "_id": "7b5248c699cf900d85991a021679642d",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1226,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1226"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"16e4a31f-b58d-4f62-b0f5-cf6f56b42589\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:47.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "56f43470-32de-43a6-86aa-0a5dd9393894"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:47.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Q8e2fLmE3TuSqjzED7BDvWajZnJNJHuOQCknsjmeOQg-1704446207-1-AQNO65qI3OurPlBy2Qi5Rsl7LV0K1XqyAOkx2ZEbI3NfuEsBwGYBbvsoEWKAX9HoFKcLw9JRyAhak8kzCbxI56o="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": ".R8Tq59s6NJwGjwcqe0pt1ogFgsMe2MpD7PMY3Rfeu0-1704446207738-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:47 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "600"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=56f43470-32de-43a6-86aa-0a5dd9393894; Expires=Sun, 05 Jan 2025 09:16:47 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Q8e2fLmE3TuSqjzED7BDvWajZnJNJHuOQCknsjmeOQg-1704446207-1-AQNO65qI3OurPlBy2Qi5Rsl7LV0K1XqyAOkx2ZEbI3NfuEsBwGYBbvsoEWKAX9HoFKcLw9JRyAhak8kzCbxI56o=; path=/; expires=Fri, 05-Jan-24 09:46:47 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=.R8Tq59s6NJwGjwcqe0pt1ogFgsMe2MpD7PMY3Rfeu0-1704446207738-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "0fc09333b8fadc1fa95a67b17a99e76b"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "b812d5d058f293e4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0fc09333b8fadc1fa95a67b17a99e76b"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fdd29e535cc-WAW"
             }
           ],
           "headersSize": 1393,
@@ -6243,8 +5734,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:23.258Z",
-        "time": 242,
+        "startedDateTime": "2024-01-05T09:16:47.457Z",
+        "time": 281,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6252,11 +5743,232 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 242
+          "wait": 281
         }
       },
       {
-        "_id": "26aecace99af45a221b18ae1292cc3e8",
+        "_id": "0b1919f4a6738de6f7663ae015188800",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 2030,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "2030"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"16e4a31f-b58d-4f62-b0f5-cf6f56b42589\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"anthropic\\\",\\\"providerModel\\\":\\\"claude-instant-1.2\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"630ab563-e036-4e78-bfc8-d4772a31afef\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"local-mixed\\\",\\\"duration\\\":0.7270829975605011,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T09:16:47.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "995279d6-d2cb-4ab0-94b5-f2f8bf28361e"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T09:46:47.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "26r4CX7G_u0_EPHNVJKhRf9138Ee29EvFtM11Nfa5go-1704446207-1-ATMt8wMjiLHV+mm0Gf5l2h/RP4XaxzXDs8NZq4kI1egPOVmYD5XRx/Bsosjd6S0xrWZcy9VlhWOxPOcuHTN94o8="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "wx3spnHjK6Qfu5O2ydoTJKEYZp3gMct4y25iB3x5vEI-1704446207739-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 09:16:47 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "600"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=995279d6-d2cb-4ab0-94b5-f2f8bf28361e; Expires=Sun, 05 Jan 2025 09:16:47 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=26r4CX7G_u0_EPHNVJKhRf9138Ee29EvFtM11Nfa5go-1704446207-1-ATMt8wMjiLHV+mm0Gf5l2h/RP4XaxzXDs8NZq4kI1egPOVmYD5XRx/Bsosjd6S0xrWZcy9VlhWOxPOcuHTN94o8=; path=/; expires=Fri, 05-Jan-24 09:46:47 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=wx3spnHjK6Qfu5O2ydoTJKEYZp3gMct4y25iB3x5vEI-1704446207739-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "471d923175a50e1d9097bfce371cbe75"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "9d6cbc1266aa8362"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/471d923175a50e1d9097bfce371cbe75"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a9fdd1fa55013-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T09:16:47.458Z",
+        "time": 281,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 281
+        }
+      },
+      {
+        "_id": "3ced032e6394bf251bf1255a89ec0a18",
         "_order": 0,
         "cache": {},
         "request": {
@@ -6309,7 +6021,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:23.756Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:47.950Z\"}]}}"
           },
           "queryString": [
             {
@@ -6329,20 +6041,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:23.000Z",
+              "expires": "2025-01-05T09:16:48.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6d8213e8-ddbe-4a6c-b2bc-f3f90d2f30b7"
+              "value": "2328fab6-d5e6-43f4-afb8-d8253e45ef59"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:24.000Z",
+              "expires": "2024-01-05T09:46:48.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "0P10HdDDfBIwmsCO.vURhnusRX6NAef4ctK2oiFbDpI-1704442824-1-ATKBFYAk78pz0UhlayW/YKCtDFbl6iLKHsbSGzG8H2c3DRlapkSpVnD0vsOZ8eBXnJLRqvjHkdEeWI6raTfmi3o="
+              "value": "MuVTFcKoMIjT8oT8ClB9G77eWj_dZ6JmDdlUv2k_41A-1704446208-1-ASHmmivZwsCo2QXCoGPP0XKJ1cML2oXFIBpj0Xu2TeBdvoncjBwu0OAe9UogpT99rnyFQZCgddW7iKPh9LSzmWE="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6351,13 +6063,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "_Z5MKkZzZTlVH_izv1.Y4m6.HZVXqZt.q3ManEuJ_64-1704442824034-0-604800000"
+              "value": "66nAPbs1g.7ujZaw7vSdD_CS_2Hh1VzwvtTvtUTvDY8-1704446208185-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:24 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:48 GMT"
             },
             {
               "name": "content-type",
@@ -6381,7 +6093,7 @@
             },
             {
               "name": "retry-after",
-              "value": "339"
+              "value": "599"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6398,17 +6110,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6d8213e8-ddbe-4a6c-b2bc-f3f90d2f30b7; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=2328fab6-d5e6-43f4-afb8-d8253e45ef59; Expires=Sun, 05 Jan 2025 09:16:48 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=0P10HdDDfBIwmsCO.vURhnusRX6NAef4ctK2oiFbDpI-1704442824-1-ATKBFYAk78pz0UhlayW/YKCtDFbl6iLKHsbSGzG8H2c3DRlapkSpVnD0vsOZ8eBXnJLRqvjHkdEeWI6raTfmi3o=; path=/; expires=Fri, 05-Jan-24 08:50:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=MuVTFcKoMIjT8oT8ClB9G77eWj_dZ6JmDdlUv2k_41A-1704446208-1-ASHmmivZwsCo2QXCoGPP0XKJ1cML2oXFIBpj0Xu2TeBdvoncjBwu0OAe9UogpT99rnyFQZCgddW7iKPh9LSzmWE=; path=/; expires=Fri, 05-Jan-24 09:46:48 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=_Z5MKkZzZTlVH_izv1.Y4m6.HZVXqZt.q3ManEuJ_64-1704442824034-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=66nAPbs1g.7ujZaw7vSdD_CS_2Hh1VzwvtTvtUTvDY8-1704446208185-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6424,15 +6136,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d1a9d428208de5a6d0dc98d48daaaad8"
+              "value": "5f562ad4efdbc3fb7b20a9697abd24de"
             },
             {
               "name": "x-trace-span",
-              "value": "f79287b8e621c16d"
+              "value": "a71e1705c41ba5ba"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d1a9d428208de5a6d0dc98d48daaaad8"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5f562ad4efdbc3fb7b20a9697abd24de"
             },
             {
               "name": "x-xss-protection",
@@ -6456,7 +6168,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d411b4efc7f-WAW"
+              "value": "840a9fe01f7f3506-WAW"
             },
             {
               "name": "content-encoding",
@@ -6469,8 +6181,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:23.758Z",
-        "time": 233,
+        "startedDateTime": "2024-01-05T09:16:47.952Z",
+        "time": 222,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6478,7 +6190,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 233
+          "wait": 222
         }
       },
       {
@@ -6555,20 +6267,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:23.000Z",
+              "expires": "2025-01-05T09:16:47.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "443ad7fd-6ff5-402f-be78-23b9e33e1480"
+              "value": "df3be5e6-5f7b-42cb-817c-17eb8d494af3"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:24.000Z",
+              "expires": "2024-01-05T09:46:48.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "lo756gH1dLz9Kb.GASJReedKqLpAAwgPHgBXJgS5vow-1704442824-1-ASGQ4o+DQXqyjqg/JAKfifTnnK0pHNwR331wF+Kucj2nsISXD7j2RugRms5BdhWZdZvNTmNYSVrAKP1AOpBqmPw="
+              "value": "GCKshavlkp_.i.rAuptburf6fD8t3HcSOD9buIsamUw-1704446208-1-AZ4IRqkCUAlRDE5Ryl10XOeSO6t3vQvtxKdL9FVqNrwrI3wMB56dPiSQgOtqYlULRPG+5e14LcbDd1g3z8wbH+4="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6577,13 +6289,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "jvnjazGNEoGQLI6yR6SnH1zMUPWvBD1UUkeb82TWfHM-1704442824061-0-604800000"
+              "value": "f9GzXSvfz2RLjfhx0b1IepXMMz7Q7DfQFKLMX.TYS.A-1704446208249-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:24 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:48 GMT"
             },
             {
               "name": "content-type",
@@ -6607,7 +6319,7 @@
             },
             {
               "name": "retry-after",
-              "value": "340"
+              "value": "599"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6628,17 +6340,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=443ad7fd-6ff5-402f-be78-23b9e33e1480; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
+              "value": "sourcegraphDeviceId=df3be5e6-5f7b-42cb-817c-17eb8d494af3; Expires=Sun, 05 Jan 2025 09:16:47 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=lo756gH1dLz9Kb.GASJReedKqLpAAwgPHgBXJgS5vow-1704442824-1-ASGQ4o+DQXqyjqg/JAKfifTnnK0pHNwR331wF+Kucj2nsISXD7j2RugRms5BdhWZdZvNTmNYSVrAKP1AOpBqmPw=; path=/; expires=Fri, 05-Jan-24 08:50:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=GCKshavlkp_.i.rAuptburf6fD8t3HcSOD9buIsamUw-1704446208-1-AZ4IRqkCUAlRDE5Ryl10XOeSO6t3vQvtxKdL9FVqNrwrI3wMB56dPiSQgOtqYlULRPG+5e14LcbDd1g3z8wbH+4=; path=/; expires=Fri, 05-Jan-24 09:46:48 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=jvnjazGNEoGQLI6yR6SnH1zMUPWvBD1UUkeb82TWfHM-1704442824061-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=f9GzXSvfz2RLjfhx0b1IepXMMz7Q7DfQFKLMX.TYS.A-1704446208249-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6654,15 +6366,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c528385b25430a4ea10b5aa2e9f207e5"
+              "value": "620252e96a918813cc26187bec228274"
             },
             {
               "name": "x-trace-span",
-              "value": "7928181e95f194f1"
+              "value": "d460c8649fdb9e99"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c528385b25430a4ea10b5aa2e9f207e5"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/620252e96a918813cc26187bec228274"
             },
             {
               "name": "x-xss-protection",
@@ -6686,7 +6398,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d3f784170b5-WAW"
+              "value": "840a9fde99223552-WAW"
             }
           ],
           "headersSize": 1425,
@@ -6695,8 +6407,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:23.494Z",
-        "time": 524,
+        "startedDateTime": "2024-01-05T09:16:47.697Z",
+        "time": 543,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6704,15 +6416,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 524
+          "wait": 543
         }
       },
       {
-        "_id": "dbc78ecb6c12baf20a01af4456506c6f",
+        "_id": "cebeb103814fa65fea3b3349476ecc7a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 527,
+          "bodySize": 524,
           "cookies": [],
           "headers": [
             {
@@ -6738,7 +6450,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "527"
+              "value": "524"
             },
             {
               "_fromType": "array",
@@ -6761,7 +6473,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"recipe-used\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:24.022Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:48.245Z\"}]}}"
           },
           "queryString": [
             {
@@ -6781,20 +6493,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:24.000Z",
+              "expires": "2025-01-05T09:16:48.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "4a20032c-44d4-4e7c-a87d-fdc895e220d3"
+              "value": "98778c07-d736-46f2-a862-4aac2beafa48"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:24.000Z",
+              "expires": "2024-01-05T09:46:48.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "yFRq5QA8J9sURux_P5t.d2i6s.aDyDuRDwXsyj0F2XI-1704442824-1-AWA7qjqzgtrRdndaAYp9ZzFCR78nEjzyRS5J/tjL17Og3d0OrrYnzg6M9cSItpPITf3MRAYCeRwtnj/5vGkOtW0="
+              "value": "nps_aEYg3bOm9F5tmHIILI4Kt9ar3OLWYrkDmIRI6wk-1704446208-1-AW8kyEWc8gZQj7eOWjmYgjmJXlNkJDJY1TS/S83IbGzvoMkrZ61w1hqftpFLnmB++VyAPFIkmwXdEu19Y6JcVEA="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6803,13 +6515,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "RBnfY.4i.d7O4DlsqTxbvvJArBh3tCVzEjd77hOorzM-1704442824302-0-604800000"
+              "value": "W3RvxrKld9zX_DSjyH2wePLjxnFoK4AmyINXZ.E_TSU-1704446208536-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:24 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:48 GMT"
             },
             {
               "name": "content-type",
@@ -6833,7 +6545,7 @@
             },
             {
               "name": "retry-after",
-              "value": "339"
+              "value": "599"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6850,17 +6562,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4a20032c-44d4-4e7c-a87d-fdc895e220d3; Expires=Sun, 05 Jan 2025 08:20:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=98778c07-d736-46f2-a862-4aac2beafa48; Expires=Sun, 05 Jan 2025 09:16:48 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=yFRq5QA8J9sURux_P5t.d2i6s.aDyDuRDwXsyj0F2XI-1704442824-1-AWA7qjqzgtrRdndaAYp9ZzFCR78nEjzyRS5J/tjL17Og3d0OrrYnzg6M9cSItpPITf3MRAYCeRwtnj/5vGkOtW0=; path=/; expires=Fri, 05-Jan-24 08:50:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=nps_aEYg3bOm9F5tmHIILI4Kt9ar3OLWYrkDmIRI6wk-1704446208-1-AW8kyEWc8gZQj7eOWjmYgjmJXlNkJDJY1TS/S83IbGzvoMkrZ61w1hqftpFLnmB++VyAPFIkmwXdEu19Y6JcVEA=; path=/; expires=Fri, 05-Jan-24 09:46:48 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=RBnfY.4i.d7O4DlsqTxbvvJArBh3tCVzEjd77hOorzM-1704442824302-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=W3RvxrKld9zX_DSjyH2wePLjxnFoK4AmyINXZ.E_TSU-1704446208536-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6876,15 +6588,15 @@
             },
             {
               "name": "x-trace",
-              "value": "0efc70c024f21fc60ff163c2d2da1f3a"
+              "value": "d68708bbd7330f3e4a43962abc6142c0"
             },
             {
               "name": "x-trace-span",
-              "value": "b95c1d373e13ffc1"
+              "value": "524bdf937c8dc7d2"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0efc70c024f21fc60ff163c2d2da1f3a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d68708bbd7330f3e4a43962abc6142c0"
             },
             {
               "name": "x-xss-protection",
@@ -6908,7 +6620,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d42cbe034d9-WAW"
+              "value": "840a9fe1f9d835b8-WAW"
             },
             {
               "name": "content-encoding",
@@ -6921,8 +6633,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:24.025Z",
-        "time": 235,
+        "startedDateTime": "2024-01-05T09:16:48.249Z",
+        "time": 276,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6930,7 +6642,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 235
+          "wait": 276
         }
       },
       {
@@ -6982,20 +6694,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:24.000Z",
+              "expires": "2025-01-05T09:16:48.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7c28d7b0-dc68-44a4-ba70-6d679a680010"
+              "value": "aafcf8cc-d94f-4eb8-a173-f7f8cc112988"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:26.000Z",
+              "expires": "2024-01-05T09:46:50.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": ".YVnRILAOX7NQr4Nmd4Y8Qh0ElHEOR_zmx.wKlOi1Mk-1704442826-1-AcTr+5dTCl9LmbjAe6eSB18ump5hRG/xIr6gADXYaEjr0EkhIODomgX31Mhlir63JjLWSFsWdbVuZJ7/VISbJKw="
+              "value": "DUZ2k2tfiCmOwexX9EX64YG7.du7ASVEiaugfQ.6CJg-1704446210-1-AefR/REk99qrgmDBh8pudEHV+DuMWrqZuvKBfC0ArUkyDd4VY10etUUwci4fjJXXW/WfnjGBPBR3NYK2ZRljr1U="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7004,13 +6716,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Nd5B0QXBzWWeXr0dLzR8x691fmdzk8SrEzUkCknrPE8-1704442826284-0-604800000"
+              "value": "J5JsD_GcsIxziRRd_vUBiw3O3Y7Y9F1hbgdQZnQhNvE-1704446210482-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:26 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:50 GMT"
             },
             {
               "name": "content-type",
@@ -7034,7 +6746,7 @@
             },
             {
               "name": "retry-after",
-              "value": "339"
+              "value": "599"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7051,17 +6763,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7c28d7b0-dc68-44a4-ba70-6d679a680010; Expires=Sun, 05 Jan 2025 08:20:24 GMT; Secure"
+              "value": "sourcegraphDeviceId=aafcf8cc-d94f-4eb8-a173-f7f8cc112988; Expires=Sun, 05 Jan 2025 09:16:48 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=.YVnRILAOX7NQr4Nmd4Y8Qh0ElHEOR_zmx.wKlOi1Mk-1704442826-1-AcTr+5dTCl9LmbjAe6eSB18ump5hRG/xIr6gADXYaEjr0EkhIODomgX31Mhlir63JjLWSFsWdbVuZJ7/VISbJKw=; path=/; expires=Fri, 05-Jan-24 08:50:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=DUZ2k2tfiCmOwexX9EX64YG7.du7ASVEiaugfQ.6CJg-1704446210-1-AefR/REk99qrgmDBh8pudEHV+DuMWrqZuvKBfC0ArUkyDd4VY10etUUwci4fjJXXW/WfnjGBPBR3NYK2ZRljr1U=; path=/; expires=Fri, 05-Jan-24 09:46:50 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Nd5B0QXBzWWeXr0dLzR8x691fmdzk8SrEzUkCknrPE8-1704442826284-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=J5JsD_GcsIxziRRd_vUBiw3O3Y7Y9F1hbgdQZnQhNvE-1704446210482-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7077,15 +6789,15 @@
             },
             {
               "name": "x-trace",
-              "value": "2c838aea2c263b35f499e7175b151fe8"
+              "value": "eed658e0f3c5528dab054af9e5814174"
             },
             {
               "name": "x-trace-span",
-              "value": "14b9bda4b83d8169"
+              "value": "3dc16ac1d46ab23c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2c838aea2c263b35f499e7175b151fe8"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/eed658e0f3c5528dab054af9e5814174"
             },
             {
               "name": "x-xss-protection",
@@ -7109,7 +6821,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d42c90a34a9-WAW"
+              "value": "840a9fe1f9983488-WAW"
             }
           ],
           "headersSize": 1396,
@@ -7118,8 +6830,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:24.024Z",
-        "time": 2269,
+        "startedDateTime": "2024-01-05T09:16:48.248Z",
+        "time": 2224,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7127,7 +6839,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2269
+          "wait": 2224
         }
       },
       {
@@ -7204,20 +6916,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:26.000Z",
+              "expires": "2025-01-05T09:16:50.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5d24c5d8-edae-43f8-934b-2a01c3f13552"
+              "value": "bfaae5fe-6ea3-4fef-8d74-d98ad8042305"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:26.000Z",
+              "expires": "2024-01-05T09:46:51.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "fz1A5KfI7TpTWHBmOJCPpbd4lLAPPyZRItGm5PktFvI-1704442826-1-AYOZyfqVCRKMgnANgiXQJKr5hrt+xeefLq8QsZbqIXtIaY/KFLdtcWCEaKTbAFO+GEbyj6ePYAQvp/DpUx/EADs="
+              "value": "Etq6ep2qnkycEBq_Fj1f7vEHe7tITYqKigFp9DSMSSM-1704446211-1-AUYiE5hHOuS/K/QDlvS+f5SZ3O6gSfUUWFNtDaCRqaJgmU12el0RYs51Gt8jls9t6prxG9MO+VZcLvlpBJMh99A="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7226,13 +6938,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "I5iGyZjrWR2rQrWd.HMqbYVNsZWmifjTou5PldZtBVQ-1704442826788-0-604800000"
+              "value": "hQfpFEQMhecapJeioEz5uCAAaWc3Pk3Fsg2WgIj4A70-1704446211067-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:26 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:51 GMT"
             },
             {
               "name": "content-type",
@@ -7256,7 +6968,7 @@
             },
             {
               "name": "retry-after",
-              "value": "337"
+              "value": "597"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7277,17 +6989,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5d24c5d8-edae-43f8-934b-2a01c3f13552; Expires=Sun, 05 Jan 2025 08:20:26 GMT; Secure"
+              "value": "sourcegraphDeviceId=bfaae5fe-6ea3-4fef-8d74-d98ad8042305; Expires=Sun, 05 Jan 2025 09:16:50 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=fz1A5KfI7TpTWHBmOJCPpbd4lLAPPyZRItGm5PktFvI-1704442826-1-AYOZyfqVCRKMgnANgiXQJKr5hrt+xeefLq8QsZbqIXtIaY/KFLdtcWCEaKTbAFO+GEbyj6ePYAQvp/DpUx/EADs=; path=/; expires=Fri, 05-Jan-24 08:50:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=Etq6ep2qnkycEBq_Fj1f7vEHe7tITYqKigFp9DSMSSM-1704446211-1-AUYiE5hHOuS/K/QDlvS+f5SZ3O6gSfUUWFNtDaCRqaJgmU12el0RYs51Gt8jls9t6prxG9MO+VZcLvlpBJMh99A=; path=/; expires=Fri, 05-Jan-24 09:46:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=I5iGyZjrWR2rQrWd.HMqbYVNsZWmifjTou5PldZtBVQ-1704442826788-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=hQfpFEQMhecapJeioEz5uCAAaWc3Pk3Fsg2WgIj4A70-1704446211067-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7303,15 +7015,15 @@
             },
             {
               "name": "x-trace",
-              "value": "031edc1260c70ddea1cbb67108910455"
+              "value": "d50b4161c19363eb7f8d18227157b087"
             },
             {
               "name": "x-trace-span",
-              "value": "0fdad18235466562"
+              "value": "7c1507002c40c254"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/031edc1260c70ddea1cbb67108910455"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d50b4161c19363eb7f8d18227157b087"
             },
             {
               "name": "x-xss-protection",
@@ -7335,7 +7047,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d50f8ac70bb-WAW"
+              "value": "840a9fefff8a70b5-WAW"
             }
           ],
           "headersSize": 1425,
@@ -7344,8 +7056,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:26.305Z",
-        "time": 500,
+        "startedDateTime": "2024-01-05T09:16:50.484Z",
+        "time": 573,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7353,15 +7065,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 500
+          "wait": 573
         }
       },
       {
-        "_id": "586804c289309e332b55a961aecc1d96",
+        "_id": "13cb064aed9c69411b23a42b8a288ebe",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 527,
+          "bodySize": 524,
           "cookies": [],
           "headers": [
             {
@@ -7387,7 +7099,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "527"
+              "value": "524"
             },
             {
               "_fromType": "array",
@@ -7410,7 +7122,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"recipe-used\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:26.809Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:51.061Z\"}]}}"
           },
           "queryString": [
             {
@@ -7430,20 +7142,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:26.000Z",
+              "expires": "2025-01-05T09:16:51.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "81f6f7ad-7754-42b1-aa6a-3f8aa71212f1"
+              "value": "20bd9577-da4a-4b0e-8b04-a40e5933b6e1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:27.000Z",
+              "expires": "2024-01-05T09:46:51.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "f1uOzTugSYdP_dLlr65Jz6IjBw5pA7addQFDyDxBl5Y-1704442827-1-AYAPruekP//OFv4Mcl5fLYyPLFCtJ/EKcWcq6pTy9NCxpBC1q0w49svvIO1Wjyiet/KZLP3P5Pe4UY+8WmQqHSk="
+              "value": "pl9YMNOlB7lIs9mgKBGg09ejmhE6Uz.sRlaiHuDBxYY-1704446211-1-AZySR3zflPCxiyqK42mmMWIo9RnI72ufnv3i5VzDidnnveN/t5CRZC6QHQylkMoCYwkv802vWY7a9SEr3K7P26o="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7452,13 +7164,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "tvhXaPNR_8OnGGFNQi3kaIbNGhaVWG_4NQgpiJ.f1k4-1704442827074-0-604800000"
+              "value": "6Mix.GX63a5Fcb3YEEsksFV1lhfwZV814cs0VsKRG90-1704446211308-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:27 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:51 GMT"
             },
             {
               "name": "content-type",
@@ -7482,7 +7194,7 @@
             },
             {
               "name": "retry-after",
-              "value": "336"
+              "value": "596"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7499,17 +7211,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=81f6f7ad-7754-42b1-aa6a-3f8aa71212f1; Expires=Sun, 05 Jan 2025 08:20:26 GMT; Secure"
+              "value": "sourcegraphDeviceId=20bd9577-da4a-4b0e-8b04-a40e5933b6e1; Expires=Sun, 05 Jan 2025 09:16:51 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=f1uOzTugSYdP_dLlr65Jz6IjBw5pA7addQFDyDxBl5Y-1704442827-1-AYAPruekP//OFv4Mcl5fLYyPLFCtJ/EKcWcq6pTy9NCxpBC1q0w49svvIO1Wjyiet/KZLP3P5Pe4UY+8WmQqHSk=; path=/; expires=Fri, 05-Jan-24 08:50:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=pl9YMNOlB7lIs9mgKBGg09ejmhE6Uz.sRlaiHuDBxYY-1704446211-1-AZySR3zflPCxiyqK42mmMWIo9RnI72ufnv3i5VzDidnnveN/t5CRZC6QHQylkMoCYwkv802vWY7a9SEr3K7P26o=; path=/; expires=Fri, 05-Jan-24 09:46:51 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=tvhXaPNR_8OnGGFNQi3kaIbNGhaVWG_4NQgpiJ.f1k4-1704442827074-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=6Mix.GX63a5Fcb3YEEsksFV1lhfwZV814cs0VsKRG90-1704446211308-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7525,15 +7237,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f3776090eef3f7d761f54bd22e4c0d28"
+              "value": "4017dd037e4989f25d4343c09719115d"
             },
             {
               "name": "x-trace-span",
-              "value": "88eaa97706d1766c"
+              "value": "1b216221982c69a9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f3776090eef3f7d761f54bd22e4c0d28"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4017dd037e4989f25d4343c09719115d"
             },
             {
               "name": "x-xss-protection",
@@ -7557,7 +7269,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d542ccd70bb-WAW"
+              "value": "840a9ff3aca85049-WAW"
             },
             {
               "name": "content-encoding",
@@ -7570,8 +7282,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:26.815Z",
-        "time": 220,
+        "startedDateTime": "2024-01-05T09:16:51.066Z",
+        "time": 234,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7579,7 +7291,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 220
+          "wait": 234
         }
       },
       {
@@ -7631,20 +7343,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:26.000Z",
+              "expires": "2025-01-05T09:16:51.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e2e7b973-4cec-43f7-b10a-808c15f56428"
+              "value": "b17d8ba5-2d5b-4786-a55a-68d11b6e8e7c"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:31.000Z",
+              "expires": "2024-01-05T09:46:55.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "_vOvOkgv.ujje5tMs9Pp10d19Twkbk2C30pazw1XIHg-1704442831-1-AUOqBwcurSm/Ev8kOR7Aifp71LvYtz5Cb2HBHVQQp5xAhLy7TrmUNuo3EQxgzWoKfYrrVhWnkEPNV0e1wxeYaBs="
+              "value": "yRY.RzweY.VH_q1Jy0FFOKFqueDgn4D7bwBWApF5hIg-1704446215-1-AUFZrNnngfpmnlqAIrg0jmB/ugdgxyxValvGOiF9IsMFMq+j/9rIPpynK8X7mH00okb8oCi7LLyldc5YqZVeKMc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7653,13 +7365,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "NzIr0WGdp5dVSJ3b1BQiHkxn.SiUFmc.Y3yuJ05bgX8-1704442831321-0-604800000"
+              "value": "J49cERU3hxZKSoDzKuYbH729KaV6PJELUBgGz4OvU.I-1704446215684-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:31 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:55 GMT"
             },
             {
               "name": "content-type",
@@ -7683,7 +7395,7 @@
             },
             {
               "name": "retry-after",
-              "value": "336"
+              "value": "596"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7700,17 +7412,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e2e7b973-4cec-43f7-b10a-808c15f56428; Expires=Sun, 05 Jan 2025 08:20:26 GMT; Secure"
+              "value": "sourcegraphDeviceId=b17d8ba5-2d5b-4786-a55a-68d11b6e8e7c; Expires=Sun, 05 Jan 2025 09:16:51 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=_vOvOkgv.ujje5tMs9Pp10d19Twkbk2C30pazw1XIHg-1704442831-1-AUOqBwcurSm/Ev8kOR7Aifp71LvYtz5Cb2HBHVQQp5xAhLy7TrmUNuo3EQxgzWoKfYrrVhWnkEPNV0e1wxeYaBs=; path=/; expires=Fri, 05-Jan-24 08:50:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=yRY.RzweY.VH_q1Jy0FFOKFqueDgn4D7bwBWApF5hIg-1704446215-1-AUFZrNnngfpmnlqAIrg0jmB/ugdgxyxValvGOiF9IsMFMq+j/9rIPpynK8X7mH00okb8oCi7LLyldc5YqZVeKMc=; path=/; expires=Fri, 05-Jan-24 09:46:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=NzIr0WGdp5dVSJ3b1BQiHkxn.SiUFmc.Y3yuJ05bgX8-1704442831321-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=J49cERU3hxZKSoDzKuYbH729KaV6PJELUBgGz4OvU.I-1704446215684-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7726,15 +7438,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5673ec0ae10c6461f9d25da5dc1c48b6"
+              "value": "e15f12654a509727877b9b248b19c7af"
             },
             {
               "name": "x-trace-span",
-              "value": "fe7454b3ad4c7974"
+              "value": "0efbf5b42d5d4819"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5673ec0ae10c6461f9d25da5dc1c48b6"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e15f12654a509727877b9b248b19c7af"
             },
             {
               "name": "x-xss-protection",
@@ -7758,7 +7470,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d53fc1534a9-WAW"
+              "value": "840a9ff358533488-WAW"
             }
           ],
           "headersSize": 1396,
@@ -7767,8 +7479,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:26.813Z",
-        "time": 5935,
+        "startedDateTime": "2024-01-05T09:16:51.065Z",
+        "time": 6540,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7776,11 +7488,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 5935
+          "wait": 6540
         }
       },
       {
-        "_id": "b325ebc527f17ce027751d81796a87e7",
+        "_id": "b31b36740fa1bf3f40c941f8cf908e38",
         "_order": 0,
         "cache": {},
         "request": {
@@ -7833,7 +7545,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.chatResponse.new\",\"action\":\"hasCode\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"lineCount\",\"value\":7},{\"key\":\"charCount\",\"value\":111},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:32.753Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.chatResponse.new\",\"action\":\"hasCode\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"lineCount\",\"value\":7},{\"key\":\"charCount\",\"value\":111},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T09:16:57.611Z\"}]}}"
           },
           "queryString": [
             {
@@ -7853,20 +7565,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T08:20:32.000Z",
+              "expires": "2025-01-05T09:16:57.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5d867362-3a49-49f6-8ccc-f90d2175349c"
+              "value": "e06fd374-2c72-4703-b635-cef232afa96b"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T08:50:33.000Z",
+              "expires": "2024-01-05T09:46:57.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3l_DCsC__DSXzP22z3JZ7KMmPiL..Zlx_QnGtJBI1dg-1704442833-1-AQciWiceAuI73AKa9ApaZOJM+AQt6vg5acQuVRHP++DyS1WCuU8Y9KqWdhU4y8UMLSbq+KxGoOu+I56Pyv4ElV4="
+              "value": "z58TNhRBvXwa5Ci5WnAox7SKMWTsJIR8cKx5.oXowTY-1704446217-1-AWq3UAvfDKDibD7VfQHBkffewwytUA0L+UfbpQNTTx1MUs9x9C8qCLeLPxp+7zK5l3kmwD844sHea+7MYJmmsMs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7875,13 +7587,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "hYEEdjTFctVff0S3tFdIg00i3DQgE6oE6_5lm0UY3jo-1704442833027-0-604800000"
+              "value": "DslcK1gJdFzjLJKcIr0BfBWB3yCN8FRJfn.z8ozf7Ew-1704446217845-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 08:20:33 GMT"
+              "value": "Fri, 05 Jan 2024 09:16:57 GMT"
             },
             {
               "name": "content-type",
@@ -7905,7 +7617,7 @@
             },
             {
               "name": "retry-after",
-              "value": "330"
+              "value": "589"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7922,17 +7634,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5d867362-3a49-49f6-8ccc-f90d2175349c; Expires=Sun, 05 Jan 2025 08:20:32 GMT; Secure"
+              "value": "sourcegraphDeviceId=e06fd374-2c72-4703-b635-cef232afa96b; Expires=Sun, 05 Jan 2025 09:16:57 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3l_DCsC__DSXzP22z3JZ7KMmPiL..Zlx_QnGtJBI1dg-1704442833-1-AQciWiceAuI73AKa9ApaZOJM+AQt6vg5acQuVRHP++DyS1WCuU8Y9KqWdhU4y8UMLSbq+KxGoOu+I56Pyv4ElV4=; path=/; expires=Fri, 05-Jan-24 08:50:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=z58TNhRBvXwa5Ci5WnAox7SKMWTsJIR8cKx5.oXowTY-1704446217-1-AWq3UAvfDKDibD7VfQHBkffewwytUA0L+UfbpQNTTx1MUs9x9C8qCLeLPxp+7zK5l3kmwD844sHea+7MYJmmsMs=; path=/; expires=Fri, 05-Jan-24 09:46:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=hYEEdjTFctVff0S3tFdIg00i3DQgE6oE6_5lm0UY3jo-1704442833027-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=DslcK1gJdFzjLJKcIr0BfBWB3yCN8FRJfn.z8ozf7Ew-1704446217845-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7948,15 +7660,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d18900baa18755df0df48cff3fb62070"
+              "value": "ed13cc02a219a216662d1cd7229d6d06"
             },
             {
               "name": "x-trace-span",
-              "value": "b76427fb872fbdab"
+              "value": "b926600747331876"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d18900baa18755df0df48cff3fb62070"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ed13cc02a219a216662d1cd7229d6d06"
             },
             {
               "name": "x-xss-protection",
@@ -7980,7 +7692,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840a4d794f8b5043-WAW"
+              "value": "840aa01c7897bf1f-WAW"
             },
             {
               "name": "content-encoding",
@@ -7993,8 +7705,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T08:20:32.755Z",
-        "time": 229,
+        "startedDateTime": "2024-01-05T09:16:57.612Z",
+        "time": 223,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -8002,7 +7714,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 229
+          "wait": 223
         }
       }
     ],

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -77,24 +77,24 @@
             "encoding": "base64",
             "mimeType": "application/json",
             "size": 139,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp\",\"pcklYalFxZn5eUpWSkamZsZmJvFGBkYmugaGugbG8aZ6RrrmlolJBgaGiWZppkZKtbW1AAAAAP//AwDYKpmXSQAAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZuYGhvFGBkYmugaGugam8aZ6RrpGxiamqSkWacnGRiZKtbW1AAAAAP//\",\"AwC7GWWbSQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:31.000Z",
+              "expires": "2025-01-05T08:20:16.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8dc31992-f2b4-4c95-ba28-5530e167e035"
+              "value": "83de075a-6894-487d-8929-151e9b79d072"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:31.000Z",
+              "expires": "2024-01-05T08:50:16.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "DQEiVWR07g5vD17lRwJIHAV_5NmgMr5j6Y0rOgDK1P8-1704298891-1-Adg/6my/Ad1pTs4AkL9yNnrap+13Ezya+wgP9vRS4na08yMkdgOYItfgChBIugDRYz6aylfrt1yeXegpLCjxWxg="
+              "value": "XoOUdJx.wr6dKfVVk_q0RNKDFGdTKzJ0DPtc5j.fGAk-1704442816-1-AXCYNDukNdbE00tg1KE4k8Jh0cvlSVyeM4O8gnV4GmRtslCGnVTzzfTnCxPblXTWlDiryx4qFscXr92LBxYySj4="
             },
             {
               "domain": ".sourcegraph.com",
@@ -103,13 +103,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "mBMRZjoTqgIAka1rjdyia_anvmoFnd84eE5T9Tp38Mo-1704298891154-0-604800000"
+              "value": "Zd2HHU_IXoCD6A6kgiLFmQblmK_A51J9GMySCfnM2fk-1704442816458-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:16 GMT"
             },
             {
               "name": "content-type",
@@ -122,6 +122,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "347"
             },
             {
               "name": "access-control-allow-credentials",
@@ -138,17 +150,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8dc31992-f2b4-4c95-ba28-5530e167e035; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=83de075a-6894-487d-8929-151e9b79d072; Expires=Sun, 05 Jan 2025 08:20:16 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=DQEiVWR07g5vD17lRwJIHAV_5NmgMr5j6Y0rOgDK1P8-1704298891-1-Adg/6my/Ad1pTs4AkL9yNnrap+13Ezya+wgP9vRS4na08yMkdgOYItfgChBIugDRYz6aylfrt1yeXegpLCjxWxg=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=XoOUdJx.wr6dKfVVk_q0RNKDFGdTKzJ0DPtc5j.fGAk-1704442816-1-AXCYNDukNdbE00tg1KE4k8Jh0cvlSVyeM4O8gnV4GmRtslCGnVTzzfTnCxPblXTWlDiryx4qFscXr92LBxYySj4=; path=/; expires=Fri, 05-Jan-24 08:50:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=mBMRZjoTqgIAka1rjdyia_anvmoFnd84eE5T9Tp38Mo-1704298891154-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Zd2HHU_IXoCD6A6kgiLFmQblmK_A51J9GMySCfnM2fk-1704442816458-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -164,15 +176,15 @@
             },
             {
               "name": "x-trace",
-              "value": "483df82c01dc5fc6f2230bdb16d76b51"
+              "value": "5655b33e9c6cae7ac41361707f9c1f24"
             },
             {
               "name": "x-trace-span",
-              "value": "4933c1ab05e5d4c1"
+              "value": "086a9571d3cf55be"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/483df82c01dc5fc6f2230bdb16d76b51"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5655b33e9c6cae7ac41361707f9c1f24"
             },
             {
               "name": "x-xss-protection",
@@ -196,21 +208,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9344bac6bfad-WAW"
+              "value": "840a4d11df613540-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:30.898Z",
-        "time": 238,
+        "startedDateTime": "2024-01-05T08:20:16.190Z",
+        "time": 226,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -218,7 +230,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 238
+          "wait": 226
         }
       },
       {
@@ -295,20 +307,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:31.000Z",
+              "expires": "2025-01-05T08:20:16.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "4df446eb-42b6-4154-a16a-f0249202c3d2"
+              "value": "d9fc37b1-fd68-4496-bdf6-77c33963f667"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:31.000Z",
+              "expires": "2024-01-05T08:50:16.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "yaNKJ.NbjPyXEKUIi2aZ2z8MoF8tsibir0WC4iOHppw-1704298891-1-ARLWtx7kQ2Z+wy68XmG0qvOUwLQnEc+c3oBW16Bn0zcd4RDRzZy5zpPrDp1JqosupD7+lwu5ae7TjL9w5QhWqUQ="
+              "value": "GWn2ilBCDdAR4rdKiwo7drhWTboeLIjSBKBdzfPOJTo-1704442816-1-AZetxLUhBTaGmBQuuGlQJR9VAr/mZ9teCZa9m+ZfA1ii0g5vxhTHdsOG/5CxXt28CrdwXQjKbpxkIMmcW2kd7BM="
             },
             {
               "domain": ".sourcegraph.com",
@@ -317,13 +329,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "QWLlGVa.dTd7zzBaCn28XgcwtMTQGXNC2AFcBY.K.pc-1704298891604-0-604800000"
+              "value": "ESbavwfmWFlxryr0I4OL_KosjMcThUfoFOqhADJ07jw-1704442816894-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:16 GMT"
             },
             {
               "name": "content-type",
@@ -336,6 +348,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -352,17 +376,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4df446eb-42b6-4154-a16a-f0249202c3d2; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=d9fc37b1-fd68-4496-bdf6-77c33963f667; Expires=Sun, 05 Jan 2025 08:20:16 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=yaNKJ.NbjPyXEKUIi2aZ2z8MoF8tsibir0WC4iOHppw-1704298891-1-ARLWtx7kQ2Z+wy68XmG0qvOUwLQnEc+c3oBW16Bn0zcd4RDRzZy5zpPrDp1JqosupD7+lwu5ae7TjL9w5QhWqUQ=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=GWn2ilBCDdAR4rdKiwo7drhWTboeLIjSBKBdzfPOJTo-1704442816-1-AZetxLUhBTaGmBQuuGlQJR9VAr/mZ9teCZa9m+ZfA1ii0g5vxhTHdsOG/5CxXt28CrdwXQjKbpxkIMmcW2kd7BM=; path=/; expires=Fri, 05-Jan-24 08:50:16 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=QWLlGVa.dTd7zzBaCn28XgcwtMTQGXNC2AFcBY.K.pc-1704298891604-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=ESbavwfmWFlxryr0I4OL_KosjMcThUfoFOqhADJ07jw-1704442816894-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -378,15 +402,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b294a5ffdc842ba0c105b11513e76201"
+              "value": "5c948bf7b1dc98f642c89146c720c174"
             },
             {
               "name": "x-trace-span",
-              "value": "d314e5e8b28ed3d9"
+              "value": "e0b51c4a74670eb7"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b294a5ffdc842ba0c105b11513e76201"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5c948bf7b1dc98f642c89146c720c174"
             },
             {
               "name": "x-xss-protection",
@@ -410,448 +434,20 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93475fff34fe-WAW"
+              "value": "840a4d149b643bbd-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:31.352Z",
-        "time": 233,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 233
-        }
-      },
-      {
-        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 164,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "164"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 341,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "SiteIdentification",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:31.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ca434d8e-9dc0-4610-a141-53d099c937ac"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:31.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "iSPyJq7p3ZmRmAowZwj6.aEuYcmxKs5Ry6hP1WhqP9o-1704298891-1-AcDu6gkBYs45F63shQywz4DVRVDq1jtX9vqwYl3xEUKC52H7+qK5VkCEprUA/qVYP8QqKBngVGYNtjKGPYEqejw="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ca434d8e-9dc0-4610-a141-53d099c937ac; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=iSPyJq7p3ZmRmAowZwj6.aEuYcmxKs5Ry6hP1WhqP9o-1704298891-1-AcDu6gkBYs45F63shQywz4DVRVDq1jtX9vqwYl3xEUKC52H7+qK5VkCEprUA/qVYP8QqKBngVGYNtjKGPYEqejw=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d77b46a41789ce29c1bef11b11c95743"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2cea555ab9fe1998"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d77b46a41789ce29c1bef11b11c95743"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc9348ef753572-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:31.594Z",
-        "time": 212,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 212
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 354,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 128,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 128,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:31.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d8c6c7dd-945f-4b1b-aa4c-f045c1b4d1b5"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:31.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ZnJc6wpO9ekBTL7GUBErys1hrDCfhwUGxptp_eaMAA0-1704298891-1-AZZya4Ex+IAQMqz48CC2CooH1srSYaiB2VQ0tKk5lpPzIWIv/IlHUnlHmFl9U6LsrIvktC7KLc5XD2zNOjpAoTg="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d8c6c7dd-945f-4b1b-aa4c-f045c1b4d1b5; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ZnJc6wpO9ekBTL7GUBErys1hrDCfhwUGxptp_eaMAA0-1704298891-1-AZZya4Ex+IAQMqz48CC2CooH1srSYaiB2VQ0tKk5lpPzIWIv/IlHUnlHmFl9U6LsrIvktC7KLc5XD2zNOjpAoTg=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=skhO6W6Cee0rzQ9DX6d_OBE2zX_avEzhipk5BDRocFE-1704298891825-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "1147d60a37380342b52e4cc6318e895a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "49a69c3d244f5f8e"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1147d60a37380342b52e4cc6318e895a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc9348eba43479-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:31.597Z",
+        "startedDateTime": "2024-01-05T08:20:16.642Z",
         "time": 210,
         "timings": {
           "blocked": -1,
@@ -937,20 +533,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:31.000Z",
+              "expires": "2025-01-05T08:20:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "51d7b782-aa37-413a-a0d6-d47b3827293f"
+              "value": "288027bd-21b0-42ad-9bf2-f89a04f245e3"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:31.000Z",
+              "expires": "2024-01-05T08:50:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ag7mU1fUQ9mz0bdKacnJqlqzEdyQSBssbiAYXMyS9TY-1704298891-1-ARTzpK8jclpEAuK9FUBqU3ys/kk6woAfSAEsmNL4jEb2b3Ik9HUNpqIO2Pzjn/F8QbxMai2SdlSBLF9yojQn8Gs="
+              "value": "TWfA1oabX1Lo3EWwtAIWbEXGJx5wSH5cyHFudjz5bw8-1704442817-1-AW4pSSEjbYMYWzKQyuDQ7nAkURJvw4aB22PPY2fq2HGgvGBZa0YVWntL8DhxXBFPfiszQk+8h8Txm6tAlxZlEbs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -959,13 +555,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "za1ZJXvC4TW4.3UxZ9K0Ki32RB2HBj_SWcShfeaeWSU-1704298891827-0-604800000"
+              "value": "zKSKbaeD_SWEwzpaD9guOL1cRWRpKb.H6IYePGo1yI8-1704442817116-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:31 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
             },
             {
               "name": "content-type",
@@ -978,6 +574,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -994,17 +602,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=51d7b782-aa37-413a-a0d6-d47b3827293f; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=288027bd-21b0-42ad-9bf2-f89a04f245e3; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=ag7mU1fUQ9mz0bdKacnJqlqzEdyQSBssbiAYXMyS9TY-1704298891-1-ARTzpK8jclpEAuK9FUBqU3ys/kk6woAfSAEsmNL4jEb2b3Ik9HUNpqIO2Pzjn/F8QbxMai2SdlSBLF9yojQn8Gs=; path=/; expires=Wed, 03-Jan-24 16:51:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=TWfA1oabX1Lo3EWwtAIWbEXGJx5wSH5cyHFudjz5bw8-1704442817-1-AW4pSSEjbYMYWzKQyuDQ7nAkURJvw4aB22PPY2fq2HGgvGBZa0YVWntL8DhxXBFPfiszQk+8h8Txm6tAlxZlEbs=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=za1ZJXvC4TW4.3UxZ9K0Ki32RB2HBj_SWcShfeaeWSU-1704298891827-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=zKSKbaeD_SWEwzpaD9guOL1cRWRpKb.H6IYePGo1yI8-1704442817116-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1020,15 +628,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3d03de286523582ba189b76dc0343ef5"
+              "value": "4e603ef75db0dd706178fe85585ecb8c"
             },
             {
               "name": "x-trace-span",
-              "value": "5d80e5a1f73d3e74"
+              "value": "bd8afbb4e867d7e9"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3d03de286523582ba189b76dc0343ef5"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4e603ef75db0dd706178fe85585ecb8c"
             },
             {
               "name": "x-xss-protection",
@@ -1052,21 +660,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9348f94834f8-WAW"
+              "value": "840a4d160813bf35-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:31.596Z",
-        "time": 211,
+        "startedDateTime": "2024-01-05T08:20:16.866Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1074,7 +682,459 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 211
+          "wait": 210
+        }
+      },
+      {
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 155,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "155"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 131,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 131,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//\",\"AwAfFAXARQAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2fb789b0-d81e-4480-a1da-dea6a92876bf"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "rFkpP9zab.dyFTJb3qlu5fEOcxuDOScuirlkXGZetYc-1704442817-1-AVyMsXQj4r+3N9PRPKZaO+NFjVN9KpD5rAueOCf/ID82OMjw7MUzeqJ7D7gGB6NfFvNMg7NJG9KtZDrTk0OigQE="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "h3JjoqjeGNepFSU6e1V1dsH9uN5W8M8NIjHs.HWpDUg-1704442817118-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2fb789b0-d81e-4480-a1da-dea6a92876bf; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=rFkpP9zab.dyFTJb3qlu5fEOcxuDOScuirlkXGZetYc-1704442817-1-AVyMsXQj4r+3N9PRPKZaO+NFjVN9KpD5rAueOCf/ID82OMjw7MUzeqJ7D7gGB6NfFvNMg7NJG9KtZDrTk0OigQE=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=h3JjoqjeGNepFSU6e1V1dsH9uN5W8M8NIjHs.HWpDUg-1704442817118-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "f7e9bf2ea3204391ebd5da3521cdc019"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e3f0244f97590567"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f7e9bf2ea3204391ebd5da3521cdc019"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d16088cfc7f-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:16.868Z",
+        "time": 209,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 209
+        }
+      },
+      {
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 164,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "164"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 341,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "SiteIdentification",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "f7bd13b3-ed32-423f-9508-05b0ab66ade7"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "smDEdLOfauiUNxHy729pYi5PLTPZh4xjXnZZDeKIXPA-1704442817-1-AWo/HVDzfEA2GVPJcBVAXRXM+R216PYd0WiDJs9/he++fN0xP8qB5hBLYNeF/3gWxLaM+jYt/VWCbRbvtWTFsTU="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "1_CuFJicaxENKYXGaP2MKFtyIJQe53tpTqm6XQ5vJkk-1704442817119-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=f7bd13b3-ed32-423f-9508-05b0ab66ade7; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=smDEdLOfauiUNxHy729pYi5PLTPZh4xjXnZZDeKIXPA-1704442817-1-AWo/HVDzfEA2GVPJcBVAXRXM+R216PYd0WiDJs9/he++fN0xP8qB5hBLYNeF/3gWxLaM+jYt/VWCbRbvtWTFsTU=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=1_CuFJicaxENKYXGaP2MKFtyIJQe53tpTqm6XQ5vJkk-1704442817119-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8ff510b8b27aab48431b4bbc2a20dea1"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "778248f2788b59e9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8ff510b8b27aab48431b4bbc2a20dea1"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d160f2170bf-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:16.864Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
         }
       },
       {
@@ -1151,20 +1211,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:31.000Z",
+              "expires": "2025-01-05T08:20:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "60f18308-2db4-4f15-8116-e73c313f984f"
+              "value": "f2d256af-ec3a-4b49-836a-5a816938677a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
+              "expires": "2024-01-05T08:50:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "h7p969sGHDS6bePDcYUCxX_dcDTWnX58ZA.bDyd0vjs-1704298892-1-AS4B4uEXSmek51Yt4aBhmWhomVINTDPlOsamZp+1oZ+RkzzzI2wBZJirOEtDalR7qmo0+LR/pJQHxO9VhfRLh8A="
+              "value": "VVHPI8APWRPLxtv1xHXWbbcW7UbOfmnSRQ6QzzxR4_c-1704442817-1-AXi6uPSy8k+yyYORNhN6QdCV8vZrDfetW6aB8rnU9gZru3xr5wP7bjiXpK18+f2wp+BerrL5UtnvFYDm6aBwD4M="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1173,13 +1233,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "SzwGZDY8A7NVnOfCkurNXTdWyTIywzFzRZ2L_DEYcnU-1704298892074-0-604800000"
+              "value": "Bw0crT0MDMWFjfLcp2S0ZjomUG66GhCQ7in467_nYhk-1704442817349-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
             },
             {
               "name": "content-type",
@@ -1192,6 +1252,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1208,17 +1280,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=60f18308-2db4-4f15-8116-e73c313f984f; Expires=Fri, 03 Jan 2025 16:21:31 GMT; Secure"
+              "value": "sourcegraphDeviceId=f2d256af-ec3a-4b49-836a-5a816938677a; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=h7p969sGHDS6bePDcYUCxX_dcDTWnX58ZA.bDyd0vjs-1704298892-1-AS4B4uEXSmek51Yt4aBhmWhomVINTDPlOsamZp+1oZ+RkzzzI2wBZJirOEtDalR7qmo0+LR/pJQHxO9VhfRLh8A=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=VVHPI8APWRPLxtv1xHXWbbcW7UbOfmnSRQ6QzzxR4_c-1704442817-1-AXi6uPSy8k+yyYORNhN6QdCV8vZrDfetW6aB8rnU9gZru3xr5wP7bjiXpK18+f2wp+BerrL5UtnvFYDm6aBwD4M=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=SzwGZDY8A7NVnOfCkurNXTdWyTIywzFzRZ2L_DEYcnU-1704298892074-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Bw0crT0MDMWFjfLcp2S0ZjomUG66GhCQ7in467_nYhk-1704442817349-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1234,15 +1306,15 @@
             },
             {
               "name": "x-trace",
-              "value": "84052aad647fb4ca9fe16434a18df8ec"
+              "value": "73a2277e894a6f2fdbae7f2edfe7dd45"
             },
             {
               "name": "x-trace-span",
-              "value": "6bb98c52c799eeca"
+              "value": "aec1171e0310c19c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/84052aad647fb4ca9fe16434a18df8ec"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/73a2277e894a6f2fdbae7f2edfe7dd45"
             },
             {
               "name": "x-xss-protection",
@@ -1266,21 +1338,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc934a7e9a34bc-WAW"
+              "value": "840a4d1759223500-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:31.837Z",
-        "time": 218,
+        "startedDateTime": "2024-01-05T08:20:17.082Z",
+        "time": 225,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1288,7 +1360,454 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 218
+          "wait": 225
+        }
+      },
+      {
+        "_id": "68618dc68610496fb5623c6778ea6c25",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 177,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "177"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "cf48c4b6-5a05-4850-b428-309075b2cead"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "eC2OiLtbwdLtCdeg5vaS0V34jXLylO9ezrNsU7j2_Ac-1704442817-1-ATmyTQKQTOq5K9NAUtt32TrbDBuNv/O5lclmM9RPW8czIKaGNzikyWEOwI1IPi9dOsItsgj3KUkhYOnCOx7/QDM="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "EWQhGz7scf1taY2iFmaPcNqCakoZk_lVSzpIaoQdRJc-1704442817558-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=cf48c4b6-5a05-4850-b428-309075b2cead; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=eC2OiLtbwdLtCdeg5vaS0V34jXLylO9ezrNsU7j2_Ac-1704442817-1-ATmyTQKQTOq5K9NAUtt32TrbDBuNv/O5lclmM9RPW8czIKaGNzikyWEOwI1IPi9dOsItsgj3KUkhYOnCOx7/QDM=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=EWQhGz7scf1taY2iFmaPcNqCakoZk_lVSzpIaoQdRJc-1704442817558-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "7fcfaedb1450d67f5479758f86234405"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "6de8ebd605b335a6"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7fcfaedb1450d67f5479758f86234405"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d18dbf2bfc8-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:17.319Z",
+        "time": 197,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 197
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 335,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 448,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 448,
+            "text": "[\"H4sIAAAAAAAAA6xSQW7DMAz7i8/VB/KAfmLYQbEV26tjZZLcNij69yErtrUd2mDAziIpiuLJBTR03cnRHktDo7AltCa0LRjVdS8nV3Ek1znNsbYJtMmeZqCKfaHgNm7hkesGLErnzTfcc5gBm7HncSpkBCboc42PKUaFRjKZgY4Ti/0gTdov7Un4OeBmuedqdDQo7LHAmI/X3lfZYa44Zg9jK5ZLrove5yhz1ccH9YV7mDAS6CGbT4BCqKCJxXwzXUnPJzQY2e/ASO0ZuJqg2sVUxmqgczU8QsoxlRyTPc2dJ6qeA0XBKf3loyHr0gIQ8rMvuUbgASahfeamIPTeSFevvFWkAVsxUENZLAmkuZccVqsAb2S9YL5+xx1UCcUnqHSAHc0HlvAfzkC5if97dl+F7Id4X8cL+fV8/gAAAP//AwDAhjmfngMAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "01575acf-e887-40c3-8413-3c0bb207dbb1"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:17.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "60KoEfxPUwS68EJnLAGx0qeHaU6qkpUojpmwThCTfcE-1704442817-1-AQD93FJQlnY6jmsBOTxe3nIMtiwQN8a4P94bnCB+FvE9i+1n+lb9bU/RbqU0SMkwncYtayb8v5gYhA0IlqRhy4M="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "z52rIZKtas9fVgoC9R9pxEsdqQU32RSgsf3azBECf94-1704442817567-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=01575acf-e887-40c3-8413-3c0bb207dbb1; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=60KoEfxPUwS68EJnLAGx0qeHaU6qkpUojpmwThCTfcE-1704442817-1-AQD93FJQlnY6jmsBOTxe3nIMtiwQN8a4P94bnCB+FvE9i+1n+lb9bU/RbqU0SMkwncYtayb8v5gYhA0IlqRhy4M=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=z52rIZKtas9fVgoC9R9pxEsdqQU32RSgsf3azBECf94-1704442817567-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "055553985536c7ccca60ab19cbd9a704"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "69185542bd51a026"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/055553985536c7ccca60ab19cbd9a704"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d18cad1357c-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:17.318Z",
+        "time": 207,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 207
         }
       },
       {
@@ -1365,20 +1884,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:32.000Z",
+              "expires": "2025-01-05T08:20:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "4f1fefea-89d9-4cb3-912c-6de8635f3cea"
+              "value": "a0591581-a566-4ecc-ad40-2555dd1b7d26"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
+              "expires": "2024-01-05T08:50:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "_iIQJtzT3yTNrBN7GFIHPhN0xY7p8XBKWEkaY0hTpEM-1704298892-1-AYIMh0KTqDGIeXm1KVHd7SCrYgHe1TojmZYQ999S4897oLVRS0c8999Mlp948vogw/8lQ8p/A3KT99GGMt2MX00="
+              "value": "wh1.BO1NM_hxuS0fpI_cdqRHLWZDlQBRbOdMeD6hYmU-1704442817-1-AZSL2RA0UoG2rhmNx3sn3V3WOzoo6y6o/4P9/Cxm4Bty132V0MGRLMTy6Px0013FDouASFN9IVCYPBaPRbzP2j0="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1387,13 +1906,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8Nf51mMTa82X01ClWb2zLnwEP6pAOwrRx8p4z2gK2Xg-1704298892298-0-604800000"
+              "value": "XBRxoJhwt49HMkZmvoYk4FHCaKBojd5erTDRiJ9YdDc-1704442817570-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:17 GMT"
             },
             {
               "name": "content-type",
@@ -1408,6 +1927,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "346"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -1422,17 +1953,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4f1fefea-89d9-4cb3-912c-6de8635f3cea; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
+              "value": "sourcegraphDeviceId=a0591581-a566-4ecc-ad40-2555dd1b7d26; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=_iIQJtzT3yTNrBN7GFIHPhN0xY7p8XBKWEkaY0hTpEM-1704298892-1-AYIMh0KTqDGIeXm1KVHd7SCrYgHe1TojmZYQ999S4897oLVRS0c8999Mlp948vogw/8lQ8p/A3KT99GGMt2MX00=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=wh1.BO1NM_hxuS0fpI_cdqRHLWZDlQBRbOdMeD6hYmU-1704442817-1-AZSL2RA0UoG2rhmNx3sn3V3WOzoo6y6o/4P9/Cxm4Bty132V0MGRLMTy6Px0013FDouASFN9IVCYPBaPRbzP2j0=; path=/; expires=Fri, 05-Jan-24 08:50:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=8Nf51mMTa82X01ClWb2zLnwEP6pAOwrRx8p4z2gK2Xg-1704298892298-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=XBRxoJhwt49HMkZmvoYk4FHCaKBojd5erTDRiJ9YdDc-1704442817570-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1448,15 +1979,15 @@
             },
             {
               "name": "x-trace",
-              "value": "7fbbe6025ea006366e22045b058b2044"
+              "value": "17271d54af8511f3412759a6b9f3ebd6"
             },
             {
               "name": "x-trace-span",
-              "value": "2af19bcc4b9f82a1"
+              "value": "74e329376a772334"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7fbbe6025ea006366e22045b058b2044"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/17271d54af8511f3412759a6b9f3ebd6"
             },
             {
               "name": "x-xss-protection",
@@ -1480,21 +2011,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc934bd987bff3-WAW"
+              "value": "840a4d18d983fbda-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:32.066Z",
-        "time": 213,
+        "startedDateTime": "2024-01-05T08:20:17.317Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1502,848 +2033,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 213
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 335,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 440,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 440,
-            "text": "[\"H4sIAAAAAAAAA5RSS24CMQy9S9b4AnOAXqLqwpN4EpdMPHUcIELcvRpRVQh1oKz9nt/HPruAhm44OzpgbmgU3gitKb1ljNUN72dXcCY3OC+hAzYTL/OSyQhCLzizh7ll48yF4GfEUqrbuXUjuWHCXOmy+10kCxUvgaLikrZhlWNpC9SmB+pABcdMYRs+ZhlhwUhQj2w+ASphhZpEzTd74MdLMcVqV/eMxaD2YniCxDFljsm4xEf8+2LWjXQyyOIxw8ynW+Om7X/scYr33D+lFxX4JBsV+bb2pzqm6J8H8wkNZvF7MKr2SguB63ozUPLdZy4RZIJF6cDSKih9NaqP73IN90KkQBO2bFANdX0xhdRH5QBVmvqnH0eoPkGhI+ypH0XDS3E3tDftG2WaybQDnRZRuwN+XC7fAAAA//8DAKhp1z2eAwAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2b4f00ad-479f-4bbb-a6ee-a8086d408dcf"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "cdHIqQ3q0xSrUPuHp3Z2ZiJGZGuKl7AD_jbrDFETR4M-1704298892-1-ARhdCcjaU1cbVJ+I1Q0vUiMizyswK4mkyaNrnt6ErnNtEzETN1JuqUTW3Ka65AWOHoOWGFD3E22edzphAMUsnFA="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gzFoZyLgMSEA5sQzKTWgGZCcmmblP1nigsNApq5us1A-1704298892323-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2b4f00ad-479f-4bbb-a6ee-a8086d408dcf; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=cdHIqQ3q0xSrUPuHp3Z2ZiJGZGuKl7AD_jbrDFETR4M-1704298892-1-ARhdCcjaU1cbVJ+I1Q0vUiMizyswK4mkyaNrnt6ErnNtEzETN1JuqUTW3Ka65AWOHoOWGFD3E22edzphAMUsnFA=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=gzFoZyLgMSEA5sQzKTWgGZCcmmblP1nigsNApq5us1A-1704298892323-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4cad2a4386e49975a194a112bfbe0a36"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ee5d334af561224e"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4cad2a4386e49975a194a112bfbe0a36"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc934bd9afc01e-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:32.065Z",
-        "time": 244,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 244
-        }
-      },
-      {
-        "_id": "68618dc68610496fb5623c6778ea6c25",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 177,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "177"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "de5cdbd5-6000-403d-9b8a-eb4c48e341b4"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xPpi0SUT5h054zqbl.LKZ0HrbjTZRyta3wN9WlLiLrs-1704298892-1-AeIjPf/Xh4tcG2kZKydepUVd1i2b1t4zChoHWeihgkFoPbjbrVBAbzvK5udi5bE7XITDrF2Q1F7yf5nOhgzFNe8="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "RdfyQTFVcllfnD7h2XsMEUi7MUfrIn3yFaxOCsjFR2k-1704298892329-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=de5cdbd5-6000-403d-9b8a-eb4c48e341b4; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=xPpi0SUT5h054zqbl.LKZ0HrbjTZRyta3wN9WlLiLrs-1704298892-1-AeIjPf/Xh4tcG2kZKydepUVd1i2b1t4zChoHWeihgkFoPbjbrVBAbzvK5udi5bE7XITDrF2Q1F7yf5nOhgzFNe8=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=RdfyQTFVcllfnD7h2XsMEUi7MUfrIn3yFaxOCsjFR2k-1704298892329-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "1b91fb5097598636086e1139a03f0f5e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "45fc9a78b92419c6"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1b91fb5097598636086e1139a03f0f5e"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc934bd8aaffbc-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:32.069Z",
-        "time": 241,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 241
-        }
-      },
-      {
-        "_id": "f183d7475b363dc45d23134c3118a915",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 180,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "180"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1988b49f-f42a-4c2b-8440-74881be63aed"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "umC0BWCyOEr1NOz7fe9MYo3L3yaC32zhzZRBve05mQU-1704298892-1-AbkJbZ4YYaUYq+55gErIw92fXmQ59sst2Rx+dYLW2lu/7j2JOovllPzc/BjehOgAtqVuteoeaZBJDrG74fEl6vY="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "CGnt51Bk_SuqnozdgP94BzV_y3QozDqZ_RKQno4Ffr4-1704298892794-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1988b49f-f42a-4c2b-8440-74881be63aed; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=umC0BWCyOEr1NOz7fe9MYo3L3yaC32zhzZRBve05mQU-1704298892-1-AbkJbZ4YYaUYq+55gErIw92fXmQ59sst2Rx+dYLW2lu/7j2JOovllPzc/BjehOgAtqVuteoeaZBJDrG74fEl6vY=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=CGnt51Bk_SuqnozdgP94BzV_y3QozDqZ_RKQno4Ffr4-1704298892794-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "77502a98050536bc319b12a3f96afd4f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "645c8de7aaf88eca"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/77502a98050536bc319b12a3f96afd4f"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc934eea4634e6-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:32.551Z",
-        "time": 224,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 224
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:32.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "9c24c044-5367-4e50-9511-8071474ff9b6"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gpHXRQ.achJQgG_43BvjwmGQ1dwMa8gSXmFGS.j0LCo-1704298892-1-AewNWx9uWJeFvlVEULsBzG8eYsxPsyT1AyiJuY8SDNhL6S3I3q1EA+L2zeTE/w+sKb5mJC5Wdo0c3nV/sLBnG5s="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "jgFHyRTuIW2Y8ZUipsHJCcMKRG0qQkwiZ7I1u_AqBos-1704298892798-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=9c24c044-5367-4e50-9511-8071474ff9b6; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=gpHXRQ.achJQgG_43BvjwmGQ1dwMa8gSXmFGS.j0LCo-1704298892-1-AewNWx9uWJeFvlVEULsBzG8eYsxPsyT1AyiJuY8SDNhL6S3I3q1EA+L2zeTE/w+sKb5mJC5Wdo0c3nV/sLBnG5s=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=jgFHyRTuIW2Y8ZUipsHJCcMKRG0qQkwiZ7I1u_AqBos-1704298892798-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8d6b484bca7356cf584ce983ef1d2afd"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "8bfd51ef180877e8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8d6b484bca7356cf584ce983ef1d2afd"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc934eeb137728-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:32.550Z",
-        "time": 230,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 230
+          "wait": 210
         }
       },
       {
@@ -2419,20 +2109,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:32.000Z",
+              "expires": "2025-01-05T08:20:17.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e10a665e-e2c4-4b80-9125-fe38e6252175"
+              "value": "6774cbf4-8de5-4890-bd55-fe6bd64c0b11"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:32.000Z",
+              "expires": "2024-01-05T08:50:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ny6tIIawD4OSClva8UhF5y2j01oCF3Ihot1QdrM7WY8-1704298892-1-AZgVvhyUmvj/hlUd8drorEOwo9grj0lcvmgMENl0nSzITJpW+fd/s8WJ6rZthIIn5KS2PsBnQu2GFAmVV2X8sf0="
+              "value": "HUElRe8SWEYXNgtMTa5Ks3bmn0yDiU5Xzsw_MbrSQBU-1704442818-1-ARXOmnEs6wN88aYbAJ6dl0hof779/Lw+ujf/ZyrEKct308Jehd3G2tgF8B0/30HA2GLKEkXfnjcWu2l+VjtdU5k="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2441,13 +2131,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Gt5XTbXHDCD9DYBmWX0X89hSHHd_uZJQfI8e.ya915g-1704298892799-0-604800000"
+              "value": "iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:32 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
             },
             {
               "name": "content-type",
@@ -2460,6 +2150,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2476,17 +2178,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e10a665e-e2c4-4b80-9125-fe38e6252175; Expires=Fri, 03 Jan 2025 16:21:32 GMT; Secure"
+              "value": "sourcegraphDeviceId=6774cbf4-8de5-4890-bd55-fe6bd64c0b11; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=ny6tIIawD4OSClva8UhF5y2j01oCF3Ihot1QdrM7WY8-1704298892-1-AZgVvhyUmvj/hlUd8drorEOwo9grj0lcvmgMENl0nSzITJpW+fd/s8WJ6rZthIIn5KS2PsBnQu2GFAmVV2X8sf0=; path=/; expires=Wed, 03-Jan-24 16:51:32 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=HUElRe8SWEYXNgtMTa5Ks3bmn0yDiU5Xzsw_MbrSQBU-1704442818-1-ARXOmnEs6wN88aYbAJ6dl0hof779/Lw+ujf/ZyrEKct308Jehd3G2tgF8B0/30HA2GLKEkXfnjcWu2l+VjtdU5k=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Gt5XTbXHDCD9DYBmWX0X89hSHHd_uZJQfI8e.ya915g-1704298892799-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2502,15 +2204,15 @@
             },
             {
               "name": "x-trace",
-              "value": "44660068b5edb6dbf77c6d06da419dc3"
+              "value": "ab530ae635d77989d594ccf65fd82864"
             },
             {
               "name": "x-trace-span",
-              "value": "c6554c83d7fd150b"
+              "value": "fc21b0bd65fe2669"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/44660068b5edb6dbf77c6d06da419dc3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ab530ae635d77989d594ccf65fd82864"
             },
             {
               "name": "x-xss-protection",
@@ -2534,17 +2236,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc934eedc8fc7b-WAW"
+              "value": "840a4d1b98a7bf4e-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:32.549Z",
-        "time": 231,
+        "startedDateTime": "2024-01-05T08:20:17.756Z",
+        "time": 217,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2552,7 +2254,449 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 231
+          "wait": 217
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1bce8d84-c861-44a6-807e-5fe7a3171f99"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:18.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "tPlYFmTtJN_g_eN3nngOmppGtx0eykdkFgxiOYGZfdo-1704442818-1-AfK0OpfqQXc4FSJR1uSaNY4IvMbzemwsz9rsC1X68FtC3PBMpwMiZPj1l49tsIcr2js6YAxgO1RwPgDJP+jp4lM="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1bce8d84-c861-44a6-807e-5fe7a3171f99; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=tPlYFmTtJN_g_eN3nngOmppGtx0eykdkFgxiOYGZfdo-1704442818-1-AfK0OpfqQXc4FSJR1uSaNY4IvMbzemwsz9rsC1X68FtC3PBMpwMiZPj1l49tsIcr2js6YAxgO1RwPgDJP+jp4lM=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=iubhN4tP8Uu.w7Azvw9J.Ed8A_DZSdGWw6XERUeBKvk-1704442818014-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3482625ad321da8d38414dc43bc21cb0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "46f563220aa010e8"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3482625ad321da8d38414dc43bc21cb0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d1b9978c014-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:17.758Z",
+        "time": 215,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 215
+        }
+      },
+      {
+        "_id": "f183d7475b363dc45d23134c3118a915",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 180,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "180"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:17.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1fd29b1d-ac1e-4ca9-a9b2-9756c2735aa0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:18.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ty348dISeoKAsGo5B6LH0MNbjmox5ZUFV5OBjuwpItg-1704442818-1-AfBQeRMtAmXTQXiC2Jn3gqc1QaqlqKCLwaHOS+T/W4jMkcw4sGOqZyVOqUq9fpISPjcaDNgKYxhVNcevQmYjVQY="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "vmM9yXmmM5Io2saBBB2DtfF_BFXuQtP2MEGOwrwqN5c-1704442818018-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1fd29b1d-ac1e-4ca9-a9b2-9756c2735aa0; Expires=Sun, 05 Jan 2025 08:20:17 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ty348dISeoKAsGo5B6LH0MNbjmox5ZUFV5OBjuwpItg-1704442818-1-AfBQeRMtAmXTQXiC2Jn3gqc1QaqlqKCLwaHOS+T/W4jMkcw4sGOqZyVOqUq9fpISPjcaDNgKYxhVNcevQmYjVQY=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=vmM9yXmmM5Io2saBBB2DtfF_BFXuQtP2MEGOwrwqN5c-1704442818018-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8a06e8e4987e8b0218569e4176655bd2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0f01d6a747a4f5c4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8a06e8e4987e8b0218569e4176655bd2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d1b9aabbf3a-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:17.759Z",
+        "time": 216,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 216
         }
       },
       {
@@ -2628,20 +2772,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:33.000Z",
+              "expires": "2025-01-05T08:20:18.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "b5b058fc-2178-4895-ad51-c052786930aa"
+              "value": "94bdfd8d-ced6-4afc-997a-7fc25f489bcc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:33.000Z",
+              "expires": "2024-01-05T08:50:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "WQ8oM.tBnK44uf7o99K84cl3GrAwDuZGf61rwW.Zsno-1704298893-1-ATVPs8xBd3EOLZvOZdbLRNllesdFb2XIs3N0dO0DuSsDIvPrBao/nv5nNmCT6unG+W8z6cxvPSX8w2wUaV7LfYg="
+              "value": "S0iudDpmtdRmek6XeHqjl.9zJ1SkK6OqzvQujtuZw78-1704442818-1-AXdPbBc9+kcZlk7EpGQGdk8Vjcrwsg7s+LWN571xrrfa7OADHyfz8X7ushmo1kk2qGMmJ35z2dzMbqCkDDOJgjc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2650,13 +2794,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "kFvdVZtH47jcaDH6Wwl1EMgh_875H8mI9snJWIX38ss-1704298893315-0-604800000"
+              "value": "0z181oBSRhsroi2aaPzgWPZvq2KA1Mp.s1DqWkGcDMI-1704442818700-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
             },
             {
               "name": "content-type",
@@ -2671,6 +2815,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -2685,17 +2841,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b5b058fc-2178-4895-ad51-c052786930aa; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=94bdfd8d-ced6-4afc-997a-7fc25f489bcc; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=WQ8oM.tBnK44uf7o99K84cl3GrAwDuZGf61rwW.Zsno-1704298893-1-ATVPs8xBd3EOLZvOZdbLRNllesdFb2XIs3N0dO0DuSsDIvPrBao/nv5nNmCT6unG+W8z6cxvPSX8w2wUaV7LfYg=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=S0iudDpmtdRmek6XeHqjl.9zJ1SkK6OqzvQujtuZw78-1704442818-1-AXdPbBc9+kcZlk7EpGQGdk8Vjcrwsg7s+LWN571xrrfa7OADHyfz8X7ushmo1kk2qGMmJ35z2dzMbqCkDDOJgjc=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=kFvdVZtH47jcaDH6Wwl1EMgh_875H8mI9snJWIX38ss-1704298893315-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=0z181oBSRhsroi2aaPzgWPZvq2KA1Mp.s1DqWkGcDMI-1704442818700-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2711,15 +2867,15 @@
             },
             {
               "name": "x-trace",
-              "value": "0ee2489d30e15cb1476daccaf9f43210"
+              "value": "5469b350cafc627bc841a06cadc9a774"
             },
             {
               "name": "x-trace-span",
-              "value": "e96b1018159e937c"
+              "value": "24ae01eb581a5a22"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0ee2489d30e15cb1476daccaf9f43210"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5469b350cafc627bc841a06cadc9a774"
             },
             {
               "name": "x-xss-protection",
@@ -2743,17 +2899,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93523f593536-WAW"
+              "value": "840a4d1fee33bf74-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:33.081Z",
-        "time": 214,
+        "startedDateTime": "2024-01-05T08:20:18.447Z",
+        "time": 211,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2761,1062 +2917,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 214
-        }
-      },
-      {
-        "_id": "376c77f6f6da3ec20db639d4790073be",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1184,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1184"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b210095b-4fed-43f8-a3a1-806323b846b0"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "yI2EzwXAhbhq_d05Gn_44v5ljvip83UHvytdHlLEICA-1704298893-1-AeyKNKey6nVsbZOj/9M5dDkw9yGLir1B1oNC9gF9bZweFBf5/dFfwvGHlRCFE+e2we8tnI3UBmLs1/fuTQ/z/3o="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "SJ6mysNYUJdvfWiHNBAF3K5_FaqrXKJULvwJVHdP5GU-1704298893360-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b210095b-4fed-43f8-a3a1-806323b846b0; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=yI2EzwXAhbhq_d05Gn_44v5ljvip83UHvytdHlLEICA-1704298893-1-AeyKNKey6nVsbZOj/9M5dDkw9yGLir1B1oNC9gF9bZweFBf5/dFfwvGHlRCFE+e2we8tnI3UBmLs1/fuTQ/z/3o=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=SJ6mysNYUJdvfWiHNBAF3K5_FaqrXKJULvwJVHdP5GU-1704298893360-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "6d26910c478d0ead4b54a312f28bd9b2"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "5f1f578f43f3aa2d"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6d26910c478d0ead4b54a312f28bd9b2"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc935238db347c-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:33.079Z",
-        "time": 260,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 260
-        }
-      },
-      {
-        "_id": "8192ad19598e6814fcd3050df70a8e5d",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "0e2aa6b7-defd-4330-afc8-17b68d46baff"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "5G.29GyQcXqSegYrkGuxl9m4hzLihSANsFUc_FIuiXI-1704298893-1-ATevc64Ak20K/875FopWQ2RpPtAdgyemmlrvXz0wz1WwVjd6uhFFtpI87zpgkAK+XgAJ3aZ8nw3joKeeMNr/TDw="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "qHR.orl5qAMbC.z6WBHb9sduShIZ_x9QabTL_9u4lM4-1704298893552-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0e2aa6b7-defd-4330-afc8-17b68d46baff; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=5G.29GyQcXqSegYrkGuxl9m4hzLihSANsFUc_FIuiXI-1704298893-1-ATevc64Ak20K/875FopWQ2RpPtAdgyemmlrvXz0wz1WwVjd6uhFFtpI87zpgkAK+XgAJ3aZ8nw3joKeeMNr/TDw=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=qHR.orl5qAMbC.z6WBHb9sduShIZ_x9QabTL_9u4lM4-1704298893552-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d1be0cad5d064b404e6cc4c6bd1a2488"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "fd59ac30fd7e516e"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d1be0cad5d064b404e6cc4c6bd1a2488"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc93539d41fbce-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:33.305Z",
-        "time": 227,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 227
-        }
-      },
-      {
-        "_id": "a0ad203278c23856d665c25dd6c1b28a",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 474,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "474"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:33.073Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "fb2110f6-c8b4-42bd-b5c1-9c446db64e61"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "eO66Q3tH8FADrdJ1qybjC6usF0zuBjvD4D2pgHa.Cek-1704298893-1-Ab5usQ2tnuE6KnNn29UA6Offgz5kS0rzmyedqpZLpK5LpezUA5dVSuDAffBLMsGwZ4hv3rCZgD7hVHyaPiYqzW0="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "NGVQtSL1WB8gx83TZPaXn8AI4qDslb38S523E56wzDE-1704298893566-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fb2110f6-c8b4-42bd-b5c1-9c446db64e61; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=eO66Q3tH8FADrdJ1qybjC6usF0zuBjvD4D2pgHa.Cek-1704298893-1-Ab5usQ2tnuE6KnNn29UA6Offgz5kS0rzmyedqpZLpK5LpezUA5dVSuDAffBLMsGwZ4hv3rCZgD7hVHyaPiYqzW0=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=NGVQtSL1WB8gx83TZPaXn8AI4qDslb38S523E56wzDE-1704298893566-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "823642c2c4f50a79dfccd8054c34e1d0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7790dfbe7315cc14"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/823642c2c4f50a79dfccd8054c34e1d0"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc93539abd3528-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:33.303Z",
-        "time": 244,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 244
-        }
-      },
-      {
-        "_id": "d9c51bc7f5683994e3e65be926827058",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 477,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "477"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:33.304Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 115,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ea7380b7-41a9-4c24-925d-230e50e9dd60"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:33.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "U9svv3N0YfSRYrRXn.Fc22PpFc28eC3xqHjVX3lwC_8-1704298893-1-AXy4VxwjG5C2NaDNzQP0HuPen5nuRqMydK/oIDKvfb0aCexRuWnR0KdSKJ9GwkWEYkYfaaW4cOrZVJYHNL4AP/o="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "nHuMZ9OsA1pT5WLlT.SNtW82logracgHIKlPYlBgDfo-1704298893576-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:33 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ea7380b7-41a9-4c24-925d-230e50e9dd60; Expires=Fri, 03 Jan 2025 16:21:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=U9svv3N0YfSRYrRXn.Fc22PpFc28eC3xqHjVX3lwC_8-1704298893-1-AXy4VxwjG5C2NaDNzQP0HuPen5nuRqMydK/oIDKvfb0aCexRuWnR0KdSKJ9GwkWEYkYfaaW4cOrZVJYHNL4AP/o=; path=/; expires=Wed, 03-Jan-24 16:51:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=nHuMZ9OsA1pT5WLlT.SNtW82logracgHIKlPYlBgDfo-1704298893576-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "60d0785408a2f42b6d9fdde40f17bcd6"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "6aa2dc5f7b139c63"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/60d0785408a2f42b6d9fdde40f17bcd6"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc93539a63f2c8-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:33.305Z",
-        "time": 255,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 255
-        }
-      },
-      {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "069403cb-6310-4376-b7c3-359c04a3d324"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "w.noDPLqDSLJ6XEbUkWNRk0LElsQrC7X2lI7KQGFJkM-1704298894-1-Ad2sogL2dhEJqVFrTxKuzgO3rAePxxYN3WKPa7cXk0hDZDNrP8YeCRhMZLu2xA8cA+ol2SiTeiHKnWrf4+pdsB0="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "44tDnrDBzS0u97bCTJhFzwuttli85rconty2xR_6_lI-1704298894129-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=069403cb-6310-4376-b7c3-359c04a3d324; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=w.noDPLqDSLJ6XEbUkWNRk0LElsQrC7X2lI7KQGFJkM-1704298894-1-Ad2sogL2dhEJqVFrTxKuzgO3rAePxxYN3WKPa7cXk0hDZDNrP8YeCRhMZLu2xA8cA+ol2SiTeiHKnWrf4+pdsB0=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=44tDnrDBzS0u97bCTJhFzwuttli85rconty2xR_6_lI-1704298894129-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "dfebc21664c8d79805d84a6ec30e37df"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "dd7a1aad06c588d0"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dfebc21664c8d79805d84a6ec30e37df"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc93575db15019-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:33.899Z",
-        "time": 213,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 213
+          "wait": 211
         }
       },
       {
@@ -3892,20 +2993,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:34.000Z",
+              "expires": "2025-01-05T08:20:18.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d41336af-0a0c-4369-af90-6c63a412c19f"
+              "value": "40688ea4-646d-4029-a229-31cae2a099d1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:34.000Z",
+              "expires": "2024-01-05T08:50:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "YkSB64d7QzdaI6vRAnMlvw64TBMEUcV3zqw2znZa1h8-1704298894-1-AXt2UsOASlL9voTPe5RgwCXsugGbl30ckMGmOd1ZVgo8Gpx6mDJ5F+YYrxMCi1HagKlgFiUgrRa+Pifh0u9JFnM="
+              "value": "JEjH2GQiu7U401Ojpe6vrdtpiBimOnl1oBbux1XIkC4-1704442818-1-AWv9Qddbk159htInTpOejj8Iuh6gcsfpJ4qqG167mOwRqAgcOszDQH4zWaARA4UkrlWbaSKb7So6YrDDWp48jhw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3914,13 +3015,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "05oy55r0knMtvic9borZ_x8NTpVDeWdI1ESI3AtuqrE-1704298894139-0-604800000"
+              "value": "yrg5yuKuzynfjgtZwVqImx0JNs.C86hsV4ROVTIRZGI-1704442818702-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
             },
             {
               "name": "content-type",
@@ -3933,6 +3034,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3949,17 +3062,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d41336af-0a0c-4369-af90-6c63a412c19f; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=40688ea4-646d-4029-a229-31cae2a099d1; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=YkSB64d7QzdaI6vRAnMlvw64TBMEUcV3zqw2znZa1h8-1704298894-1-AXt2UsOASlL9voTPe5RgwCXsugGbl30ckMGmOd1ZVgo8Gpx6mDJ5F+YYrxMCi1HagKlgFiUgrRa+Pifh0u9JFnM=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=JEjH2GQiu7U401Ojpe6vrdtpiBimOnl1oBbux1XIkC4-1704442818-1-AWv9Qddbk159htInTpOejj8Iuh6gcsfpJ4qqG167mOwRqAgcOszDQH4zWaARA4UkrlWbaSKb7So6YrDDWp48jhw=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=05oy55r0knMtvic9borZ_x8NTpVDeWdI1ESI3AtuqrE-1704298894139-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=yrg5yuKuzynfjgtZwVqImx0JNs.C86hsV4ROVTIRZGI-1704442818702-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3975,15 +3088,15 @@
             },
             {
               "name": "x-trace",
-              "value": "932cef7d9d6e70276c0a849223abc27e"
+              "value": "640b8f63be349bacebb00ea34a4775a4"
             },
             {
               "name": "x-trace-span",
-              "value": "5449a9530ffaff59"
+              "value": "7fd811214f7aa456"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/932cef7d9d6e70276c0a849223abc27e"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/640b8f63be349bacebb00ea34a4775a4"
             },
             {
               "name": "x-xss-protection",
@@ -4007,17 +3120,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93575bf5bfc3-WAW"
+              "value": "840a4d1fe823c019-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:33.897Z",
-        "time": 225,
+        "startedDateTime": "2024-01-05T08:20:18.449Z",
+        "time": 209,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4025,15 +3138,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 225
+          "wait": 209
         }
       },
       {
-        "_id": "243255429fc6f137e796538de9eb469f",
+        "_id": "2bbf280183fdae3c39a73013105339ae",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 189,
+          "bodySize": 199,
           "cookies": [],
           "headers": [
             {
@@ -4059,7 +3172,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "189"
+              "value": "199"
             },
             {
               "_fromType": "array",
@@ -4082,7 +3195,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
           },
           "queryString": [
             {
@@ -4093,28 +3206,28 @@
           "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 37,
+          "bodySize": 38,
           "content": {
             "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:34.000Z",
+              "expires": "2025-01-05T08:20:18.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e5bb4fb4-ac4d-4b3b-b7bb-ba0a77d0500d"
+              "value": "14f4641e-0c05-448f-bcc2-434b629d2103"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:34.000Z",
+              "expires": "2024-01-05T08:50:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "AHjmC0gTJT5ufKbMDUdBESS8NBtrrNnFOmUEKhaQhm0-1704298894-1-AQ894nAfjabmY68sedCO62f6yTjmeZRHhDW6FCCf2G2KQ6v5EI44hxLVnGUiH76XuIqcmpuTDlQYFDXt/z3TyaM="
+              "value": "13LQvfuq8AUEL_wTW0w0AC1._5rKcsj7bL_HcWzsYYA-1704442818-1-AdAkjR8rddIUnS1N+wjv3VhTbhYPv01uQ4lhjev6hacK2e4NLCPa8hBJjfklZ7TiMiZZuOI9u5KZ7ysDiZ9Mtp8="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4123,13 +3236,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XhspBy9DUuiEvPHDfgfOnu7I0ZL8TwUYKOAcggaXdC8-1704298894149-0-604800000"
+              "value": "ehmjEaUp6RFaOU2_vfe0WwyPZ7oBBnxdH8ohYNsZRsg-1704442818705-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
             },
             {
               "name": "content-type",
@@ -4137,11 +3250,23 @@
             },
             {
               "name": "content-length",
-              "value": "37"
+              "value": "38"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4158,17 +3283,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e5bb4fb4-ac4d-4b3b-b7bb-ba0a77d0500d; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=14f4641e-0c05-448f-bcc2-434b629d2103; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=AHjmC0gTJT5ufKbMDUdBESS8NBtrrNnFOmUEKhaQhm0-1704298894-1-AQ894nAfjabmY68sedCO62f6yTjmeZRHhDW6FCCf2G2KQ6v5EI44hxLVnGUiH76XuIqcmpuTDlQYFDXt/z3TyaM=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=13LQvfuq8AUEL_wTW0w0AC1._5rKcsj7bL_HcWzsYYA-1704442818-1-AdAkjR8rddIUnS1N+wjv3VhTbhYPv01uQ4lhjev6hacK2e4NLCPa8hBJjfklZ7TiMiZZuOI9u5KZ7ysDiZ9Mtp8=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=XhspBy9DUuiEvPHDfgfOnu7I0ZL8TwUYKOAcggaXdC8-1704298894149-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=ehmjEaUp6RFaOU2_vfe0WwyPZ7oBBnxdH8ohYNsZRsg-1704442818705-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4184,15 +3309,15 @@
             },
             {
               "name": "x-trace",
-              "value": "41224bf4030f70c62316915aa7ffccb8"
+              "value": "89763fc8827dc54433d3d3558e5b46c0"
             },
             {
               "name": "x-trace-span",
-              "value": "af49eb7bb33d30b8"
+              "value": "a246dd1b9f21bfab"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/41224bf4030f70c62316915aa7ffccb8"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/89763fc8827dc54433d3d3558e5b46c0"
             },
             {
               "name": "x-xss-protection",
@@ -4216,17 +3341,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93575eb1cc8f-WAW"
+              "value": "840a4d1ffd79c008-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:33.897Z",
-        "time": 232,
+        "startedDateTime": "2024-01-05T08:20:18.452Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4234,221 +3359,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
-        }
-      },
-      {
-        "_id": "fdfcc7f2c502f374d01b3e1824ad5539",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 477,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "477"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:33.892Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ec774367-81a4-482d-ab38-b10e032bc456"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "SNZAkZp2J3lLO79GZ6bqxbIE7q5CumhduUhaMCJo1mM-1704298894-1-AXP4v9Cnyigg3pr3KZ50hwsbppz+KPfXtzOK5Jr6VgyxMAWWsfXdS8xJ3QgB+zqMwn7Y7PhuYYB8KrSASRE3Rgk="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "1plC34s0lNAYMpk9LP3BfvnPQ5UjFsHPQWXiwzsqtJA-1704298894157-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ec774367-81a4-482d-ab38-b10e032bc456; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=SNZAkZp2J3lLO79GZ6bqxbIE7q5CumhduUhaMCJo1mM-1704298894-1-AXP4v9Cnyigg3pr3KZ50hwsbppz+KPfXtzOK5Jr6VgyxMAWWsfXdS8xJ3QgB+zqMwn7Y7PhuYYB8KrSASRE3Rgk=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=1plC34s0lNAYMpk9LP3BfvnPQ5UjFsHPQWXiwzsqtJA-1704298894157-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "eb1c43b0d71af17ba1e91d41cdd4cb32"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "3186e21b1f41c0ad"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/eb1c43b0d71af17ba1e91d41cdd4cb32"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc93575974bfe4-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:33.894Z",
-        "time": 245,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 245
+          "wait": 210
         }
       },
       {
@@ -4524,20 +3435,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:34.000Z",
+              "expires": "2025-01-05T08:20:18.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c6d0b807-4c48-450e-a5ff-a28c07cfba08"
+              "value": "6267d119-583f-46e7-8117-496463145355"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:34.000Z",
+              "expires": "2024-01-05T08:50:18.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "kzigPvr.4_uwT4zB1guS31Ofivut.f.uXnL7JsvJCqI-1704298894-1-AX6tyapva6QGGO9ax40OPSUpOTMTBqdYF8Ffo5xCkBV3PgGk8S5dndzgeclT14Bg/Ok5tn/X0DE4Slhty6puYeo="
+              "value": "izku26brNLUIC66DHFfxt1KafWBQ.rmgACWRitd0eNQ-1704442818-1-AYZ0LjCW1VoaS9O7YJbMhfM82VhOq0Psv3Xwl/BWSEwWnXuzy4zNVCft3CbVfjr9bXLpvmGH6U2LyuV9dF09SW4="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4546,13 +3457,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "dhueYJ1XnIfAcGMbuc3cAW_XRRg0__rFRD_Qj.iIOeY-1704298894187-0-604800000"
+              "value": "aC6FbybCh3UCR418nzdcvhVFO7CzXqkGC_pkCFITIWk-1704442818710-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
             },
             {
               "name": "content-type",
@@ -4565,6 +3476,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4581,17 +3504,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c6d0b807-4c48-450e-a5ff-a28c07cfba08; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=6267d119-583f-46e7-8117-496463145355; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=kzigPvr.4_uwT4zB1guS31Ofivut.f.uXnL7JsvJCqI-1704298894-1-AX6tyapva6QGGO9ax40OPSUpOTMTBqdYF8Ffo5xCkBV3PgGk8S5dndzgeclT14Bg/Ok5tn/X0DE4Slhty6puYeo=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=izku26brNLUIC66DHFfxt1KafWBQ.rmgACWRitd0eNQ-1704442818-1-AYZ0LjCW1VoaS9O7YJbMhfM82VhOq0Psv3Xwl/BWSEwWnXuzy4zNVCft3CbVfjr9bXLpvmGH6U2LyuV9dF09SW4=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=dhueYJ1XnIfAcGMbuc3cAW_XRRg0__rFRD_Qj.iIOeY-1704298894187-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=aC6FbybCh3UCR418nzdcvhVFO7CzXqkGC_pkCFITIWk-1704442818710-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4607,15 +3530,15 @@
             },
             {
               "name": "x-trace",
-              "value": "89732910a58196ea16edb70c998a9356"
+              "value": "772086011081a2d593abae07b165fd16"
             },
             {
               "name": "x-trace-span",
-              "value": "a0aafd524f1cf3e5"
+              "value": "b2bb73e7d2408015"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/89732910a58196ea16edb70c998a9356"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/772086011081a2d593abae07b165fd16"
             },
             {
               "name": "x-xss-protection",
@@ -4639,17 +3562,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93575aa0bf8d-WAW"
+              "value": "840a4d1fe825c019-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:33.898Z",
-        "time": 269,
+        "startedDateTime": "2024-01-05T08:20:18.451Z",
+        "time": 216,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4657,7 +3580,1348 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 269
+          "wait": 216
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:18.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "35578159-04ef-4620-9d39-68f0161ec017"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:18.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XYauyC5SK9WiXLg9c_gBJYo1fKV82e1mWHf.5P3mpr0-1704442818-1-ATs8qHOKQmlYpiaJmYoPpukn1lg7c/55TspG2ghjefZpAEC/UC1X7iEMy7wH8cGre68kpx7LhMorduTAnOP9Cfs="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "g2dkiUOR0IWu9.isfmq2T7PHvlat.j5eqigCZJJUJec-1704442818711-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=35578159-04ef-4620-9d39-68f0161ec017; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=XYauyC5SK9WiXLg9c_gBJYo1fKV82e1mWHf.5P3mpr0-1704442818-1-ATs8qHOKQmlYpiaJmYoPpukn1lg7c/55TspG2ghjefZpAEC/UC1X7iEMy7wH8cGre68kpx7LhMorduTAnOP9Cfs=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=g2dkiUOR0IWu9.isfmq2T7PHvlat.j5eqigCZJJUJec-1704442818711-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "0aa23972a99c19b839b99f8b52536a62"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "1ec2dab3257304bf"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0aa23972a99c19b839b99f8b52536a62"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d1fedb6ffc0-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:18.450Z",
+        "time": 218,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 218
+        }
+      },
+      {
+        "_id": "501141f683aafdd826d483e7a19d6aa3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:18.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6fdab9de-93f4-4fd6-a3df-0c3fdd9b5626"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:18.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "gLkuGe4_2ynjElccythMgkVvdTMIFR0wItSJRhSuYUs-1704442818-1-AXJOy6J7E/786EAJaM8zYb9Wj//gWCImJN1pG4nBKL0pJlwYZTBYOWfSk5sRWB4mnUR5y5N4KV72GSHwtESTe80="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "d.qUHyW410JwJughC4265YAInJIYXY7NkIof5BKon1g-1704442818726-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "345"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6fdab9de-93f4-4fd6-a3df-0c3fdd9b5626; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=gLkuGe4_2ynjElccythMgkVvdTMIFR0wItSJRhSuYUs-1704442818-1-AXJOy6J7E/786EAJaM8zYb9Wj//gWCImJN1pG4nBKL0pJlwYZTBYOWfSk5sRWB4mnUR5y5N4KV72GSHwtESTe80=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=d.qUHyW410JwJughC4265YAInJIYXY7NkIof5BKon1g-1704442818726-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "c5fda37732d84ed4136f41b7c24984d7"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "6b27700f2499b694"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c5fda37732d84ed4136f41b7c24984d7"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d1fe95e7730-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:18.444Z",
+        "time": 242,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 242
+        }
+      },
+      {
+        "_id": "5c802486f7d3cc4353253e4635acde23",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 477,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "477"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:18.441Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:18.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "7b425b89-16a3-4f41-9a13-01a8aee014a5"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:18.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "AxAlwL6lIhDdiwG1UNH7.ZEYoppZL3hnRm7HaWdtL1Y-1704442818-1-AQBRo23Ex1f5eufwoh+WDS6aVRDruzrS9Pbx7ZGlaTnci97lBZNSziMwPu33ZRyJlUMTWIIDbVucFDEjthQPI18="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "DriZMnn1dmtUsQFPyY5fKZHTJmf49VosoAumHOt9SQI-1704442818946-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:18 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "344"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=7b425b89-16a3-4f41-9a13-01a8aee014a5; Expires=Sun, 05 Jan 2025 08:20:18 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=AxAlwL6lIhDdiwG1UNH7.ZEYoppZL3hnRm7HaWdtL1Y-1704442818-1-AQBRo23Ex1f5eufwoh+WDS6aVRDruzrS9Pbx7ZGlaTnci97lBZNSziMwPu33ZRyJlUMTWIIDbVucFDEjthQPI18=; path=/; expires=Fri, 05-Jan-24 08:50:18 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=DriZMnn1dmtUsQFPyY5fKZHTJmf49VosoAumHOt9SQI-1704442818946-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "6d94b145cdaa36c3dcc77429eb10c7ed"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "aafa2816411c97c9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6d94b145cdaa36c3dcc77429eb10c7ed"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d215deebf4e-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:18.685Z",
+        "time": 218,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 218
+        }
+      },
+      {
+        "_id": "f5b753070f506f2f8efbe8b3b36ee4a3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1184,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "1184"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 340,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "dfa22658-86a0-4162-8d76-0909edba82fc"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "5QRKl0upQUj9cngnQOg9o2YFgrn8qQ5PPaiWU4kavEg-1704442820-1-AdooBqPwCrvPbwjYA7DhJt0Kwq0VNWMC4kgU29Eep65iErFBayfgIwG66txkyQE7I1aYa/eCqOIBVXIA3kDU7HU="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "M2Jp2fT5VSekPyHoIO.djqNnl_Zh8hwgcx7jW_XTrAI-1704442820614-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "343"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=dfa22658-86a0-4162-8d76-0909edba82fc; Expires=Sun, 05 Jan 2025 08:20:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=5QRKl0upQUj9cngnQOg9o2YFgrn8qQ5PPaiWU4kavEg-1704442820-1-AdooBqPwCrvPbwjYA7DhJt0Kwq0VNWMC4kgU29Eep65iErFBayfgIwG66txkyQE7I1aYa/eCqOIBVXIA3kDU7HU=; path=/; expires=Fri, 05-Jan-24 08:50:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=M2Jp2fT5VSekPyHoIO.djqNnl_Zh8hwgcx7jW_XTrAI-1704442820614-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "75209c3b199439055f104461884302aa"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "3b1dbf97b3ffee78"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/75209c3b199439055f104461884302aa"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d2bbe2770c2-WAW"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:20.336Z",
+        "time": 234,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 234
+        }
+      },
+      {
+        "_id": "db3120835c70b59b5f9cfff4ecec6cf4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 474,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "474"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:20.332Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 119,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:20.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "9689c554-f9af-4ce4-afb4-d6834522c149"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:20.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "fWIZIqyzDzf7MfOl7NZ5fnJWKgU81A3RMhr8C8UZ.8w-1704442820-1-AUR6ne/9RmTKdpL93/EcgZlkk0i7HPqF5YURk7zaztUZjbhLv+RpvswjBp1fsL1sInbxfJSa+VMzD3X++Ll+e6Q="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "8Yp4gMBOgNK7xmf01ggMFa6SmaWSpeqZvk3QJHHyydY-1704442820615-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:20 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "343"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=9689c554-f9af-4ce4-afb4-d6834522c149; Expires=Sun, 05 Jan 2025 08:20:20 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=fWIZIqyzDzf7MfOl7NZ5fnJWKgU81A3RMhr8C8UZ.8w-1704442820-1-AUR6ne/9RmTKdpL93/EcgZlkk0i7HPqF5YURk7zaztUZjbhLv+RpvswjBp1fsL1sInbxfJSa+VMzD3X++Ll+e6Q=; path=/; expires=Fri, 05-Jan-24 08:50:20 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=8Yp4gMBOgNK7xmf01ggMFa6SmaWSpeqZvk3QJHHyydY-1704442820615-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "1d5067223809101b3fd5f922374becb0"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "d97c57f0c662cdf9"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/1d5067223809101b3fd5f922374becb0"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d2bb8bbbfcd-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:20.337Z",
+        "time": 235,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 235
+        }
+      },
+      {
+        "_id": "fd5fcdff6c39e8c32664df5b4799519c",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 477,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "477"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:21.022Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:21.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "f2cb6149-00f0-44f0-b496-bc8f24f4b514"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:21.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "TOxgAS0PTf29feZuxCKIXThCqk_5arff1BuvgPslPXI-1704442821-1-ASof8ps8aNlgcgVKAwBoYR38n4SZDH8LlTc3BSPmGRSlv93sBSxif9wIfmqWCM32o52gvzIlkp6AK3vEc2WX0n0="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "B49bhb8f.NGZJ96gRJGdS4O2NkXJ9d_Yq0v0UBHp1EM-1704442821295-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:21 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "342"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=f2cb6149-00f0-44f0-b496-bc8f24f4b514; Expires=Sun, 05 Jan 2025 08:20:21 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=TOxgAS0PTf29feZuxCKIXThCqk_5arff1BuvgPslPXI-1704442821-1-ASof8ps8aNlgcgVKAwBoYR38n4SZDH8LlTc3BSPmGRSlv93sBSxif9wIfmqWCM32o52gvzIlkp6AK3vEc2WX0n0=; path=/; expires=Fri, 05-Jan-24 08:50:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=B49bhb8f.NGZJ96gRJGdS4O2NkXJ9d_Yq0v0UBHp1EM-1704442821295-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "da9984ea930359dbb06663b94cf5fb9d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "04423cf74415fda5"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/da9984ea930359dbb06663b94cf5fb9d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d300ef134fc-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:21.024Z",
+        "time": 229,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 229
         }
       },
       {
@@ -4733,20 +4997,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:34.000Z",
+              "expires": "2025-01-05T08:20:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6f4f1919-0df3-4ef6-8e25-7109b532191d"
+              "value": "55d9e334-a02c-4cc2-8ac8-d1c1847e5b1a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:34.000Z",
+              "expires": "2024-01-05T08:50:21.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "yZEgpTSXZt8tgty2Ci22OpgsjRpl0P847hzciF5JdCU-1704298894-1-AStd6XzMiCaJLU1L1OJNc3Qu+JY3yyqjqlasgGii2H3jcvs9BzQ7PKBt2frF36l+QH66zHda1Ek8zuoqgFnYGbo="
+              "value": "BlW5G55fOOCH6544QQ2GkU6r6KjkrHEXNVuoNcl11K4-1704442821-1-AUHYl88qGzegAU3scwTD7ZDTEs4nzZR8dVyQrNGjFtkR6ekQMLgL5o1/7a8zNbQM05i/yJb383t6IF7az+XVYeY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4755,13 +5019,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "tDk3aKNfmul8NuxndJd4qnCpEdxAHHOlkp9yHN2i00E-1704298894596-0-604800000"
+              "value": "ooJzuLumAeFng3vSu34fiTsioCPsiqvDjf1zpZ8HoLk-1704442821748-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:34 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:21 GMT"
             },
             {
               "name": "content-type",
@@ -4774,6 +5038,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "342"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4790,17 +5066,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6f4f1919-0df3-4ef6-8e25-7109b532191d; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=55d9e334-a02c-4cc2-8ac8-d1c1847e5b1a; Expires=Sun, 05 Jan 2025 08:20:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=yZEgpTSXZt8tgty2Ci22OpgsjRpl0P847hzciF5JdCU-1704298894-1-AStd6XzMiCaJLU1L1OJNc3Qu+JY3yyqjqlasgGii2H3jcvs9BzQ7PKBt2frF36l+QH66zHda1Ek8zuoqgFnYGbo=; path=/; expires=Wed, 03-Jan-24 16:51:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=BlW5G55fOOCH6544QQ2GkU6r6KjkrHEXNVuoNcl11K4-1704442821-1-AUHYl88qGzegAU3scwTD7ZDTEs4nzZR8dVyQrNGjFtkR6ekQMLgL5o1/7a8zNbQM05i/yJb383t6IF7az+XVYeY=; path=/; expires=Fri, 05-Jan-24 08:50:21 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=tDk3aKNfmul8NuxndJd4qnCpEdxAHHOlkp9yHN2i00E-1704298894596-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=ooJzuLumAeFng3vSu34fiTsioCPsiqvDjf1zpZ8HoLk-1704442821748-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4816,15 +5092,15 @@
             },
             {
               "name": "x-trace",
-              "value": "8f0919196c2a1f8b0f3a17e3acf58d5e"
+              "value": "213c794a996307855f6b51092f5b082c"
             },
             {
               "name": "x-trace-span",
-              "value": "e9de1c9a25dc1a24"
+              "value": "e1c247535520d5e1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8f0919196c2a1f8b0f3a17e3acf58d5e"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/213c794a996307855f6b51092f5b082c"
             },
             {
               "name": "x-xss-protection",
@@ -4848,17 +5124,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc935a39f5353a-WAW"
+              "value": "840a4d32ebb6352d-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:34.367Z",
-        "time": 210,
+        "startedDateTime": "2024-01-05T08:20:21.453Z",
+        "time": 252,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4866,7 +5142,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 210
+          "wait": 252
         }
       },
       {
@@ -4937,20 +5213,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:34.000Z",
+              "expires": "2025-01-05T08:20:21.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ae1c7e1e-658a-4bff-b5ec-58fad6422108"
+              "value": "e85e24b4-4ab6-406a-bdc7-4c06d75d1106"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:35.000Z",
+              "expires": "2024-01-05T08:50:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "M.EUlM9UT97pPNxZaJV0sTLBGpcsZ8ZVI7GOhuqM2oM-1704298895-1-AfIYZ0EYUUFj6IbUpMpyxV/RR2reU/k6XlbzhsZcs5VFQFdKhTC3FC6PqvzhdDVTPIWA2hU5kNruChF8al+94Lw="
+              "value": "0MKwvRwCQ0236VV62jmwbNOcSlgqY.C.N5P1uBxaVtc-1704442823-1-AZzwAyFdVCoaGO4VyI1qgsIyU90H3K4rX98avsjnO5rwREL0KYWzAEJrxzQe5f6xSh7UKnNKEtX+u+IbPXq31mw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4959,13 +5235,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "GatHzGn8WRArlSTsxCIff.4BPc3AvbrH6jjjLlVY5JY-1704298895845-0-604800000"
+              "value": "kNzgEdrQBlkkkDdi0GuAlSUSQjulbl0FaZSx6SGXuJ8-1704442823148-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:35 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
             },
             {
               "name": "content-type",
@@ -4978,6 +5254,18 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "341"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4994,17 +5282,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ae1c7e1e-658a-4bff-b5ec-58fad6422108; Expires=Fri, 03 Jan 2025 16:21:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=e85e24b4-4ab6-406a-bdc7-4c06d75d1106; Expires=Sun, 05 Jan 2025 08:20:21 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=M.EUlM9UT97pPNxZaJV0sTLBGpcsZ8ZVI7GOhuqM2oM-1704298895-1-AfIYZ0EYUUFj6IbUpMpyxV/RR2reU/k6XlbzhsZcs5VFQFdKhTC3FC6PqvzhdDVTPIWA2hU5kNruChF8al+94Lw=; path=/; expires=Wed, 03-Jan-24 16:51:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=0MKwvRwCQ0236VV62jmwbNOcSlgqY.C.N5P1uBxaVtc-1704442823-1-AZzwAyFdVCoaGO4VyI1qgsIyU90H3K4rX98avsjnO5rwREL0KYWzAEJrxzQe5f6xSh7UKnNKEtX+u+IbPXq31mw=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=GatHzGn8WRArlSTsxCIff.4BPc3AvbrH6jjjLlVY5JY-1704298895845-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=kNzgEdrQBlkkkDdi0GuAlSUSQjulbl0FaZSx6SGXuJ8-1704442823148-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5020,15 +5308,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c810a6b7a9d2eeb6bb3c2b3783200b74"
+              "value": "f243707e3d43e7ddc2140ff6e5c54017"
             },
             {
               "name": "x-trace-span",
-              "value": "2f11c8b6b05179c8"
+              "value": "0361b5494a7de6b4"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c810a6b7a9d2eeb6bb3c2b3783200b74"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f243707e3d43e7ddc2140ff6e5c54017"
             },
             {
               "name": "x-xss-protection",
@@ -5052,17 +5340,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc935baafa35b4-WAW"
+              "value": "840a4d345b36fc63-WAW"
             }
           ],
-          "headersSize": 1289,
+          "headersSize": 1396,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:34.587Z",
-        "time": 1239,
+        "startedDateTime": "2024-01-05T08:20:21.712Z",
+        "time": 1509,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5070,15 +5358,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1239
+          "wait": 1509
         }
       },
       {
-        "_id": "de15dd5a1d2440a81de0322eceb1d59a",
+        "_id": "ec449ff29bc7d399b19b885c81c5c731",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2030,
+          "bodySize": 1696,
           "cookies": [],
           "headers": [
             {
@@ -5104,7 +5392,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "2030"
+              "value": "1696"
             },
             {
               "_fromType": "array",
@@ -5121,45 +5409,46 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 340,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"anthropic\\\",\\\"providerModel\\\":\\\"claude-instant-1.2\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"fa1afd4f-9ed8-4e2d-92e7-bf7f9d961339\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"local-mixed\\\",\\\"duration\\\":1.0849169492721558,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"interactionID\":\"f385caed-70c3-43b4-b940-5d7327ec8ef7\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":0.687624990940094},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"anthropic\",\"providerModel\":\"claude-instant-1.2\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"f385caed-70c3-43b4-b940-5d7327ec8ef7\",\"contextSummary\":{\"strategy\":\"local-mixed\",\"duration\":0.687624990940094,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}}},\"timestamp\":\"2024-01-05T08:20:23.255Z\"}]}}"
           },
           "queryString": [
             {
-              "name": "LogEventMutation",
+              "name": "RecordTelemetryEvents",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 26,
+          "bodySize": 112,
           "content": {
+            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "f75b0263-87d4-4368-8019-523ac267e7d0"
+              "value": "7d61d76b-876e-4b81-a5a6-4d347ab5641d"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:36.000Z",
+              "expires": "2024-01-05T08:50:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "c6MewJuZR8ly_nPy9txvwH3gM32uOEFmfFgq0qsHK70-1704298896-1-AagTPwmLnTJQ1TFPtuMHp4Sv2nzbmZEH/26ECYUW6qjULakOoaLjDEO4Un8BpYQxdFiqa36HKyVGDieg8aeDMOw="
+              "value": "R_0zFZCJVUk1Yc.MPuuY96p2eBhrADID7yoR5DiG3pQ-1704442823-1-ARg9baonmybyfQkNQpZopB0CsR/sp/7R06T0hl4YocXdgkgUkO+w7MPS8rIM2cprU4xlcV9bPvFI0HPME1IKK/w="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5168,25 +5457,37 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "LTm8Q4NwVKnWNgfK442vIxedCgYR3Qmh6m0g6gHi9IQ-1704298896183-0-604800000"
+              "value": "Du.4fsgYqbtDNB5aJwssbLr2QzDvXO2UdR1znZaDG7w-1704442823533-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "content-length",
-              "value": "26"
+              "name": "transfer-encoding",
+              "value": "chunked"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "340"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5203,17 +5504,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f75b0263-87d4-4368-8019-523ac267e7d0; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=7d61d76b-876e-4b81-a5a6-4d347ab5641d; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=c6MewJuZR8ly_nPy9txvwH3gM32uOEFmfFgq0qsHK70-1704298896-1-AagTPwmLnTJQ1TFPtuMHp4Sv2nzbmZEH/26ECYUW6qjULakOoaLjDEO4Un8BpYQxdFiqa36HKyVGDieg8aeDMOw=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=R_0zFZCJVUk1Yc.MPuuY96p2eBhrADID7yoR5DiG3pQ-1704442823-1-ARg9baonmybyfQkNQpZopB0CsR/sp/7R06T0hl4YocXdgkgUkO+w7MPS8rIM2cprU4xlcV9bPvFI0HPME1IKK/w=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=LTm8Q4NwVKnWNgfK442vIxedCgYR3Qmh6m0g6gHi9IQ-1704298896183-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Du.4fsgYqbtDNB5aJwssbLr2QzDvXO2UdR1znZaDG7w-1704442823533-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5229,15 +5530,15 @@
             },
             {
               "name": "x-trace",
-              "value": "4ca5cc0e72ecc4fb56ec03d014eb68b4"
+              "value": "9d4e0e4b0c5e44f9880ad96c8ccfc5b4"
             },
             {
               "name": "x-trace-span",
-              "value": "c7297b7462cdd51e"
+              "value": "00c03711692b7b05"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4ca5cc0e72ecc4fb56ec03d014eb68b4"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9d4e0e4b0c5e44f9880ad96c8ccfc5b4"
             },
             {
               "name": "x-xss-protection",
@@ -5261,17 +5562,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9363dcdb35d6-WAW"
+              "value": "840a4d3e0bad35ae-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:35.895Z",
-        "time": 268,
+        "startedDateTime": "2024-01-05T08:20:23.259Z",
+        "time": 236,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5279,11 +5584,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 268
+          "wait": 236
         }
       },
       {
-        "_id": "eb9eb798a8d1611b980687fe88d488ca",
+        "_id": "a61f9ee0b93db1eca63e63f464134a67",
         "_order": 0,
         "cache": {},
         "request": {
@@ -5336,7 +5641,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"71972015-c6ff-4769-afff-769d04b6e92f\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
@@ -5355,20 +5660,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8b3030b3-1926-44b6-9f77-c5490b7d22dc"
+              "value": "711863eb-5464-4c46-895b-4c5461423795"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:36.000Z",
+              "expires": "2024-01-05T08:50:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "WeA8fjQxrsYRax6W.NpeSWJQmaBnK2iJv7.LPc5L7Us-1704298896-1-AQk1ecjcJUzH3wNorMEoKGZKcauOmvpcd2pHKB5Gg++V+YCI0uZ7CzkEvmGZgBxe3Rq/ROuCEs/LliQaTVfWw3A="
+              "value": "vrFNPWOUglf2twgXTeIFJDa2MYRgtHWV_VudzUjoF6k-1704442823-1-Abf6ezSyNDNTvdFB7BgIql+ObNXjkWwqsW6Ygi5+3fm+kyaWPZyeBrt1v0PUUYxxIl/cGKvTE+Sq0cY7LdGH/WY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5377,13 +5682,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "xOXQFQgkGhi7wU8HMCACcwlqfWXnSAhZIXIt3mxPNkU-1704298896499-0-604800000"
+              "value": "4ehlcjAYRaoHgWG.6FyACKZTM1Lgul4xtyiYDbKF0Pg-1704442823539-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
             },
             {
               "name": "content-type",
@@ -5396,6 +5701,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "340"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5412,17 +5729,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8b3030b3-1926-44b6-9f77-c5490b7d22dc; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=711863eb-5464-4c46-895b-4c5461423795; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=WeA8fjQxrsYRax6W.NpeSWJQmaBnK2iJv7.LPc5L7Us-1704298896-1-AQk1ecjcJUzH3wNorMEoKGZKcauOmvpcd2pHKB5Gg++V+YCI0uZ7CzkEvmGZgBxe3Rq/ROuCEs/LliQaTVfWw3A=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=vrFNPWOUglf2twgXTeIFJDa2MYRgtHWV_VudzUjoF6k-1704442823-1-Abf6ezSyNDNTvdFB7BgIql+ObNXjkWwqsW6Ygi5+3fm+kyaWPZyeBrt1v0PUUYxxIl/cGKvTE+Sq0cY7LdGH/WY=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=xOXQFQgkGhi7wU8HMCACcwlqfWXnSAhZIXIt3mxPNkU-1704298896499-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=4ehlcjAYRaoHgWG.6FyACKZTM1Lgul4xtyiYDbKF0Pg-1704442823539-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5438,15 +5755,15 @@
             },
             {
               "name": "x-trace",
-              "value": "7e904ef5465b84e375413f20c781cf9f"
+              "value": "88e7b6aece22f917b131eb7f1382aaf9"
             },
             {
               "name": "x-trace-span",
-              "value": "f400bd86840f217d"
+              "value": "9b0f0557be2f316b"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7e904ef5465b84e375413f20c781cf9f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/88e7b6aece22f917b131eb7f1382aaf9"
             },
             {
               "name": "x-xss-protection",
@@ -5470,17 +5787,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9363c88c3566-WAW"
+              "value": "840a4d3e0baac012-WAW"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:35.894Z",
-        "time": 676,
+        "startedDateTime": "2024-01-05T08:20:23.256Z",
+        "time": 239,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5488,11 +5805,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 676
+          "wait": 239
         }
       },
       {
-        "_id": "2045fa645bf1bb8bc4c29fdbe40533b2",
+        "_id": "f04aa5e380c4dbe7d64c31b9a6d05f49",
         "_order": 0,
         "cache": {},
         "request": {
@@ -5545,7 +5862,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:35.892Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:23.255Z\"}]}}"
           },
           "queryString": [
             {
@@ -5556,29 +5873,29 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 122,
+          "bodySize": 119,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 122,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c8de4a24-6922-4f16-99ec-2ac22f0676e0"
+              "value": "2ae8b36f-1daa-47eb-957f-fd1760639e86"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:36.000Z",
+              "expires": "2024-01-05T08:50:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "FJeo7LH0tCBcPpz2iT5DJ_YfaCuQXY0Z6SXjccu7k58-1704298896-1-AYxASx/PZp1SFASvt2uDy0YTm2SwBxaYd+BsR9Xyer9gVN8WrOv1t8VbjEKmaFsxql8Y3qwSXtxSFEAP0cIBa2U="
+              "value": "GZartLClsgqZqURFKPHbCZBjjJXj083k7KMzsj_Z7E4-1704442823-1-AW2elo2203e9UJqLZqMzNR7otjOD3+aLqD2E5OZJVCkJEyhzMIu9o1B6KoOKGetQIYYRA7DL2m+Y9jIbATVN4z8="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5587,13 +5904,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "vydBsUgOlTfJeM.GGQxavRWv4bTjFxxU8qJAA0A9keU-1704298896507-0-604800000"
+              "value": "vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
             },
             {
               "name": "content-type",
@@ -5606,6 +5923,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "340"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5622,17 +5951,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c8de4a24-6922-4f16-99ec-2ac22f0676e0; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=2ae8b36f-1daa-47eb-957f-fd1760639e86; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=FJeo7LH0tCBcPpz2iT5DJ_YfaCuQXY0Z6SXjccu7k58-1704298896-1-AYxASx/PZp1SFASvt2uDy0YTm2SwBxaYd+BsR9Xyer9gVN8WrOv1t8VbjEKmaFsxql8Y3qwSXtxSFEAP0cIBa2U=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=GZartLClsgqZqURFKPHbCZBjjJXj083k7KMzsj_Z7E4-1704442823-1-AW2elo2203e9UJqLZqMzNR7otjOD3+aLqD2E5OZJVCkJEyhzMIu9o1B6KoOKGetQIYYRA7DL2m+Y9jIbATVN4z8=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=vydBsUgOlTfJeM.GGQxavRWv4bTjFxxU8qJAA0A9keU-1704298896507-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5648,15 +5977,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d9f3c3413a21155726ccab74be0a32c7"
+              "value": "b68c07eb6cc7bdd6ec4f7e8405d83677"
             },
             {
               "name": "x-trace-span",
-              "value": "8f13cd8922d29b0f"
+              "value": "7a64aab8358d4673"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d9f3c3413a21155726ccab74be0a32c7"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b68c07eb6cc7bdd6ec4f7e8405d83677"
             },
             {
               "name": "x-xss-protection",
@@ -5680,21 +6009,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9363c93834e0-WAW"
+              "value": "840a4d3e0a6f3524-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:35.896Z",
-        "time": 674,
+        "startedDateTime": "2024-01-05T08:20:23.259Z",
+        "time": 241,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5702,15 +6031,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 674
+          "wait": 241
         }
       },
       {
-        "_id": "df5a9eb392a5c64b9d4b8c9e4770f874",
+        "_id": "301ea02d32e7fa81522fd24d2df31a8e",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 1698,
+          "bodySize": 2029,
           "cookies": [],
           "headers": [
             {
@@ -5736,7 +6065,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "1698"
+              "value": "2029"
             },
             {
               "_fromType": "array",
@@ -5753,46 +6082,45 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 345,
+          "headersSize": 340,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"interactionID\":\"fa1afd4f-9ed8-4e2d-92e7-bf7f9d961339\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":1.0849169492721558},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"anthropic\",\"providerModel\":\"claude-instant-1.2\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"fa1afd4f-9ed8-4e2d-92e7-bf7f9d961339\",\"contextSummary\":{\"strategy\":\"local-mixed\",\"duration\":1.0849169492721558,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}}},\"timestamp\":\"2024-01-03T16:21:35.893Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"87897cde-94e6-4156-af51-e3655a534b7a\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"anthropic\\\",\\\"providerModel\\\":\\\"claude-instant-1.2\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"f385caed-70c3-43b4-b940-5d7327ec8ef7\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"local-mixed\\\",\\\"duration\\\":0.687624990940094,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.1\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.1\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
           },
           "queryString": [
             {
-              "name": "RecordTelemetryEvents",
+              "name": "LogEventMutation",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
         },
         "response": {
-          "bodySize": 122,
+          "bodySize": 26,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 122,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "d288d5e2-320f-49f8-a108-78950f47e255"
+              "value": "8df0a05f-df23-4c2f-880a-0b744b1bab19"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:36.000Z",
+              "expires": "2024-01-05T08:50:23.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "oMt41Cy87.SKGtAk2mVuSFRlLgLhlEL1jSCvXMptyQs-1704298896-1-AY3iY9ZtWGgWyq7ob9QClFkFSCdtHkzQqglgiF/gLr/cQ5kQL7Ub/Eea/feEzSoO69+dZVnAtFcsMffi5FjId+I="
+              "value": "3Tkoee21QEAXEaGuvi.FehWeYSKWHF_I1vvEpZnEaJA-1704442823-1-ASz6hGgYMni4afrKsab03U+T2FfqdBupD7N1kOc2F93VtuF7EJe5eTCcSEUfrJNV+rhdkV0er2fecOfHIoK3rYw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5801,25 +6129,37 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "1qQMlo0R6j1jTsghNYjvXIXo_TmJTLqr4K357NAeOoU-1704298896584-0-604800000"
+              "value": "vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:23 GMT"
             },
             {
               "name": "content-type",
               "value": "application/json"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "26"
             },
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "340"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5836,17 +6176,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d288d5e2-320f-49f8-a108-78950f47e255; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=8df0a05f-df23-4c2f-880a-0b744b1bab19; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=oMt41Cy87.SKGtAk2mVuSFRlLgLhlEL1jSCvXMptyQs-1704298896-1-AY3iY9ZtWGgWyq7ob9QClFkFSCdtHkzQqglgiF/gLr/cQ5kQL7Ub/Eea/feEzSoO69+dZVnAtFcsMffi5FjId+I=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=3Tkoee21QEAXEaGuvi.FehWeYSKWHF_I1vvEpZnEaJA-1704442823-1-ASz6hGgYMni4afrKsab03U+T2FfqdBupD7N1kOc2F93VtuF7EJe5eTCcSEUfrJNV+rhdkV0er2fecOfHIoK3rYw=; path=/; expires=Fri, 05-Jan-24 08:50:23 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=1qQMlo0R6j1jTsghNYjvXIXo_TmJTLqr4K357NAeOoU-1704298896584-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=vcwmcSEnIDw1Jy0kRZ8oKgs6dOMwRHMFfs3MscJt_sg-1704442823543-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5862,15 +6202,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c29c1a5c6d339e582eaaf2710787e2cc"
+              "value": "fa3bb6c7dfe6b740cf2c5c2cd406fab9"
             },
             {
               "name": "x-trace-span",
-              "value": "990ac3e16b889000"
+              "value": "cdcf81e8d77e7118"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c29c1a5c6d339e582eaaf2710787e2cc"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fa3bb6c7dfe6b740cf2c5c2cd406fab9"
             },
             {
               "name": "x-xss-protection",
@@ -5894,21 +6234,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9363ca0835b1-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
+              "value": "840a4d3e08c870c1-WAW"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:35.896Z",
-        "time": 674,
+        "startedDateTime": "2024-01-05T08:20:23.258Z",
+        "time": 242,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5916,7 +6252,233 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 674
+          "wait": 242
+        }
+      },
+      {
+        "_id": "26aecace99af45a221b18ae1292cc3e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 477,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "477"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 344,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:23.756Z\"}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T08:20:23.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6d8213e8-ddbe-4a6c-b2bc-f3f90d2f30b7"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T08:50:24.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "0P10HdDDfBIwmsCO.vURhnusRX6NAef4ctK2oiFbDpI-1704442824-1-ATKBFYAk78pz0UhlayW/YKCtDFbl6iLKHsbSGzG8H2c3DRlapkSpVnD0vsOZ8eBXnJLRqvjHkdEeWI6raTfmi3o="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "_Z5MKkZzZTlVH_izv1.Y4m6.HZVXqZt.q3ManEuJ_64-1704442824034-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 08:20:24 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "339"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6d8213e8-ddbe-4a6c-b2bc-f3f90d2f30b7; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=0P10HdDDfBIwmsCO.vURhnusRX6NAef4ctK2oiFbDpI-1704442824-1-ATKBFYAk78pz0UhlayW/YKCtDFbl6iLKHsbSGzG8H2c3DRlapkSpVnD0vsOZ8eBXnJLRqvjHkdEeWI6raTfmi3o=; path=/; expires=Fri, 05-Jan-24 08:50:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=_Z5MKkZzZTlVH_izv1.Y4m6.HZVXqZt.q3ManEuJ_64-1704442824034-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "d1a9d428208de5a6d0dc98d48daaaad8"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "f79287b8e621c16d"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d1a9d428208de5a6d0dc98d48daaaad8"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840a4d411b4efc7f-WAW"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T08:20:23.758Z",
+        "time": 233,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 233
         }
       },
       {
@@ -5984,29 +6546,29 @@
           "url": "https://sourcegraph.com/.api/graphql?LegacyEmbeddingsSearch"
         },
         "response": {
-          "bodySize": 2554,
+          "bodySize": 2227,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 2554,
-            "text": "[\"H4sIAAAAAAAA/8RX247cuBH9lYqMwB5vq9WXGXs=\",\"0ovBxp71wgPYa8OXOAtrsE2JJYkYilTIUl9gDLDfkLcAAYLkKd/lL8gnBEV1z6h7Lrt5imG03WSxTtWpU0X2l0gKEtHsS4R1hlIqU/r3KFxe8VpuJb5D32ry0ezzl6hQGn8UNUazaOF5M/EuTzy6hcrRJ89aqt46u1AS3XtVN1oVCuWQfDSIPAlHr5TBaPbkeBChkd2Xp6NBlFtDaCiaRZepiS4HtwERekpwgkmhVm0TS8ytE2TdkDduQDx90oc43oE4uB+jUCtqHfpkad2Fb0SOiTISV8OKar2LMuqBjCd9kLQdjab5775/c/rhp7cvgI+GJUxNt8UroIUpT9IITRptdwEANhYoZH/1eqdGEpBXwnmkkzT6+OGH+DiNILnHuiJqYvxLqxYnafTn+OOz+NTWjSCVaUwj2AR+kkZnL05Qlvgr7oyo8SSNFgqXjXW042GpJFUnElkScfgyAGUUKaFjnwuNJ+Ph6G7/pEhjt/UStbZwauW620p6e32mkn2quuVse3DXuL+8Pd8rz740tMqSVgWd55Wg5IMTxudONXRGWA/Jr3Y1MZlMe6qYTJ70ZcFhHKTmHgkGHFs3GklZ4xNtyxLvEPlkOulDTY/2oS5/HUvbXOg4HFtRIu3SaCtk7Nd1cQNvPO6nNh7fSO0yNbc0MDPoK+FQXrPoMFcN+oSYTS0Ib4AdHvawDp/+dqh+sZRpWjrdJHdaCTrrLdys3XG/oY+n+5hbtUy3WrmF2v1krcRMeLxiuEbvRYn+Jrmjoz65o+N99PNbM871Jl2t0HDChE7kQTs3Ke3P3aMb6W3/fD6/7smD7r8Hv4nt7eS8CdznlQt7E/hy0CGdD26FwgnGyvgGc7IuIHYzOff+7pE82bla/qhqnlXQOv3oIc9DP0uSwhryw9LaUqNolB/mtk5y7yffFaJWen1y9vz1N281rr55bY3luk+ebHZ+bI2izZJUvtFifeKXonl48G1qUjNz1hJ86bKKY9/mOXof51ZbNwNXZuLR4RTG02N4MoEEnh79ns91xkvhjDLljvFkOoLx+A8w2jeWwpTodm1HYzic8N8928w6eW37QMjsKJO37saTGTzIUR5KcbXvUWNOKK/OF+NiWhx9GyqWGh6s24SZ17gjagYdUwPwwvjYo1PF9gi3xyA1jcNbDz48e/4amH1g9h8OoLbGhiv5241KzgcRt9X9b5Sl0BdUOduWlU9ES3YzYHFYy3su9HFfPQ8e8EWE8Kx3nDPoZoKqS/AuP0mjrbA8WSdK3JeWt63LsXSiqWLhPZJPMm3LZMHKkBhbk1nh+BUW96Lm1048GU2mbLSO+ynE5FfDUhXXL4jUvOeEYOkUKVMC+wVhZLhIYam0hu1hoApBK4PwyLrwBQ0ph1C0JsyQAyisg7Vth/BSEZDIgCyIPMeGgr1vyxI9mw4Z+fHjr3//N7x1NibV+HC49RxEwO7H/fjxlrvMdZF//eVfO+xC69FvQJyzrZE72WwGKsejTGFdvRePH4C3oAqOHgyiZMuyVRJBUVjMhQEhJQjmo0ZDIDK76JGytu1Dh4AyEDm8LeCfNn4qu0AH4YOPlw7XvVgY2iOCALJWZ8KBLUBoQmcEqcVe2MLDErXmfy1V7LYJO+DbvOLVjn9mQwCzqxGW1kkQxAiqxntDbX2XYhp9cIofF7usC4LT1nnrwqOurplrskAbW9FVoJcbo5p1wB1sqs3uJRai1QQXuA6SBl9ZR3lLnPv8TUhpDvM0nYM1UIv8zftQ1/kzTdfrn5SRdumhG7PwSpl2NbzzQbPT6IVa3d/fo73+/kGtQo//H9pa+IuYbMwh7/eyrQ==\",\"kSomdeksfyqqWJgu1OE7+OgxNNfXX/7mIY2e+Yuu18hyPrs1LNQKFA3AOsBVo4UyoVKNs5nG+q4GLtTqqvECOvu/vX23ErMNdq7/84+//hNqNO2gOyrMrTF2Ah9AtobaLrYKyoMMu6ZihYWetEUvEmEAnbMuCOdaeruSg/lpR8Ec5sOe2KyD+akjfbV8h9buTlNob8GpsiLItcov2AkHqghrDxt20+htx69PozBAbQF/et9dJhx2d6neRsudMpc2T5aY/S+3F3zCDHBFaDz37CNcNegUDz2hD7jwAZnLvY1NeS6AQ0N6DdboNfDb0kiUm7GOnOHW+nv0F2SbARhL8LmLcyhxcf5o2znXawdMfTfZlpjF/DyWsBBOCUO+R08Q5Eu7xAU6/glJDhslQeICtW3Q+Z1x9nOlykqvoZ/ZzwzQS3sDEhIIP3y2zth8O7xQdUO3YLceYQLcgVb6GccTw7vWwLwxTQ2uNbAUlFcziYvZErN5qChVuGkBzn2WdL+xKutpNh2NRkxbaGCOLXN26dEN2fHZFZ2D4Jqzmr8SrcmrK55fXJfwE2bMCjzvXBzMQWLWcqOaQpWtE1e38rvWmG1vXJMR9Kk8LMWai82Fs0WhciW05sur4dcySi4WX69hlX+GogwD+Pzy8vK/AQAA//+tBIeePRIAAA==\"]"
+            "size": 2227,
+            "text": "[\"H4sIAAAAAAAA/8RX327byPV+lfPjXvziQBRlOX+8AoTC9WaRAEETxEnTxTJYDTmH5MDDGXbmUJQQGNhn6F2BAkV71efKE/QRijOULMqyte5VfSGDZ2bOd/583xnyayQFiWj2NcI6QymVKf0VCpdXbMutxA/oW00+mv38NSqUxj+IGqNZtPS8mHiXJ7VQZkw+GkWehKO3ymA0ezGdjiI0cvv0bBTl1hAaimbRTWqim9FD/jy6pcrRJxctVe+dXSqJ7krVjVaFQnkIdT5Aejn5DSCtssRXwqEMYHklKGmcrRvySR9EHM6vKKlQN+j8AeCzly8GiM9enj8uN0JPCU4xKdSqbWKJuXWCrBvzwgHIHsYdiJPjGIVaUevQJ511174ROSbKSFyNK6r1PspkAHI6HYKk7WRylv/fD+8uP/70/hXw0WDC1PRLbAEtTDlPIzRptF0FANjsQCGH1t1KjSQgr4TzSPM0+vTxx/g8jSA5srsiamL8c6uW8zT6U/zpIr60dSNIZRrTCDaBz9Pozas5yhJ/w50RNc7TaKmwa6yjPQ+dklTNJTIL4/AwAmUUKaFjnwuN89Px5GH/pEhjv/QatbZwaeW6X0oGa8NKJXdL1Zuz7cH9zUPz9vygPUekFdjOPzEnvuH9/fz7/vmAGt/v8Y9DYQ4e4WEAs3WjkZQ1PtG2LPEBpk/PhqNievb8sVj3Sdlhrhr0CTlhvBaEh+p9tifeA7DUHB9P2uZC384IaTujrZCxX9fFAdbp6dlQYKcvHofGibVql5QyTUuXG8TLStCbgWFMfrWPej5U9fnZXcwtZc62hHlEaa3ETPjdaKzRe1Hi4Ww8PX2+l/EBcb48KuOP3L7cqYbeENaHKU6nw8JOpwcww7+Tm7sSTaRaDoV1S7Avo4jzO37pdUJfU+VsW1Y+ES3ZDdNxXMsj4/V0GON33/FYQLgYHE/NVs+qLsG7fJ5GPPb8LEk8WSdKHJfWlhpFo/w4t3XibetyLJ1oqlh4j+STTNsyWfo4XGXWZFY4vtbjQdR898TTyfSMN63jYQox+dW4VMVunqfmihOCzilSpgT2C8LIMNagU1rD9jBQhaCVQXhiXXhAQ8ohFK3JeRCcQGEdrG07hteKgEQGZEHkOTYU9vu2LNHz1jEjP3367W//gvfOxqQaHw63noMI2MO4nz7d1i5zfeTffv3nXnWh9eg3IM7Z1si9bDbM5niUKayr78TjR+AtqIKjB4MoeWfZKomgKBhzYUBICYLrUaMhEJldDoqytu3/OwSUoZDj+wL+aeOnskt0EH74eOlwPYiFoT0iCCBrdSYc2AKEJnRGkFreCVt46FBr/m+pYrdNWAHf5hVb+/pzNQRwdTVCZ50EQYygajwaauv7FNPoo1M85ferLgguW+etC1dsXXOtyQJt9oq+A4PcGNWsA+5o0212L7EQrSa4xnWgNPjKOspb4twX70JKC1ik6QKsgVrk765CXxcXmnb2z8pI2/kwBqYv4K0y7Wr84LjfE3qhVsf1Pbmj7x/VKmj8fyBr4a9jsjGHfFfLtkaquKids/yrqGJiutCH38Enj0Fc3379q4c0uvDXvdbIcj77PSzUChSNwDrAVaOFMqFTjbOZxvohARdqdSu8gM7+75fvlmK2wd71v//+l39AjaYd9UeFuTfGnuAjyNZQ2+WWQXmgYS8qZljQpC0GkQgD6Jx1gTg76u1TDhaXfQkWsBgPyA==\",\"Zh0sLh3pW/MDXHs4TaG9BafKiiDXKr9mJxyoIqw9bKqbRu/7+vo0CgPUFvDHq/4y4bA9aszpvrI8SHNp86TD7L+5veAzZoArQuNZs09w1aBTPPSEPuHGB2Ru9zY25bkBDg3pNVij16DYm0S5GevIGW53/4D+mmwzAmMJfu7jHEtcfnmyVc7OdsKl7ydbh1nM7ykSlsIpYcgPyhMI+dp2uETHL/TksFESJC5RW/7Q2xtnv1SqrPQahpn9wgCDtDcgIYHwWrh1xtu3wwtVP3QLdusRpsAKtNLPOJ4YPrQGFo1panCtgU5QXs0kLmcdZovQUapwIwHOfZb0b6CV9TQ7m0wmXLYgYI4tc7bz6Mbs+M1tOUfBNWe1eCtak1e3dX61a+FnzLgq8PvexckCJGYtC9UUqmyduL2VP7TGbLWxK0bgp/LQiTU3mxtni0LlSmjNl1fD31kouVl8vQYrfw+gDAP4y83NzX8CAAD//8Fpti6OEAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:23.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "cc78db0c-e0f6-4bbf-a8ce-66421f8e6c8e"
+              "value": "443ad7fd-6ff5-402f-be78-23b9e33e1480"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:36.000Z",
+              "expires": "2024-01-05T08:50:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HTgnNgWPMfJhPZfvjnGWGKQCynKqMLxRnyGk7E.0la8-1704298896-1-Afpwaa5tkEoSBgQwfRR91ARv7ISiCvJLHhXgJB16jaKFRhdbvWpYeK0EpCwjUq08BUrcTkQdG1ZR8TVAktW9P4A="
+              "value": "lo756gH1dLz9Kb.GASJReedKqLpAAwgPHgBXJgS5vow-1704442824-1-ASGQ4o+DQXqyjqg/JAKfifTnnK0pHNwR331wF+Kucj2nsISXD7j2RugRms5BdhWZdZvNTmNYSVrAKP1AOpBqmPw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6015,13 +6577,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "jsZNIExFH4AK_t5I7kRNQiVfp2GPLM33oBdMU1EAewQ-1704298896695-0-604800000"
+              "value": "jvnjazGNEoGQLI6yR6SnH1zMUPWvBD1UUkeb82TWfHM-1704442824061-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:24 GMT"
             },
             {
               "name": "content-type",
@@ -6034,6 +6596,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "340"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6054,17 +6628,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cc78db0c-e0f6-4bbf-a8ce-66421f8e6c8e; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=443ad7fd-6ff5-402f-be78-23b9e33e1480; Expires=Sun, 05 Jan 2025 08:20:23 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HTgnNgWPMfJhPZfvjnGWGKQCynKqMLxRnyGk7E.0la8-1704298896-1-Afpwaa5tkEoSBgQwfRR91ARv7ISiCvJLHhXgJB16jaKFRhdbvWpYeK0EpCwjUq08BUrcTkQdG1ZR8TVAktW9P4A=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=lo756gH1dLz9Kb.GASJReedKqLpAAwgPHgBXJgS5vow-1704442824-1-ASGQ4o+DQXqyjqg/JAKfifTnnK0pHNwR331wF+Kucj2nsISXD7j2RugRms5BdhWZdZvNTmNYSVrAKP1AOpBqmPw=; path=/; expires=Fri, 05-Jan-24 08:50:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=jsZNIExFH4AK_t5I7kRNQiVfp2GPLM33oBdMU1EAewQ-1704298896695-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=jvnjazGNEoGQLI6yR6SnH1zMUPWvBD1UUkeb82TWfHM-1704442824061-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6080,15 +6654,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b84187e48895d8a79cf6646fe5504d3e"
+              "value": "c528385b25430a4ea10b5aa2e9f207e5"
             },
             {
               "name": "x-trace-span",
-              "value": "45f0bd6d42f966c8"
+              "value": "7928181e95f194f1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b84187e48895d8a79cf6646fe5504d3e"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c528385b25430a4ea10b5aa2e9f207e5"
             },
             {
               "name": "x-xss-protection",
@@ -6112,17 +6686,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93655d15f2cc-WAW"
+              "value": "840a4d3f784170b5-WAW"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:36.137Z",
-        "time": 540,
+        "startedDateTime": "2024-01-05T08:20:23.494Z",
+        "time": 524,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6130,15 +6704,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 540
+          "wait": 524
         }
       },
       {
-        "_id": "dd061dc14aab25a042520650837ae4a2",
+        "_id": "dbc78ecb6c12baf20a01af4456506c6f",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 524,
+          "bodySize": 527,
           "cookies": [],
           "headers": [
             {
@@ -6164,7 +6738,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "524"
+              "value": "527"
             },
             {
               "_fromType": "array",
@@ -6187,7 +6761,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:36.683Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"recipe-used\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:24.022Z\"}]}}"
           },
           "queryString": [
             {
@@ -6198,29 +6772,29 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 115,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:24.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "69e2ec10-c542-471e-9b4a-0961c86341a8"
+              "value": "4a20032c-44d4-4e7c-a87d-fdc895e220d3"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:36.000Z",
+              "expires": "2024-01-05T08:50:24.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "XHCGeSZcWX7ioK.1fxLG0ogb8kV1m23dfDFtP6O5LZY-1704298896-1-AZF/mmO5h4BNhO6oOMnhjGimID+zhq0Fkwfvw4jmqUwJgzAkBQddoARSCLqGyvhdN1mderk+cpFTNvLsdw3dQ3Q="
+              "value": "yFRq5QA8J9sURux_P5t.d2i6s.aDyDuRDwXsyj0F2XI-1704442824-1-AWA7qjqzgtrRdndaAYp9ZzFCR78nEjzyRS5J/tjL17Og3d0OrrYnzg6M9cSItpPITf3MRAYCeRwtnj/5vGkOtW0="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6229,13 +6803,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Fx14W9Dn9sr2zSAsY7ntskDf8MFTEy5mPG5W2WVPpB8-1704298896948-0-604800000"
+              "value": "RBnfY.4i.d7O4DlsqTxbvvJArBh3tCVzEjd77hOorzM-1704442824302-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:36 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:24 GMT"
             },
             {
               "name": "content-type",
@@ -6248,6 +6822,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "339"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6264,17 +6850,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=69e2ec10-c542-471e-9b4a-0961c86341a8; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=4a20032c-44d4-4e7c-a87d-fdc895e220d3; Expires=Sun, 05 Jan 2025 08:20:24 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=XHCGeSZcWX7ioK.1fxLG0ogb8kV1m23dfDFtP6O5LZY-1704298896-1-AZF/mmO5h4BNhO6oOMnhjGimID+zhq0Fkwfvw4jmqUwJgzAkBQddoARSCLqGyvhdN1mderk+cpFTNvLsdw3dQ3Q=; path=/; expires=Wed, 03-Jan-24 16:51:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=yFRq5QA8J9sURux_P5t.d2i6s.aDyDuRDwXsyj0F2XI-1704442824-1-AWA7qjqzgtrRdndaAYp9ZzFCR78nEjzyRS5J/tjL17Og3d0OrrYnzg6M9cSItpPITf3MRAYCeRwtnj/5vGkOtW0=; path=/; expires=Fri, 05-Jan-24 08:50:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Fx14W9Dn9sr2zSAsY7ntskDf8MFTEy5mPG5W2WVPpB8-1704298896948-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=RBnfY.4i.d7O4DlsqTxbvvJArBh3tCVzEjd77hOorzM-1704442824302-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6290,15 +6876,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e598a96f98ff6dad1286fa56961e46df"
+              "value": "0efc70c024f21fc60ff163c2d2da1f3a"
             },
             {
               "name": "x-trace-span",
-              "value": "7f9e6c125f5d4c35"
+              "value": "b95c1d373e13ffc1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e598a96f98ff6dad1286fa56961e46df"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/0efc70c024f21fc60ff163c2d2da1f3a"
             },
             {
               "name": "x-xss-protection",
@@ -6322,21 +6908,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9368b93ecca3-WAW"
+              "value": "840a4d42cbe034d9-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:36.688Z",
-        "time": 242,
+        "startedDateTime": "2024-01-05T08:20:24.025Z",
+        "time": 235,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6344,229 +6930,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 242
+          "wait": 235
         }
       },
       {
-        "_id": "5d38dae5bd0498aa351bb3cbc23ff21e",
+        "_id": "53745732e068932b67a08d011abced38",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 477,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "477"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:36.818Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 115,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-03T16:21:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "8465edba-7e26-468f-a4ff-543fd1879e29"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "mMwMbwUA5IMSRPhKyb1fiYHJ8Fv0u_qdr18Oh1mK2qM-1704298897-1-AeAPWGN0RanMa/d2DnpnT5IycWM4RL/2IIz+Klx8PVohrogIv3nK5Q+k3gjRP0s1AysVusErBI6yRkyzqYu1rJE="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Oab6qK0_BHwZSdkMra25hc9bJ3NU50ZSn9LOpvfMo40-1704298897081-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:37 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8465edba-7e26-468f-a4ff-543fd1879e29; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=mMwMbwUA5IMSRPhKyb1fiYHJ8Fv0u_qdr18Oh1mK2qM-1704298897-1-AeAPWGN0RanMa/d2DnpnT5IycWM4RL/2IIz+Klx8PVohrogIv3nK5Q+k3gjRP0s1AysVusErBI6yRkyzqYu1rJE=; path=/; expires=Wed, 03-Jan-24 16:51:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=Oab6qK0_BHwZSdkMra25hc9bJ3NU50ZSn9LOpvfMo40-1704298897081-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "e6236129739c67886aaee798ae65a93a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "cfc7ff525eea84e8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e6236129739c67886aaee798ae65a93a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83fc93698f45347c-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-03T16:21:36.821Z",
-        "time": 242,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 242
-        }
-      },
-      {
-        "_id": "a511620fa04208be0b3f5a247d516a54",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 5808,
+          "bodySize": 5371,
           "cookies": [],
           "headers": [
             {
@@ -6596,7 +6968,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/e2e-inspector/src/index.css`:\\n```css\\n@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=Nunito&display=swap');\\n\\n:root {\\n    --success-color: rgba(43 138 62 / 75%);\\n    --warning-color: rgba(230 119 0 / 75%);\\n    --danger-color: rgba(201 42 42 / 75%);\\n    --border-color: #adb5bd;\\n    --border-color-2: #ced4da;\\n    --selected-color: #f1f3f5;\\n}\\n\\nbody {\\n    font-family: Nunito, sans-serif;\\n}\\n\\ncode,\\npre {\\n    font-family: 'IBM Plex Mono', monospace;\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/fixtures.ts`:\\n```ts\\n        },\\n    ],\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/cli/src/client/interactions.ts`:\\n```ts\\n            []\\n        )\\n    )\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n                )}\\n        </div>\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/chat/chat-view/prompt.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/vscode-context/helpers.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/main.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
           },
           "queryString": [],
           "url": "https://sourcegraph.com/.api/completions/stream"
@@ -6610,20 +6982,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:36.000Z",
+              "expires": "2025-01-05T08:20:24.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "b94df24e-8208-41f9-97eb-e8e2ff7807e6"
+              "value": "7c28d7b0-dc68-44a4-ba70-6d679a680010"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:39.000Z",
+              "expires": "2024-01-05T08:50:26.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": ".6ZMv0W94ju2x.6VVVOdSpydv49ppiNeWqChjAncdR0-1704298899-1-ASE/Rkha1wmTQ1A98mpPKKzHMsE14DelMh8qx5cJBXoTV0Z5OnKHWtxpvrdbZOsA6/bztOD6uJjBlGRf1DNAua0="
+              "value": ".YVnRILAOX7NQr4Nmd4Y8Qh0ElHEOR_zmx.wKlOi1Mk-1704442826-1-AcTr+5dTCl9LmbjAe6eSB18ump5hRG/xIr6gADXYaEjr0EkhIODomgX31Mhlir63JjLWSFsWdbVuZJ7/VISbJKw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6632,13 +7004,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "bGfXXUk79r97JEzZCdH4uBGxRORa5q5CWMCElp8iNFE-1704298899201-0-604800000"
+              "value": "Nd5B0QXBzWWeXr0dLzR8x691fmdzk8SrEzUkCknrPE8-1704442826284-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:39 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:26 GMT"
             },
             {
               "name": "content-type",
@@ -6651,6 +7023,18 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "339"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6667,17 +7051,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b94df24e-8208-41f9-97eb-e8e2ff7807e6; Expires=Fri, 03 Jan 2025 16:21:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=7c28d7b0-dc68-44a4-ba70-6d679a680010; Expires=Sun, 05 Jan 2025 08:20:24 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=.6ZMv0W94ju2x.6VVVOdSpydv49ppiNeWqChjAncdR0-1704298899-1-ASE/Rkha1wmTQ1A98mpPKKzHMsE14DelMh8qx5cJBXoTV0Z5OnKHWtxpvrdbZOsA6/bztOD6uJjBlGRf1DNAua0=; path=/; expires=Wed, 03-Jan-24 16:51:39 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=.YVnRILAOX7NQr4Nmd4Y8Qh0ElHEOR_zmx.wKlOi1Mk-1704442826-1-AcTr+5dTCl9LmbjAe6eSB18ump5hRG/xIr6gADXYaEjr0EkhIODomgX31Mhlir63JjLWSFsWdbVuZJ7/VISbJKw=; path=/; expires=Fri, 05-Jan-24 08:50:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=bGfXXUk79r97JEzZCdH4uBGxRORa5q5CWMCElp8iNFE-1704298899201-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Nd5B0QXBzWWeXr0dLzR8x691fmdzk8SrEzUkCknrPE8-1704442826284-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6693,15 +7077,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c0a57668e49e85db4372b783b13b8b6b"
+              "value": "2c838aea2c263b35f499e7175b151fe8"
             },
             {
               "name": "x-trace-span",
-              "value": "072f172d05ccb534"
+              "value": "14b9bda4b83d8169"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c0a57668e49e85db4372b783b13b8b6b"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2c838aea2c263b35f499e7175b151fe8"
             },
             {
               "name": "x-xss-protection",
@@ -6725,17 +7109,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9368bd813539-WAW"
+              "value": "840a4d42c90a34a9-WAW"
             }
           ],
-          "headersSize": 1289,
+          "headersSize": 1396,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:36.687Z",
-        "time": 2495,
+        "startedDateTime": "2024-01-05T08:20:24.024Z",
+        "time": 2269,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6743,7 +7127,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2495
+          "wait": 2269
         }
       },
       {
@@ -6811,29 +7195,29 @@
           "url": "https://sourcegraph.com/.api/graphql?LegacyEmbeddingsSearch"
         },
         "response": {
-          "bodySize": 5896,
+          "bodySize": 5330,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 5896,
-            "text": "[\"H4sIAAAAAAAA/+x7bW8bSXL/V6nj7YGkl+TI8g==\",\"7t4eF8QfOtne1cFeCSv5fAfTf6s5Uxx21NM9291DitAKyKsgL/LqEOTVAUECBMjn2k+QjxBUd88TSdGS7WTvRYjFmpzph+rq6l/9qrp000mYZZ3xTQezGSYJl6k5R6bjBT2LVYI/oCmENZ3xm5vOnAv8nmXYGXeWhl5GFo2N5vzaFhpNtFL6yuQsxugl43L0d2zJOoOOsUzbF1xiZ3ww6KBM/PfHB4NOrKRFaTvjThTBxYIb4AYYGJblAoGmg8JgAlwCXluUhisJXFpMNbP0neY3o6mcyryYCR5DLJgxQNPDzVQCAOSaL5lF96zXh5tbau1e+B7GMstjWCqeQEZtzq3mMn3zFphOTZ+GmdrztbGYjVRhR7nm0grZm3a+QyHUAFZKi2Ta6X/jh72dytup7NwOHqIvLhO8Hi1sJvYo7LCpsGlxcPAk/tXT0+OLP589A+rqHuFU+lf0BAST6WTaQTntlG9JxtACWdJ8Wr/J0DKIF0wbtJNp59XF8+HX0w5Ee1ovrM2H+GPBl5Np50/DV0fDY5XlzPKZwGkHguCTaefk2QSTFN8znGQZTqadJcdVrrRtjbDiiV1MElzyGIfuxwC45JYzMTQxEzh5PDq4e3zLrUD/yu0gHKtk7V9FjXdNTUWbqvKPZ2XHduPm47J/Y3vuMA2j48hqxKHh1qKOfixQr4fOwJ3ZDOmkRjnTKK0ZWXO3oXz5VdNQ8JoUCPNCxu7IrBbMmld5r18ekFhJY0G7cw6T8mkU0f9/qpW3ZKLAMUDXfek2jX0qowiG9/hQ0015DJepQJL8j0xzNhO4KRp7t0S9fieUTN8tQ5t3ZCAwaUvjZb7r89PDZSWo0XMWI1zhVVszDe0EzRiHGx+vkByvag1sL+mnpmrIJsZOuGrjGhJ1V2rVHVQ7Rf9otIWWrl+QNEzvx1tkWQYTePzAJXjUPZI8Y2JL8qbAuoit0gGGP1BRfrKnKk2V9wrJ5tQB2WdMNzS5c+saKrm5/WQmzSUtlhs6gScyQWmdt6pl4XPouQW0pPNb4PYOJiALIb4pT4DWagUT6PVh4mFk96r2fxprLqdTAkdCpb2uR8LX5Mp+1e1/cwdGrXBGiGyiozwfWXPdxqAnXzxpoNCTr1oOfior9aRoX6OIVYYv0RiW4u/Xp+c9Zcoj1C+/tGFg1erzkumrRK0kTOAyjAbWY/mv4JyEgpXmlkYh0YHJxL2EFRcCWGFVrIhlWATBJRrXAKXlGquNNDBXGtaqcAzjQoEuJLxxoxyrLGMyMW97sf82jlWyHjHXbxSemVGGsugThwG7IBBZzxTTCZiF0jYubPAYJmfSm/Vk2ikbDctGleuu2vrfnzVMQBmYTCbQTZhecdmF/wfdn//pP7owhu6RsBVYe2dUD7E55PEdLRoPBm4lO+Sm9Q85bVUp8NFWZ5gV1io5AKVB83Rhh7Hg8RUwuV4tUCMRvbUqtNsyp/Q/qwJiJsGZGTCQuCJiYoH+k2uwPENYcbv4W1Nl9H5VkhYKcn/3V+l3d6nUKeu50pApjWB57g3aah5fmQEY9Bb45lu07ky4E4IJfFvwBDeMOBy0vhvhTaJi87ZH9M6Mo8ioQsdEv/MFWXlEbyPq1R9N5WXLx+w+r/vY8f0oEHeQ8h4K9HUTe2ruo1meo24TjAoDw9tu37+retHUd/mRClU/wG20JjhjmmXmTscfZgkifoq50KLuLZnYQzU+3azOgb3epf2Gc2vxqId7ug/fiEBfUpR2UxkfQBobzDaVjCK9Xt8NsC3vg8aNIqBjitI2RnvwII8eTSU8qkdqrhQeRR+61vILHehA73Zt1kPE/SiQSA==\",\"VFzQAilWGEryJvvg4qvH/ytw8Ymg4nkh411A8X8YUYr4EVBQT0dqfv+UYbpPBTkfN9RxHWO19FeHXe2pPtYa70a4h+JSHWlfoLEn1a8ddvdAFW3CiOCzyCyYxsRBCZHJSGPMczTRnF8X+RZSHB580cCKw8NWXDMEoqguqJgh5FoteYKJp6Q8qN6FEiH1QkFKihI1szgAlLFQIcPpqd1nN2c/nL48u3h3cXp2cnw+Ovn+/OKHV8cXJ6ffn9+2iOQ9WsKfXr4Ay1IzclJmhbEwV0KoFbFBg20JY6ZxXgix9tRROcYokFB2NJVDOJViXUrsabpGkyvpxrlD/NNXF2evLvYL3mrTEPmpcpET0XxlF6irV1BIgcaQfGtgGiGn4EDNncClcpMyiBjSQFLZcnPcgCxJOK2aidIVMr0GNlOFdaO4mHGtCmqIyciv3S83bO7OuabyYuFy1hq4gbjQGqUVa9IPtSczHMNNaY3OjM+CVE6h7QEb0YHfNfrV3LJxmWC8j9XIm0bX2yo1eY+ul7tT5hpZokgvc359plWWWwrGSeFkbLQvTMLRCek91SzLSHpmDDeWSQurhXLZfgl4naO2pKM5v6ZGqLXSxqmZy3obaVSzUIVIgF5cgbGYD2frIf1L9poLFuLHOb8udTjDOYVEQbOVPjltvSpsXtjNwVGaQvt4qciTejcyZuMFOrMDXqd13GlZLbhFl8sv7dB1CftOBmG6YFCgTxBUx0ljppah8VyrbGdz4HNvixrBicYtqY5sWiKSfe7hSiHNQeYSpWiHXAoucdh4HMiTYDItWIpmRL+3UPDrr5p3EY+/bILgXZR817UJfTovC2F5LpyynozBP4TPgZe3KJufW0BhWn7+3nOdPn16nwmmnfaLy8Drbvul9UcRXJw+PR3DU7QYW7i8nU4liTWdyptLyBkhpXQ5IyesueI5CJXy2Pd3xLDrLn08hMTkh/LuAJhZy/iO7F6Znv+xoF0aw3G1cRVFM2/ewgTevN3sxC1mBibAVoxbSNGeuL2vRzAn0qC2F3hte+3V5z4c3dZVgmT4l7uVSEvvcWmBwwQOvgEevAI8fvwN8M8/7+/bQD6HHoffwCFMJnDQv7vhnjHo8/O//ON2g8vB9rM3u8epT8Ydq6wm+ue/HoeA4LXm1t1h9O40MKiT8Ls+zmJKFTz5SBVsi7V95PaehnsI+0mFc2c0SPTxhO3x75qJaEffNi9Of1mHyZLk0zhM5q7sfVbUObv1HUzhoQ7041xnPcTDfGauMcakytm3vSeZhJvvJJVKexqXa1xyVZg2kbWKkChjts1SA+qWmcgRnFRulMUx5i5ZQJ1L1lndMZRp6XKkQclAvSNOuMbYOm8uHF0I3DkIvnMfdkcMbtmWwgTa6RlRg8ZAcaGN0veJGs5+eHb87OnJ99/uZ96bzXbFC/7ygtisk03BAkXu6EhtLU2a1OhKmtWYI0U91QilLr0BlYqUGKMxTK8foqAZhkjm4Qp6fvrixenr9ypos9nfgoL+h/Nijw8fN4neF0/at3ieWZS37zRwt7oAvfHPfe7voRmAew9cfj7lBAnOWSH82+YkD51jY7idabudqdGfti9Fdvm93HkN2tAsJ6jZfwvypJWpCJywBqN3eeWDnjeTAroQhJULJJg2K3RXsdkaHAMNYac7o40EQMD/GaNTpzxue+F94c61BfJ8zXDcFGmKxl3jkTdK/bFe+XE0MnctWA8SgsAjITajZHeUZgjzQgggeu1wvIrI/dGuhPcH+WZRZEyeyLyw5V3eRgt3neV1Rl4GpX23YEIUMZfMu5lJqPrpHDktuTVXg7jllg==\",\"gduVDDjl9QlKu0vNjF0hMFihEEMuyWVhAmmBxgw8H7QoBGQ+EZEo2bV+JG5HFK1s1G74sU1dCWJRZ+Srx9D9XllMRnASbr+9FA5lJG1NKXVz/7ipBiihyCGwT8VU+RG/P6OyzKSKWbcm1TgnHakG0rn+roOHatIQJtwq164pZSlgNY/PpLx3ClqPryMs42eh1JXjVbY9x4YiKJLZjOLDDW0QODgE5wyaUr3gxo5rBrxXRMGNy1tRP1PH/3WCKFALpdfUrKJVblkbKmrJX0mUs/iKpfgHs2NHyrIEdxMPgs8005xINYWVdI6ACaKsazBoi7x1Oe8Vqza2x2tiu6wowFZtmg0UGu+ApJ2DeFiqhmgdxvEdZ3TnQAk3uWDr50HJjoOXhP25s6vL/QWcjQrUqCr12Jk0aaLx4W+baMwzJ9EjYIY4PvF5t/9d/6PrkuKNNn7+0Mb/aLa5ATa3qE9qyS7Q2EGg8FuPU7QXmkkTa57bAawYt6+k5QJuwwyjiFgMkargAS9On54GGuOrbsn+nJE4VKAIxHBXtkuOijqZglvsdctKme6gdof1TQQdg5EX8hmLF72d8vYbbd0yXdNdC65yNT6j0iw5usBr+8yBy2tuF+clTvX6Y6BYjJvAAZeKJztvlU5zlFAVNtev/IaN1FXPb8uoKuutvz1XIkFt+psZmoxx+Qe2ZK80h0nY49ErzUc50wZ7l5/dvHfMNwdvR4XmI6t84XKvf1uXX19uzWgrNVSJoXIKLhO1GpmFWpGungam2GvIWKk3qMRr0YNjh9pNO5ChXaikblZPOKoTmhNnMGHiei++HMDBAH47qHIft43cm8YUrx3mRP9/4crVKsCsguTPotatYfn4B9d18p6OdZZuZK543us+u84F4xKO6bDtz9JVKbY7zaxz+3bQIWXsr6hfMXFlF1oV6cJEzTK1UZbsqQ1vXWD/+tdOZDhqdK+ZEM9SMDqeTDtVUY9VmqU4SpVKBbKcG1fb06j1GZKRWxPNhEqjpRmSqEMlXXUVl+mwIfUwwXh4eHD4ZOjKl5pLGFpzPUr5vC5Gn8r3lupVZXruNopLhF7wzRvVev2qWg++4xYsmzkX6SJ7z0c94eShWurRo5//+p909oeuXGpeVWO5uZtyP3pU6m6mveQ///2/t7RLvtSESbRWhUxaqykpsFXged6GPGYARpVkUaLPIKQFT1yqfx1q4FiSACuvqxrZAaeUtSq62tMnLtPRLoHLWrqFWhIHXQbKmmpcN2ShqQ0SL7VKiRnTxDyYsKjJpy43xGbG0Vf61xNDlXv6a4p44Xyb079jXKHUm7xG4ur3XPXeXlFLijLtXGiepqjbWmcWjl3I7/4+wPkZx61CW+Z3oLG2RtXgoHG7VsZr2wWaag6Xp25Jl8QSLokbZyw+PXf7enkkbP38tQNQ43ji4VfwgsvienQnk2gddPRIs/+M/27jjDfhqT7eS56gcuZ7JtgasoLItVAqByI9xl8BbP/Vgj/sDdhe5/4PMBJUUZZ/0bwe+VD0WOHMcIvRmVZJEdvfHB64um1/N+XQIujB4wsrUsKRUWP2aOPvKpx4NZi8MuhPr7tkp70GLocJ5nYBbmhPC51FyzXkHH3usWT5PqVYJ1/LK7Gy/pfGNL5ychwil3bOxkcvg0CpXXHrwCPAQilDduzE+/kf/tLevU6r2JUJ42uNQxzjDbtyWq4CeVyVIMNLlMV96pAHsFrweAELZh5i9ce7jf54n83vRldJfMWyBjg67kjL2Q2xTlmVRoJxlNfDVqlBfRU/7RyZq2rzg3KnnYBHZQj3X//6l38DUoZxNcizdXOnSA==\",\"KuWNwN+clXFf50yrmcDMTDvOrag5/PHcbdxe8EpwHpBZg1pJiAtjVeYXXq6l3CGHugW3gwo4Q3LGJUXK27+Q/K/seK7iIgTsuSJg4EyAwbjQ3K6BG1OgKXHuzbGfvjKb3u/Rsv49SnsjL/iwlLV/T1CrrW8fqj3ZZi51ef0vwFpKKN7gKU4sOjkMNJNpgI2gSnfl6/uVpj1oXpsUkggJ7eCgvLKpErG0kR4jMqU/HdKwbdzw4OMouiy2Aaf0tR8KL780utTcrZRrN6iUi54VXCT16fyE5yNcVfjxQu5jUCbRuLTK/wmD0pCjdnTQY0LCnYHUptC5fXt7e/vfAQAA//+7npP6pTsAAA==\"]"
+            "size": 5330,
+            "text": "[\"H4sIAAAAAAAA/+xbW28cOXb+K2drs1DL0xdJnpmdbaMfvJKc6YVtCVZ7vAOXYbGrTlcxYpE1JKtbDY2APAV5XgR5WiBInvK75hfkJwSHrFtf1JZsbSYPWw+WVEUeHp7Ldy6kb4KYWRYMbwLMphjHXCbmApmOUnoXqRjfoCmENcHw/U0w4wJfswyDYTA39HFg0djBjF/bQqMZLJS+MjmLcPCKcdn/JzZnQTcwlmn7kksMhgfdAGXsfz886AaRkhalDYbBYACTlBvgBhgYluUCgZaDwmAMXAJeW5SGKwlcWkw0s/Q7rW/6oQxlXkwFjyASzBig5eEmlAAAueZzZtG96+zDzS2Ndh/8DGOZ5RHMFY8hozEXVnOZvP8ATCdmn8iE9mJpLGZ9Vdh+rrm0QnbC4HsUQnVhobSIw2D/mSd7G8rbUAa33YfIi8sYr/upzcQOgR21BRYWBwdPo9+cnB1Pfjw/BZrqXmEo/Sd6A4LJZBQGKMOg+ko8liOQxe23zZcMLYMoZdqgHYXB28mL3ndhAIMdo1Nr8x7+VPD5KAz+3Hv7vHesspxZPhUYBlAyPgqD8ekI4wQ/QU6yDEdhMOe4yJW2KxQWPLbpKMY5j7Dn/ugCl9xyJnomYgJHh/2Du+lbbgX6T06DcKzipf80aH1rS2qwLir/elpNXB3cfl3Nb6lnl2m0bHuQoshRm741qzbxXdsovvu2bRTERKSksWDx2p7G3CoNI2ALxi34dfoLLmO16JtULSZ4bU9UVGQobYds/09szt5qvl+5yGAAFygwsmBThDCgMWEAGdpUxX5Is1DfuKHkliOQuKgWvKhed77pwkEXft+Fg/1dTmJ0NLAasWe4tagHPxWolz3n6k5KPcKsQc40SrspnrZ0vlmRDl6TKcGskJ7LRcqseZt39iuo8KLTDvFgVL0dDOjfnxszmjNR4BBgz/2y13b7UA4G0LvHQ0PX+TFcJgKJ8x+Y5mwqcJ019nGOevlRKJl8nJdjPpKrwGiVG8/zXc/PD+eVDFPPWIRwhVerkmlJp5SMcQj65QLJ8aqRwOaWfm6Lhmxi6JirFdfiaG+hFnvdWlP0Q6MttHTzSk7L5T29NMsyGMHhA7fg489zyTMmNjhvM6yLyCpdBqTPFJRf7EQlifLxMV5fuoxxU6ZbktyqupZIbm4fzaS5pM1yQx44ljFK67Ct4YXPoOM2sMKdV4HTHWFJIcSzygO0VgsYQWcfRh5Qt+9q99Pac7WcEtgXKuns+ZjwjoL6b/b2n30RRnEHPZ/AqO/aGNWAk2Z5jnoVAWomy697+/5bPYuWvkvR9bY/Q68rC5wzzTJzp2eWq5QsPsZaaFF35kzswILHW9VZ2Ltt0m9Z3wrQPdwUP18RJb4kKO26MD4D1VuhJ5GMktLOviOwye+D6A4GEKmM0ooWtQcTefIklPCkodTeKTwZfO5eq1/IoUv83aash7D7RSARlxkYBfOepIxpF1x8e/h/AhePBBUvChltA4q/Y0TF4hdAQbMcifnTS5bLPRbkfBmp4yYJWpFfkxetLvWl1ng3wj0Ul5pUeILGjuu/ttjdA0W0DiOCTwcmZRpjByVRyuxAY8RzNIMZvy7yDaQ4Ovi6hRVHRys9lh78qApYcCFgipBrNecxxrDgNgVeip4raaCsjcAqSFCiZha7gDISqmzG+Kr2H27O35y9Op98nJydj48v+uPXF5M3b48n47PXF7dltQ==\",\"68vfe4yEP796CZYlpu+4zApjYaaEUAuqPQ2uchgxjbNCiCUwGROfVJ8KJJTth7IHZ1IsK45hqQpNVV2upKNzB/tnbyfnbye7GV8Z02L5REFhEJhcgrIp6voTFFKgMcTfEphGyJm2oGaO4Uq4MbhCmRg/USCVrZTjCLI45rRrJqpQyPQS2FQVviynubRHGohx3+/db7dU7ta1QjlJXXtNAzcQFZrKabEk+dB4MsMh3FTW6Mz4vOTKCXSVIBRUvfqZTmv0V1tlw6oXch+rkTetqbd1F+UeUy+3d/c0sliRXGb8+lyrLKf6/pIETsZGemESno9J7olmWUbcM0OFC5MWFqlyjUkJeJ2jtiSjGb+mQai10saJmctGjUTVpKoQMdCHKzAW89502aOfZK+5YNLLccavKxlOcaZ0rapanpxUrwqbF3adOEpTaHTDijxutJExG6XozA54U3c5b1mk3KJrO1Z26KaUeieDMHtQ93Iad9KYqXk5eKZVtnU4FXTLUqSONW5JdGTTEpHsc0euFKksF+jMZZCg7XEpuMRe63WZPAkmk4IlaPr092aH7Nt22/Twm/UW2bZnW4eXnuBVISzPhRPW0yH4l/AV8Krhu/7cAgqzEufvvdbZycl9FgiD1Q+XZV53227cTc5OzoZwghYjC5e3YSiJrTCUN5eQM0JKCTOlPbPmiucgVMKjqqtnbGfP9ac9hEQUh/K9LjCzlNEd5XfVP/upIC0N4bhWXJ2imfcfYATvP6xP4hYzU7cqE7Rjp/uGghlLg9pO8Np2Vnef+3J0U1YxkuFfbhcibb3DpQUOIzh4BryMCnB4+Az4V1/t71Ign0GHw+/gCEYj18y8a+AOGvT88u//ujngsrv57v12Oo1n3LHLeqF/++txWRC809y6JmPnTgODpku27XEWU4ng6ReKYJOtTZfb6Q33YPZRmXM+WnL05Qnb4R+ethM2St/Wz3h+3YDJ4vhxAiZzp4vuYMAHu+UdmcJDA+iXhc6GxMNiZq4xQrejLdGTTMKtN06k0j6NyzXOuSrMaiJrFSFRxuxqllqi7iumr2K1kH0Y12GURRHmrllAk6ussxpJjKxQ6lYZqA/EMdcYWRfNhUsXyty5ZHyrHrZXDG7blsoE0vSUUoMWoajQRun7VA3nb06PT0/Gr/9xd+a9PmxbvUDCsClls443BSmK3KUjjbW006TWVJKsxhyp6qkpVLL0BlQJUmKExjC9fIiAplhWMg8X0Iuzly/P3n1SQOvD/j8I6G/cFzs8Omwnel8/XQHPskFSHY8R4b36hOLGv/e9v4d2AO5NuHoec4EYZ6wQ/mt7kYeusUZua9tua2v0582D221xL3dRgxSa5QQ1u09Bnq50KsqcsAGjj3kdg160mwK6EISVKRJMmwVqAuRsCS4DLctO56OtBkCJ/1NGXqc8bnvm/R2DawsU+drluCmSBI0lpKVolHi3Xng6GtmVw+CaSFkEPhdivUp2rjRFmBVCAKXXDsfrity7ds28d+SbtMiYHMu8sLel76+NCCn98zKjKIPSfkyZEEXEJfNhZlReUAieOym5PddE3Harwu1Kljjl5QlKQ8QkZOwKgcEChehxSSELY0gKNKbr80GLQkDmGxGxknvWU+K2T9XK2uGqp22ao1qLOqNYPYS918pi3IexR9WSC4cyklRTcd3WHzc1gQqKHAL7VkzdH/H66VfnwHXNurGoxhnJSLWQzs13EzxUk4TQ36+waoXLisF6Hd9J+eQStB9/5amqn4VSVy6vsqtrrAmCKpn1Kt7bScVwGRBcMGhz9ZIbO2wy4J0sCm5c34rmmab+bxpEZQ==\",\"aqH0kobVaZXb1pqIVvivOcpZdMUS/JPZohEfuBA0T1ILgk8105ySaioryY+ACUpZl2DQFnkdmBrBqjX1eElsnvuXsNWYZguFhlsgaSsRD0s1iRVnHN7ho1sJxdzkgi1flEJ2OXiVsL9wdnW5icZ4hD0uTe60cb+rZb9/lKtl9fett6Xuc6nsb3kDrNxWrwcnZ/D6bAJvTl+d/XAKk+/HF/Bi/PIUer3t492I8QVMvj+F09eTNz/64S/O3rhX707/+MP49N3W6a0LZWOvEnfdDFDGPat6KGP4qWCC2yXgnInClxz+CpLZdilty4W06uWUCLsjllEY2BQz7MVMX227+hfzOfB4FAZaKVsP8KRjPt+cYCLNcwt2mZNSMhUX7lqf0dEoDCjmezOz5nqNmp+4xv3KDbnNO3LB7YduQIF49+XTBRNXNtWqSFIzYIVVZTsE+1m8w9ZXDlB/+1vSB8Lz1vSGJ54l5RZTa3MzHAyMVZol2E+USgSynJt+pLKBUYWOMNEsT3vMGLRmMBUqGcxNj1jtKTlVTFO52Gtx3Ysx6h0dHD2lQcteews9a677CZ+1neuCNgQLzW1ddlJt6uzJoWQ12Z+GcInQKWMDSss11knefoWHffieW7Bs6iDaVZY+H/IJj+//hvLJk1/++t9wrlXP8ty4yb7f79Zu8/3kSW2N2nP+yz//14p0CctNuYjWqpDxym6qFMwq8HnGGj+mC0ZVyYpEX8EmBY9dq5leUrrC4hhYdVzSqk6dUJaq2NM+fHOZ9Lcx/GNJJ1VzyoHmZcqUaFy2eKGlDVJeZJUSU6Yp8jFhUROmz9fYZsalT/TTJyYq9+mXKaKU3nr5u4hf3gWkFDGm+M/A8gx3slqFyDCYaJ4kqFelziwcu5LTAWmWVedm5VjmNdDaG3Pprlu32zrdqeqFK1w6k6Z0WtuocMnB5Znb0iVFqUvKzTIWnV04vV4+F7Z5/85dQjUOXI6+hZdcFtf9Oy+Erjg6XueCcbnbx/+w5uOnfpLz9ca9qVhXznzPBVtCVlByJ5TKqRxeGt+C3oKFztmbvKkERUdtkOVft9vzn4seC5wabnFwrlVcRPZ3RwfuYp8/G3FoUcrB4wsrEsKRfmv1wRrmOvYaMHlr0HuvO+QlXQOXvRhzm4Ij7dMSZ9FyCTlH3/uqskzf0mqaf9WRjD9Z9DSddjAelpnzas/AZ8/dMqWLBI+uuh4BUqUM2bFj75d/+cuq9gK3QmX1TBgFupBVHu0Nu05P3xMNdxBB7w28Qll86JTDhiTHPvPHXOU7089QFvtdWKQ8SiFl5iFWf7zd6I932fx2dJUxamNZCxxdRUPb2Q6xTli1RErjqI4nrVLd5ig4DJ6bq1r5pXDDoMSjqoT4n//4y38CCcN0qQicLtuaIq6UNwJ/clPVHcG5VlOBmQkDF1bUDH64cIrbCV4xzkpk1qAWEqLCWJX5jVd7qTTkULfgtlsDZ9kccEV5dfpUNp9rO56pqCgLxlwRMHAmwGBUaMq9uDEFmgrn3h/75Wuz6fwRLdv/0Kn9uHFY58CxirxXDjzjvYrX/XuCWmN9u1Dt6WbmsqyZ/BWylgqK1/IUxxZ5DgPNZFLCRilKd+To51Wm3W237QtJCQlpsFsdGdSNQFKkx4hM6cdDGraJGx583H91kMUm4FSx9nPh5ddGlyZ3q/jaDirVpqcFF3HjnY/oH2Wr3NMra+9u1cTh0iqqGC0BUI7apYMeE2LuDKQxheD2w+3t7f8GAAD//2DsbtfQNgAA\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:39.000Z",
+              "expires": "2025-01-05T08:20:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "41db6941-01e5-46c8-9ece-eb0febc9c5d1"
+              "value": "5d24c5d8-edae-43f8-934b-2a01c3f13552"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:39.000Z",
+              "expires": "2024-01-05T08:50:26.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "UpyIi4uM3DoIggHVYSWhFEKYgdpOXgI6xoKMd_D64E4-1704298899-1-AVhoIZ/1TOF9ifq3ufaKkNdFnoJR3vqOIuTN6co2qv1debdNyTsQAfTEMOTi2CGrAsdsRzRDopqKJZ1CzIULWn8="
+              "value": "fz1A5KfI7TpTWHBmOJCPpbd4lLAPPyZRItGm5PktFvI-1704442826-1-AYOZyfqVCRKMgnANgiXQJKr5hrt+xeefLq8QsZbqIXtIaY/KFLdtcWCEaKTbAFO+GEbyj6ePYAQvp/DpUx/EADs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6842,13 +7226,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "olM49GgpcTkooH4uDWQyUpm6rINURmOWzftblTKskfQ-1704298899715-0-604800000"
+              "value": "I5iGyZjrWR2rQrWd.HMqbYVNsZWmifjTou5PldZtBVQ-1704442826788-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:39 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:26 GMT"
             },
             {
               "name": "content-type",
@@ -6861,6 +7245,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "337"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6881,17 +7277,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=41db6941-01e5-46c8-9ece-eb0febc9c5d1; Expires=Fri, 03 Jan 2025 16:21:39 GMT; Secure"
+              "value": "sourcegraphDeviceId=5d24c5d8-edae-43f8-934b-2a01c3f13552; Expires=Sun, 05 Jan 2025 08:20:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=UpyIi4uM3DoIggHVYSWhFEKYgdpOXgI6xoKMd_D64E4-1704298899-1-AVhoIZ/1TOF9ifq3ufaKkNdFnoJR3vqOIuTN6co2qv1debdNyTsQAfTEMOTi2CGrAsdsRzRDopqKJZ1CzIULWn8=; path=/; expires=Wed, 03-Jan-24 16:51:39 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=fz1A5KfI7TpTWHBmOJCPpbd4lLAPPyZRItGm5PktFvI-1704442826-1-AYOZyfqVCRKMgnANgiXQJKr5hrt+xeefLq8QsZbqIXtIaY/KFLdtcWCEaKTbAFO+GEbyj6ePYAQvp/DpUx/EADs=; path=/; expires=Fri, 05-Jan-24 08:50:26 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=olM49GgpcTkooH4uDWQyUpm6rINURmOWzftblTKskfQ-1704298899715-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=I5iGyZjrWR2rQrWd.HMqbYVNsZWmifjTou5PldZtBVQ-1704442826788-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6907,15 +7303,15 @@
             },
             {
               "name": "x-trace",
-              "value": "655ac2babdcd5130ab071a9e35207730"
+              "value": "031edc1260c70ddea1cbb67108910455"
             },
             {
               "name": "x-trace-span",
-              "value": "15858622e5739fed"
+              "value": "0fdad18235466562"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/655ac2babdcd5130ab071a9e35207730"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/031edc1260c70ddea1cbb67108910455"
             },
             {
               "name": "x-xss-protection",
@@ -6939,17 +7335,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc93786cd6772e-WAW"
+              "value": "840a4d50f8ac70bb-WAW"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:39.195Z",
-        "time": 557,
+        "startedDateTime": "2024-01-05T08:20:26.305Z",
+        "time": 500,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6957,15 +7353,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 557
+          "wait": 500
         }
       },
       {
-        "_id": "4c110131880710a943dee57f6d125cd6",
+        "_id": "586804c289309e332b55a961aecc1d96",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 524,
+          "bodySize": 527,
           "cookies": [],
           "headers": [
             {
@@ -6991,7 +7387,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "524"
+              "value": "527"
             },
             {
               "_fromType": "array",
@@ -7014,7 +7410,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:39.755Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"recipe-used\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:26.809Z\"}]}}"
           },
           "queryString": [
             {
@@ -7025,29 +7421,29 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 115,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:39.000Z",
+              "expires": "2025-01-05T08:20:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c617b8f6-b14e-4c2a-b716-de649148419f"
+              "value": "81f6f7ad-7754-42b1-aa6a-3f8aa71212f1"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:40.000Z",
+              "expires": "2024-01-05T08:50:27.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ELbjmS2kRmJOEJAQa05RgsWFhyAdhv2ZtP1geKSbagY-1704298900-1-AT6bDDHKrAbRGG//xW+tvGOqaY6kcQs9zh3sVPk3VIGdjAHuWu290sRKqb98vGva2EvH814bvynfkvu7l6xmkZY="
+              "value": "f1uOzTugSYdP_dLlr65Jz6IjBw5pA7addQFDyDxBl5Y-1704442827-1-AYAPruekP//OFv4Mcl5fLYyPLFCtJ/EKcWcq6pTy9NCxpBC1q0w49svvIO1Wjyiet/KZLP3P5Pe4UY+8WmQqHSk="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7056,13 +7452,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "CACQsgflfGbhQ8_ue6ftY06wgq2p7vCgnnc2Av3Dn.w-1704298900012-0-604800000"
+              "value": "tvhXaPNR_8OnGGFNQi3kaIbNGhaVWG_4NQgpiJ.f1k4-1704442827074-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:40 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:27 GMT"
             },
             {
               "name": "content-type",
@@ -7075,6 +7471,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "336"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7091,17 +7499,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c617b8f6-b14e-4c2a-b716-de649148419f; Expires=Fri, 03 Jan 2025 16:21:39 GMT; Secure"
+              "value": "sourcegraphDeviceId=81f6f7ad-7754-42b1-aa6a-3f8aa71212f1; Expires=Sun, 05 Jan 2025 08:20:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=ELbjmS2kRmJOEJAQa05RgsWFhyAdhv2ZtP1geKSbagY-1704298900-1-AT6bDDHKrAbRGG//xW+tvGOqaY6kcQs9zh3sVPk3VIGdjAHuWu290sRKqb98vGva2EvH814bvynfkvu7l6xmkZY=; path=/; expires=Wed, 03-Jan-24 16:51:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=f1uOzTugSYdP_dLlr65Jz6IjBw5pA7addQFDyDxBl5Y-1704442827-1-AYAPruekP//OFv4Mcl5fLYyPLFCtJ/EKcWcq6pTy9NCxpBC1q0w49svvIO1Wjyiet/KZLP3P5Pe4UY+8WmQqHSk=; path=/; expires=Fri, 05-Jan-24 08:50:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=CACQsgflfGbhQ8_ue6ftY06wgq2p7vCgnnc2Av3Dn.w-1704298900012-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=tvhXaPNR_8OnGGFNQi3kaIbNGhaVWG_4NQgpiJ.f1k4-1704442827074-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7117,15 +7525,15 @@
             },
             {
               "name": "x-trace",
-              "value": "43ecc8e2575265be12aea57e5b5dda6f"
+              "value": "f3776090eef3f7d761f54bd22e4c0d28"
             },
             {
               "name": "x-trace-span",
-              "value": "193f5b008b608267"
+              "value": "88eaa97706d1766c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/43ecc8e2575265be12aea57e5b5dda6f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f3776090eef3f7d761f54bd22e4c0d28"
             },
             {
               "name": "x-xss-protection",
@@ -7149,21 +7557,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc937bffddfbd2-WAW"
+              "value": "840a4d542ccd70bb-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:39.761Z",
-        "time": 232,
+        "startedDateTime": "2024-01-05T08:20:26.815Z",
+        "time": 220,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7171,15 +7579,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
+          "wait": 220
         }
       },
       {
-        "_id": "040e40f17249803ef11aca01e7a7a32c",
+        "_id": "92ea164d64d62063a6d19e766379f33c",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 16068,
+          "bodySize": 14839,
           "cookies": [],
           "headers": [
             {
@@ -7209,34 +7617,34 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/commands.md`:\\n## Cody Commands\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-explain.gif\\\">\\n\\nCody has a range of commands for explaining code, generating unit tests, adding documentation, and more.\\n\\nTo get started: select code in your editor, right click, and choose a command from the \\\"Cody\\\" menu.\\n\\nYou can also use the [Cody: Commands Menu](command:cody.action.commands.menu) which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.\\n\\n**✨ Pro-tips for using Cody commands**\\n<br>• You can build your own [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands) with custom prompts, output into chat or perform code edits, and more.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/explain.md`:\\n## Explain Code\\n\\n<video autoPlay muted loop playsInline>\\n    <source\\n        type=\\\"video/mp4\\\"\\n        src=\\\"https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/cody-explain-code-aug2023.mp4\\\"\\n    />\\n</video>\\n\\nUse Cody to get an in-depth explanation of any piece of code in any programming language.\\n\\nTo get started: select code in your editor, right click, and choose \\\"Cody → Explain Code\\\".\\n\\nYou can also run this command from the [Cody: Commands Menu](command:cody.action.commands.menu), which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.\\n\\n**✨ Pro-tips for understanding code with Cody**\\n<br>• Cody can also explain errors too, with the \\\"Ask Cody to Explain\\\" option in the 💡 menus, or by right clicking on any items in the \\\"Problems\\\" tab of VS Code.\\n<br>• You can define your own custom code explain commands to suit, such as prompt that requests an explanation focused on potential security issues, using [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands).\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/integration/commands.test.ts`:\\n```ts\\nimport * as assert from 'assert'\\n\\nimport * as vscode from 'vscode'\\n\\nimport { afterIntegrationTest, beforeIntegrationTest, getTranscript, waitUntil } from './helpers'\\n\\n// TODO update tests to work with new simple chat\\n\\nsuite('Commands', function () {\\n    this.beforeEach(beforeIntegrationTest)\\n    this.afterEach(afterIntegrationTest)\\n\\n    async function getTextEditorWithSelection(): Promise<void> {\\n        // Open Main.java\\n        assert.ok(vscode.workspace.workspaceFolders)\\n        const mainJavaUri = vscode.Uri.parse(`${vscode.workspace.workspaceFolders[0].uri.toString()}/Main.java`)\\n        const textEditor = await vscode.window.showTextDocument(mainJavaUri)\\n\\n        // Select the \\\"main\\\" method\\n        textEditor.selection = new vscode.Selection(5, 0, 7, 0)\\n    }\\n\\n    // regex for /^hello from the assistant$/\\n    const assistantRegex = /^hello from the assistant$/\\n\\n    test.skip('Explain Code', async () => {\\n        await getTextEditorWithSelection()\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/templates.ts`:\\n```ts\\nconst instruction_prompt = `Follow these rules when answering my questions:\\n- Your response should based on the shared context only.\\n- Do not suggest anything that would break any shared code.\\n- All generated code must be full workable code.\\n\\n<questions>{humanInput}</questions>\\n`\\nconst prevent_hallucinations =\\n    \\\"Answer the questions only if you know the answer or can make a well-informed guess, else tell me you don't know it.\\\"\\n\\nexport const answers = {\\n    terminal: 'Noted. I will answer your next question based on this terminal output with other code you shared.',\\n    selection: 'Noted. I will refer to this code you selected in the editor to answer your question.',\\n    file: 'Noted. I will refer to this codebase file you are looking at to answer you next question for the code in the <selected> tags.',\\n    fileList:\\n        'Noted. I will refer to this list of files from the {fileName} directory of your codebase to answer your next question.',\\n    packageJson: 'Noted. I will use the right libraries/framework already setup in your codebase for your questions.',\\n}\\n\\nexport const prompts = {\\n    instruction: instruction_prompt,\\n}\\n\\nexport const rules = {\\n    hallucination: prevent_hallucinations,\\n}\\n\\nexport const displayFileName = `/n\\n    File: `\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/documentable-node.ts`:\\n```ts\\n\\nconst name = 'test'\\nexport { name }\\n// |\\n\\n// ------------------------------------\\n\\nconst name = 'test'\\nexport { name }\\n//         |\\n\\n// ------------------------------------\\n\\nconst name = 'test'\\nexport default name\\n//        |\\n\\n// ------------------------------------\\n\\nexport default function testFunc() {}\\n//                |\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/fixup.ts`:\\n```ts\\n<${PROMPT_TOPICS.INSTRUCTIONS}>\\n{instruction}\\n</${PROMPT_TOPICS.INSTRUCTIONS}>`\\n\\n    public static readonly addPrompt = `\\n- You are an AI programming assistant who is an expert in adding new code by following instructions.\\n- You should think step-by-step to plan your code before generating the final output.\\n- You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.\\n- Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.\\n- You will be provided with code that is above the users' cursor, enclosed in <${PROMPT_TOPICS.PRECEDING}></${PROMPT_TOPICS.PRECEDING}> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.\\n- You will be provided with code that is below the users' cursor, enclosed in <${PROMPT_TOPICS.FOLLOWING}></${PROMPT_TOPICS.FOLLOWING}> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/get-inline-completions-tests/languages.test.ts`:\\n```ts\\n                        System.out.println(\\\\\\\\\\\"Multiple of 3: \\\\\\\\\\\" + i);\\n                    } else {\\n                        System.out.println(\\\\\\\\\\\"ODD \\\\\\\\\\\" + i);\\n                    }\\\"\\n            `)\\n    })\\n\\n    // TODO: Detect `}/nelse/n{` pattern for else skip logic\\n    test('works with csharp', async () => {\\n        const requests: CompletionParameters[] = []\\n        const items = await getInlineCompletionsInsertText(\\n            params(\\n                dedent`\\n                    for (int i = 0; i < 11; i++) {\\n                        if (i % 2 == 0)\\n                        {\\n                            █\\n                `,\\n                [\\n                    completion`\\n                            ├Console.WriteLine(i);\\n                        }\\n                        else if (i % 3 == 0)\\n                        {\\n                            Console.WriteLine(\\\"Multiple of 3: \\\" + i);\\n                        }\\n                        else\\n                        {\\n                            Console.WriteLine(\\\"ODD \\\" + i);\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/fixup.ts`:\\n```ts\\n- You will be provided with instructions on what to generate, enclosed in <${PROMPT_TOPICS.INSTRUCTIONS}></${PROMPT_TOPICS.INSTRUCTIONS}> XML tags. You must follow these instructions carefully and to the letter.\\n- Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.\\n- Do not provide any additional commentary about the code you added. Only respond with the generated code.\\n\\nThe user is currently in the file: {fileName}\\n\\nProvide your generated code using the following instructions:\\n<${PROMPT_TOPICS.INSTRUCTIONS}>\\n{instruction}\\n</${PROMPT_TOPICS.INSTRUCTIONS}>`\\n\\n    public static readonly fixPrompt = `\\n- You are an AI programming assistant who is an expert in fixing errors within code.\\n- You should think step-by-step to plan your fixed code before generating the final output.\\n- You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.\\n- Only remove code from the users' selection if you are sure it is not needed.\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/documentable-node.ts`:\\n```ts\\nfunction wrapper() {\\n    console.log('wrapper')\\n    function test() {\\n        //      |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction testFunc() {\\n    //        |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction testParameter(val) {\\n    //                 |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction arrowWrapper() {\\n    const arrow = (value: string) => {\\n        //  |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nconst arrowFunc = (value: string) => {\\n    //  |\\n}\\n\\n// ------------------------------------\\n\\nclass Agent {\\n    //   |\\n}\\n\\n// ------------------------------------\\n\\nclass AgentConstructor {\\n    constructor() {\\n    //   |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction signature()\\n//           |\\n\\n// ------------------------------------\\n\\ninterface TestInterface {\\n    //          |\\n}\\n\\n// ------------------------------------\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/intents.ts`:\\n```ts\\nfunction wrapper() {\\n    console.log('wrapper')\\n    function test() {\\n        //          |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction testParams() {\\n    //             |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction testParameter(val) {\\n    //                 |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction arrowWrapper() {\\n    const arrow = (value: string) => {\\n        //                           |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nclass Agent {\\n    //      |\\n}\\n\\n// ------------------------------------\\n\\nfunction signature()\\n//                |\\n\\n// ------------------------------------\\n\\n// comment\\n//       |\\n\\n// ------------------------------------\\n\\n/**\\n * comment\\n //      |\\n */\\n\\n// ------------------------------------\\n\\nfunction functionName() {}\\n//                  |\\n\\n// ------------------------------------\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/webviews/App.tsx`:\\n```tsx\\n\\nfunction getWelcomeMessageByOS(os: string): string {\\n    const welcomeMessageMarkdown = `Welcome to Cody! Start writing code and Cody will autocomplete lines and entire functions for you.\\n\\nTo run [Cody Commands](command:cody.action.commands.menu) use the keyboard shortcut <span class=\\\"keyboard-shortcut\\\"><span>${\\n        os === 'darwin' ? '⌥' : 'Alt'\\n    }</span><span>C</span></span>, the <span class=\\\"cody-icons\\\">A</span> button, or right-click anywhere in your code.\\n\\nYou can start a new chat at any time with <span class=\\\"keyboard-shortcut\\\"><span>${\\n        os === 'darwin' ? '⌥' : 'Alt'\\n    }</span><span>/</span></span> or using the <span class=\\\"cody-icons\\\">H</span> button.\\n\\nFor more tips and tricks, see the [Getting Started Guide](command:cody.welcome) and [docs](https://sourcegraph.com/docs/cody).\\n`\\n    return welcomeMessageMarkdown\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/parents.ts`:\\n```ts\\nexport function whatsUp() {\\n    const result = {\\n    //    |\\n        value:  'value'\\n    }\\n}\\n\\n// ------------------------------------\\n\\nexport function singleLineVariable() {\\n    const a_very_long_variable_name = 'value'\\n    //                            |\\n}\\n\\n// ------------------------------------\\n\\ninterface kek {\\n    //        |\\n    value: string\\n}\\n\\n// ------------------------------------\\n\\nexport function pek() {\\n    //                |\\n    const data: kek = {\\n        value: 'wow',\\n    }\\n    return data\\n}\\n\\nexport const hmmm = 1\\n\\n// ------------------------------------\\n\\nclass Animal {\\n    //       |\\n    constructor() {}\\n}\\n\\n// ------------------------------------\\n\\nexport class Doggo extends Animal {\\n    public bark() {\\n        //        |\\n        return {}\\n    }\\n}\\n\\n// ------------------------------------\\n\\nexport function inconsistentIndentation() {\\n    if (Doggo) {\\n        const value = null; const arrow = () => {\\n        //                                      |\\n            console.log('Hello World!');\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/Main.java`:\\n```java\\n// This is a sample file used in extension integration tests.\\n\\npublic class Main {\\n    private Main() {}\\n\\n    public static void main(String[] args) {\\n\\tSystem.out.println(\\\"Hello, world\\\");\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Generate simple hello world function in java!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/commands.md`:\\n## Cody Commands\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-explain.gif\\\">\\n\\nCody has a range of commands for explaining code, generating unit tests, adding documentation, and more.\\n\\nTo get started: select code in your editor, right click, and choose a command from the \\\"Cody\\\" menu.\\n\\nYou can also use the [Cody: Commands Menu](command:cody.action.commands.menu) which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.\\n\\n**✨ Pro-tips for using Cody commands**\\n<br>• You can build your own [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands) with custom prompts, output into chat or perform code edits, and more.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/explain.md`:\\n## Explain Code\\n\\n<video autoPlay muted loop playsInline>\\n    <source\\n        type=\\\"video/mp4\\\"\\n        src=\\\"https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/cody-explain-code-aug2023.mp4\\\"\\n    />\\n</video>\\n\\nUse Cody to get an in-depth explanation of any piece of code in any programming language.\\n\\nTo get started: select code in your editor, right click, and choose \\\"Cody → Explain Code\\\".\\n\\nYou can also run this command from the [Cody: Commands Menu](command:cody.action.commands.menu), which has the default keyboard shortcut of `Option` `C` on macOS and `Alt` `C` on Windows & Linux.\\n\\n**✨ Pro-tips for understanding code with Cody**\\n<br>• Cody can also explain errors too, with the \\\"Ask Cody to Explain\\\" option in the 💡 menus, or by right clicking on any items in the \\\"Problems\\\" tab of VS Code.\\n<br>• You can define your own custom code explain commands to suit, such as prompt that requests an explanation focused on potential security issues, using [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands).\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/e2e-inspector/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n\\n<head>\\n    <meta charset=\\\"UTF-8\\\" />\\n    <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n    <!-- DO NOT REMOVE THIS FILE -->\\n    <!-- THIS IS THE ENTRY FILE FOR THE WEBVIEW -->\\n    <title>Inspect Cody end-to-end quality evaluation results</title>\\n</head>\\n\\n<body class=\\\"theme-dark\\\">\\n    <div id=\\\"root\\\"></div>\\n    <script type=\\\"module\\\" src=\\\"src/index.tsx\\\"></script>\\n</body>\\n\\n</html>\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/templates.ts`:\\n```ts\\nconst instruction_prompt = `Follow these rules when answering my questions:\\n- Your response should based on the shared context only.\\n- Do not suggest anything that would break any shared code.\\n- All generated code must be full workable code.\\n\\n<questions>{humanInput}</questions>\\n`\\nconst prevent_hallucinations =\\n    \\\"Answer the questions only if you know the answer or can make a well-informed guess, else tell me you don't know it.\\\"\\n\\nexport const answers = {\\n    terminal: 'Noted. I will answer your next question based on this terminal output with other code you shared.',\\n    selection: 'Noted. I will refer to this code you selected in the editor to answer your question.',\\n    file: 'Noted. I will refer to this codebase file you are looking at to answer you next question for the code in the <selected> tags.',\\n    fileList:\\n        'Noted. I will refer to this list of files from the {fileName} directory of your codebase to answer your next question.',\\n    packageJson: 'Noted. I will use the right libraries/framework already setup in your codebase for your questions.',\\n}\\n\\nexport const prompts = {\\n    instruction: instruction_prompt,\\n}\\n\\nexport const rules = {\\n    hallucination: prevent_hallucinations,\\n}\\n\\nexport const displayFileName = `/n\\n    File: `\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/documentable-node.ts`:\\n```ts\\n\\nconst name = 'test'\\nexport { name }\\n// |\\n\\n// ------------------------------------\\n\\nconst name = 'test'\\nexport { name }\\n//         |\\n\\n// ------------------------------------\\n\\nconst name = 'test'\\nexport default name\\n//        |\\n\\n// ------------------------------------\\n\\nexport default function testFunc() {}\\n//                |\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/fixup.ts`:\\n```ts\\n<${PROMPT_TOPICS.INSTRUCTIONS}>\\n{instruction}\\n</${PROMPT_TOPICS.INSTRUCTIONS}>`\\n\\n    public static readonly addPrompt = `\\n- You are an AI programming assistant who is an expert in adding new code by following instructions.\\n- You should think step-by-step to plan your code before generating the final output.\\n- You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.\\n- Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.\\n- You will be provided with code that is above the users' cursor, enclosed in <${PROMPT_TOPICS.PRECEDING}></${PROMPT_TOPICS.PRECEDING}> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.\\n- You will be provided with code that is below the users' cursor, enclosed in <${PROMPT_TOPICS.FOLLOWING}></${PROMPT_TOPICS.FOLLOWING}> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/get-inline-completions-tests/languages.test.ts`:\\n```ts\\n                        System.out.println(\\\\\\\\\\\"Multiple of 3: \\\\\\\\\\\" + i);\\n                    } else {\\n                        System.out.println(\\\\\\\\\\\"ODD \\\\\\\\\\\" + i);\\n                    }\\\"\\n            `)\\n    })\\n\\n    // TODO: Detect `}/nelse/n{` pattern for else skip logic\\n    test('works with csharp', async () => {\\n        const requests: CompletionParameters[] = []\\n        const items = await getInlineCompletionsInsertText(\\n            params(\\n                dedent`\\n                    for (int i = 0; i < 11; i++) {\\n                        if (i % 2 == 0)\\n                        {\\n                            █\\n                `,\\n                [\\n                    completion`\\n                            ├Console.WriteLine(i);\\n                        }\\n                        else if (i % 3 == 0)\\n                        {\\n                            Console.WriteLine(\\\"Multiple of 3: \\\" + i);\\n                        }\\n                        else\\n                        {\\n                            Console.WriteLine(\\\"ODD \\\" + i);\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/fixup.ts`:\\n```ts\\n- You will be provided with instructions on what to generate, enclosed in <${PROMPT_TOPICS.INSTRUCTIONS}></${PROMPT_TOPICS.INSTRUCTIONS}> XML tags. You must follow these instructions carefully and to the letter.\\n- Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.\\n- Do not provide any additional commentary about the code you added. Only respond with the generated code.\\n\\nThe user is currently in the file: {fileName}\\n\\nProvide your generated code using the following instructions:\\n<${PROMPT_TOPICS.INSTRUCTIONS}>\\n{instruction}\\n</${PROMPT_TOPICS.INSTRUCTIONS}>`\\n\\n    public static readonly fixPrompt = `\\n- You are an AI programming assistant who is an expert in fixing errors within code.\\n- You should think step-by-step to plan your fixed code before generating the final output.\\n- You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.\\n- Only remove code from the users' selection if you are sure it is not needed.\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/documentable-node.ts`:\\n```ts\\nfunction wrapper() {\\n    console.log('wrapper')\\n    function test() {\\n        //      |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction testFunc() {\\n    //        |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction testParameter(val) {\\n    //                 |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction arrowWrapper() {\\n    const arrow = (value: string) => {\\n        //  |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nconst arrowFunc = (value: string) => {\\n    //  |\\n}\\n\\n// ------------------------------------\\n\\nclass Agent {\\n    //   |\\n}\\n\\n// ------------------------------------\\n\\nclass AgentConstructor {\\n    constructor() {\\n    //   |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction signature()\\n//           |\\n\\n// ------------------------------------\\n\\ninterface TestInterface {\\n    //          |\\n}\\n\\n// ------------------------------------\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/intents.ts`:\\n```ts\\nfunction wrapper() {\\n    console.log('wrapper')\\n    function test() {\\n        //          |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nfunction testParams() {\\n    //             |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction testParameter(val) {\\n    //                 |\\n    wrapper\\n}\\n\\n// ------------------------------------\\n\\nfunction arrowWrapper() {\\n    const arrow = (value: string) => {\\n        //                           |\\n    }\\n}\\n\\n// ------------------------------------\\n\\nclass Agent {\\n    //      |\\n}\\n\\n// ------------------------------------\\n\\nfunction signature()\\n//                |\\n\\n// ------------------------------------\\n\\n// comment\\n//       |\\n\\n// ------------------------------------\\n\\n/**\\n * comment\\n //      |\\n */\\n\\n// ------------------------------------\\n\\nfunction functionName() {}\\n//                  |\\n\\n// ------------------------------------\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/tree-sitter/query-tests/test-data/parents.ts`:\\n```ts\\nexport function whatsUp() {\\n    const result = {\\n    //    |\\n        value:  'value'\\n    }\\n}\\n\\n// ------------------------------------\\n\\nexport function singleLineVariable() {\\n    const a_very_long_variable_name = 'value'\\n    //                            |\\n}\\n\\n// ------------------------------------\\n\\ninterface kek {\\n    //        |\\n    value: string\\n}\\n\\n// ------------------------------------\\n\\nexport function pek() {\\n    //                |\\n    const data: kek = {\\n        value: 'wow',\\n    }\\n    return data\\n}\\n\\nexport const hmmm = 1\\n\\n// ------------------------------------\\n\\nclass Animal {\\n    //       |\\n    constructor() {}\\n}\\n\\n// ------------------------------------\\n\\nexport class Doggo extends Animal {\\n    public bark() {\\n        //        |\\n        return {}\\n    }\\n}\\n\\n// ------------------------------------\\n\\nexport function inconsistentIndentation() {\\n    if (Doggo) {\\n        const value = null; const arrow = () => {\\n        //                                      |\\n            console.log('Hello World!');\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/integration/helpers.ts`:\\n```ts\\n    const textEditor = await vscode.window.showTextDocument(mainJavaUri)\\n\\n    // Select the \\\"main\\\" method\\n    textEditor.selection = new vscode.Selection(5, 0, 7, 0)\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/Main.java`:\\n```java\\n// This is a sample file used in extension integration tests.\\n\\npublic class Main {\\n    private Main() {}\\n\\n    public static void main(String[] args) {\\n\\tSystem.out.println(\\\"Hello, world\\\");\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Generate simple hello world function in java!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
           },
           "queryString": [],
           "url": "https://sourcegraph.com/.api/completions/stream"
         },
         "response": {
-          "bodySize": 6971,
+          "bodySize": 16795,
           "content": {
             "mimeType": "text/event-stream",
-            "size": 6971,
-            "text": "event: completion\ndata: {\"completion\":\" Here\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[]\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n   \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\");\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple hello world function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "size": 16795,
+            "text": "event: completion\ndata: {\"completion\":\" Here\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[]\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args)\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n   \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\");\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\"\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point for\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point for a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point for a Java\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point for a Java program\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point for a Java program.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Here is a simple Hello World function in Java:\\n\\n```java\\npublic class Main {\\n\\n  public static void main(String[] args) {\\n    System.out.println(\\\"Hello World!\\\"); \\n  }\\n\\n}\\n```\\n\\nThis defines a Main class with a main method that prints \\\"Hello World!\\\" when executed. The main method is the entry point for a Java program.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:39.000Z",
+              "expires": "2025-01-05T08:20:26.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "89ff63ac-3044-4847-9026-e4bc06f629ae"
+              "value": "e2e7b973-4cec-43f7-b10a-808c15f56428"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:43.000Z",
+              "expires": "2024-01-05T08:50:31.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "2_wE.5_ByTatLsVbSeoZe.wpOsBMXIwQWJL7wXVBEkQ-1704298903-1-AeXFntLzHt+tG6DRTjbHqSDULeSaMpbkmdGv5SGcc2qKeuyagFKoNMWAfHPZyvqg4MAs9eI5Jj7yOVmpthVSxw4="
+              "value": "_vOvOkgv.ujje5tMs9Pp10d19Twkbk2C30pazw1XIHg-1704442831-1-AUOqBwcurSm/Ev8kOR7Aifp71LvYtz5Cb2HBHVQQp5xAhLy7TrmUNuo3EQxgzWoKfYrrVhWnkEPNV0e1wxeYaBs="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7245,13 +7653,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Dr4bhizDbMnCpvCkTo2X1xPLbr5l1Fv9pkW79CsHKT4-1704298903896-0-604800000"
+              "value": "NzIr0WGdp5dVSJ3b1BQiHkxn.SiUFmc.Y3yuJ05bgX8-1704442831321-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:43 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:31 GMT"
             },
             {
               "name": "content-type",
@@ -7264,6 +7672,18 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "336"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7280,17 +7700,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=89ff63ac-3044-4847-9026-e4bc06f629ae; Expires=Fri, 03 Jan 2025 16:21:39 GMT; Secure"
+              "value": "sourcegraphDeviceId=e2e7b973-4cec-43f7-b10a-808c15f56428; Expires=Sun, 05 Jan 2025 08:20:26 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=2_wE.5_ByTatLsVbSeoZe.wpOsBMXIwQWJL7wXVBEkQ-1704298903-1-AeXFntLzHt+tG6DRTjbHqSDULeSaMpbkmdGv5SGcc2qKeuyagFKoNMWAfHPZyvqg4MAs9eI5Jj7yOVmpthVSxw4=; path=/; expires=Wed, 03-Jan-24 16:51:43 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=_vOvOkgv.ujje5tMs9Pp10d19Twkbk2C30pazw1XIHg-1704442831-1-AUOqBwcurSm/Ev8kOR7Aifp71LvYtz5Cb2HBHVQQp5xAhLy7TrmUNuo3EQxgzWoKfYrrVhWnkEPNV0e1wxeYaBs=; path=/; expires=Fri, 05-Jan-24 08:50:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Dr4bhizDbMnCpvCkTo2X1xPLbr5l1Fv9pkW79CsHKT4-1704298903896-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=NzIr0WGdp5dVSJ3b1BQiHkxn.SiUFmc.Y3yuJ05bgX8-1704442831321-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7306,15 +7726,15 @@
             },
             {
               "name": "x-trace",
-              "value": "8782c6b0963ac9adfd23b050dac17256"
+              "value": "5673ec0ae10c6461f9d25da5dc1c48b6"
             },
             {
               "name": "x-trace-span",
-              "value": "e6808b9379ef67f0"
+              "value": "fe7454b3ad4c7974"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8782c6b0963ac9adfd23b050dac17256"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5673ec0ae10c6461f9d25da5dc1c48b6"
             },
             {
               "name": "x-xss-protection",
@@ -7338,17 +7758,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc937bbf383539-WAW"
+              "value": "840a4d53fc1534a9-WAW"
             }
           ],
-          "headersSize": 1289,
+          "headersSize": 1396,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:39.760Z",
-        "time": 4799,
+        "startedDateTime": "2024-01-05T08:20:26.813Z",
+        "time": 5935,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7356,11 +7776,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 4799
+          "wait": 5935
         }
       },
       {
-        "_id": "4513df7f1ecd2925ab87523d3ebb9370",
+        "_id": "b325ebc527f17ce027751d81796a87e7",
         "_order": 0,
         "cache": {},
         "request": {
@@ -7413,7 +7833,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.chatResponse.new\",\"action\":\"hasCode\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"lineCount\",\"value\":7},{\"key\":\"charCount\",\"value\":111},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-03T16:21:44.564Z\"}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.chatResponse.new\",\"action\":\"hasCode\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.1\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"lineCount\",\"value\":7},{\"key\":\"charCount\",\"value\":111},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2024-01-05T08:20:32.753Z\"}]}}"
           },
           "queryString": [
             {
@@ -7433,20 +7853,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-03T16:21:44.000Z",
+              "expires": "2025-01-05T08:20:32.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c01caf81-28b9-4684-96ae-9ad7ffb62ac4"
+              "value": "5d867362-3a49-49f6-8ccc-f90d2175349c"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-03T16:51:44.000Z",
+              "expires": "2024-01-05T08:50:33.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "9z.BlHmmwAmDxAc4yzcKzvto7cqV3kovJFI4neHyTpc-1704298904-1-AT21S+Ko2Lx6Oyf9o44/CsKHFY4QXa4P6j/EHaCVIo7wuVafE3bOggiIGB/xZH9Fs8PI3jxO8bQLhBD27rU5K3I="
+              "value": "3l_DCsC__DSXzP22z3JZ7KMmPiL..Zlx_QnGtJBI1dg-1704442833-1-AQciWiceAuI73AKa9ApaZOJM+AQt6vg5acQuVRHP++DyS1WCuU8Y9KqWdhU4y8UMLSbq+KxGoOu+I56Pyv4ElV4="
             },
             {
               "domain": ".sourcegraph.com",
@@ -7455,13 +7875,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "rHjgq1ZsBoajXjl2l3RpS_EVIOLXqDuJ_N12_.IwoAE-1704298904820-0-604800000"
+              "value": "hYEEdjTFctVff0S3tFdIg00i3DQgE6oE6_5lm0UY3jo-1704442833027-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Wed, 03 Jan 2024 16:21:44 GMT"
+              "value": "Fri, 05 Jan 2024 08:20:33 GMT"
             },
             {
               "name": "content-type",
@@ -7474,6 +7894,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "330"
             },
             {
               "name": "access-control-allow-credentials",
@@ -7490,17 +7922,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c01caf81-28b9-4684-96ae-9ad7ffb62ac4; Expires=Fri, 03 Jan 2025 16:21:44 GMT; Secure"
+              "value": "sourcegraphDeviceId=5d867362-3a49-49f6-8ccc-f90d2175349c; Expires=Sun, 05 Jan 2025 08:20:32 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=9z.BlHmmwAmDxAc4yzcKzvto7cqV3kovJFI4neHyTpc-1704298904-1-AT21S+Ko2Lx6Oyf9o44/CsKHFY4QXa4P6j/EHaCVIo7wuVafE3bOggiIGB/xZH9Fs8PI3jxO8bQLhBD27rU5K3I=; path=/; expires=Wed, 03-Jan-24 16:51:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=3l_DCsC__DSXzP22z3JZ7KMmPiL..Zlx_QnGtJBI1dg-1704442833-1-AQciWiceAuI73AKa9ApaZOJM+AQt6vg5acQuVRHP++DyS1WCuU8Y9KqWdhU4y8UMLSbq+KxGoOu+I56Pyv4ElV4=; path=/; expires=Fri, 05-Jan-24 08:50:33 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=rHjgq1ZsBoajXjl2l3RpS_EVIOLXqDuJ_N12_.IwoAE-1704298904820-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=hYEEdjTFctVff0S3tFdIg00i3DQgE6oE6_5lm0UY3jo-1704442833027-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -7516,15 +7948,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3a568c67a8a16f3359d487d4e658e5c3"
+              "value": "d18900baa18755df0df48cff3fb62070"
             },
             {
               "name": "x-trace-span",
-              "value": "7129c0371dce1964"
+              "value": "b76427fb872fbdab"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3a568c67a8a16f3359d487d4e658e5c3"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d18900baa18755df0df48cff3fb62070"
             },
             {
               "name": "x-xss-protection",
@@ -7548,21 +7980,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "83fc9399f93bfbe2-WAW"
+              "value": "840a4d794f8b5043-WAW"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-03T16:21:44.565Z",
-        "time": 235,
+        "startedDateTime": "2024-01-05T08:20:32.755Z",
+        "time": 229,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -7570,2526 +8002,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 235
-        }
-      },
-      {
-        "_id": "f4524d7d83fe3954399f5325e8ff7374",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1184,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1184"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:failed\",\"userCookieID\":\"119dabec-98b8-420c-b020-3db9ed373cbf\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:24.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1fe7090f-8476-4cd9-a543-ea27c4270269"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:24.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "WnU4qLghsx018cOC4saHGBnYjwWkzqSnGKnQH6uPuLY-1703613804-1-AScHVVwogyWUsY9L9oW8x6oB/5xDNEgffJ+zel+QtNgsWr19eDgxpcmoVfF1N84kJUXciVx4SgWz2fHgS5crPuE="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "oUG3yzJ6isc7RIZib52NXbsxSjEggzRDaQg5N8m6L98-1703613804820-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:24 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1fe7090f-8476-4cd9-a543-ea27c4270269; Expires=Thu, 26 Dec 2024 18:03:24 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=WnU4qLghsx018cOC4saHGBnYjwWkzqSnGKnQH6uPuLY-1703613804-1-AScHVVwogyWUsY9L9oW8x6oB/5xDNEgffJ+zel+QtNgsWr19eDgxpcmoVfF1N84kJUXciVx4SgWz2fHgS5crPuE=; path=/; expires=Tue, 26-Dec-23 18:33:24 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=oUG3yzJ6isc7RIZib52NXbsxSjEggzRDaQg5N8m6L98-1703613804820-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "7607b3c74fdeb67114ea1718cca743a5"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "db78f40ea313c766"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7607b3c74fdeb67114ea1718cca743a5"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d86f8a770b7-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:24.459Z",
-        "time": 272,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 272
-        }
-      },
-      {
-        "_id": "8eeecf493e555338db8c4545d7a69758",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"119dabec-98b8-420c-b020-3db9ed373cbf\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\"}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "3b1489a5-ed33-4912-81d9-3ed44a37faea"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "y_4jbyf8Ryo6w0J6b_cnS94yWVMgHw9DOozR_oeoshY-1703613805-1-AcUZ290XzPRxUK6DWK82oWrywf8aQWuqn/+qnFfFIPIAplXc1FrknjXHdmiDuqDsRihaM89tz9zg0cVICgcUkT4="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gapd3.8OF4KCA17pZS4CCsyWns3d.8WFo3R2oLTKCAc-1703613805150-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3b1489a5-ed33-4912-81d9-3ed44a37faea; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=y_4jbyf8Ryo6w0J6b_cnS94yWVMgHw9DOozR_oeoshY-1703613805-1-AcUZ290XzPRxUK6DWK82oWrywf8aQWuqn/+qnFfFIPIAplXc1FrknjXHdmiDuqDsRihaM89tz9zg0cVICgcUkT4=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=gapd3.8OF4KCA17pZS4CCsyWns3d.8WFo3R2oLTKCAc-1703613805150-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "c08891123dfac821f453848f3120c372"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ce725a9fcb627a56"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c08891123dfac821f453848f3120c372"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d891d4fbf8d-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:24.712Z",
-        "time": 350,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 350
-        }
-      },
-      {
-        "_id": "24073ed025b5ce7646cf44eb7576d0f0",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 474,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "474"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2023-12-26T18:03:24.454Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 115,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "20a6f507-0cc6-454a-81f9-584ffd2bd7b4"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "w0.fPKli_4XQpoJfkpv0b3UCDVV21QS.uVS5kMANfjk-1703613805-1-AdIvYVx0fZfxTAxs6ndFTFfCPuCnNVaqyV+odOvf4uqODZNEG6O0A8s+0jWTpYi/dh059OcqkS4o4dDPJfZgOIU="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "u5tK.Z6_484TjDT4zj7Eq4B77IMExNgZb0iWWPw2PGU-1703613805159-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=20a6f507-0cc6-454a-81f9-584ffd2bd7b4; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=w0.fPKli_4XQpoJfkpv0b3UCDVV21QS.uVS5kMANfjk-1703613805-1-AdIvYVx0fZfxTAxs6ndFTFfCPuCnNVaqyV+odOvf4uqODZNEG6O0A8s+0jWTpYi/dh059OcqkS4o4dDPJfZgOIU=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=u5tK.Z6_484TjDT4zj7Eq4B77IMExNgZb0iWWPw2PGU-1703613805159-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d2c900a8e7538f8d1440c02ab5b878d6"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7bca6cab140fa2e1"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d2c900a8e7538f8d1440c02ab5b878d6"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d893c913566-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:24.729Z",
-        "time": 370,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 370
-        }
-      },
-      {
-        "_id": "bfeef68d0bc0c4f3ea69673b054d3732",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 477,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "477"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2023-12-26T18:03:24.709Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "d80886ac-a0c5-4d95-9067-f90e12f96401"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "YlqLy2CoOx7rWwFwGU8cWe1GjfY0syQ9h3ja5znYaHk-1703613805-1-AaVKjDvjLsaeem7k5yrnlE4WJDOxkIhaHBBc66a1UCYMUMDhdQN0ANEQ9KVrlLX6AL4PeYZTr9LALyDyZXkGyN0="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "YpzQ9knl8Am95LdLBB_HdcmlmtuQVrUnEN43eeaZcbQ-1703613805414-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=d80886ac-a0c5-4d95-9067-f90e12f96401; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=YlqLy2CoOx7rWwFwGU8cWe1GjfY0syQ9h3ja5znYaHk-1703613805-1-AaVKjDvjLsaeem7k5yrnlE4WJDOxkIhaHBBc66a1UCYMUMDhdQN0ANEQ9KVrlLX6AL4PeYZTr9LALyDyZXkGyN0=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=YpzQ9knl8Am95LdLBB_HdcmlmtuQVrUnEN43eeaZcbQ-1703613805414-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b5b4126ed1ab2ed37d2af5bdeecb03cd"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d0ed0a56377901b4"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b5b4126ed1ab2ed37d2af5bdeecb03cd"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8acde235b8-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.045Z",
-        "time": 281,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 281
-        }
-      },
-      {
-        "_id": "ed04f5168e92e14801aa9fdc8100c9c5",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 477,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "477"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2023-12-26T18:03:25.345Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:25.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c80b75ec-4275-4639-859e-627d2e96f840"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:25.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "e1Jw9Nh1uEOmsOoIp9cnpiVCA_4Vc8ql96sWOZxyVDk-1703613805-1-AWY+p/UlI9rHGmzNHot5WaxOs7eO6cmaROQ4Ezve8ueVzbwxHeNthB2M3iDqlt0J5rMPz1QBDSPpbpoE8QZpuR8="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "LsrEZLCXWLYwK75dk82ALA1rzkoe6ZWUU9qAHIVk8Is-1703613805709-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:25 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c80b75ec-4275-4639-859e-627d2e96f840; Expires=Thu, 26 Dec 2024 18:03:25 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=e1Jw9Nh1uEOmsOoIp9cnpiVCA_4Vc8ql96sWOZxyVDk-1703613805-1-AWY+p/UlI9rHGmzNHot5WaxOs7eO6cmaROQ4Ezve8ueVzbwxHeNthB2M3iDqlt0J5rMPz1QBDSPpbpoE8QZpuR8=; path=/; expires=Tue, 26-Dec-23 18:33:25 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=LsrEZLCXWLYwK75dk82ALA1rzkoe6ZWUU9qAHIVk8Is-1703613805709-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "41bafa1c96958076ca307b23476dd4d7"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "da1a04b074714f97"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/41bafa1c96958076ca307b23476dd4d7"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d8c8ddc34f8-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:25.349Z",
-        "time": 272,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 272
-        }
-      },
-      {
-        "_id": "655f4a5576ce322849772678587446b2",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1696,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1696"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 345,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"interactionID\":\"1a973e9a-59a2-4f13-9ab2-cedb14a1e8a1\",\"metadata\":[{\"key\":\"multiline\",\"value\":1},{\"key\":\"artificialDelay\",\"value\":0},{\"key\":\"contextSummary.duration\",\"value\":1.007999986410141},{\"key\":\"contextSummary.totalChars\",\"value\":0},{\"key\":\"items.0.lineCount\",\"value\":1},{\"key\":\"items.0.charCount\",\"value\":13},{\"key\":\"items.0.lineTruncatedCount\",\"value\":0},{\"key\":\"otherCompletionProviderEnabled\",\"value\":0},{\"key\":\"acceptedItem.lineCount\",\"value\":1},{\"key\":\"acceptedItem.charCount\",\"value\":13},{\"key\":\"acceptedItem.lineTruncatedCount\",\"value\":0},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}],\"privateMetadata\":{\"triggerKind\":\"Manual\",\"providerIdentifier\":\"anthropic\",\"providerModel\":\"claude-instant-1.2\",\"languageId\":\"typescript\",\"multilineMode\":\"block\",\"id\":\"1a973e9a-59a2-4f13-9ab2-cedb14a1e8a1\",\"contextSummary\":{\"strategy\":\"local-mixed\",\"duration\":1.007999986410141,\"totalChars\":0,\"retrieverStats\":{}},\"source\":\"Network\",\"items\":[{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}],\"otherCompletionProviders\":[],\"acceptedItem\":{\"lineCount\":1,\"charCount\":13,\"stopReason\":\"stop_sequence\",\"lineTruncatedCount\":0,\"truncatedWith\":\"indentation\",\"insertText\":\"return a + b;\"}}},\"timestamp\":\"2023-12-26T18:03:27.456Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "5357ebe8-30b2-4b48-8423-6acccca2e8b2"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "57rt3W2jTID8zjrYKe3k2cf94rFv4jDL.yOMzWrGys8-1703613807-1-AUhmLont8qJSG6aHuKonnzg63mfD+LFGrVUTg//cYI7uAgFgklNi8PGmXIFob43ih9Dn7F7RTueVzXUjGGqCjfE="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "PWlndC3_rWEJDC_UXnUWOGYeytgkzXpw9zn27bOYT5A-1703613807937-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5357ebe8-30b2-4b48-8423-6acccca2e8b2; Expires=Thu, 26 Dec 2024 18:03:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=57rt3W2jTID8zjrYKe3k2cf94rFv4jDL.yOMzWrGys8-1703613807-1-AUhmLont8qJSG6aHuKonnzg63mfD+LFGrVUTg//cYI7uAgFgklNi8PGmXIFob43ih9Dn7F7RTueVzXUjGGqCjfE=; path=/; expires=Tue, 26-Dec-23 18:33:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=PWlndC3_rWEJDC_UXnUWOGYeytgkzXpw9zn27bOYT5A-1703613807937-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "314d4cbb879d752867e2256806a935c1"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "20205c7809e3ca99"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/314d4cbb879d752867e2256806a935c1"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d9a895f35c4-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:27.460Z",
-        "time": 398,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 398
-        }
-      },
-      {
-        "_id": "a675fb9695cea865ff00276901d96dea",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 1226,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "1226"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"119dabec-98b8-420c-b020-3db9ed373cbf\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "3cd68a63-e8b5-467e-849a-82bb9881697b"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "rk5nIFPEiIzT5b53IyOfqUDtfb.3z4MjVaLcbrFCrU0-1703613807-1-AbJSGlqntnnYgUE+a5M1ac2AI3ecIFnlD5XTxRPeGoz9exyz2b7d/HJOielZ6OA1NxSvAVhDqV8bx83ILkEwenE="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "leWUYLo8vldbn1iaNkwJMo5kwLrHi3bAKPYSKUxb.kg-1703613807949-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3cd68a63-e8b5-467e-849a-82bb9881697b; Expires=Thu, 26 Dec 2024 18:03:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=rk5nIFPEiIzT5b53IyOfqUDtfb.3z4MjVaLcbrFCrU0-1703613807-1-AbJSGlqntnnYgUE+a5M1ac2AI3ecIFnlD5XTxRPeGoz9exyz2b7d/HJOielZ6OA1NxSvAVhDqV8bx83ILkEwenE=; path=/; expires=Tue, 26-Dec-23 18:33:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=leWUYLo8vldbn1iaNkwJMo5kwLrHi3bAKPYSKUxb.kg-1703613807949-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "9257990edd6d35e7e53b1995047dfd18"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d2b535b2d3376911"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9257990edd6d35e7e53b1995047dfd18"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d9a89bd34bc-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:27.457Z",
-        "time": 403,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 403
-        }
-      },
-      {
-        "_id": "8b53d4795e3f47f2145a9bcd4171ec0c",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 496,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "496"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"unexpectedNotSuggested\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2023-12-26T18:03:27.455Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 115,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a10aa680-2dd7-41ab-bcff-7f7de6d39a7f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "VlMwdSUkMvPUECLy8MxhwL2QBPIyE2YJvhVXVYwYXDg-1703613807-1-AV9railJt1WFRzlNnz3kROCpPj+Z7ayqIjRj+Zb44iNU0QvlTwub+1ARrfNl0T6I5GUY0+Rj3ZYve2N+UZgWa10="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "kt22rdGliO0o9pR6EWODbNCJdx4S5WC3JCCcf528_e8-1703613807956-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a10aa680-2dd7-41ab-bcff-7f7de6d39a7f; Expires=Thu, 26 Dec 2024 18:03:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=VlMwdSUkMvPUECLy8MxhwL2QBPIyE2YJvhVXVYwYXDg-1703613807-1-AV9railJt1WFRzlNnz3kROCpPj+Z7ayqIjRj+Zb44iNU0QvlTwub+1ARrfNl0T6I5GUY0+Rj3ZYve2N+UZgWa10=; path=/; expires=Tue, 26-Dec-23 18:33:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=kt22rdGliO0o9pR6EWODbNCJdx4S5WC3JCCcf528_e8-1703613807956-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d24b7517bff8ed00d6ffe8bff1152dfb"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "eeab15604dbf5539"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d24b7517bff8ed00d6ffe8bff1152dfb"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d9a8e95bf8f-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:27.459Z",
-        "time": 407,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 407
-        }
-      },
-      {
-        "_id": "9d9770a3575447876e8ab7e0c3ce6722",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 2029,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "2029"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 340,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"119dabec-98b8-420c-b020-3db9ed373cbf\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"argument\":\"{}\",\"publicArgument\":\"{\\\"multiline\\\":true,\\\"triggerKind\\\":\\\"Manual\\\",\\\"providerIdentifier\\\":\\\"anthropic\\\",\\\"providerModel\\\":\\\"claude-instant-1.2\\\",\\\"languageId\\\":\\\"typescript\\\",\\\"artificialDelay\\\":0,\\\"multilineMode\\\":\\\"block\\\",\\\"id\\\":\\\"1a973e9a-59a2-4f13-9ab2-cedb14a1e8a1\\\",\\\"contextSummary\\\":{\\\"strategy\\\":\\\"local-mixed\\\",\\\"duration\\\":1.007999986410141,\\\"totalChars\\\":0,\\\"retrieverStats\\\":{}},\\\"source\\\":\\\"Network\\\",\\\"items\\\":[{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"}],\\\"otherCompletionProviderEnabled\\\":false,\\\"otherCompletionProviders\\\":[],\\\"acceptedItem\\\":{\\\"lineCount\\\":1,\\\"charCount\\\":13,\\\"stopReason\\\":\\\"stop_sequence\\\",\\\"lineTruncatedCount\\\":0,\\\"truncatedWith\\\":\\\"indentation\\\",\\\"insertText\\\":\\\"return a + b;\\\"},\\\"serverEndpoint\\\":\\\"https://sourcegraph.com/\\\",\\\"extensionDetails\\\":{\\\"ide\\\":\\\"VSCode\\\",\\\"ideExtensionType\\\":\\\"Cody\\\",\\\"platform\\\":\\\"macos\\\",\\\"arch\\\":\\\"aarch64\\\",\\\"version\\\":\\\"1.0.4\\\"},\\\"configurationDetails\\\":{\\\"contextSelection\\\":\\\"embeddings\\\",\\\"chatPredictions\\\":false,\\\"guardrails\\\":false},\\\"version\\\":\\\"1.0.4\\\",\\\"hasV2Event\\\":true}\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\",\"hashedLicenseKey\":\"bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:27.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "61df2092-51c0-4a5f-8c74-d6a89efec473"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:27.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OvL1ukt8X0HlnWN48WO6dPuqZzWa.p_tkFRm4hLSTbk-1703613807-1-ASnKk72MwVcb0H5mB4AxxN7JMW9+WWDwcqT9/nb6b/AtytNVVGfLGbxG0vgpcKIp1jrDIeEbejl/YYpqPsxWeHk="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "v7HhLxib5FHoFIM579diDo4eGX6PtflUfjoCnEldkXs-1703613807958-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:27 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=61df2092-51c0-4a5f-8c74-d6a89efec473; Expires=Thu, 26 Dec 2024 18:03:27 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=OvL1ukt8X0HlnWN48WO6dPuqZzWa.p_tkFRm4hLSTbk-1703613807-1-ASnKk72MwVcb0H5mB4AxxN7JMW9+WWDwcqT9/nb6b/AtytNVVGfLGbxG0vgpcKIp1jrDIeEbejl/YYpqPsxWeHk=; path=/; expires=Tue, 26-Dec-23 18:33:27 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=v7HhLxib5FHoFIM579diDo4eGX6PtflUfjoCnEldkXs-1703613807958-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b62d20e666a2910a68ba91cba9c67af9"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "09c90fb710945670"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b62d20e666a2910a68ba91cba9c67af9"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d9a8f913506-WAW"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:27.458Z",
-        "time": 411,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 411
-        }
-      },
-      {
-        "_id": "6f0a3d30ce6f1bbefbda851579ac7452",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 477,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "477"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2023-12-26T18:03:28.145Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:28.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "cf623832-d2b9-41de-9efa-07449dbc945f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:28.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Rm0BzcCs86FFmoGVSy9x9TglJvzBY2.kuaC_Q5lNAaE-1703613808-1-AeCBAwLBqaUi9IyOpMsSuUVB2i7J7lyHSk9FQlk6DJvPjb5n7iM2aAls6MH5Jy4JdQRUa1y7cz86i7U9K7DmQjI="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "QSmjM9RGYWl78_xOK2VEpB0dJ_ujlKORgNhzRnx5mYw-1703613808497-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:28 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cf623832-d2b9-41de-9efa-07449dbc945f; Expires=Thu, 26 Dec 2024 18:03:28 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Rm0BzcCs86FFmoGVSy9x9TglJvzBY2.kuaC_Q5lNAaE-1703613808-1-AeCBAwLBqaUi9IyOpMsSuUVB2i7J7lyHSk9FQlk6DJvPjb5n7iM2aAls6MH5Jy4JdQRUa1y7cz86i7U9K7DmQjI=; path=/; expires=Tue, 26-Dec-23 18:33:28 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=QSmjM9RGYWl78_xOK2VEpB0dJ_ujlKORgNhzRnx5mYw-1703613808497-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "04d3eef18ea7819e7c99dfbec1c0f378"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "7d59592edbebe28b"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/04d3eef18ea7819e7c99dfbec1c0f378"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3d9df8093bcf-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:28.147Z",
-        "time": 261,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 261
-        }
-      },
-      {
-        "_id": "0a0e5ef3cd70405fb1be2a344285d775",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 524,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "524"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 344,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.recipe.chat-question\",\"action\":\"executed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.4\"},\"parameters\":{\"version\":0,\"metadata\":[{\"key\":\"embeddings\",\"value\":15},{\"key\":\"contextSelection\",\"value\":1},{\"key\":\"chatPredictions\",\"value\":0},{\"key\":\"guardrails\",\"value\":0}]},\"timestamp\":\"2023-12-26T18:03:28.585Z\"}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:28.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ef95671f-92a5-4af9-8a8e-6c2752b7121e"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:28.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "W.WpDZbcUyPaBu87DeegbmQfA1sKSXqzUc1Y6hTDRS8-1703613808-1-AahrWNsSSHlv9FW8Bg3LfVrOBappXcFeg6zQHqYfhvTx2LFGU8Cjbf1cix2RDqTU9Q2bF5U30Vx6p2sBZNGBxdM="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "5Xw7hvIIOeO5JLFI1sO3pIsxD7TmrtiPuelgwL6.6pU-1703613808933-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:28 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ef95671f-92a5-4af9-8a8e-6c2752b7121e; Expires=Thu, 26 Dec 2024 18:03:28 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=W.WpDZbcUyPaBu87DeegbmQfA1sKSXqzUc1Y6hTDRS8-1703613808-1-AahrWNsSSHlv9FW8Bg3LfVrOBappXcFeg6zQHqYfhvTx2LFGU8Cjbf1cix2RDqTU9Q2bF5U30Vx6p2sBZNGBxdM=; path=/; expires=Tue, 26-Dec-23 18:33:28 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=5Xw7hvIIOeO5JLFI1sO3pIsxD7TmrtiPuelgwL6.6pU-1703613808933-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "219ed7f01ed6a8791bccef843421313d"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d11a4abb8b0c7bcb"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/219ed7f01ed6a8791bccef843421313d"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3da0bc733bcc-WAW"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:28.591Z",
-        "time": 254,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 254
-        }
-      },
-      {
-        "_id": "dd2aac9e33fa30aebfd9ba88f030f33a",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 5385,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "accept-encoding",
-              "value": "gzip;q=0"
-            },
-            {
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 261,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/agent/src/cli/evaluate-autocomplete/strategy-git-log.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/treeViewItems.ts`:\\n```ts\\n]\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/chat/chat-view/chat-helpers.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
-          },
-          "queryString": [],
-          "url": "https://sourcegraph.com/.api/completions/stream"
-        },
-        "response": {
-          "bodySize": 232,
-          "content": {
-            "mimeType": "text/event-stream",
-            "size": 232,
-            "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
-          },
-          "cookies": [
-            {
-              "expires": "2024-12-26T18:03:28.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "57c5160d-5e3f-4da0-b271-7ca86f1a5207"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2023-12-26T18:33:31.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "6opuEo61pH85uSQ8zly03pewZ9_8frWLq2BvAHOhBJw-1703613811-1-AadG9EQzd9LNRXvVrxYjDGxxQnI2vephQ+SNHZbFs/6neEpF92cfhXxRP+Jt3hY5+Kjsey1cHPcN5sbo1QawDk8="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "GvBTljSaAAsTdn11OBT04UUv_RPRrwT27zV7vfHEarY-1703613811519-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Tue, 26 Dec 2023 18:03:31 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "text/event-stream"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=57c5160d-5e3f-4da0-b271-7ca86f1a5207; Expires=Thu, 26 Dec 2024 18:03:28 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=6opuEo61pH85uSQ8zly03pewZ9_8frWLq2BvAHOhBJw-1703613811-1-AadG9EQzd9LNRXvVrxYjDGxxQnI2vephQ+SNHZbFs/6neEpF92cfhXxRP+Jt3hY5+Kjsey1cHPcN5sbo1QawDk8=; path=/; expires=Tue, 26-Dec-23 18:33:31 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=GvBTljSaAAsTdn11OBT04UUv_RPRrwT27zV7vfHEarY-1703613811519-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "24a490cccad334244d1491d6b3b9917e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "fc2b15a00787c60b"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/24a490cccad334244d1491d6b3b9917e"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "83bb3da0b9a4fc8b-WAW"
-            }
-          ],
-          "headersSize": 1284,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2023-12-26T18:03:28.590Z",
-        "time": 2955,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 2955
+          "wait": 229
         }
       }
     ],

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -216,7 +216,7 @@ describe('Agent', () => {
         messages.push(message)
     })
 
-    it('allows us to send a chat message', async () => {
+    it('allows us to send a very short chat message', async () => {
         await openFile(animalUri)
         const id = await client.request('chat/new', null)
         const reply = await client.request('chat/submitMessage', {
@@ -240,6 +240,50 @@ describe('Agent', () => {
           }
         `
         )
+    }, 20_000)
+
+    it('allows us to send a longer chat message', async () => {
+        await openFile(animalUri)
+        const id = await client.request('chat/new', null)
+        const reply = await client.request('chat/submitMessage', {
+            id,
+            message: {
+                command: 'submit',
+                text: 'Generate simple hello world function in java!',
+                submitType: 'user',
+                addEnhancedContext: true,
+                contextFiles: [],
+            },
+        })
+        const lastMessage: any = reply.type === 'transcript' ? reply.messages.at(-1) : reply
+        expect(lastMessage).toMatchInlineSnapshot(`
+          {
+            "contextFiles": [],
+            "displayText": " Here is a simple hello world function in Java:
+
+          \`\`\`java
+          public class Main {
+
+            public static void main(String[] args) {
+              System.out.println(\\"Hello World!\\"); 
+            }
+
+          }
+          \`\`\`",
+            "speaker": "assistant",
+            "text": " Here is a simple hello world function in Java:
+
+          \`\`\`java
+          public class Main {
+
+            public static void main(String[] args) {
+              System.out.println(\\"Hello World!\\"); 
+            }
+
+          }
+          \`\`\`",
+          }
+        `)
     }, 20_000)
 
     // TODO Fix test - fails intermittently on macOS on Github Actions

--- a/lib/shared/src/chat/typewriter.ts
+++ b/lib/shared/src/chat/typewriter.ts
@@ -9,6 +9,11 @@ export interface IncrementalTextConsumer {
      * Notify the consumer that the text is complete.
      */
     close: () => void
+
+    /**
+     * Notify the consumer about the error.
+     */
+    error?: (error: Error) => void
 }
 
 // Maximum/minimum amount of time to wait between character chunks
@@ -113,9 +118,16 @@ export class Typewriter implements IncrementalTextConsumer {
         }
         // Clean up the consumer, finished promise.
         if (this.upstreamClosed) {
-            this.consumer.close()
-        } else {
-            console.error('Typewriter stopped', error)
+            if (error) {
+                console.error('Typewriter stopped', error)
+                if (this.consumer.error) {
+                    this.consumer.error(error)
+                } else {
+                    this.consumer.close()
+                }
+            } else {
+                this.consumer.close()
+            }
         }
     }
 }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -723,6 +723,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
             close: () => {
                 callbacks.close(lastContent)
             },
+            error: error => {
+                callbacks.error(lastContent, error)
+            },
         })
 
         this.cancelInProgressCompletion()
@@ -741,7 +744,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                     this.cancelInProgressCompletion()
                     typewriter.close()
                     typewriter.stop(error)
-                    callbacks.error(lastContent, error)
                 },
             },
             { model: this.chatModel.modelID }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/233

## Test plan

Automatic tests to cover the issue were added. 

## Details

Error `Error: Cannot add a bot message after a bot message` was popping out when message was sent to agent with rate limit exhausted. It was caused by `SimpleChatPanelProvider` closing  `typewriter`, which in turn was calling `close` callback from `sendLLMRequest` in `SimpleChatPanelProvider`.
Close callback was then dumping remaining content, resulting in adding agent message twice.

```
    at SimpleChatPanelProvider.addBotMessageWithGuardrails (cody/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts:855:21)
    at Object.close (cody/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts:690:26)
    at Object.close (cody/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts:729:27)
    at Typewriter.stop (cody/lib/shared/src/chat/typewriter.ts:116:27)
    at Object.onError (cody/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts:748:32)
    at onErrorOnce (cody/lib/shared/src/sourcegraph-api/completions/nodeClient.ts:29:20)
    at handleError (cody/lib/shared/src/sourcegraph-api/completions/nodeClient.ts:82:25)
    at IncomingMessage.<anonymous> (cody/lib/shared/src/sourcegraph-api/completions/nodeClient.ts:107:41)
    at IncomingMessage.emit (node:events:529:35)
    at IncomingMessage.emit (node:domain:489:12)
```