### PR TITLE
Chat: fallback to local keyword search when embeddings fail

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1070,8 +1070,6 @@ class ContextProvider implements IContextProvider {
 
     public async getEnhancedContext(text: string): Promise<ContextItem[]> {
         const searchContext: ContextItem[] = []
-        let localEmbeddingsError
-        let remoteEmbeddingsError
         logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
         let hasEmbeddingsContext = false
         const localEmbeddingsResults = this.searchEmbeddingsLocal(text)
@@ -1082,7 +1080,6 @@ class ContextProvider implements IContextProvider {
             searchContext.push(...r)
         } catch (error) {
             logDebug('SimpleChatPanelProvider', 'getEnhancedContext > local embeddings', error)
-            localEmbeddingsError = error
         }
         try {
             const r = await remoteEmbeddingsResults
@@ -1090,16 +1087,8 @@ class ContextProvider implements IContextProvider {
             searchContext.push(...r)
         } catch (error) {
             logDebug('SimpleChatPanelProvider', 'getEnhancedContext > remote embeddings', error)
-            remoteEmbeddingsError = error
         }
         logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (end)')
-        if (localEmbeddingsError && remoteEmbeddingsError) {
-            throw new Error(
-                `local and remote embeddings search failed (local: ${getErrorMessage(
-                    localEmbeddingsError
-                )}) (remote: ${getErrorMessage(remoteEmbeddingsError)})`
-            )
-        }
 
         if (!hasEmbeddingsContext && this.symf) {
             try {
@@ -1482,13 +1471,6 @@ function extractQuestion(input: string): string | undefined {
 
 function isAbortError(error: Error): boolean {
     return error.message === 'aborted' || error.message === 'socket hang up'
-}
-
-function getErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message
-    }
-    return String(error)
 }
 
 function getContextWindowForModel(authStatus: AuthStatus, modelID: string): number {


### PR DESCRIPTION
Before, if both embeddings search methods fail then we display an error in chat. Now, we just log the error and fall back to local keyword search. This avoids a situation we've seen at customer sites where they hit the embeddings rate limit, then their users run into a bunch of errors in chats. 

I don't think this is actually a change in behavior, because the local embeddings client swallows errors and returns "no results", which caused us to fall back to keyword search (accidentally?) It really just clarifies the logic.

## Test plan

Updated embeddings search methods to throw errors (just for testing), and checked we still produce codebase context.
