### PR TITLE
Edit: Support user provided files ("@name") and symbols ("@#name")

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Edit: Added support for user-provided context. Use "@" to include files and "@#" to include specific symbols. [pull/2574](https://github.com/sourcegraph/cody/pull/2574)
+
 ### Fixed
 
 - Chat no longer shows "embeddings" as the source for all automatically included context files [issues/2244](https://github.com/sourcegraph/cody/issues/2244)/[pull/2408](https://github.com/sourcegraph/cody/pull/2408)

--- a/vscode/src/edit/execute.ts
+++ b/vscode/src/edit/execute.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { ContextFile } from '@sourcegraph/cody-shared'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { EditIntent } from './types'
@@ -7,6 +8,7 @@ import { EditIntent } from './types'
 export interface ExecuteEditArguments {
     document?: vscode.TextDocument
     instruction?: string
+    userContextFiles?: ContextFile[]
     intent?: EditIntent
     range?: vscode.Range
     insertMode?: boolean

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -76,6 +76,7 @@ export class EditManager implements vscode.Disposable {
             ? await this.controller.createTask(
                   document.uri,
                   args.instruction,
+                  args.userContextFiles ?? [],
                   range,
                   args.intent,
                   args.insertMode,

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -13,7 +13,7 @@ import { FixupTask } from '../../non-stop/FixupTask'
 import { EditIntent } from '../types'
 
 import { claude } from './claude'
-import { getContextFromIntent } from './context'
+import { getContext } from './context'
 import { EditLLMInteraction, GetLLMInteractionOptions, LLMInteraction } from './type'
 
 type SupportedModels = 'anthropic/claude-2.0' | 'anthropic/claude-2.1'
@@ -93,10 +93,11 @@ export const buildInteraction = async ({
     const interaction = new Interaction(
         { speaker: 'human', text: prompt, displayText: prompt },
         { speaker: 'assistant', text: assistantText, prefix: assistantPrefix },
-        getContextFromIntent({
+        getContext({
             intent: task.intent,
             fileName: task.fixupFile.uri.fsPath,
             selectionRange: task.selectionRange,
+            userContextFiles: task.userContextFiles,
             context,
             editor,
             followingText,

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1017,7 +1017,6 @@ export class FixupController
         // Revert and remove the previous task
         await this.undoTask(task)
 
-        // TODO: Can we just use executeEdit?
         void vscode.commands.executeCommand(
             'cody.command.edit-code',
             {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1007,8 +1007,8 @@ export class FixupController
 
         // Prompt the user for a new instruction, and create a new fixup
         const input = await this.typingUI.getInputFromQuickPick({
-            value: previousInstruction,
-            selectedContextFiles: previousUserContextFiles,
+            initialValue: previousInstruction,
+            initialSelectedContextFiles: previousUserContextFiles,
         })
         if (!input) {
             return

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { ContextFile } from '@sourcegraph/cody-shared'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { ExecuteEditArguments } from '../edit/execute'
@@ -161,6 +162,7 @@ export class FixupController
     public async createTask(
         documentUri: vscode.Uri,
         instruction: string,
+        userContextFiles: ContextFile[],
         selectionRange: vscode.Range,
         intent?: EditIntent,
         insertMode?: boolean,
@@ -171,7 +173,7 @@ export class FixupController
         if (intent !== 'add') {
             selectionRange = await this.getFixupTaskSmartSelection(documentUri, selectionRange)
         }
-        const task = new FixupTask(fixupFile, instruction, intent, selectionRange, insertMode, source)
+        const task = new FixupTask(fixupFile, instruction, userContextFiles, intent, selectionRange, insertMode, source)
         this.tasks.set(task.id, task)
         this.setTaskState(task, CodyTaskState.working)
         return task
@@ -1000,17 +1002,32 @@ export class FixupController
         }
         const previousRange = task.originalRange
         const previousInstruction = task.instruction
+        const previousUserContextFiles = task.userContextFiles
         const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
 
         // Prompt the user for a new instruction, and create a new fixup
-        const instruction = await this.typingUI.getInstructionFromQuickPick({ value: previousInstruction })
+        const input = await this.typingUI.getInputFromQuickPick({
+            value: previousInstruction,
+            selectedContextFiles: previousUserContextFiles,
+        })
+        if (!input) {
+            return
+        }
 
         // Revert and remove the previous task
         await this.undoTask(task)
 
+        // TODO: Can we just use executeEdit?
         void vscode.commands.executeCommand(
             'cody.command.edit-code',
-            { range: previousRange, instruction, document, intent: task.intent, insertMode: task.insertMode },
+            {
+                range: previousRange,
+                instruction: input.instruction,
+                userContextFiles: input.userContextFiles,
+                document,
+                intent: task.intent,
+                insertMode: task.insertMode,
+            } satisfies ExecuteEditArguments,
             'code-lens'
         )
     }

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { ContextFile } from '@sourcegraph/cody-shared'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { EditIntent } from '../edit/types'
@@ -45,6 +46,7 @@ export class FixupTask {
     constructor(
         public readonly fixupFile: FixupFile,
         public readonly instruction: string,
+        public readonly userContextFiles: ContextFile[],
         /* The intent of the edit, derived from the source of the command. */
         public readonly intent: EditIntent = 'edit',
         public selectionRange: vscode.Range,

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode'
 
+import { ContextFile } from '@sourcegraph/cody-shared'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { EDIT_COMMAND, menu_buttons } from '../commands/utils/menu'
 import { ExecuteEditArguments } from '../edit/execute'
 import { getEditor } from '../editor/active-editor'
-import { getFileContextFiles } from '../editor/utils/editor-context'
+import { getFileContextFiles, getSymbolContextFiles } from '../editor/utils/editor-context'
 
 import { FixupTask } from './FixupTask'
 import { FixupTaskFactory } from './roles'
@@ -18,23 +19,81 @@ function removeAfterLastAt(str: string): string {
     return str.slice(0, lastIndex)
 }
 
+/* Match strings that end with a '@' followed by any characters except a space */
+const MATCHING_CONTEXT_FILE_REGEX = /@(\S+)$/
+
+/* Match strings that end with a '@#' followed by any characters except a space */
+const MATCHING_SYMBOL_REGEX = /@#(\S+)$/
+
+interface FixupMatchingContext {
+    /* Associated text label with the context */
+    label: string
+    file: ContextFile
+}
+
+interface QuickPickParams {
+    title?: string
+    placeholder?: string
+    value?: string
+    prefix?: string
+    selectedContextFiles?: ContextFile[]
+}
+
 /**
  * The UI for creating non-stop fixup tasks by typing instructions.
  */
 export class FixupTypingUI {
     constructor(private readonly taskFactory: FixupTaskFactory) {}
 
-    public async getInstructionFromQuickPick({
+    private async getMatchingContext(instruction: string): Promise<FixupMatchingContext[]> {
+        const cancellation = new vscode.CancellationTokenSource()
+        const symbolMatch = instruction.match(MATCHING_SYMBOL_REGEX)
+        if (symbolMatch) {
+            const symbolResults = await getSymbolContextFiles(symbolMatch[1], 5)
+            return symbolResults.map(result => ({
+                file: result,
+                label: result.fileName,
+            }))
+        }
+
+        const fileMatch = instruction.match(MATCHING_CONTEXT_FILE_REGEX)
+        if (fileMatch) {
+            const fileResults = await getFileContextFiles(fileMatch[1], 5, cancellation.token)
+            return fileResults.map(result => ({
+                file: result,
+                label: result.path?.relative ?? result.fileName,
+            }))
+        }
+
+        return []
+    }
+
+    public async getInputFromQuickPick({
         title = `${EDIT_COMMAND.description} (${EDIT_COMMAND.slashCommand})`,
         placeholder = 'Your instructions',
         value = '',
+        selectedContextFiles = [],
         prefix = EDIT_COMMAND.slashCommand,
-    } = {}): Promise<string> {
+    }: QuickPickParams = {}): Promise<{
+        instruction: string
+        userContextFiles: ContextFile[]
+    } | null> {
         const quickPick = vscode.window.createQuickPick()
         quickPick.title = title
         quickPick.placeholder = placeholder
         quickPick.buttons = [menu_buttons.back]
         quickPick.value = value
+
+        // ContextItems to store possible context
+        const contextItems = new Map<string, ContextFile>()
+        const selectedContextItems = new Map<string, ContextFile>()
+
+        // Initialize the selectedContextItems with any previous items
+        // This is primarily for edit retries, where a user may want to reuse their context
+        selectedContextFiles.forEach(file => {
+            // TODO: Fix the label generation, either return with labels or have a single function to determine the label
+            selectedContextItems.set(file.fileName, file)
+        })
 
         // VS Code automatically sorts quick pick items by label.
         // We want the 'edit' item to always be first, so we remove this.
@@ -47,16 +106,21 @@ export class FixupTypingUI {
         })
 
         quickPick.onDidChangeValue(async value => {
-            const cancellation = new vscode.CancellationTokenSource()
-            const regex = /@(\w+)/
-            const match = value.match(regex)
-            if (match) {
-                const instruction = match[1]
-                const fileResults = await getFileContextFiles(instruction, 5, cancellation.token)
-                quickPick.items = fileResults.map(file => ({ alwaysShow: true, label: file.path?.relative || 'eee' }))
-            } else {
+            const matchingContext = await this.getMatchingContext(value)
+            if (matchingContext.length === 0) {
+                // Clear out any existing items
                 quickPick.items = []
+                return
             }
+
+            // Update stored context items so we can retrieve them later
+            for (const { label, file } of matchingContext) {
+                contextItems.set(label, file)
+            }
+
+            // Add human-friendly labels to the quick pick so the user can select them
+            quickPick.items = matchingContext.map(({ label }) => ({ alwaysShow: true, label }))
+            return
         })
 
         quickPick.show()
@@ -64,20 +128,29 @@ export class FixupTypingUI {
         return new Promise(resolve =>
             quickPick.onDidAccept(() => {
                 const instruction = quickPick.value.trim()
+
+                // Empty input flow, do nothing
                 if (!instruction) {
-                    // noop
                     return
                 }
 
-                if (quickPick.selectedItems.length > 0) {
-                    const cleanValue = removeAfterLastAt(instruction).trim()
-                    // Don't accept, update value to include item
-                    quickPick.value = `${cleanValue} ${quickPick.selectedItems[0].label}`
+                // Selected item flow, update the input and store it for submission
+                const selectedItem = quickPick.selectedItems[0]
+                if (selectedItem && contextItems.has(selectedItem.label)) {
+                    // Replace fuzzy value with actual context in input
+                    quickPick.value = `${removeAfterLastAt(instruction).trim()} @${selectedItem.label} `
+                    selectedContextItems.set(selectedItem.label, contextItems.get(selectedItem.label)!)
                     return
                 }
 
+                // Submission flow, validate selected items and return final output
                 quickPick.hide()
-                return resolve(prefix ? `${prefix} ${instruction}` : instruction)
+                return resolve({
+                    instruction: `${prefix} ${instruction}`.trim(),
+                    userContextFiles: Array.from(selectedContextItems)
+                        .filter(([key]) => instruction.includes(`@${key}`))
+                        .map(([, value]) => value),
+                })
             })
         )
     }
@@ -92,19 +165,20 @@ export class FixupTypingUI {
         if (!document || !range) {
             return null
         }
-        const instruction = (await this.getInstructionFromQuickPick())?.trim()
-        if (!instruction) {
-            return null
-        }
-        const CHAT_RE = /^\/chat(|\s.*)$/
-        const match = instruction.match(CHAT_RE)
-        if (match?.[1]) {
-            // If we got here, we have a selection; start chat with match[1].
-            await vscode.commands.executeCommand('cody.action.chat', match[1], 'fixup')
+        const input = await this.getInputFromQuickPick()
+        if (!input) {
             return null
         }
 
-        const task = this.taskFactory.createTask(document.uri, instruction, range, args.intent, args.insertMode, source)
+        const task = this.taskFactory.createTask(
+            document.uri,
+            input.instruction,
+            input.userContextFiles,
+            range,
+            args.intent,
+            args.insertMode,
+            source
+        )
 
         // Return focus to the editor
         void vscode.window.showTextDocument(document)

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -14,9 +14,19 @@ import { FixupTaskFactory } from './roles'
 function removeAfterLastAt(str: string): string {
     const lastIndex = str.lastIndexOf('@')
     if (lastIndex === -1) {
+        // Return the original string if "@" is not found
         return str
-    } // Return the original string if "@" is not found
+    }
     return str.slice(0, lastIndex)
+}
+
+function getLabelForContextFile(file: ContextFile): string {
+    const isFileType = file.type === 'file'
+    const rangeLabel = file.range ? `:${file.range?.start.line}-${file.range?.end.line}` : ''
+    if (isFileType) {
+        return `${file.path?.relative}${rangeLabel}`
+    }
+    return `${file.path?.relative}${rangeLabel}#${file.fileName}`
 }
 
 /* Match strings that end with a '@' followed by any characters except a space */
@@ -24,6 +34,11 @@ const MATCHING_CONTEXT_FILE_REGEX = /@(\S+)$/
 
 /* Match strings that end with a '@#' followed by any characters except a space */
 const MATCHING_SYMBOL_REGEX = /@#(\S+)$/
+
+const MAX_FUZZY_RESULTS = 20
+const FILE_HELP_LABEL = 'Search for a file to include, or type # to search symbols..'
+const SYMBOL_HELP_LABEL = 'Search for a symbol to include...'
+const NO_MATCHES_LABEL = 'No matches found'
 
 interface FixupMatchingContext {
     /* Unique identifier for the context, shown in the input value but not necessarily in the quick pick selector */
@@ -40,20 +55,6 @@ interface QuickPickParams {
     prefix?: string
     selectedContextFiles?: ContextFile[]
 }
-
-function getLabelForContextFile(file: ContextFile): string {
-    const isFileType = file.type === 'file'
-    const rangeLabel = file.range ? `:${file.range?.start.line}-${file.range?.end.line}` : ''
-    if (isFileType) {
-        return `${file.path?.relative}${rangeLabel}`
-    }
-    return `${file.path?.relative}${rangeLabel}#${file.fileName}`
-}
-
-const MAX_FUZZY_RESULTS = 20
-const FILE_HELP_LABEL = 'Search for a file to include, or type # to search symbols..'
-const SYMBOL_HELP_LABEL = 'Search for a symbol to include...'
-const NO_MATCHES_LABEL = 'No matches found'
 
 /**
  * The UI for creating non-stop fixup tasks by typing instructions.

--- a/vscode/src/non-stop/roles.ts
+++ b/vscode/src/non-stop/roles.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { ContextFile } from '@sourcegraph/cody-shared'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import { EditIntent } from '../edit/types'
@@ -39,6 +40,7 @@ export interface FixupTaskFactory {
     createTask(
         documentUri: vscode.Uri,
         instruction: string,
+        userContextFiles: ContextFile[],
         selectionRange: vscode.Range,
         intent?: EditIntent,
         insertMode?: boolean,


### PR DESCRIPTION
## Description

This PR adds the edit functionality for:
- User provided file context, e.g. `@fileName`
- User provided symbol context. e.g. `@#symbolName`

Attempted to get this to closely match the chat fuzzy matching:
- Helpful messages for certain suffixes/no matches
- Icons for different symbols
- Same syntax - `@fileName` and `@#symbolName`

Demo:

https://github.com/sourcegraph/cody/assets/9516420/f37d11f1-2375-41d1-b074-02676390b428

## Test plan

1. Create an edit using `@fileName`
2. Create an edit using `@symbolName`
3. Create an edit using multiple `@fileName` and `@symbolName`
4. Create an edit after removing `@fileName` context, check it doesn't still use it
5. Retry an edit that used `@fileName` or `@symbolName` context, check that the context is still used


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


