### PR TITLE
refactor: rename .cody/.ignore to .cody/ignore

### DIFF
--- a/lib/shared/src/chat/ignore-helper.ts
+++ b/lib/shared/src/chat/ignore-helper.ts
@@ -5,13 +5,15 @@ import { URI } from 'vscode-uri'
 
 /**
  * The Cody ignore file path in the native platform style (backslashes on Windows).
+ *
+ * e.g: `C:\\Users\\me\\my-project\\.cody\\ignore` or `Users/username/my-project/.cody/ignore`
  */
-export const CODY_IGNORE_FILENAME = path.join('.cody', '.ignore')
+export const CODY_IGNORE_FILENAME = path.join('.cody', 'ignore')
 
 /**
  * The Cody ignore file path in POSIX style (always forward slashes).
  */
-export const CODY_IGNORE_FILENAME_POSIX_GLOB = path.posix.join('**', '.cody', '.ignore')
+export const CODY_IGNORE_FILENAME_POSIX_GLOB = path.posix.join('**', '.cody', 'ignore')
 
 /**
  * A helper to efficiently check if a file should be ignored from a set

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,7 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-- [Internal] New `cody.internal.unstable` setting for enabling unstable experimental features for internal use only. Included .cody/.ignore for internal testing. [pulls/1382](https://github.com/sourcegraph/cody/pull/1382)
+- [Internal] New `cody.internal.unstable` setting for enabling unstable experimental features for internal use only. Included `.cody/ignore` for internal testing. [pulls/1382](https://github.com/sourcegraph/cody/pull/1382)
 
 ### Fixed
 

--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -11,7 +11,7 @@ import { getCodebaseFromWorkspaceUri } from '../repository/repositoryHelpers'
 const utf8 = new TextDecoder('utf-8')
 
 /**
- * Parses `.code/.ignore` files from the workspace and sets up a watcher to refresh
+ * Parses `.code/ignore` files from the workspace and sets up a watcher to refresh
  * whenever the files change.
  *
  * This is called once the git extension has started up


### PR DESCRIPTION
- Renames the ignore filename for Cody from `.cody/.ignore` to `.cody/ignore` for simplicity. 
- Updates references across the codebase.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- build from this branch and create a `.cody/ignore` file in the root of the workspace
- add a directory e.g. `vscode/**` to the file then save
- open a file from that directory and then highlight some code
- ask cody to explain selected code
- cody should tell you there is no selected code to explain, and if you check the context files, you will see there is no files from the ignored directory was shared with cody

![image](https://github.com/sourcegraph/cody/assets/68532117/17eb8e93-fcd2-4732-9c83-fe68df5be18c)
