### PR TITLE
Autocomplete: skip request manager cache on manual completion trigger

### DIFF
--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -317,7 +317,7 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
 
     CompletionLogger.networkRequestStarted(logId, contextResult?.logSummary)
 
-    const reqContext: RequestParams = {
+    const requestParams: RequestParams = {
         document,
         docContext,
         position,
@@ -326,14 +326,15 @@ async function doGetInlineCompletions(params: InlineCompletionsParams): Promise<
     }
 
     // Get the processed completions from providers
-    const { completions, source } = await requestManager.request(
-        reqContext,
-        completionProviders,
-        contextResult?.context ?? [],
-        tracer ? createCompletionProviderTracer(tracer) : undefined
-    )
+    const { completions, source } = await requestManager.request({
+        requestParams,
+        providers: completionProviders,
+        context: contextResult?.context ?? [],
+        isCacheEnabled: triggerKind !== TriggerKind.Manual,
+        tracer: tracer ? createCompletionProviderTracer(tracer) : undefined,
+    })
 
-    CompletionLogger.loaded(logId, reqContext, completions, source, isDotComUser)
+    CompletionLogger.loaded(logId, requestParams, completions, source, isDotComUser)
 
     return {
         logId,

--- a/vscode/src/completions/request-manager.test.ts
+++ b/vscode/src/completions/request-manager.test.ts
@@ -70,7 +70,12 @@ describe('RequestManager', () => {
         const requestManager = new RequestManager()
 
         createRequest = (prefix: string, provider: Provider, suffix?: string) =>
-            requestManager.request(docState(prefix, suffix), [provider], [])
+            requestManager.request({
+                requestParams: docState(prefix, suffix),
+                providers: [provider],
+                context: [],
+                isCacheEnabled: true,
+            })
     })
 
     it('resolves a single request', async () => {

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -37,6 +37,14 @@ export interface RequestManagerResult {
     source: InlineCompletionsResultSource
 }
 
+interface RequestsManagerParams {
+    requestParams: RequestParams
+    providers: Provider[]
+    context: ContextSnippet[]
+    isCacheEnabled: boolean
+    tracer?: CompletionProviderTracer
+}
+
 /**
  * This class can handle concurrent requests for code completions. The idea is
  * that requests are not cancelled even when the user continues typing in the
@@ -64,14 +72,12 @@ export class RequestManager {
         this.disableRecyclingOfPreviousRequests = disableRecyclingOfPreviousRequests
     }
 
-    public async request(
-        params: RequestParams,
-        providers: Provider[],
-        context: ContextSnippet[],
-        tracer?: CompletionProviderTracer
-    ): Promise<RequestManagerResult> {
-        const cachedCompletions = this.cache.get(params)
-        if (cachedCompletions) {
+    public async request(params: RequestsManagerParams): Promise<RequestManagerResult> {
+        const { requestParams, providers, context, isCacheEnabled, tracer } = params
+
+        const cachedCompletions = this.cache.get(requestParams)
+        if (isCacheEnabled && cachedCompletions) {
+            console.log('using cache', cachedCompletions)
             return cachedCompletions
         }
 
@@ -79,11 +85,11 @@ export class RequestManager {
         // not interrupt requests that are no longer relevant. Instead, we let all previous requests
         // complete and try to see if their results can be reused for other inflight requests.
         let abortController: AbortController = new AbortController()
-        if (this.disableRecyclingOfPreviousRequests && params.abortSignal) {
-            abortController = forkSignal(params.abortSignal)
+        if (this.disableRecyclingOfPreviousRequests && requestParams.abortSignal) {
+            abortController = forkSignal(requestParams.abortSignal)
         }
 
-        const request = new InflightRequest(params, abortController)
+        const request = new InflightRequest(requestParams, abortController)
         this.inflightRequests.add(request)
 
         Promise.all(
@@ -114,11 +120,13 @@ export class RequestManager {
             .then(res => res.flat())
             .then(completions => {
                 // Shared post-processing logic
-                return startAsyncSpan('autocomplete.post-process', () => processInlineCompletions(completions, params))
+                return startAsyncSpan('autocomplete.post-process', () =>
+                    processInlineCompletions(completions, requestParams)
+                )
             })
             .then(processedCompletions => {
                 // Cache even if the request was aborted or already fulfilled.
-                this.cache.set(params, {
+                this.cache.set(requestParams, {
                     completions: processedCompletions,
                     source: InlineCompletionsResultSource.Cache,
                 })


### PR DESCRIPTION
## Context

- Bypass request manager cache on manual completion triggers.
- We already have the last candidate cache disabled for this case. The request manager cache was implemented after that we never got to skipping it too. 

## Test plan

- Use the keyboard shortcut to trigger a completion generation multiple times at the same cursor position.
- Every time, a new request should be issued according to Cody's output channel.
