### PR TITLE
Autocomplete: do not adjust insert text in a VS Code-specific way for the agent

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -402,7 +402,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                 // return `CompletionEvent` telemetry data to the agent command `autocomplete/execute`.
                 const autocompleteResult: AutocompleteResult = {
                     logId: result.logId,
-                    items: autocompleteItems,
+                    items: updateInsertRangeForVSCode(autocompleteItems),
                     completionEvent: CompletionLogger.getCompletionEvent(result.logId),
                 }
 
@@ -413,10 +413,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     this.unstable_handleDidShowCompletionItem(autocompleteItems[0])
                 }
 
-                return {
-                    ...autocompleteResult,
-                    items: updateInsertRangeForVSCode(autocompleteItems),
-                }
+                return autocompleteResult
             } catch (error) {
                 this.onError(error as Error)
                 throw error

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -39,6 +39,7 @@ import { getRequestParamsFromLastCandidate } from './reuse-last-candidate'
 import {
     analyticsItemToAutocompleteItem,
     suggestedAutocompleteItemsCache,
+    updateInsertRangeForVSCode,
     type AutocompleteInlineAcceptedCommandArgs,
     type AutocompleteItem,
 } from './suggested-autocomplete-items-cache'
@@ -51,7 +52,7 @@ interface AutocompleteResult extends vscode.InlineCompletionList {
     completionEvent?: CompletionBookkeepingEvent
 }
 
-interface CodyCompletionItemProviderConfig {
+export interface CodyCompletionItemProviderConfig {
     providerConfig: ProviderConfig
     statusBar: CodyStatusBar
     tracer?: ProvideInlineCompletionItemsTracer | null
@@ -348,16 +349,7 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     this.handleUnwantedCompletionItem(getRequestParamsFromLastCandidate(document, this.lastCandidate))
                 }
 
-                const items = analyticsItemToAutocompleteItem(
-                    result.logId,
-                    document,
-                    docContext,
-                    position,
-                    result.items,
-                    context
-                )
-
-                const visibleItems = items.filter(item =>
+                const visibleItems = result.items.filter(item =>
                     isCompletionVisible(
                         item,
                         document,
@@ -392,27 +384,39 @@ export class InlineCompletionItemProvider implements vscode.InlineCompletionItem
                     }
                 }
 
+                const autocompleteItems = analyticsItemToAutocompleteItem(
+                    result.logId,
+                    document,
+                    docContext,
+                    position,
+                    visibleItems,
+                    context
+                )
+
                 // Store the log ID for each completion item so that we can later map to the selected
                 // item from the ID alone
-                for (const item of visibleItems) {
+                for (const item of autocompleteItems) {
                     suggestedAutocompleteItemsCache.add(item)
+                }
+
+                // return `CompletionEvent` telemetry data to the agent command `autocomplete/execute`.
+                const autocompleteResult: AutocompleteResult = {
+                    logId: result.logId,
+                    items: autocompleteItems,
+                    completionEvent: CompletionLogger.getCompletionEvent(result.logId),
                 }
 
                 if (!this.config.isRunningInsideAgent) {
                     // Since VS Code has no callback as to when a completion is shown, we assume
                     // that if we pass the above visibility tests, the completion is going to be
                     // rendered in the UI
-                    this.unstable_handleDidShowCompletionItem(visibleItems[0])
+                    this.unstable_handleDidShowCompletionItem(autocompleteItems[0])
                 }
 
-                // return `CompletionEvent` telemetry data to the agent command `autocomplete/execute`.
-                const autocompleteResult: AutocompleteResult = {
-                    logId: result.logId,
-                    items: visibleItems,
-                    completionEvent: CompletionLogger.getCompletionEvent(result.logId),
+                return {
+                    ...autocompleteResult,
+                    items: updateInsertRangeForVSCode(autocompleteItems),
                 }
-
-                return autocompleteResult
             } catch (error) {
                 this.onError(error as Error)
                 throw error

--- a/vscode/src/completions/is-completion-visible.ts
+++ b/vscode/src/completions/is-completion-visible.ts
@@ -1,10 +1,10 @@
 import type * as vscode from 'vscode'
 
 import { type DocumentContext } from './get-current-doc-context'
-import { type AutocompleteItem } from './suggested-autocomplete-items-cache'
+import { type InlineCompletionItemWithAnalytics } from './text-processing/process-inline-completions'
 
 export function isCompletionVisible(
-    completion: AutocompleteItem,
+    completion: InlineCompletionItemWithAnalytics,
     document: vscode.TextDocument,
     position: vscode.Position,
     docContext: DocumentContext,
@@ -35,7 +35,7 @@ export function isCompletionVisible(
     const isAborted = abortSignal ? abortSignal.aborted : false
     const isMatchingPopupItem = completeSuggestWidgetSelection
         ? true
-        : completionMatchesPopupItem(completion, position, document, context)
+        : completionMatchesPopupItem(completion, document, context)
     const isMatchingSuffix = completionMatchesSuffix(completion, docContext.currentLineSuffix)
     const isVisible = !isAborted && isMatchingPopupItem && isMatchingSuffix
 
@@ -47,8 +47,7 @@ export function isCompletionVisible(
 //
 // VS Code won't show a completion if it won't.
 function completionMatchesPopupItem(
-    completion: AutocompleteItem,
-    position: vscode.Position,
+    completion: InlineCompletionItemWithAnalytics,
     document: vscode.TextDocument,
     context: vscode.InlineCompletionContext
 ): boolean {
@@ -61,19 +60,17 @@ function completionMatchesPopupItem(
             return true
         }
 
-        // To ensure a good experience, the VS Code insertion might have the range start at the
-        // beginning of the line. When this happens, the insertText needs to be adjusted to only
-        // contain the insertion after the current position.
-        const offset = position.character - (completion.range?.start.character ?? position.character)
-        const correctInsertText = insertText.slice(offset)
-        if (!(currentText + correctInsertText).startsWith(selectedText)) {
+        if (!(currentText + insertText).startsWith(selectedText)) {
             return false
         }
     }
     return true
 }
 
-function completionMatchesSuffix(completion: Pick<AutocompleteItem, 'insertText'>, currentLineSuffix: string): boolean {
+export function completionMatchesSuffix(
+    completion: Pick<InlineCompletionItemWithAnalytics, 'insertText'>,
+    currentLineSuffix: string
+): boolean {
     if (typeof completion.insertText !== 'string') {
         return false
     }

--- a/vscode/src/completions/suggested-autocomplete-items-cache.ts
+++ b/vscode/src/completions/suggested-autocomplete-items-cache.ts
@@ -103,27 +103,16 @@ export function analyticsItemToAutocompleteItem(
 ): AutocompleteItem[] {
     return items.map(item => {
         const { insertText, range } = item
-
         const currentLine = document.lineAt(position)
-        const currentLinePrefix = document.getText(currentLine.range.with({ end: position }))
 
-        // Return the completion from the start of the current line (instead of starting at the
-        // given position). This avoids UI jitter in VS Code; when typing or deleting individual
-        // characters, VS Code reuses the existing completion while it waits for the new one to
-        // come in.
-        const start = currentLine.range.start
+        const start = range?.start || position
 
         // If the completion does not have a range set it will always exclude the same line suffix,
         // so it has to overwrite the current same line suffix and reach to the end of the line.
         const end = range?.end || currentLine.range.end
 
         const vscodeInsertRange = new vscode.Range(start, end)
-        const trackedRange = new vscode.Range(
-            currentLine.range.start.line,
-            currentLinePrefix.length,
-            end.line,
-            end.character
-        )
+        const trackedRange = new vscode.Range(start.line, start.character, end.line, end.character)
 
         const command = {
             title: 'Completion accepted',
@@ -144,7 +133,7 @@ export function analyticsItemToAutocompleteItem(
         } satisfies RequestParams
 
         const autocompleteItem = new AutocompleteItem({
-            insertText: currentLinePrefix + insertText,
+            insertText,
             logId,
             range: vscodeInsertRange,
             trackedRange,
@@ -156,5 +145,36 @@ export function analyticsItemToAutocompleteItem(
         command.arguments[0].codyCompletion = autocompleteItem
 
         return autocompleteItem
+    })
+}
+
+/**
+ * Adjust the completion insert text and range to start from beginning of the current line
+ * (instead of starting at the given position). This avoids UI jitter in VS Code; when
+ * typing or deleting individual characters, VS Code reuses the existing completion
+ * while it waits for the new one to come in.
+ */
+export function updateInsertRangeForVSCode(items: AutocompleteItem[]): AutocompleteItem[] {
+    return items.map(item => {
+        const {
+            insertText,
+            range,
+            requestParams: { position, document },
+        } = item
+
+        const currentLine = document.lineAt(position)
+        const currentLinePrefix = document.getText(currentLine.range.with({ end: position }))
+
+        const start = currentLine.range.start
+        // If the completion does not have a range set it will always exclude the same line suffix,
+        // so it has to overwrite the current same line suffix and reach to the end of the line.
+        const end = range?.end || currentLine.range.end
+
+        const vscodeInsertRange = new vscode.Range(start, end)
+
+        item.range = vscodeInsertRange
+        item.insertText = currentLinePrefix + (insertText as string)
+
+        return item
     })
 }


### PR DESCRIPTION
## Context

UPD: I added back the VS Code specific `insertText` processing, so this PR no longer has any breaking changes. But this logic is not extracted into a separate function and is called separately. If we decide to change this behavior, it will be easy to do in the future.

- This PR proposes to change the behavior of the `autocomplete/execute` requests for the agent based on the [feedback in Slack](https://sourcegraph.slack.com/archives/C05AGQYD528/p1704164215488589). 
- The only functional change: `InlineCompletionItemProvider.provideInlineCompletionItems()` does not execute the VS Code-specific logic anymore, which makes all completions start at the beginning of the line no matter what the current cursor position is. This logic was added to avoid UI jitter in VS Code, but it does not apply to other Cody clients and requires them to implement additional post-processing logic with no apparent reason.
    - ~~This is a breaking change for clients using the agent API `autocomplete/execute`**.  cc @olafurpg~~
- Based on the clean-up work in another branch https://github.com/sourcegraph/cody/pull/2572

## Test plan

- CI
- Manually verify that completions still work as expected in VS Code.
