### PR TITLE
Autocomplete: adjust leading whitespace in the last candidate text on indentation

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -90,16 +90,6 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
-    it('is reused when adding leading whitespace', async () =>
-        // The user types ``, sees ghost text `x = 1`, then types ` ` (space). The original
-        // completion should be reused.
-        expect(await getInlineCompletions(params(' █', [], { lastCandidate: lastCandidate('█', 'x = 1') }))).toEqual<V>(
-            {
-                items: [{ insertText: 'x = 1' }],
-                source: InlineCompletionsResultSource.LastCandidate,
-            }
-        ))
-
     it('is reused when the deleting back to the start of the original trigger (but no further)', async () =>
         // The user types `const x`, accepts a completion to `const x = 123`, then deletes back
         // to `const x` (i.e., to the start of the original trigger). The original completion
@@ -220,6 +210,14 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
+    it('is reused for a multi-line completion', async () =>
+        // The user types ``, sees ghost text `x\ny`, then types ` ` (space). The original
+        // completion should be reused.
+        expect(await getInlineCompletions(params('x█', [], { lastCandidate: lastCandidate('█', 'x\ny') }))).toEqual<V>({
+            items: [{ insertText: '\ny' }],
+            source: InlineCompletionsResultSource.LastCandidate,
+        }))
+
     describe('partial acceptance', () => {
         it('marks a completion as partially accepted when you type at least one word', async () => {
             const handleDidPartiallyAcceptCompletionItem = vitest.fn()
@@ -243,6 +241,44 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
         })
     })
 
+    describe('adding leading whitespace', () => {
+        it('is reused when adding leading whitespace', async () =>
+            // The user types ``, sees ghost text `x = 1`, then types ` ` (space). The original
+            // completion should be reused.
+            expect(
+                await getInlineCompletions(params(' █', [], { lastCandidate: lastCandidate('█', 'x = 1') }))
+            ).toEqual<V>({
+                items: [{ insertText: 'x = 1' }],
+                source: InlineCompletionsResultSource.LastCandidate,
+            }))
+
+        it('is reused when adding more leading whitespace than present in the last candidate current line prefix', async () => {
+            /*
+             * The user types on a new line `\t`, the completion is generated in the background
+             * `\t\tconst foo = 1`, while user adds `\t\t\t` to the current line.
+             * As a result all `\t` should be removed from the completion as user typed them forward
+             * as suggested. The resuling completion `const foo = 1`.
+             */
+            expect(
+                await getInlineCompletionsInsertText(
+                    params('\t\t\t\t█', [], {
+                        lastCandidate: lastCandidate('\t█', '\t\tconst x = 1'),
+                    })
+                )
+            ).toEqual(['const x = 1'])
+        })
+
+        it('is reused when adding leading whitespace for a multi-line completion', async () =>
+            // The user types ``, sees ghost text `x\ny`, then types ` `. The original completion
+            // should be reused.
+            expect(
+                await getInlineCompletions(params(' █', [], { lastCandidate: lastCandidate('█', 'x\ny') }))
+            ).toEqual<V>({
+                items: [{ insertText: 'x\ny' }],
+                source: InlineCompletionsResultSource.LastCandidate,
+            }))
+    })
+
     describe('deleting leading whitespace', () => {
         const candidate = lastCandidate('\t\t█', 'const x = 1')
 
@@ -250,7 +286,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             // The user types on a new line `\t\t`, sees ghost text `const x = 1`, then
             // deletes one `\t`. The same ghost text should still be displayed.
             expect(await getInlineCompletions(params('\t█', [], { lastCandidate: candidate }))).toEqual<V>({
-                items: [{ insertText: '\tconst x = 1' }],
+                items: [{ insertText: 'const x = 1' }],
                 source: InlineCompletionsResultSource.LastCandidate,
             }))
 
@@ -259,7 +295,7 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             // all leading whitespace (both `\t\t`). The same ghost text should still be
             // displayed.
             expect(await getInlineCompletions(params('█', [], { lastCandidate: candidate }))).toEqual<V>({
-                items: [{ insertText: '\t\tconst x = 1' }],
+                items: [{ insertText: 'const x = 1' }],
                 source: InlineCompletionsResultSource.LastCandidate,
             }))
 
@@ -287,22 +323,6 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
                 source: InlineCompletionsResultSource.Network,
             }))
     })
