### PR TITLE
Add install/auth events to `loggedEvents` in e2e tests

### DIFF
--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -300,17 +300,5 @@ export function storeLoggedEvents(event: string): void {
     }
     const parsedEvent = JSON.parse(JSON.stringify(event)) as ParsedEvent
     const name = parsedEvent.event
-    if (
-        ![
-            'CodyInstalled',
-            'CodyVSCodeExtension:Auth:failed',
-            'CodyVSCodeExtension:auth:clickOtherSignInOptions',
-            'CodyVSCodeExtension:login:clicked',
-            'CodyVSCodeExtension:auth:selectSigninMenu',
-            'CodyVSCodeExtension:auth:fromToken',
-            'CodyVSCodeExtension:Auth:connected',
-        ].includes(name)
-    ) {
-        loggedEvents.push(name)
-    }
+    loggedEvents.push(name)
 }


### PR DESCRIPTION
This PR adds the install and auth events to the loggedEvents variable in e2e tests. Previously these events were omitted to avoid bottlenecking developers when creating new tests. However, since most tests are not doing a holistic validation of all events, it makes sense to add these events back so they can be verified within each test as needed.

By including these events in loggedEvents, individual tests can now assert that the expected install/auth events are fired without having to repeat setup logic. This will make it easier to validate these important events are logged correctly from various entry points.


## Test plan
All tests passed via `pnpm test:e2e`
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
