### PR TITLE
fix: show error after Cody response in chat UI

### DIFF
--- a/lib/ui/src/chat/ErrorItem.module.css
+++ b/lib/ui/src/chat/ErrorItem.module.css
@@ -18,7 +18,8 @@
     margin: 0;
 }
 
-.error-item h1, .error-item p {
+.error-item h1,
+.error-item p {
     margin: 0;
 }
 
@@ -57,7 +58,6 @@
     right: 0;
     overflow: hidden;
     height: 100px;
-
 }
 
 @property --error-item-reflection-position {
@@ -72,15 +72,14 @@
     padding: 6px 30px;
     transform: translateY(50%) translateX(25%) rotate(45deg);
     border: 1px solid rgba(0 0 0 / 16%);
-    background:
-        linear-gradient(
+    background: linear-gradient(
             45deg,
             rgb(255 220 220 / 0%) calc(var(--error-item-reflection-position) + 35%),
             rgb(255 220 220 / 50%) calc(var(--error-item-reflection-position) + 50%),
             rgb(255 220 220 / 0%) calc(var(--error-item-reflection-position) + 65%)
         ),
         linear-gradient(rgb(255 255 255 / 55%), rgb(255 255 255 / 55%)),
-        repeating-conic-gradient(#4AC1E8, #7048E8, #FF5543, #7048E8, #4AC1E8);
+        repeating-conic-gradient(#4ac1e8, #7048e8, #ff5543, #7048e8, #4ac1e8);
     box-shadow: 0 4px 8px 0 rgb(0 0 0 / 15%);
     transition: box-shadow 650ms ease-in-out;
     color: #080808;
@@ -96,11 +95,12 @@
 .error-item .banner:hover {
     --error-item-reflection-position: 100%;
 
-    transition: --error-item-reflection-position 1.5s cubic-bezier(0.455, 0.03, 0.515, 0.955),
-                box-shadow 750ms ease-in-out;
-    box-shadow: 0 4px 8px 0 rgb(0 0 0 / 15%),
-                0 0 10px 0 rgb(255 255 255 / 35%);
-;
+    transition:
+        --error-item-reflection-position 1.5s cubic-bezier(0.455, 0.03, 0.515, 0.955),
+        box-shadow 750ms ease-in-out;
+    box-shadow:
+        0 4px 8px 0 rgb(0 0 0 / 15%),
+        0 0 10px 0 rgb(255 255 255 / 35%);
 }
 
 .error-item .banner::before {
@@ -123,4 +123,22 @@
     height: 5px;
     transform: translateY(-27px) rotate(225deg);
     background: linear-gradient(rgb(255 255 255 / 0%), rgb(255 255 255 / 80%));
+}
+
+.request-error {
+    background-color: #f7bcbc;
+    color: #de3400;
+
+    margin-top: 0.5rem;
+    padding: 0.5rem;
+
+    word-break: break-word;
+    text-wrap: wrap;
+    line-height: 150%;
+
+    border-left: 0.5rem solid #d8000c;
+}
+
+.request-error-title {
+    font-weight: bold;
 }

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -46,8 +46,8 @@ export const RequestErrorItem: React.FunctionComponent<{
     error: string
 }> = React.memo(function ErrorItemContent({ error }) {
     return (
-        <div className="cody-chat-error">
-            <span>Request failed: </span>
+        <div className={styles.requestError}>
+            <span className={styles.requestErrorTitle}>Request Failed: </span>
             {error}
         </div>
     )

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -162,6 +162,26 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </div>
             )}
+            <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
+                {message.displayText ? (
+                    EditTextArea ? (
+                        !inProgress && !message.displayText.startsWith('/') && EditTextArea
+                    ) : (
+                        <CodeBlocks
+                            displayText={message.displayText}
+                            copyButtonClassName={codeBlocksCopyButtonClassName}
+                            copyButtonOnSubmit={copyButtonOnSubmit}
+                            insertButtonClassName={codeBlocksInsertButtonClassName}
+                            insertButtonOnSubmit={insertButtonOnSubmit}
+                            metadata={message.metadata}
+                            inProgress={inProgress}
+                            guardrails={guardrails}
+                        />
+                    )
+                ) : (
+                    inProgress && <BlinkingCursor />
+                )}
+            </div>
             {message.error ? (
                 typeof message.error === 'string' ? (
                     <RequestErrorItem error={message.error} />
@@ -173,28 +193,7 @@ export const TranscriptItem: React.FunctionComponent<
                         postMessage={postMessage}
                     />
                 )
-            ) : (
-                <div className={classNames(styles.contentPadding, EditTextArea ? undefined : styles.content)}>
-                    {message.displayText && !message.error ? (
-                        EditTextArea ? (
-                            !inProgress && !message.displayText.startsWith('/') && EditTextArea
-                        ) : (
-                            <CodeBlocks
-                                displayText={message.displayText}
-                                copyButtonClassName={codeBlocksCopyButtonClassName}
-                                copyButtonOnSubmit={copyButtonOnSubmit}
-                                insertButtonClassName={codeBlocksInsertButtonClassName}
-                                insertButtonOnSubmit={insertButtonOnSubmit}
-                                metadata={message.metadata}
-                                inProgress={inProgress}
-                                guardrails={guardrails}
-                            />
-                        )
-                    ) : (
-                        inProgress && <BlinkingCursor />
-                    )}
-                </div>
-            )}
+            ) : null}
             {message.buttons?.length && ChatButtonComponent && (
                 <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>
             )}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,7 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - @-mentioning files on Windows no longer sometimes renders visible markdown for the links in the chat [issues/2388](https://github.com/sourcegraph/cody/issues/2388)/[pull/2398](https://github.com/sourcegraph/cody/pull/2398)
 - Mentioning multiple files in chat no longer only includes the first file [issues/2402](https://github.com/sourcegraph/cody/issues/2402)/[pull/2405](https://github.com/sourcegraph/cody/pull/2405)
 - Enhanced context is no longer added to commands and custom commands that do not require codebase context. [pulls/2537](https://github.com/sourcegraph/cody/pull/2537)
-- Display error messages from the LLM without replacing existing responses from Cody in the Chat UI.
+- Display error messages from the LLM without replacing existing responses from Cody in the Chat UI. [pull/2566](https://github.com/sourcegraph/cody/pull/2566)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - @-mentioning files on Windows no longer sometimes renders visible markdown for the links in the chat [issues/2388](https://github.com/sourcegraph/cody/issues/2388)/[pull/2398](https://github.com/sourcegraph/cody/pull/2398)
 - Mentioning multiple files in chat no longer only includes the first file [issues/2402](https://github.com/sourcegraph/cody/issues/2402)/[pull/2405](https://github.com/sourcegraph/cody/pull/2405)
 - Enhanced context is no longer added to commands and custom commands that do not require codebase context. [pulls/2537](https://github.com/sourcegraph/cody/pull/2537)
+- Display error messages from the LLM without replacing existing responses from Cody in the Chat UI.
 
 ### Changed
 


### PR DESCRIPTION
![image](https://github.com/sourcegraph/cody/assets/68532117/b49129b3-fc48-4494-9614-4bc7f296c6e8)

This PR addresses the issue mentioned in https://github.com/sourcegraph/cody/issues/2539, where long response from chat gpt 4.0 will resulted in error, and the error message will replace the response text from Cody.

- Display error message in additional to the text that cody has already responded 
- Add new styles for .request-error and .request-error-title classes.
- Update ErrorItem.tsx to use new CSS classes for request error display.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Switch chat to use chat gpt 4.0
2. Open a large file and select the whole file
3. Run the /test command
4. If the response is longer than the answer limit, it should display an error message after the text that Cody has already responsed
- before: the text will be replaced with the error message

## Demo

### Before

https://github.com/sourcegraph/cody/assets/68532117/40609eef-8a27-4202-a195-7b75b7ddc260

https://www.loom.com/share/2136a5de267d4c21849b735bb38619d9?sid=b8d8652e-2bba-4498-bcf6-aec9c2c9a0cc

### After

Error message will not replace the text that's already returned by the LLM

![image](https://github.com/sourcegraph/cody/assets/68532117/bee4d51b-c7d0-45c2-916b-eb265031defe)

https://www.loom.com/share/3e183dfec7f940079100b48e519235eb?sid=2e55abad-e4d4-4ba0-8a6a-05078f48ef0a