### PR TITLE
fix: only prevent default on Ctrl key combo

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -387,7 +387,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             // Checks if the Ctrl key is pressed with a key not in the allow list
             // to avoid triggering default browser shortcuts and bubbling the event.
             const ctrlKeysAllowList = new Set(['a', 'c', 'v', 'x', 'y', 'z'])
-            if ((event.ctrlKey || event.getModifierState('AltGraph')) && !ctrlKeysAllowList.has(event.key)) {
+            if (event.ctrlKey && !ctrlKeysAllowList.has(event.key)) {
                 event.preventDefault()
                 return
             }


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/2383

The previous check for Ctrl or AltGraph being pressed was too broad and prevented some default browser shortcuts from working properly, and created blockers for users on different keyboard layouts

This fixes it by checking specifically for Ctrl keys combo only.

Alt + C is still prevented. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Try using alt + key combos when focusing in input box - this should now work
2. Try pressing alt + c when focusing in input box - this should open the command menu