### PR TITLE
refactor: remove command inline mode

### DIFF
--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -73,12 +73,11 @@ export interface CodyPrompt {
 
 /**
  * - ask mode is the default mode, run prompt in sidebar
- * - inline mode will run prompt in inline chat
  * - edit mode will run prompt with fixup
  * - insert mode is the same as edit, but instead of replacing selection with cody's response,
  * it adds to the top of the selection instead
  */
-export type CodyPromptMode = 'ask' | 'inline' | 'edit' | 'insert'
+export type CodyPromptMode = 'ask' | 'edit' | 'insert'
 
 // Type of context available for prompt building
 export interface CodyPromptContext {

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -70,7 +70,6 @@ export type ChatEventSource =
     | 'editor'
     | 'menu'
     | 'code-action'
-    | 'commands'
     | 'custom-commands'
     | 'test'
     | 'code-lens'

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -70,6 +70,7 @@ export type ChatEventSource =
     | 'editor'
     | 'menu'
     | 'code-action'
+    | 'commands'
     | 'custom-commands'
     | 'test'
     | 'code-lens'

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- The `inline` mode for Custom Commands has been removed. [pull/2551](https://github.com/sourcegraph/cody/pull/2551)
+
 ## [1.0.4]
 
 ### Added

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -161,7 +161,7 @@ export class CommandRunner implements vscode.Disposable {
         const range = this.kind === 'doc' ? getDocCommandRange(this.editor, selection, doc.languageId) : selection
         const intent: FixupIntent = this.kind === 'doc' ? 'doc' : 'edit'
         const instruction = insertMode ? addSelectionToPrompt(this.command.prompt, code) : this.command.prompt
-        const source = this.kind as ChatEventSource
+        const source = this.kind === 'custom' ? 'custom-commands' : this.kind
         await executeEdit(
             {
                 range,
@@ -170,7 +170,7 @@ export class CommandRunner implements vscode.Disposable {
                 intent,
                 insertMode,
             } satisfies ExecuteEditArguments,
-            source
+            source as ChatEventSource
         )
     }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -292,8 +292,13 @@ const register = async (
         args: ExecuteEditArguments = {},
         source: ChatEventSource = 'editor' // where the command was triggered from
     ): Promise<void> => {
-        telemetryService.log('CodyVSCodeExtension:command:edit:executed', { source }, { hasV2Event: true })
-        telemetryRecorder.recordEvent('cody.command.edit', 'executed', { privateMetadata: { source } })
+        const commandEventName = source === 'doc' ? 'doc' : 'edit'
+        telemetryService.log(
+            `CodyVSCodeExtension:command:${commandEventName}:executed`,
+            { source },
+            { hasV2Event: true }
+        )
+        telemetryRecorder.recordEvent(`cody.command.${commandEventName}`, 'executed', { privateMetadata: { source } })
         const editor = getEditor()
         if (editor.ignored) {
             console.error('File was ignored by Cody.')


### PR DESCRIPTION
- Removes `inline` from `CodyPromptMode`
- Logs non-edit commands only in CommandRunner Close https://github.com/sourcegraph/cody/issues/2545

## Demo


https://github.com/sourcegraph/cody/assets/68532117/6a9a5fdb-b3ff-4fcd-bfdb-ced9dde3fc10



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Run the `doc` command, only `CodyVSCodeExtension:command:doc:executed` should be logged without `CodyVSCodeExtension:command:edit:executed`

Log for example:
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:command:doc:executed VSCode {"properties":{"source":"doc"},"opts":{"hasV2Event":true}}
█ telemetry-v2: recordEvent (no-op): cody.command.doc/executed: {"parameters":{"version":0,"privateMetadata":{"source":"doc"}},"timestamp":"2024-01-03T15:57:44.677Z"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:recipe:fixup:executed VSCode {"properties":{"contextSummary":{"embeddings":0,"local":2,"user":0},"source":"doc"}
```

2. Run the `edit` command, `CodyVSCodeExtension:command:edit:executed` should be logged once

Log for example:
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:command:edit:executed VSCode {"properties":{"source":"editor"},"opts":{"hasV2Event":true}}
█ telemetry-v2: recordEvent (no-op): cody.command.edit/executed: {"parameters":{"version":0,"privateMetadata":{"source":"editor"}},"timestamp":"2024-01-03T16:00:24.386Z"}
█ logEvent (telemetry disabled): CodyVSCodeExtension:recipe:fixup:executed VSCode {"properties":{"contextSummary":{"embeddings":1,"local":2,"user":0},"source":"editor","requestID":"c374e01f-4182-4fa9-b5c2-760c6b260857"}
```