### PR TITLE
fix: remove enhanced context from commands

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,12 +6,13 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-- [Internal] New `cody.internal.unstable` setting for enabling unstable experimental features for internal use only. Included .cody/.ignore for internal testing. [issues/1382](https://github.com/sourcegraph/cody/pull/1382)
+- [Internal] New `cody.internal.unstable` setting for enabling unstable experimental features for internal use only. Included .cody/.ignore for internal testing. [pulls/1382](https://github.com/sourcegraph/cody/pull/1382)
 
 ### Fixed
 
 - @-mentioning files on Windows no longer sometimes renders visible markdown for the links in the chat [issues/2388](https://github.com/sourcegraph/cody/issues/2388)/[pull/2398](https://github.com/sourcegraph/cody/pull/2398)
 - Mentioning multiple files in chat no longer only includes the first file [issues/2402](https://github.com/sourcegraph/cody/issues/2402)/[pull/2405](https://github.com/sourcegraph/cody/pull/2405)
+- Enhanced context is no longer added to commands and custom commands that do not require codebase context. [pulls/2537](https://github.com/sourcegraph/cody/pull/2537)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -555,7 +555,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, IChatPanelPro
                 await vscode.commands.executeCommand('cody.settings.commands')
                 return
             }
-            return this.executeRecipe('custom-prompt', text.trim(), 'chat', userContextFiles, addEnhancedContext)
+            return this.executeRecipe('custom-prompt', text.trim(), 'chat', userContextFiles, false)
         }
 
         const displayText = userContextFiles?.length

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -83,12 +83,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
      * If found, creates a new Cody command runner instance for that prompt and input.
      * Returns the ID of the created runner, or 'invalid' if not found.
      */
-    public async addCommand(
-        text: string,
-        requestID?: string,
-        contextFiles?: ContextFile[],
-        addEnhancedContext?: boolean
-    ): Promise<string> {
+    public async addCommand(text: string, requestID?: string, contextFiles?: ContextFile[]): Promise<string> {
         const commandSplit = text.split(' ')
         // The unique key for the command. e.g. /test
         const commandKey = commandSplit.shift() || text
@@ -102,10 +97,6 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
         if (command.slashCommand === '/ask') {
             command.prompt = text
-        }
-
-        if (!command.context && addEnhancedContext) {
-            command.context = { codebase: addEnhancedContext }
         }
 
         command.additionalInput = commandInput


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/2536

1. Removed the 'addEnhancedContext' parameter from the addCommand() method in CommandsController. 
2. All commands should be run without enhancedContext unless it's specified in the cody.json to include `codybase` as context

We previously added extra context to custom command which caused confusion to LLM and affected command quality. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Highlight some code in a file
2. Run `/smell` command
4. Check and make sure only 1 file (current file) is used as context.

Before:

On top of the current file, it would add other unrelated files as enhanced context

![image](https://github.com/sourcegraph/cody/assets/68532117/e87f8282-877d-453c-a341-f3454839ce0a)


After:

It should only use the correct file as context and nothing else

![image](https://github.com/sourcegraph/cody/assets/68532117/9859acf1-1e5f-48ef-8d59-defcdf0665cf)