-
-    it('is reused for a multi-line completion', async () =>
-        // The user types ``, sees ghost text `x\ny`, then types ` ` (space). The original
-        // completion should be reused.
-        expect(await getInlineCompletions(params('x█', [], { lastCandidate: lastCandidate('█', 'x\ny') }))).toEqual<V>({
-            items: [{ insertText: '\ny' }],
-            source: InlineCompletionsResultSource.LastCandidate,
-        }))
-
-    it('is reused when adding leading whitespace for a multi-line completion', async () =>
-        // The user types ``, sees ghost text `x\ny`, then types ` `. The original completion
-        // should be reused.
-        expect(await getInlineCompletions(params(' █', [], { lastCandidate: lastCandidate('█', 'x\ny') }))).toEqual<V>({
-            items: [{ insertText: 'x\ny' }],
-            source: InlineCompletionsResultSource.LastCandidate,
-        }))
 
     describe('completeSuggestWidgetSelection', () => {
         it('is not reused when selected item info differs', async () =>

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -89,6 +89,7 @@ export function reuseLastCandidate({
             const lastCompletion = lastTriggerCurrentLinePrefixInDocument + item.insertText
             const isTypingAsSuggested =
                 lastCompletion.startsWith(currentLinePrefix) && position.isAfterOrEqual(lastTriggerPosition)
+
             if (isTypingAsSuggested) {
                 const remaining = lastCompletion.slice(currentLinePrefix.length)
                 const alreadyInsertedText = item.insertText.slice(0, -remaining.length)
@@ -136,10 +137,36 @@ export function reuseLastCandidate({
 
             // Allow reuse if only the indentation (leading whitespace) has changed.
             if (isIndentationChange) {
+                if (isIndentation) {
+                    const leadingWhitespace = item.insertText.match(/^\s*/)?.[0] ?? ''
+
+                    /**
+                     * Consider the following completion:
+                     *
+                     * lastTriggerCurrentLinePrefixInDocument = '\t'
+                     * insertText = '\t\tconst foo = 1'
+                     * currentLinePrefix = '\t\t\t\t'
+                     *
+                     *
+                     * The user types on a new line `\t`, the completion is generated in the background
+                     * `\t\tconst foo = 1`, while user adds `\t\t\t` to the current line.
+                     * As a result all `\t` should be removed from the completion as user typed them forward
+                     * as suggested. The resuling completion `const foo = 1`.
+                     */
+                    const whiteSpaceToRemove = Math.min(
+                        currentLinePrefix.length - lastTriggerCurrentLinePrefixInDocument.length,
+                        leadingWhitespace.length
+                    )
+
+                    return {
+                        ...item,
+                        insertText: item.insertText.slice(whiteSpaceToRemove),
+                    }
+                }
+
                 return {
                     ...item,
-                    insertText:
-                        lastTriggerCurrentLinePrefixInDocument.slice(currentLinePrefix.length) + item.insertText,
+                    insertText: item.insertText,
                 }
             }
 


### PR DESCRIPTION
## Context

- It was a tricky one to pinpoint because of the time-sensitive nature of the bug. It happens when a user initializes a completion generation by placing a cursor on the new line and then almost instantly tabs 2+ times. For example: 

    ```ts
      function test() {
    █
      }
    ```
    
    The initial completion generation request comes back in the background with the insert-text: `\t\tconst x = 1`, but a user already added three tabs manually:
    
    ```ts
      function test() {
          █
      }
    ```
    
    We reuse (`reuseLastCandidate`) the initial completion that was generated in the background because only whitespace on the current line was changed, and the previous logic returned the final insert text as the following: `lastTriggerCurrentLinePrefixInDocument.slice(currentLinePrefix.length) + item.insertText` which didn't account for leading whitespace that user added manually. Notice extra whitespace in the ghost text:

    ```ts
      function test() {
          █    const x = 1
      }
    ```

    This PR fixes the issue by removing the manually added whitespace from the insert-text if it's present there. Note that the `isTypingAsSuggested` clause missed this issue because a user adds more whitespace than there's present in the current line: `lastCompletion.startsWith(currentLinePrefix) === false`.

- Closes #2532

## Test plan

- Manually tested that this is not happening anymore. This is tricky because the bug is time-sensitive.
- Added a unit test for this specific issue. 
