### PR TITLE
Revert "refactor: move commands away from recipe (#2542)"

### DIFF
--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -81,20 +81,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:33.000Z",
+              "expires": "2025-01-05T11:28:52.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0bd4f5e9-8e29-4668-984e-55eac01c7e5d"
+              "value": "24259cb3-4476-4a4a-b993-45a4e1f1290a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:34.000Z",
+              "expires": "2024-01-05T11:58:52.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "E.ksRsElgdGMMsW_3o_Ujcuc2AXsXNtq6Hrf4u86Tfw-1704453334-1-ATyfIZztohmcTQQxQIbsQXPduJupUZxoohu8xrF9BzwuYZkkbhKFV1Klb9kBBzfBxtKLoanW2z27nVhlXRZDahM="
+              "value": "t5rHcj_bO6yfX.e7O_x6lwiN5VAcP2HW.Cn.43GDV3k-1704454132-1-AdXHrrh4bXtYW3IuvcQEVNmtXydvq6OtCv6p00GdyOV+OIVgMd13CvIz+qtBnb7Y0OTkh8ujrXQkaJnAQer5gVQ="
             },
             {
               "domain": ".sourcegraph.com",
@@ -103,13 +103,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "_IlQxRyfOE7MIIbCngyjqnxn7t3tYuVm2qi6akSGYEA-1704453334059-0-604800000"
+              "value": "_1THriXLBkaHi.w9UXc7DbrzLMuJdn.Jan8RDRTRirA-1704454132370-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:34 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:52 GMT"
             },
             {
               "name": "content-type",
@@ -138,17 +138,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0bd4f5e9-8e29-4668-984e-55eac01c7e5d; Expires=Sun, 05 Jan 2025 11:15:33 GMT; Secure"
+              "value": "sourcegraphDeviceId=24259cb3-4476-4a4a-b993-45a4e1f1290a; Expires=Sun, 05 Jan 2025 11:28:52 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=E.ksRsElgdGMMsW_3o_Ujcuc2AXsXNtq6Hrf4u86Tfw-1704453334-1-ATyfIZztohmcTQQxQIbsQXPduJupUZxoohu8xrF9BzwuYZkkbhKFV1Klb9kBBzfBxtKLoanW2z27nVhlXRZDahM=; path=/; expires=Fri, 05-Jan-24 11:45:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=t5rHcj_bO6yfX.e7O_x6lwiN5VAcP2HW.Cn.43GDV3k-1704454132-1-AdXHrrh4bXtYW3IuvcQEVNmtXydvq6OtCv6p00GdyOV+OIVgMd13CvIz+qtBnb7Y0OTkh8ujrXQkaJnAQer5gVQ=; path=/; expires=Fri, 05-Jan-24 11:58:52 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=_IlQxRyfOE7MIIbCngyjqnxn7t3tYuVm2qi6akSGYEA-1704453334059-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=_1THriXLBkaHi.w9UXc7DbrzLMuJdn.Jan8RDRTRirA-1704454132370-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -164,15 +164,15 @@
             },
             {
               "name": "x-trace",
-              "value": "d523249f9a03ebf83cc826c202bba3fb"
+              "value": "de815d1d248be73392f29ec10c32cb80"
             },
             {
               "name": "x-trace-span",
-              "value": "8f34ffd4f18ad065"
+              "value": "999595203fb232e3"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d523249f9a03ebf83cc826c202bba3fb"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/de815d1d248be73392f29ec10c32cb80"
             },
             {
               "name": "x-xss-protection",
@@ -196,7 +196,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4dd5f9ab7127-OSL"
+              "value": "840b61563adb0b4d-OSL"
             },
             {
               "name": "content-encoding",
@@ -209,8 +209,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:33.369Z",
-        "time": 682,
+        "startedDateTime": "2024-01-05T11:28:52.118Z",
+        "time": 248,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -218,7 +218,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 682
+          "wait": 248
         }
       },
       {
@@ -286,29 +286,29 @@
           "url": "https://sourcegraph.com/.api/graphql?Repository"
         },
         "response": {
-          "bodySize": 148,
+          "bodySize": 158,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 148,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA\"]"
+            "size": 158,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8=\",\"AwD/h5WCVAAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:34.000Z",
+              "expires": "2025-01-05T11:28:52.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "2fefd71b-4e68-40c3-b638-d8ddaaa38344"
+              "value": "1facf2c0-9d13-4dff-8b0a-ca76da7a0a33"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
+              "expires": "2024-01-05T11:58:52.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "psAIBzPss9JwEmssO9RmrsZ7YNraVOyMLPMqcGeebC0-1704453335-1-AQCdURgkSzaogEqdxi5I7gBbPemmzdOIJ5eVx+G2a92Tn+NDM3dNjoCebzQczfNnJr+EPOJ8jA+1N7MKoIg6W0k="
+              "value": "bfbiAfcoO6Xw291GgsS1vyODrULSG0Mtxwkf2Vs5xQU-1704454132-1-AfeKIk53aSIVSHnCFY09O/2QijSVSD0ormC5fGKBW5gujYDbAF8M4dEZPNwZmUYyjXoTcxh+GRhhJCnrOw61GjY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -317,13 +317,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Ooaxb4_6Wb1UZStp50iz7WPQdk5RPhd0Fw_k9lOfEus-1704453335427-0-604800000"
+              "value": "7JnHbgEJQnH1d2qx2MuudoSR41F4Gj3EWzw4d3X_j_w-1704454132850-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:52 GMT"
             },
             {
               "name": "content-type",
@@ -352,17 +352,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2fefd71b-4e68-40c3-b638-d8ddaaa38344; Expires=Sun, 05 Jan 2025 11:15:34 GMT; Secure"
+              "value": "sourcegraphDeviceId=1facf2c0-9d13-4dff-8b0a-ca76da7a0a33; Expires=Sun, 05 Jan 2025 11:28:52 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=psAIBzPss9JwEmssO9RmrsZ7YNraVOyMLPMqcGeebC0-1704453335-1-AQCdURgkSzaogEqdxi5I7gBbPemmzdOIJ5eVx+G2a92Tn+NDM3dNjoCebzQczfNnJr+EPOJ8jA+1N7MKoIg6W0k=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=bfbiAfcoO6Xw291GgsS1vyODrULSG0Mtxwkf2Vs5xQU-1704454132-1-AfeKIk53aSIVSHnCFY09O/2QijSVSD0ormC5fGKBW5gujYDbAF8M4dEZPNwZmUYyjXoTcxh+GRhhJCnrOw61GjY=; path=/; expires=Fri, 05-Jan-24 11:58:52 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Ooaxb4_6Wb1UZStp50iz7WPQdk5RPhd0Fw_k9lOfEus-1704453335427-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=7JnHbgEJQnH1d2qx2MuudoSR41F4Gj3EWzw4d3X_j_w-1704454132850-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -378,15 +378,15 @@
             },
             {
               "name": "x-trace",
-              "value": "205a8b667877fbd2399b08c64d6b26dd"
+              "value": "2d4507ef453c255ef4bd4f93fb1dd04d"
             },
             {
               "name": "x-trace-span",
-              "value": "c6928d630cba1e44"
+              "value": "7a64de49e245b2fd"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/205a8b667877fbd2399b08c64d6b26dd"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2d4507ef453c255ef4bd4f93fb1dd04d"
             },
             {
               "name": "x-xss-protection",
@@ -410,7 +410,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4ddd4d84b523-OSL"
+              "value": "840b61593c9756b1-OSL"
             },
             {
               "name": "content-encoding",
@@ -423,8 +423,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:34.552Z",
-        "time": 864,
+        "startedDateTime": "2024-01-05T11:28:52.629Z",
+        "time": 211,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -432,7 +432,221 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 864
+          "wait": 211
+        }
+      },
+      {
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 164,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "164"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "SiteIdentification",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:53.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6fd0c956-540f-4744-9821-f62a40d3cce3"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:53.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "7xHvHejNKpXyYAvKjrCX2UhTP9qaWPJCC3Ts6s8eICc-1704454133-1-AekpFMnYDAh/4/IH6m7UnLxqp1hv+QHrZoj1s/8cbRSKBH4XcvGb+b5Z7Xa7LLhVphFQD1B3geGzoAkCs5Y5KyA="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "qyJRb0_fEiAed07UDpy7N9wNsoVVZeIL6X0Bv_pDBZ8-1704454133081-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6fd0c956-540f-4744-9821-f62a40d3cce3; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=7xHvHejNKpXyYAvKjrCX2UhTP9qaWPJCC3Ts6s8eICc-1704454133-1-AekpFMnYDAh/4/IH6m7UnLxqp1hv+QHrZoj1s/8cbRSKBH4XcvGb+b5Z7Xa7LLhVphFQD1B3geGzoAkCs5Y5KyA=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=qyJRb0_fEiAed07UDpy7N9wNsoVVZeIL6X0Bv_pDBZ8-1704454133081-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "8886653aeb5a4547efe8d82ec4af6add"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "71b68f645f35e040"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8886653aeb5a4547efe8d82ec4af6add"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b615abdca568f-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:52.867Z",
+        "time": 204,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 204
         }
       },
       {
@@ -509,20 +723,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:35.000Z",
+              "expires": "2025-01-05T11:28:53.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "01923998-c17e-4d6e-9650-8d2f768625bb"
+              "value": "4e23d54a-d88a-4cc2-845e-5adc2ed9965e"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
+              "expires": "2024-01-05T11:58:53.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "9KVVn_uX6STXh_VOxZbXGoWbe70mMRUAhS2AyWL.KAk-1704453335-1-AfRqApx3fGF0dEuM8snw8mjNbI6UXMp8AubfO0Da/zgu433VP2OLyHUHBiYvz3gDluIAM38EVYGRqaqaGtFkD1c="
+              "value": "xAAl.RLAkDL6KGBSbQZH04HqeA0jT4nu7xi2P8KKQ5o-1704454133-1-AZFmTC27vRvSEF0+7cB2VLZo0T/27aLGq1J+N8zM1N/szQfgHSaXNsLs0FVT7iDj70999GRY6td5gOWPDd8bXg0="
             },
             {
               "domain": ".sourcegraph.com",
@@ -531,13 +745,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "Eqn8gTRwKiFlZE22K3bPIwX2CeBrB1eQbRgJvypToR4-1704453335657-0-604800000"
+              "value": "ehHexxlPnkLCRdM10V34lpbr2UOZZmbGLJfIhz_NQrE-1704454133091-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
             },
             {
               "name": "content-type",
@@ -566,17 +780,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=01923998-c17e-4d6e-9650-8d2f768625bb; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=4e23d54a-d88a-4cc2-845e-5adc2ed9965e; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=9KVVn_uX6STXh_VOxZbXGoWbe70mMRUAhS2AyWL.KAk-1704453335-1-AfRqApx3fGF0dEuM8snw8mjNbI6UXMp8AubfO0Da/zgu433VP2OLyHUHBiYvz3gDluIAM38EVYGRqaqaGtFkD1c=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=xAAl.RLAkDL6KGBSbQZH04HqeA0jT4nu7xi2P8KKQ5o-1704454133-1-AZFmTC27vRvSEF0+7cB2VLZo0T/27aLGq1J+N8zM1N/szQfgHSaXNsLs0FVT7iDj70999GRY6td5gOWPDd8bXg0=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=Eqn8gTRwKiFlZE22K3bPIwX2CeBrB1eQbRgJvypToR4-1704453335657-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=ehHexxlPnkLCRdM10V34lpbr2UOZZmbGLJfIhz_NQrE-1704454133091-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -592,15 +806,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5b30b5b71799ebb7eb439d6951536a98"
+              "value": "ef22a5e116b2dda6873d772c37212c54"
             },
             {
               "name": "x-trace-span",
-              "value": "2df00778b1e52155"
+              "value": "3f8bed4e42749a97"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5b30b5b71799ebb7eb439d6951536a98"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ef22a5e116b2dda6873d772c37212c54"
             },
             {
               "name": "x-xss-protection",
@@ -624,7 +838,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4de2cccf7128-OSL"
+              "value": "840b615abb8856c5-OSL"
             },
             {
               "name": "content-encoding",
@@ -637,8 +851,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:35.443Z",
-        "time": 204,
+        "startedDateTime": "2024-01-05T11:28:52.870Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -646,7 +860,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 204
+          "wait": 210
         }
       },
       {
@@ -714,29 +928,29 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
         },
         "response": {
-          "bodySize": 215,
+          "bodySize": 212,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 215,
-            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UF\",\"jiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:35.000Z",
+              "expires": "2025-01-05T11:28:53.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6366d665-4903-4052-851f-2d0948e6d77a"
+              "value": "0fa8eae4-9f38-470e-b29b-502a9853d320"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
+              "expires": "2024-01-05T11:58:53.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "AJyUAqqYNi670gFuSMaQPAt0_CqVt5Qm_mS1U9R5CM0-1704453335-1-AfEqanrGzN3esXYW8PlBE/QHOoR7z8qjMSUcTm16UEKSpT3K8+sxnHRXiT7ijk3j7IdnMMYa49nrw2wjKlkOskA="
+              "value": "L37C2N2IsIW5PNpisELylYLlX7Ylhzg4ACkBRiM4z7c-1704454133-1-AT3uMKyJKllsvfVVrWDjfef5Zs1z3Qp5l0zjKU+mJdzuKmcZHkPaUw5Ja1quHPSz+r87TExOgTPsrHPR1CuAktk="
             },
             {
               "domain": ".sourcegraph.com",
@@ -745,13 +959,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "pHH3t5eFTfoU6mH2bS4wySDO0uKUjXlC8sFluYyCQa0-1704453335664-0-604800000"
+              "value": "2OzIbCd8eChZ0G_F0IuPs5dIoNSuExNA1XALwiyNgeY-1704454133105-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
             },
             {
               "name": "content-type",
@@ -780,17 +994,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6366d665-4903-4052-851f-2d0948e6d77a; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=0fa8eae4-9f38-470e-b29b-502a9853d320; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=AJyUAqqYNi670gFuSMaQPAt0_CqVt5Qm_mS1U9R5CM0-1704453335-1-AfEqanrGzN3esXYW8PlBE/QHOoR7z8qjMSUcTm16UEKSpT3K8+sxnHRXiT7ijk3j7IdnMMYa49nrw2wjKlkOskA=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=L37C2N2IsIW5PNpisELylYLlX7Ylhzg4ACkBRiM4z7c-1704454133-1-AT3uMKyJKllsvfVVrWDjfef5Zs1z3Qp5l0zjKU+mJdzuKmcZHkPaUw5Ja1quHPSz+r87TExOgTPsrHPR1CuAktk=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=pHH3t5eFTfoU6mH2bS4wySDO0uKUjXlC8sFluYyCQa0-1704453335664-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=2OzIbCd8eChZ0G_F0IuPs5dIoNSuExNA1XALwiyNgeY-1704454133105-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -806,15 +1020,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e29879e358f991ce00b8444d1859dede"
+              "value": "5b750df8ab11502c9eefacab0a2ede51"
             },
             {
               "name": "x-trace-span",
-              "value": "391387ba26229f33"
+              "value": "81ecc08d7e8e13f0"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e29879e358f991ce00b8444d1859dede"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5b750df8ab11502c9eefacab0a2ede51"
             },
             {
               "name": "x-xss-protection",
@@ -838,7 +1052,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4de2db4c5685-OSL"
+              "value": "840b615abd6256c1-OSL"
             },
             {
               "name": "content-encoding",
@@ -851,8 +1065,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:35.442Z",
-        "time": 219,
+        "startedDateTime": "2024-01-05T11:28:52.869Z",
+        "time": 224,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -860,221 +1074,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 219
-        }
-      },
-      {
-        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 164,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "164"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 324,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "SiteIdentification",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
-        },
-        "response": {
-          "bodySize": 222,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 222,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaR\",\"wfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8=\",\"AwBhzrhaoAAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:35.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "60d00a83-6609-4cf8-8c70-9b2f1e4cfbb7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9WI1H8qnpeHl7r3n9Bj6NrywTOz2lOcSqkuACx6GmwY-1704453335-1-AdOI8w0ae3wmjJYSql7CxKRjF3mexgOvLSkX+LbmR+ojYxG3tJbWc057PY2kBWa2zXFNVlUYNAjtkk/c3ClyUFM="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ufe2Obh2yyxIere2YW9LAeKmV.635_dG4hhhmd7IIww-1704453335944-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=60d00a83-6609-4cf8-8c70-9b2f1e4cfbb7; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=9WI1H8qnpeHl7r3n9Bj6NrywTOz2lOcSqkuACx6GmwY-1704453335-1-AdOI8w0ae3wmjJYSql7CxKRjF3mexgOvLSkX+LbmR+ojYxG3tJbWc057PY2kBWa2zXFNVlUYNAjtkk/c3ClyUFM=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=ufe2Obh2yyxIere2YW9LAeKmV.635_dG4hhhmd7IIww-1704453335944-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "26c2201a8aec5d98eebed69ca3436b0c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2fabd3c039c51ced"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/26c2201a8aec5d98eebed69ca3436b0c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de2cae156b5-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:35.438Z",
-        "time": 491,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 491
+          "wait": 224
         }
       },
       {
@@ -1151,20 +1151,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:35.000Z",
+              "expires": "2025-01-05T11:28:53.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "135a35d0-e6a5-46a4-ac8e-cdcf1ffab215"
+              "value": "116cf52b-3ad4-4349-808a-6d60586aef63"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
+              "expires": "2024-01-05T11:58:53.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "YirGbPk4atdUeb5GaVPDeO3OHjJOUxMYmjdL89kFWxE-1704453336-1-AbWngC5ctJhnfcBdwoPDAlZ/p4Nq2LU3p+9lrOs3DSSuJ0Serbp5TntgbjU//bcesjbjK1HPhuHHKP4LRkOc6vA="
+              "value": "jQa1bsIzD6Z2JfN0R00mwOg_mj_iSBqV55ZTGQ65N_s-1704454133-1-AQkFpfy/nfZPlsAK4F78LNVLEIL9DDQMtZKbnNk+lN8ucsORy3fpXtlTLfPnMY/rjuVHcAC15Su9HeCwRTZyI+Q="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1173,13 +1173,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "gqSn4h9e0irpeml4tUWz0RCv8kF3y5.AbD.lsD7EGmk-1704453336338-0-604800000"
+              "value": "cGo9KcwXRjD3KR8YE9NxwQYK1y0UMPdq_vmQWDTywdY-1704454133323-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
             },
             {
               "name": "content-type",
@@ -1208,17 +1208,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=135a35d0-e6a5-46a4-ac8e-cdcf1ffab215; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
+              "value": "sourcegraphDeviceId=116cf52b-3ad4-4349-808a-6d60586aef63; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=YirGbPk4atdUeb5GaVPDeO3OHjJOUxMYmjdL89kFWxE-1704453336-1-AbWngC5ctJhnfcBdwoPDAlZ/p4Nq2LU3p+9lrOs3DSSuJ0Serbp5TntgbjU//bcesjbjK1HPhuHHKP4LRkOc6vA=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=jQa1bsIzD6Z2JfN0R00mwOg_mj_iSBqV55ZTGQ65N_s-1704454133-1-AQkFpfy/nfZPlsAK4F78LNVLEIL9DDQMtZKbnNk+lN8ucsORy3fpXtlTLfPnMY/rjuVHcAC15Su9HeCwRTZyI+Q=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=gqSn4h9e0irpeml4tUWz0RCv8kF3y5.AbD.lsD7EGmk-1704453336338-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=cGo9KcwXRjD3KR8YE9NxwQYK1y0UMPdq_vmQWDTywdY-1704454133323-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1234,15 +1234,15 @@
             },
             {
               "name": "x-trace",
-              "value": "4cb68afcacfa0b9a189569c720df66dd"
+              "value": "f27c783272fa975e2b29178d407d7d49"
             },
             {
               "name": "x-trace-span",
-              "value": "0c1b046f9b476eb7"
+              "value": "56c8878738916b41"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4cb68afcacfa0b9a189569c720df66dd"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f27c783272fa975e2b29178d407d7d49"
             },
             {
               "name": "x-xss-protection",
@@ -1266,7 +1266,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4de4380956c5-OSL"
+              "value": "840b615c2d9d0b06-OSL"
             },
             {
               "name": "content-encoding",
@@ -1279,8 +1279,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:35.671Z",
-        "time": 653,
+        "startedDateTime": "2024-01-05T11:28:53.103Z",
+        "time": 211,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1288,7 +1288,430 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 653
+          "wait": 211
+        }
+      },
+      {
+        "_id": "68618dc68610496fb5623c6778ea6c25",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 177,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "177"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:53.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "26894eaa-cbd2-44a6-a186-66a7400c1c9c"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:53.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "4aovktl8_GePSee6tM6INsk0ar.3jNxuMBL6.NbqANw-1704454133-1-AZ1eYDbz0AUml+zQIfzCd+l8/R0OS1ikpHicuDSv3ulcfaOc8u2ShvBJvpHbuJctVuqhmzEO+PoORUfKybomhkE="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "QSSsrMye9n0vqkq2vspss5nqs3VVYw3Pz.IBBNBkXT8-1704454133578-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=26894eaa-cbd2-44a6-a186-66a7400c1c9c; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=4aovktl8_GePSee6tM6INsk0ar.3jNxuMBL6.NbqANw-1704454133-1-AZ1eYDbz0AUml+zQIfzCd+l8/R0OS1ikpHicuDSv3ulcfaOc8u2ShvBJvpHbuJctVuqhmzEO+PoORUfKybomhkE=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=QSSsrMye9n0vqkq2vspss5nqs3VVYw3Pz.IBBNBkXT8-1704454133578-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "3d84e33a56a80f7f29986527b99d19d2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "4e494f5e6f808758"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3d84e33a56a80f7f29986527b99d19d2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b615dcf44b4f4-OSL"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:53.341Z",
+        "time": 226,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 226
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 318,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 799,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 799,
+            "text": "[\"H4sIAAAAAAAA/5xVXW7zOAy8i5/LC+QAvcRiH2g=\",\"irG5kSWVpJJ4i979g5wiaNPabr83A+bvzHD02gV07A6vHZ8xVnQOz4xelZ8jDtYd/nntEk7cHTrKYQasnilPJbIzuCJJGrqnruVydzhiNH57uqdwwj4ymCvjJGmAQRz62H7ec1zrx5SXKnQCc1QHz1XhmLV1HTm5UJsPqrHaetNBC8H/mU++2qSFrP5c9qQRHaZMJ3C29UJfMQlzwkkIphpdoiSG91+S08bQS6GiGf5j7xXlY+xDT+zhLCae9QbQRXyElJ37nE/rad+Mykes0RewKQdWGOdeJayWMEalESgn5+TQo3GAiGmAwM7UVtzZ8FP/pc7VoT8OMMmVw3qyc+SJXWfga8m6Q8iFe8AY9/aQVKqDjfkCo5hnnbfL8rWwysTJcb120RwqOVjtjVTKwjsoY8PXWM9CDEiUa/JtsPbGz5fEaqOU7amL5l9oorFZcWgfzol2h0h8gRPPl6wb7Cm2yjKJG/CVmAOH5a7bbW0ayJ1ODovglUkK/0rkYosHKdNMsXlQPkJRPkuujZeXyuYbh9nH3ENpiNhFnEZAZbSmGnWqvj7KO0CB+7qxIIZJEmDCOLuQwc0x10+w3Yyi+c1VBJODzcnxCqMMY5Rh3Ab0e3n+Spc/MxGwXJV4UCzj35hCzIRxzxYe0SOk8U75Rp7JkGoBq3rm+SvmX8JvVP7MHRXT6RMFj/ZNxGbSNHmU2B5RXn8N7/o3Cdyj7ge2h+sh6t+3tz8BAAD//5ZBG6LnBwAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:53.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6a21b3ee-2150-467d-ba69-efee5137fdad"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:53.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "6jlngUlIKjZ42sP882ZdtA7Z63p7s5iWvytaKK4M9Vw-1704454133-1-Ab0PGH+tJWkloWM4NfSWgsGGhg5I7l/gAT/p2lMkIGKEKdkJCE3qKm1IzP5eGm7C74tkDlrpwOfiAamPUGMSPNk="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "a9bHiLe5wpPzOwQ3oP5kv9cm8MUoyxECgCwREGDdIdU-1704454133595-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6a21b3ee-2150-467d-ba69-efee5137fdad; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=6jlngUlIKjZ42sP882ZdtA7Z63p7s5iWvytaKK4M9Vw-1704454133-1-Ab0PGH+tJWkloWM4NfSWgsGGhg5I7l/gAT/p2lMkIGKEKdkJCE3qKm1IzP5eGm7C74tkDlrpwOfiAamPUGMSPNk=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=a9bHiLe5wpPzOwQ3oP5kv9cm8MUoyxECgCwREGDdIdU-1704454133595-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4a8f7c1f92bd5593b5ec594419433a29"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "91ecd81b357a721c"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4a8f7c1f92bd5593b5ec594419433a29"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b615dc902b4f9-OSL"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:53.333Z",
+        "time": 251,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 251
         }
       },
       {
@@ -1365,20 +1788,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:36.000Z",
+              "expires": "2025-01-05T11:28:53.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "aae4d3df-4b9c-4bcb-937a-9da692d9bff7"
+              "value": "19b84fd6-7aa9-4d45-b709-cf60105294f7"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
+              "expires": "2024-01-05T11:58:53.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HpYML10w6m_7BucTYrb9J4lkSRXLhszrUHE2sTw4bww-1704453336-1-AXVVNXoalpk+qne8g5scu0uxKH1fFZGl5wTrioFf/K0JQiQWihf7PD57Gmr0syz03vCo+k/w7kP1aTU8vZ81XcI="
+              "value": "qLp_4mHTrzAeRgzFk9u_qLk.9it1V5j7kS77.hpAYiU-1704454133-1-AaLkfoR4MNvmF8HiO8vxBupamPrtODqaWx1Fre2x5rVj53VpfBj0JlOZXdJXmEy2ElPzrL4dhySYtwCNB8vpGXU="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1387,13 +1810,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "xx356VYP3H8VSI9Br_Z_a7.iOoK6Dcm071GpziqiV6U-1704453336569-0-604800000"
+              "value": "giLgU5eM1qDYm722l7tFy72c8LLvH35gq5pd5iLXJ8Y-1704454133629-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
             },
             {
               "name": "content-type",
@@ -1422,17 +1845,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=aae4d3df-4b9c-4bcb-937a-9da692d9bff7; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=19b84fd6-7aa9-4d45-b709-cf60105294f7; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HpYML10w6m_7BucTYrb9J4lkSRXLhszrUHE2sTw4bww-1704453336-1-AXVVNXoalpk+qne8g5scu0uxKH1fFZGl5wTrioFf/K0JQiQWihf7PD57Gmr0syz03vCo+k/w7kP1aTU8vZ81XcI=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=qLp_4mHTrzAeRgzFk9u_qLk.9it1V5j7kS77.hpAYiU-1704454133-1-AaLkfoR4MNvmF8HiO8vxBupamPrtODqaWx1Fre2x5rVj53VpfBj0JlOZXdJXmEy2ElPzrL4dhySYtwCNB8vpGXU=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=xx356VYP3H8VSI9Br_Z_a7.iOoK6Dcm071GpziqiV6U-1704453336569-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=giLgU5eM1qDYm722l7tFy72c8LLvH35gq5pd5iLXJ8Y-1704454133629-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1448,15 +1871,15 @@
             },
             {
               "name": "x-trace",
-              "value": "044b7f321d39e2c6b11c131461d4bf7d"
+              "value": "b8bc2cee7c5b8a6bdd04783309a2964a"
             },
             {
               "name": "x-trace-span",
-              "value": "6cc41912e0d1d8ce"
+              "value": "43f036b8d9eaa863"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/044b7f321d39e2c6b11c131461d4bf7d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b8bc2cee7c5b8a6bdd04783309a2964a"
             },
             {
               "name": "x-xss-protection",
@@ -1480,7 +1903,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4de87913b4fd-OSL"
+              "value": "840b615dc9350b31-OSL"
             },
             {
               "name": "content-encoding",
@@ -1493,8 +1916,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.348Z",
-        "time": 207,
+        "startedDateTime": "2024-01-05T11:28:53.339Z",
+        "time": 278,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1502,639 +1925,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 207
-        }
-      },
-      {
-        "_id": "68618dc68610496fb5623c6778ea6c25",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 177,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "177"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-tracing\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e5835af2-9cdd-4488-a96e-611e696daa9d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OX_GcrirqGf64OsWZxMrDL_FeUwfkTq8goutUYKBuEs-1704453336-1-AbZv1cMMP2SQPh99ZnPGO5u04ObFZTHIOHBTDhwNrvhW/96uUJYdmDdEa3PmIFRS4FSiObrHBzuQ8w3bZYk6pTQ="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e5835af2-9cdd-4488-a96e-611e696daa9d; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=OX_GcrirqGf64OsWZxMrDL_FeUwfkTq8goutUYKBuEs-1704453336-1-AbZv1cMMP2SQPh99ZnPGO5u04ObFZTHIOHBTDhwNrvhW/96uUJYdmDdEa3PmIFRS4FSiObrHBzuQ8w3bZYk6pTQ=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "cf90da919caa30b2423cd60862354d0c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ca3248552ef49a56"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cf90da919caa30b2423cd60862354d0c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de87a1c069b-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:36.351Z",
-        "time": 248,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 248
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 318,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 800,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 800,
-            "text": "[\"H4sIAAAAAAAA/5RVUXLbOgy8i76DC/gAucSb9wGCsISaIhUAtK1mcvcObU/aOqFV/2mG4GKJXazeh4iOw+594COmis7xldGr8mvC0Ybdf+9DxpmH3UAlrsPL0Mp42LlW/nj5PBx1oe5huwknDmASOaB2C41RaQIq2Tk7BDSOkDCPENmZXEr+fXePyb504fPCKjNnx/SAT3ZFc6AyL0kwO9iaHc8wyTglGSeXPG50wurlcp+dr4zPDqkQJpjlzPGZ6+2JFcf24ZypP+bPSWJ69Lx7/Mh7rMnBHJVKZIVpDSoRrFQlHhWXaYNva0oT+uOuixb4wR4UJVu3dNESKzlYDUYqS9PVwFiPQgxIVGr2Ph/nxDO7XtQu2qd0s5NiPvyl510ZBjiKiRcFL1XhJD5BLs6hlEP/FUjEZhISw14SgyvzFhXJS3WwqZxgEvOifam/H5IyNvn+eVbfeGHNOAvBXJNLksxwO2r4fSCMs2TAjGl1IQPOGNKfLv/ODs0wMBc6gLP1dbrHJqSJIYrdtbjnZDLmuoBVPfL6ldF9ecso+Fn40GdyxQBzZZwljzCKQ0jtcEPZzCc48HoqurX5bZM4XuymTLJw32L9oAn7cStmbsSum765ts+kyVWYxn6l1KZU9rAoH6XU5tC3yuYPrPRWhQ6XLPLrwu2Ltg4TZxdqvyCoxvoAQbGFpsziBnwm5sjxgtJs9jC6QyoBlha1dhKnCVAZrW2kOlXvS3GbZjllVptkeWJerkgPSd2wI4f61F+nF+t33P7/+PgVAAD//2e0EsLnBwAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "fed647a3-6658-4320-83bc-485078f0dc02"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "GXS6BO6345MQSWIj8kuIG64Fv.oGTkuH__L1p4VNgRk-1704453336-1-AWcpS+/qWgOTyDwAbfcL6NSPiRKXeAmt9DLJ3Ps5YbgIjXN5/zluvywmeeZ39Rlt/05nFze1paXzGQmZ+O8c8gs="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fed647a3-6658-4320-83bc-485078f0dc02; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=GXS6BO6345MQSWIj8kuIG64Fv.oGTkuH__L1p4VNgRk-1704453336-1-AWcpS+/qWgOTyDwAbfcL6NSPiRKXeAmt9DLJ3Ps5YbgIjXN5/zluvywmeeZ39Rlt/05nFze1paXzGQmZ+O8c8gs=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "b9786baff4f1f2ae61544359bd49090e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "375da26d6b47e476"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b9786baff4f1f2ae61544359bd49090e"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de87fd75697-OSL"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:36.341Z",
-        "time": 259,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 259
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b92b91d5-fe2b-43ed-b886-3b9b8a610a90"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "RDTunnXaEjzsZcXxarYYhoeNDU0M0ezCjc1B27j_V.E-1704453337-1-AZDhh6MAyg4Pw5YuLy36YXl6JzjQUOR4mkmmUNKxE87IZmrEPHU+krg4//WF1UufbH/OvV5dCQSOs2FplBtIjFU="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "z2F613RBPJtHDGdKAUeiaXPp4E99yFx84WblqeT0dJM-1704453337053-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b92b91d5-fe2b-43ed-b886-3b9b8a610a90; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=RDTunnXaEjzsZcXxarYYhoeNDU0M0ezCjc1B27j_V.E-1704453337-1-AZDhh6MAyg4Pw5YuLy36YXl6JzjQUOR4mkmmUNKxE87IZmrEPHU+krg4//WF1UufbH/OvV5dCQSOs2FplBtIjFU=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=z2F613RBPJtHDGdKAUeiaXPp4E99yFx84WblqeT0dJM-1704453337053-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d67c85d5f612a4ab6ce8323e8dfa9421"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "13f5622f7939e8fe"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d67c85d5f612a4ab6ce8323e8dfa9421"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4deb8e600b49-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:36.836Z",
-        "time": 202,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 202
+          "wait": 278
         }
       },
       {
@@ -2210,20 +2001,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:36.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "b0f952d0-6f34-48eb-88ac-e18b2e088639"
+              "value": "8edfba7f-9e28-4326-a9b1-1de70b39419e"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
+              "expires": "2024-01-05T11:58:54.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "enNL8TpbfrwgWxg62kaJVO826gjfE2v93EQNjPFEunI-1704453337-1-AXOUFGPqX368wZ4KGzubRsDRbHvVcHZlYPAScKEnqLyA1vQ8HeJvBtgFprQSKK/3Cc9viIuHzroAVMURtzHHh9Q="
+              "value": "8MheeIRP6uf8arsbmeV3slbG6Yp.92R6pFUnu2yfSPo-1704454134-1-AW8w++6Esj3tYyosX7RqUk/mSXaZSLNDurHk75jxdOXN7QBp53pO8F/2x62hTqIdOzPbsPfKNKEPuy/igQnjGHc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2232,13 +2023,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "pF6QjGNdmemUwX9ZllAwShOrBSgaIvPrFat8_oc0qJ4-1704453337060-0-604800000"
+              "value": "0VbiBRyz5R0WgZz4GkNbLdjgS3EbHYJ5nY6Pk9YPd6s-1704454134122-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
             },
             {
               "name": "content-type",
@@ -2267,17 +2058,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b0f952d0-6f34-48eb-88ac-e18b2e088639; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=8edfba7f-9e28-4326-a9b1-1de70b39419e; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=enNL8TpbfrwgWxg62kaJVO826gjfE2v93EQNjPFEunI-1704453337-1-AXOUFGPqX368wZ4KGzubRsDRbHvVcHZlYPAScKEnqLyA1vQ8HeJvBtgFprQSKK/3Cc9viIuHzroAVMURtzHHh9Q=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=8MheeIRP6uf8arsbmeV3slbG6Yp.92R6pFUnu2yfSPo-1704454134-1-AW8w++6Esj3tYyosX7RqUk/mSXaZSLNDurHk75jxdOXN7QBp53pO8F/2x62hTqIdOzPbsPfKNKEPuy/igQnjGHc=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=pF6QjGNdmemUwX9ZllAwShOrBSgaIvPrFat8_oc0qJ4-1704453337060-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=0VbiBRyz5R0WgZz4GkNbLdjgS3EbHYJ5nY6Pk9YPd6s-1704454134122-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2293,15 +2084,15 @@
             },
             {
               "name": "x-trace",
-              "value": "66ac1a4c81ff012cddf33c08dd701f9f"
+              "value": "ab4b602f5dc2e3480ce43cb2f4340527"
             },
             {
               "name": "x-trace-span",
-              "value": "8fe48d85f9ecbd7a"
+              "value": "475e00651eefcfaa"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/66ac1a4c81ff012cddf33c08dd701f9f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ab4b602f5dc2e3480ce43cb2f4340527"
             },
             {
               "name": "x-xss-protection",
@@ -2325,7 +2116,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4deb8a5a56c0-OSL"
+              "value": "840b61612a1356c9-OSL"
             }
           ],
           "headersSize": 1286,
@@ -2334,8 +2125,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.834Z",
-        "time": 213,
+        "startedDateTime": "2024-01-05T11:28:53.895Z",
+        "time": 215,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2343,7 +2134,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 213
+          "wait": 215
         }
       },
       {
@@ -2419,20 +2210,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:36.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8c63ae46-045b-4824-911c-8ac0b9a36a0c"
+              "value": "065ad317-8678-4f76-9d43-46940619e4f5"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
+              "expires": "2024-01-05T11:58:54.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "QcDyftBVhmlZKGe.mecoqZhzRMUTCzgKVwgwilU5Xyo-1704453337-1-AcfPI1U7ohn7TyoFFPg0B7pD5eJCb0ZzvXTR3lSFEaPoJfeWawI6J8wNfxMonZO0EfShX3k3zmDPyr1WbkDYEkY="
+              "value": "Ilj7KSb1JT.HYCswK_.uG_5nneomFd2fYt_hNfVAa_o-1704454134-1-AbY1L9UEr10ghw8NB9qsdJmOhIewU4NRFC2jhK8WwpDQFOt1wFmX41DuTSh7AhC4CkGnHXCRV8QjkQ8cQ60EmWQ="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2441,13 +2232,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "20F_BTYGn6ciZXFcC0HthscL_qO69gZoWKweoggdePc-1704453337095-0-604800000"
+              "value": "ob8M0drlCn_NIi3GTGDlL0oz0igUYWTK4NIjsP9kK7w-1704454134124-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
             },
             {
               "name": "content-type",
@@ -2476,17 +2267,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8c63ae46-045b-4824-911c-8ac0b9a36a0c; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
+              "value": "sourcegraphDeviceId=065ad317-8678-4f76-9d43-46940619e4f5; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=QcDyftBVhmlZKGe.mecoqZhzRMUTCzgKVwgwilU5Xyo-1704453337-1-AcfPI1U7ohn7TyoFFPg0B7pD5eJCb0ZzvXTR3lSFEaPoJfeWawI6J8wNfxMonZO0EfShX3k3zmDPyr1WbkDYEkY=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=Ilj7KSb1JT.HYCswK_.uG_5nneomFd2fYt_hNfVAa_o-1704454134-1-AbY1L9UEr10ghw8NB9qsdJmOhIewU4NRFC2jhK8WwpDQFOt1wFmX41DuTSh7AhC4CkGnHXCRV8QjkQ8cQ60EmWQ=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=20F_BTYGn6ciZXFcC0HthscL_qO69gZoWKweoggdePc-1704453337095-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=ob8M0drlCn_NIi3GTGDlL0oz0igUYWTK4NIjsP9kK7w-1704454134124-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2502,15 +2293,15 @@
             },
             {
               "name": "x-trace",
-              "value": "17a563402cdb7d5385d3c9da2bd50e38"
+              "value": "83287e47b7c302d83b2c307c8739c82a"
             },
             {
               "name": "x-trace-span",
-              "value": "e2a24625d6600f0c"
+              "value": "00238d33e61c89c8"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/17a563402cdb7d5385d3c9da2bd50e38"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83287e47b7c302d83b2c307c8739c82a"
             },
             {
               "name": "x-xss-protection",
@@ -2534,7 +2325,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4deb8b6056b7-OSL"
+              "value": "840b61613d055694-OSL"
             }
           ],
           "headersSize": 1286,
@@ -2543,8 +2334,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.837Z",
-        "time": 243,
+        "startedDateTime": "2024-01-05T11:28:53.905Z",
+        "time": 211,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2552,7 +2343,216 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 243
+          "wait": 211
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:54.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "cb32d239-6a1e-4a4f-9433-7e2d26e9a562"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:54.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "jUoj5TO3os2G5BnbDzOB6v8VzqefW4Zbvj5fnl6wMcE-1704454134-1-AZYU2TOJoYLiGpBRZqTw6ju8UmKEZWaMT6Z8S4pHmfk+HWCAYHeeP4SLjP8aHpw60tJD/19d2XV6Ei5yvYWlWqg="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "8Rj.HsgXhEko8HaYQaBdFN8ueDt0YEecrCljnpmKXmU-1704454134131-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=cb32d239-6a1e-4a4f-9433-7e2d26e9a562; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=jUoj5TO3os2G5BnbDzOB6v8VzqefW4Zbvj5fnl6wMcE-1704454134-1-AZYU2TOJoYLiGpBRZqTw6ju8UmKEZWaMT6Z8S4pHmfk+HWCAYHeeP4SLjP8aHpw60tJD/19d2XV6Ei5yvYWlWqg=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=8Rj.HsgXhEko8HaYQaBdFN8ueDt0YEecrCljnpmKXmU-1704454134131-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "448bfbb57713ba516e53df0036dcab93"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "1e5982e3bf404077"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/448bfbb57713ba516e53df0036dcab93"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b616129dc5688-OSL"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:53.904Z",
+        "time": 229,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 229
         }
       },
       {
@@ -2628,20 +2628,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:37.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "ce2b3973-a713-4f38-96e1-8876e72a327f"
+              "value": "8436fd71-f727-4ce6-9c5c-e3fe30bd01b5"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
+              "expires": "2024-01-05T11:58:54.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "PTsifwH32icHGzP2SKe6FT1ppDnv3sKPrFVu2IB6rt8-1704453337-1-AXeN8/k7KCiJdDzTzC4yGsvY2Xo64UzMWtJQ5NzW6BvNmYK70hKJD0w6Ery8jnLtBCXfiqqDYzCYvS1dHc0e8JY="
+              "value": "R1iFNzwg47RHbMlnkluQjYhRdHDTvdFqOWn1SimRFZo-1704454134-1-AUhxi540qYnuJvdJVlnZX+QTAndGE4sa6yLNiJVQgzvvd1QzqrWAOQy2jeup6o0Ye/q0HsFW3duaQ/4e8S4dQL8="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2650,13 +2650,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "rh9JVAEpDtufRHV3l9oZjIaysYb9uDVbF8w1Il0I4o4-1704453337554-0-604800000"
+              "value": "tLZeBpxGi4YKaz1yjsX2p_YRxbFE2msCG6UwDTSpbGs-1704454134609-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
             },
             {
               "name": "content-type",
@@ -2685,17 +2685,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ce2b3973-a713-4f38-96e1-8876e72a327f; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
+              "value": "sourcegraphDeviceId=8436fd71-f727-4ce6-9c5c-e3fe30bd01b5; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=PTsifwH32icHGzP2SKe6FT1ppDnv3sKPrFVu2IB6rt8-1704453337-1-AXeN8/k7KCiJdDzTzC4yGsvY2Xo64UzMWtJQ5NzW6BvNmYK70hKJD0w6Ery8jnLtBCXfiqqDYzCYvS1dHc0e8JY=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=R1iFNzwg47RHbMlnkluQjYhRdHDTvdFqOWn1SimRFZo-1704454134-1-AUhxi540qYnuJvdJVlnZX+QTAndGE4sa6yLNiJVQgzvvd1QzqrWAOQy2jeup6o0Ye/q0HsFW3duaQ/4e8S4dQL8=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=rh9JVAEpDtufRHV3l9oZjIaysYb9uDVbF8w1Il0I4o4-1704453337554-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=tLZeBpxGi4YKaz1yjsX2p_YRxbFE2msCG6UwDTSpbGs-1704454134609-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2711,15 +2711,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3f62ee305887689353cb7e500a9bfef6"
+              "value": "886859cb9043d5b84d2dbe5ca871eef2"
             },
             {
               "name": "x-trace-span",
-              "value": "0b018b25a7f97851"
+              "value": "7beab3fe95fa2272"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3f62ee305887689353cb7e500a9bfef6"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/886859cb9043d5b84d2dbe5ca871eef2"
             },
             {
               "name": "x-xss-protection",
@@ -2743,7 +2743,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4dee987456b7-OSL"
+              "value": "840b61643b610b55-OSL"
             }
           ],
           "headersSize": 1286,
@@ -2752,8 +2752,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.326Z",
-        "time": 212,
+        "startedDateTime": "2024-01-05T11:28:54.390Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2761,7 +2761,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 212
+          "wait": 221
         }
       },
       {
@@ -2837,20 +2837,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:37.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7a1885ab-e18a-4127-9b29-bfc9f8703e99"
+              "value": "6eb3f9e3-6ee1-4ed4-b533-7f7026898eab"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
+              "expires": "2024-01-05T11:58:54.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "sX8aT.iQXsEH4k32KZLhTMhzJofZwaPbsHaW0Ch3XHE-1704453337-1-AT+7QzjabssfPx5zJ5NM6yD6zbA1z76uwmiTloKpF0lzLbCC0RgYxnhoy3/B6rK6/zYWvJr+eWtDFlh7VwmmMdA="
+              "value": "nraJ2FEsjqluiVbNKME_LKmR74fHistigS6E0ZcLmhs-1704454134-1-ATPHVaa1q39s14JevW4qsclvWOmcJAC+thghZGOZWCWo/6MttJKJ0G+/Gk6WPlDr23KWAUWZXoBRr3ENQtrAhxY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2859,13 +2859,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "uf3mEc.Durx4I5BpVdw8vma2qRvxZ2Lk31dpxsbc2r8-1704453337642-0-604800000"
+              "value": "xqUMwFjlVAlak9BEgS0_IrTELCD9F65sNP2Xqx9qnxk-1704454134621-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
             },
             {
               "name": "content-type",
@@ -2894,17 +2894,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7a1885ab-e18a-4127-9b29-bfc9f8703e99; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
+              "value": "sourcegraphDeviceId=6eb3f9e3-6ee1-4ed4-b533-7f7026898eab; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=sX8aT.iQXsEH4k32KZLhTMhzJofZwaPbsHaW0Ch3XHE-1704453337-1-AT+7QzjabssfPx5zJ5NM6yD6zbA1z76uwmiTloKpF0lzLbCC0RgYxnhoy3/B6rK6/zYWvJr+eWtDFlh7VwmmMdA=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=nraJ2FEsjqluiVbNKME_LKmR74fHistigS6E0ZcLmhs-1704454134-1-ATPHVaa1q39s14JevW4qsclvWOmcJAC+thghZGOZWCWo/6MttJKJ0G+/Gk6WPlDr23KWAUWZXoBRr3ENQtrAhxY=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=uf3mEc.Durx4I5BpVdw8vma2qRvxZ2Lk31dpxsbc2r8-1704453337642-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=xqUMwFjlVAlak9BEgS0_IrTELCD9F65sNP2Xqx9qnxk-1704454134621-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2920,15 +2920,15 @@
             },
             {
               "name": "x-trace",
-              "value": "198a643140ece9961f2e025c1d868d8c"
+              "value": "86db7f12c4567a69994701dbe715384d"
             },
             {
               "name": "x-trace-span",
-              "value": "016c17fee191ae5b"
+              "value": "288c02e34e2d1f05"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/198a643140ece9961f2e025c1d868d8c"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/86db7f12c4567a69994701dbe715384d"
             },
             {
               "name": "x-xss-protection",
@@ -2952,7 +2952,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4dee9f81067b-OSL"
+              "value": "840b61643d69b524-OSL"
             }
           ],
           "headersSize": 1286,
@@ -2961,8 +2961,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.324Z",
-        "time": 301,
+        "startedDateTime": "2024-01-05T11:28:54.389Z",
+        "time": 225,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2970,7 +2970,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 301
+          "wait": 225
         }
       },
       {
@@ -3046,20 +3046,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:37.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "804623ee-9011-475f-b4d3-059c14c482e3"
+              "value": "6d3f320f-d2ff-406c-8bf7-3c718b9a8ef0"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
+              "expires": "2024-01-05T11:58:54.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "LxCS_Tca_VtRhFnq5dZJcUGreAeHHRKC1yyU986i1T0-1704453337-1-AcuzpjnkOdXEkXPFG49jTY9Q+JS3nme2QPuXsmvNfmL+3O34LgfV2Bo6P1AVxiYvbrR9U8EPN1TqRxiI7XCZv/4="
+              "value": "TZHZ7BIOZ6mCfijc6pkOpk8KVSkMWDH4KxKQwB1YW8M-1704454134-1-AY6jWmcAx8DDcE2dj6x/4j+9so21DNjyucEQLbHpwGqsqNL2px42nWR4rdQn4qKbzGK9o169jgqqvx54vEPMcic="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3068,13 +3068,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "9OnM5JKTNeOY1zdXk3igRRvpb..40ADayapp9Y6p0Lw-1704453337798-0-604800000"
+              "value": "bDxMHh1Bxk17B30zVfnRe6mrq2cXdsgfz6uzRuImYN4-1704454134859-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
             },
             {
               "name": "content-type",
@@ -3103,17 +3103,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=804623ee-9011-475f-b4d3-059c14c482e3; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
+              "value": "sourcegraphDeviceId=6d3f320f-d2ff-406c-8bf7-3c718b9a8ef0; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=LxCS_Tca_VtRhFnq5dZJcUGreAeHHRKC1yyU986i1T0-1704453337-1-AcuzpjnkOdXEkXPFG49jTY9Q+JS3nme2QPuXsmvNfmL+3O34LgfV2Bo6P1AVxiYvbrR9U8EPN1TqRxiI7XCZv/4=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=TZHZ7BIOZ6mCfijc6pkOpk8KVSkMWDH4KxKQwB1YW8M-1704454134-1-AY6jWmcAx8DDcE2dj6x/4j+9so21DNjyucEQLbHpwGqsqNL2px42nWR4rdQn4qKbzGK9o169jgqqvx54vEPMcic=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=9OnM5JKTNeOY1zdXk3igRRvpb..40ADayapp9Y6p0Lw-1704453337798-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=bDxMHh1Bxk17B30zVfnRe6mrq2cXdsgfz6uzRuImYN4-1704454134859-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3129,15 +3129,15 @@
             },
             {
               "name": "x-trace",
-              "value": "4b4757a9c6b368023b69c7edc0e85d7f"
+              "value": "f6ac6812868758d9047f4a79f7af5acd"
             },
             {
               "name": "x-trace-span",
-              "value": "8f31ebe753b507ab"
+              "value": "5e229c51115f923b"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4b4757a9c6b368023b69c7edc0e85d7f"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f6ac6812868758d9047f4a79f7af5acd"
             },
             {
               "name": "x-xss-protection",
@@ -3161,7 +3161,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df00f2b069b-OSL"
+              "value": "840b6165af6c5691-OSL"
             }
           ],
           "headersSize": 1286,
@@ -3170,8 +3170,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.546Z",
-        "time": 268,
+        "startedDateTime": "2024-01-05T11:28:54.619Z",
+        "time": 227,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3179,7 +3179,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 268
+          "wait": 227
         }
       },
       {
@@ -3256,20 +3256,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:37.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7b6e9d04-496d-443d-a8b2-3cd39119cb92"
+              "value": "5e0a32c6-4c5b-4562-b946-23d758ce41cc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
+              "expires": "2024-01-05T11:58:54.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "qjO66cuXQnqYqliPV7XF2uQZyJ4JNlgo5BJh_xEHIcw-1704453337-1-Adw8gbbJYxuFqnc3TIvLqFu9ZLEoCKFBOJi7cmfYPzNIRf66iGH7hV7qAg9qSSvYOW4BoGFyr8/0CXGRlJ7Fv9g="
+              "value": "t7Vyb28.3_Bd5d8jd7GpUOgY07bVmiVW76QSYwPD4sw-1704454134-1-Aa1N6flLCeVPi9ibJ/5DCy5jNRXTrOgPlJDObvxW8WzMhuT9hsppDu6jGzn240+7EBnbDN+Ey/8XaWUQAJY04wk="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3278,13 +3278,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "uK_XY_jdjCZiaoimq1HSjSnOhU6bKI9NMUEVbcLis7c-1704453337826-0-604800000"
+              "value": ".uZP9Uv4b2sXak1qjX04QW2BvobskP9h4Y4HPfDRU9w-1704454134862-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
             },
             {
               "name": "content-type",
@@ -3313,17 +3313,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7b6e9d04-496d-443d-a8b2-3cd39119cb92; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
+              "value": "sourcegraphDeviceId=5e0a32c6-4c5b-4562-b946-23d758ce41cc; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=qjO66cuXQnqYqliPV7XF2uQZyJ4JNlgo5BJh_xEHIcw-1704453337-1-Adw8gbbJYxuFqnc3TIvLqFu9ZLEoCKFBOJi7cmfYPzNIRf66iGH7hV7qAg9qSSvYOW4BoGFyr8/0CXGRlJ7Fv9g=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=t7Vyb28.3_Bd5d8jd7GpUOgY07bVmiVW76QSYwPD4sw-1704454134-1-Aa1N6flLCeVPi9ibJ/5DCy5jNRXTrOgPlJDObvxW8WzMhuT9hsppDu6jGzn240+7EBnbDN+Ey/8XaWUQAJY04wk=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=uK_XY_jdjCZiaoimq1HSjSnOhU6bKI9NMUEVbcLis7c-1704453337826-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=.uZP9Uv4b2sXak1qjX04QW2BvobskP9h4Y4HPfDRU9w-1704454134862-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3339,15 +3339,15 @@
             },
             {
               "name": "x-trace",
-              "value": "9d9b493a87d5e2de6f85ab5ab50e7160"
+              "value": "2000e5c9c94c47c01fb1f8e028a146c2"
             },
             {
               "name": "x-trace-span",
-              "value": "f95c12c049e07f60"
+              "value": "ce9465de58f8c45e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9d9b493a87d5e2de6f85ab5ab50e7160"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2000e5c9c94c47c01fb1f8e028a146c2"
             },
             {
               "name": "x-xss-protection",
@@ -3371,7 +3371,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df049cc56cb-OSL"
+              "value": "840b6165aa0456be-OSL"
             },
             {
               "name": "content-encoding",
@@ -3384,8 +3384,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.587Z",
-        "time": 230,
+        "startedDateTime": "2024-01-05T11:28:54.622Z",
+        "time": 228,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3393,7 +3393,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 230
+          "wait": 228
         }
       },
       {
@@ -3461,29 +3461,29 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 122,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 122,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:37.000Z",
+              "expires": "2025-01-05T11:28:54.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "e0fc4749-140b-4dff-bf76-332bc299cecd"
+              "value": "57ad26c3-3484-4462-880f-ebee04d942cf"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
+              "expires": "2024-01-05T11:58:55.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "hSZiEWUIcUJFmRGk7DskWJgYLTnUK.HFz4VAsIntQ_8-1704453338-1-Abz+6YCKNQhSJr9mU4FbwR/E8/0JyjVWKrCJSeZmmal7F/YjYEuEZwbpbjKQmuwF3iF298oBLP5/kgoYymzDJH0="
+              "value": "iqT9tuzCYI89WO2CVLiRw_IfqTOvbxkrRlyEhZze8Ag-1704454135-1-AU54+E4rNtW3BKN89lz5zBBq7bfQ5f+JHifpK5mxc6dR04edDnqOhTcnotBglCzXj2Ypk7h7FyNpdYTZt9aXOSI="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3492,13 +3492,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "n1sMYNGLNvycWx7dmQjWodWsILLg627tpauMczuQkY4-1704453338052-0-604800000"
+              "value": "UGcwFwGC8LiAI47unvyyf7mkNcC39.7dFrkG0kdR_dI-1704454135068-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
             },
             {
               "name": "content-type",
@@ -3527,17 +3527,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e0fc4749-140b-4dff-bf76-332bc299cecd; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
+              "value": "sourcegraphDeviceId=57ad26c3-3484-4462-880f-ebee04d942cf; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=hSZiEWUIcUJFmRGk7DskWJgYLTnUK.HFz4VAsIntQ_8-1704453338-1-Abz+6YCKNQhSJr9mU4FbwR/E8/0JyjVWKrCJSeZmmal7F/YjYEuEZwbpbjKQmuwF3iF298oBLP5/kgoYymzDJH0=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=iqT9tuzCYI89WO2CVLiRw_IfqTOvbxkrRlyEhZze8Ag-1704454135-1-AU54+E4rNtW3BKN89lz5zBBq7bfQ5f+JHifpK5mxc6dR04edDnqOhTcnotBglCzXj2Ypk7h7FyNpdYTZt9aXOSI=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=n1sMYNGLNvycWx7dmQjWodWsILLg627tpauMczuQkY4-1704453338052-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=UGcwFwGC8LiAI47unvyyf7mkNcC39.7dFrkG0kdR_dI-1704454135068-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3553,15 +3553,15 @@
             },
             {
               "name": "x-trace",
-              "value": "595604a13f0ec3ec7566601bb415391d"
+              "value": "fea652cab62db7cd2da126a6f94e633b"
             },
             {
               "name": "x-trace-span",
-              "value": "22ee63bbb182c9dc"
+              "value": "8b6b651f9e20914d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/595604a13f0ec3ec7566601bb415391d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fea652cab62db7cd2da126a6f94e633b"
             },
             {
               "name": "x-xss-protection",
@@ -3585,7 +3585,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df199b756bd-OSL"
+              "value": "840b616708657129-OSL"
             },
             {
               "name": "content-encoding",
@@ -3598,8 +3598,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.782Z",
-        "time": 273,
+        "startedDateTime": "2024-01-05T11:28:54.840Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3607,7 +3607,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
+          "wait": 218
         }
       },
       {
@@ -3683,20 +3683,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:38.000Z",
+              "expires": "2025-01-05T11:28:55.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c93fd369-27e7-4ba8-b8f4-f5f8b11d115f"
+              "value": "c533f712-503e-4ec5-b5c4-f8b14bb75d91"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
+              "expires": "2024-01-05T11:58:55.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "zR4zHgcEpvM.B6UWzptR69KmWAxEx2cMS6kfLVBRZVk-1704453338-1-AYret9HqkumfNTq/8YxqqPs8HR6BhnA5ljYGLAOxOPt5q4pBOFVDgdeYKQJQfImDDH7NHHUusfc0Muz5vvrnXa8="
+              "value": "dRoN.i9AWDwbZ9khGUjPWZlbuIy5FoYyFDzYZOii0F4-1704454135-1-AVLUI4PFcwEki5TTvRRoJrOEy34amZ0o3NEXO/b26hOFhKLPhvut/rxNhozfkekk3LAkQ7n/vtzpSdzpf317XHw="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3705,13 +3705,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "e7Pe27KtI4W07lbAU.0W6m752ky0fhjG2ECpSkOVoU0-1704453338269-0-604800000"
+              "value": "JscS2MV.Pjg8DMroV8JY2mvTwdh8nCqT_mvZlTrx6.s-1704454135418-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
             },
             {
               "name": "content-type",
@@ -3740,17 +3740,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c93fd369-27e7-4ba8-b8f4-f5f8b11d115f; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=c533f712-503e-4ec5-b5c4-f8b14bb75d91; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=zR4zHgcEpvM.B6UWzptR69KmWAxEx2cMS6kfLVBRZVk-1704453338-1-AYret9HqkumfNTq/8YxqqPs8HR6BhnA5ljYGLAOxOPt5q4pBOFVDgdeYKQJQfImDDH7NHHUusfc0Muz5vvrnXa8=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=dRoN.i9AWDwbZ9khGUjPWZlbuIy5FoYyFDzYZOii0F4-1704454135-1-AVLUI4PFcwEki5TTvRRoJrOEy34amZ0o3NEXO/b26hOFhKLPhvut/rxNhozfkekk3LAkQ7n/vtzpSdzpf317XHw=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=e7Pe27KtI4W07lbAU.0W6m752ky0fhjG2ECpSkOVoU0-1704453338269-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=JscS2MV.Pjg8DMroV8JY2mvTwdh8nCqT_mvZlTrx6.s-1704454135418-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3766,15 +3766,15 @@
             },
             {
               "name": "x-trace",
-              "value": "83bb6473d19dab7c6a087a79e94a5bb4"
+              "value": "d902466064aabf9fa73b1e75953d12f7"
             },
             {
               "name": "x-trace-span",
-              "value": "fef316eb0eb2de38"
+              "value": "9438532a37fe74c8"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83bb6473d19dab7c6a087a79e94a5bb4"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d902466064aabf9fa73b1e75953d12f7"
             },
             {
               "name": "x-xss-protection",
@@ -3798,7 +3798,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df32bbbb521-OSL"
+              "value": "840b61694d39b511-OSL"
             }
           ],
           "headersSize": 1286,
@@ -3807,8 +3807,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.049Z",
-        "time": 204,
+        "startedDateTime": "2024-01-05T11:28:55.198Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3816,7 +3816,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 204
+          "wait": 210
         }
       },
       {
@@ -3892,20 +3892,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:38.000Z",
+              "expires": "2025-01-05T11:28:55.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1b682244-f8d3-4187-ad57-8e4070a1229d"
+              "value": "8e268b8d-c7cb-453c-bc43-a2bfc1881988"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
+              "expires": "2024-01-05T11:58:55.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "037zV3Js2kg32keh0iFFZSxw0mXACkvaa7bT7NfrIO0-1704453338-1-AXiSIJohNRtUcqLIIv6Zho0RUsja8GGAKunwNOIr4SzzM/W8xtnZt6DQXJXcmY1kDSQI2hPvCnC3XaSCI5jYa/E="
+              "value": "ys6y7LL_8EsCLnlGIgDRy8qPZrSEGQJp0actYroeDdM-1704454135-1-AVEiSFTJZTsuemt6enJ0XZNr71Db32eUzZpvhDAdG30K08SEkOH2gpHMdn8zGfAkxzb1ZqRP+BawRDqVgSpall0="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3914,13 +3914,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "cmyRjffGzNcUGY5kwYnJFLEAin2dAB6LGeSaF9vlN9I-1704453338275-0-604800000"
+              "value": "Ci1aJkTRbkHIc5sJFa3C9mWMYaJgJSajIqAEl5IpYD4-1704454135422-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
             },
             {
               "name": "content-type",
@@ -3949,17 +3949,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1b682244-f8d3-4187-ad57-8e4070a1229d; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=8e268b8d-c7cb-453c-bc43-a2bfc1881988; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=037zV3Js2kg32keh0iFFZSxw0mXACkvaa7bT7NfrIO0-1704453338-1-AXiSIJohNRtUcqLIIv6Zho0RUsja8GGAKunwNOIr4SzzM/W8xtnZt6DQXJXcmY1kDSQI2hPvCnC3XaSCI5jYa/E=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=ys6y7LL_8EsCLnlGIgDRy8qPZrSEGQJp0actYroeDdM-1704454135-1-AVEiSFTJZTsuemt6enJ0XZNr71Db32eUzZpvhDAdG30K08SEkOH2gpHMdn8zGfAkxzb1ZqRP+BawRDqVgSpall0=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=cmyRjffGzNcUGY5kwYnJFLEAin2dAB6LGeSaF9vlN9I-1704453338275-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Ci1aJkTRbkHIc5sJFa3C9mWMYaJgJSajIqAEl5IpYD4-1704454135422-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3975,15 +3975,15 @@
             },
             {
               "name": "x-trace",
-              "value": "856fd4b8841b784809f22cb13b1f3282"
+              "value": "025347d508d662bc7edbb550757f4f15"
             },
             {
               "name": "x-trace-span",
-              "value": "c57368360d8a2ce4"
+              "value": "4cfe5adb8bebf4e0"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/856fd4b8841b784809f22cb13b1f3282"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/025347d508d662bc7edbb550757f4f15"
             },
             {
               "name": "x-xss-protection",
@@ -4007,7 +4007,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df32a1056af-OSL"
+              "value": "840b61694d30b521-OSL"
             }
           ],
           "headersSize": 1286,
@@ -4016,8 +4016,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.050Z",
-        "time": 209,
+        "startedDateTime": "2024-01-05T11:28:55.200Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4025,216 +4025,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 209
-        }
-      },
-      {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 208,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "208"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "f09f5db0-30ae-4f13-ad85-c6f8ec67f70f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ZO8zf5QVvzgeC2JArdYgQ6V7Kypyk0RdXIsbx66fkmg-1704453338-1-AeSx+/Ag5hfuxYAqLRRrQuIUhFzOfhfbXXLl4Tn6YLC34wsE3OVHtXDLwcEHyxqI4uVd4vX8jqwrernTOi23f5w="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "JvXdvmgcQaLECFwmreqwsXNOFEo0oCBctUV6ubBBz8c-1704453338278-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f09f5db0-30ae-4f13-ad85-c6f8ec67f70f; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ZO8zf5QVvzgeC2JArdYgQ6V7Kypyk0RdXIsbx66fkmg-1704453338-1-AeSx+/Ag5hfuxYAqLRRrQuIUhFzOfhfbXXLl4Tn6YLC34wsE3OVHtXDLwcEHyxqI4uVd4vX8jqwrernTOi23f5w=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=JvXdvmgcQaLECFwmreqwsXNOFEo0oCBctUV6ubBBz8c-1704453338278-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d3d34e76fc155aba95fab5fe5799259c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d5f5e31359c157e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d3d34e76fc155aba95fab5fe5799259c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df32fe3b4f7-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:38.050Z",
-        "time": 217,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 217
+          "wait": 218
         }
       },
       {
@@ -4310,20 +4101,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:38.000Z",
+              "expires": "2025-01-05T11:28:55.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "c6ee1c02-b229-45a0-b38b-cc68175a12f7"
+              "value": "901a817e-7133-4ae7-af48-04085efdc465"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
+              "expires": "2024-01-05T11:58:55.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "hY.straIut02_Wcb..Xpq59Rc3ynYKvP5gxJ.LYOOAk-1704453338-1-AZX9PtaaxR5xbOrlIfyH9+XoAQytxT6lmV1RHRED6avK/y02M7IK6LLrRcfoPXNQ0xWJlABh6N+cAyne59c+D6w="
+              "value": "sg5XHGrf5ajd1835XctQQSR.q_W69xuDMqMFnKoIxlc-1704454135-1-AYbUNA690OQJlrM00BobzcyuLKoZt8twIJtou63BrIQ2Hqvg7sUdwLfOWYggHb8vFyrEaN4UH1BzwzMHktjDn+w="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4332,13 +4123,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "tsYSXo6kZc.7Er2y8tY4pEwun9bmQSUj5xqwgJzrg_Y-1704453338280-0-604800000"
+              "value": "48t8yKSdCB.1nIK6bnBfaT2k68b1ql9CZH00zYCM6o4-1704454135426-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
             },
             {
               "name": "content-type",
@@ -4367,17 +4158,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c6ee1c02-b229-45a0-b38b-cc68175a12f7; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=901a817e-7133-4ae7-af48-04085efdc465; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=hY.straIut02_Wcb..Xpq59Rc3ynYKvP5gxJ.LYOOAk-1704453338-1-AZX9PtaaxR5xbOrlIfyH9+XoAQytxT6lmV1RHRED6avK/y02M7IK6LLrRcfoPXNQ0xWJlABh6N+cAyne59c+D6w=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=sg5XHGrf5ajd1835XctQQSR.q_W69xuDMqMFnKoIxlc-1704454135-1-AYbUNA690OQJlrM00BobzcyuLKoZt8twIJtou63BrIQ2Hqvg7sUdwLfOWYggHb8vFyrEaN4UH1BzwzMHktjDn+w=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=tsYSXo6kZc.7Er2y8tY4pEwun9bmQSUj5xqwgJzrg_Y-1704453338280-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=48t8yKSdCB.1nIK6bnBfaT2k68b1ql9CZH00zYCM6o4-1704454135426-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4393,15 +4184,15 @@
             },
             {
               "name": "x-trace",
-              "value": "4755c3c117b2651c59096d7cf86dadea"
+              "value": "e41e1b9c85d27284ed4c209a84fc4e1c"
             },
             {
               "name": "x-trace-span",
-              "value": "cca0dacb4da7d287"
+              "value": "6cdd807efbadd71e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4755c3c117b2651c59096d7cf86dadea"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e41e1b9c85d27284ed4c209a84fc4e1c"
             },
             {
               "name": "x-xss-protection",
@@ -4425,7 +4216,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df32e520b31-OSL"
+              "value": "840b61695efa568f-OSL"
             }
           ],
           "headersSize": 1286,
@@ -4434,8 +4225,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.051Z",
-        "time": 231,
+        "startedDateTime": "2024-01-05T11:28:55.201Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4443,7 +4234,216 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 231
+          "wait": 221
+        }
+      },
+      {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:55.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "de4ed741-3eed-4eef-a878-28fc9c539276"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:55.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "3cjPI6NTJzLeVkM9RWB72n7Yk_Vz24FJjbhk0P8pCug-1704454135-1-AfWcS7OVYwanMIL5FzaAb124WDgVSyNZ8MY36/ctBXyL9VcBM8Mz8X45MLjZC6r1+AG5PpMVw3hSgzdEqqwC4Y8="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "D59CMWk8SkjQ6VmoofK5dQ4qB5y52hLgV2O4969xMdc-1704454135429-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=de4ed741-3eed-4eef-a878-28fc9c539276; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=3cjPI6NTJzLeVkM9RWB72n7Yk_Vz24FJjbhk0P8pCug-1704454135-1-AfWcS7OVYwanMIL5FzaAb124WDgVSyNZ8MY36/ctBXyL9VcBM8Mz8X45MLjZC6r1+AG5PpMVw3hSgzdEqqwC4Y8=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=D59CMWk8SkjQ6VmoofK5dQ4qB5y52hLgV2O4969xMdc-1704454135429-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "cfaf8eddc61a8a4f0ec4ea069f314ebb"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "e6391675590980ad"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cfaf8eddc61a8a4f0ec4ea069f314ebb"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b61694e9db529-OSL"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:55.200Z",
+        "time": 223,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 223
         }
       },
       {
@@ -4519,20 +4519,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:38.000Z",
+              "expires": "2025-01-05T11:28:55.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "97216359-0d36-4e2f-bc40-d6d6c81f7dc5"
+              "value": "cfb4124b-d835-40b4-9993-336bcb3f8498"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
+              "expires": "2024-01-05T11:58:55.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "rgXRrKSbP3Vdarg5s4ozRivgzqOnYBWnKh2Blmb7Ge8-1704453338-1-AWU34KKOP/hndWjEKqR94obR3ozHqesNbgUb72g1BLEVCQtztcE6M7Fsi/vr/c5goj783M3OgNJnpN1pyyq82E4="
+              "value": "cHo6ZfSRYazxO6nGIH8wD3nYbBxWwR2vd73d58kiYek-1704454135-1-AZHS/kQ3ABAbcQDStWZN9wBCWnF7M266pt2KIiSW4ujLG6tJPkxBT+Xxusc+99ovk83p6nuX7PQYQjW/u2Vu7TI="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4541,13 +4541,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "J6c3XzLoTLo4bMpRE.iJXRL9qRAI8uAr9cPXEZ5n9dk-1704453338742-0-604800000"
+              "value": "TPJb.qj4XANAlJkAwGPmBubZ_QyQiqRpoQzhKvHQ2Dg-1704454135858-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
             },
             {
               "name": "content-type",
@@ -4576,17 +4576,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=97216359-0d36-4e2f-bc40-d6d6c81f7dc5; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=cfb4124b-d835-40b4-9993-336bcb3f8498; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=rgXRrKSbP3Vdarg5s4ozRivgzqOnYBWnKh2Blmb7Ge8-1704453338-1-AWU34KKOP/hndWjEKqR94obR3ozHqesNbgUb72g1BLEVCQtztcE6M7Fsi/vr/c5goj783M3OgNJnpN1pyyq82E4=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=cHo6ZfSRYazxO6nGIH8wD3nYbBxWwR2vd73d58kiYek-1704454135-1-AZHS/kQ3ABAbcQDStWZN9wBCWnF7M266pt2KIiSW4ujLG6tJPkxBT+Xxusc+99ovk83p6nuX7PQYQjW/u2Vu7TI=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=J6c3XzLoTLo4bMpRE.iJXRL9qRAI8uAr9cPXEZ5n9dk-1704453338742-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=TPJb.qj4XANAlJkAwGPmBubZ_QyQiqRpoQzhKvHQ2Dg-1704454135858-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4602,15 +4602,15 @@
             },
             {
               "name": "x-trace",
-              "value": "88ff54d72e660dda662811530cbd3f69"
+              "value": "a82d3cc530ac67788df83edaa74310ef"
             },
             {
               "name": "x-trace-span",
-              "value": "e7770bdb24d11cd1"
+              "value": "32bb49528023cd2e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/88ff54d72e660dda662811530cbd3f69"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a82d3cc530ac67788df83edaa74310ef"
             },
             {
               "name": "x-xss-protection",
@@ -4634,7 +4634,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df61ba8b4fa-OSL"
+              "value": "840b616c0accb4ed-OSL"
             }
           ],
           "headersSize": 1286,
@@ -4643,7 +4643,7 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.525Z",
+        "startedDateTime": "2024-01-05T11:28:55.642Z",
         "time": 204,
         "timings": {
           "blocked": -1,
@@ -4715,28 +4715,28 @@
           "url": "https://sourcegraph.com/.api/completions/code"
         },
         "response": {
-          "bodySize": 702,
+          "bodySize": 619,
           "content": {
             "mimeType": "text/event-stream",
-            "size": 702,
-            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\\n\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\\n\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "size": 619,
+            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:38.000Z",
+              "expires": "2025-01-05T11:28:56.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0fdb380f-2f08-44ae-a7c0-c11b288b7069"
+              "value": "3e1d8c41-cbc7-42fc-9f3c-d879b814338a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
+              "expires": "2024-01-05T11:58:57.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": ".jDHp6mvF5OQktHAFibvrAm8RoctiGaoRNInH5QJ.Xc-1704453340-1-AX1uuB3qzPSd8n6un6aMOrXHjrYrgj/9XsthuUl4bP3PwyM4eq9AWZFI+gjkdAg8cXrmv4eTiHeztMAnbukNBfE="
+              "value": "9GOSh4aI_bqrridoiY5g.UU9FN3oRFU9tryZ2tq.H60-1704454137-1-ARBHWTvqvezK31jYK//ljcqm3aDVk9GqKNLBtVyHKwgJs2FnvdGejIB3R9KMhi1qXUoWY3kISpixVvIA89q5sF8="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4745,13 +4745,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "CiIPknEXwHWCnHxVCKUc2RcHB0sNijxaotb7SASNpxM-1704453340087-0-604800000"
+              "value": "n6LKO5DA5Wck46WPHhPet5NhXiue9LiemZyuhR27yKE-1704454137629-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
             },
             {
               "name": "content-type",
@@ -4780,17 +4780,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0fdb380f-2f08-44ae-a7c0-c11b288b7069; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
+              "value": "sourcegraphDeviceId=3e1d8c41-cbc7-42fc-9f3c-d879b814338a; Expires=Sun, 05 Jan 2025 11:28:56 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=.jDHp6mvF5OQktHAFibvrAm8RoctiGaoRNInH5QJ.Xc-1704453340-1-AX1uuB3qzPSd8n6un6aMOrXHjrYrgj/9XsthuUl4bP3PwyM4eq9AWZFI+gjkdAg8cXrmv4eTiHeztMAnbukNBfE=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=9GOSh4aI_bqrridoiY5g.UU9FN3oRFU9tryZ2tq.H60-1704454137-1-ARBHWTvqvezK31jYK//ljcqm3aDVk9GqKNLBtVyHKwgJs2FnvdGejIB3R9KMhi1qXUoWY3kISpixVvIA89q5sF8=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=CiIPknEXwHWCnHxVCKUc2RcHB0sNijxaotb7SASNpxM-1704453340087-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=n6LKO5DA5Wck46WPHhPet5NhXiue9LiemZyuhR27yKE-1704454137629-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4806,15 +4806,15 @@
             },
             {
               "name": "x-trace",
-              "value": "6df0bdce020eb91a7d5dec37c33d2e9c"
+              "value": "f2e92694504e0cc9ec4fc3e59ea708c1"
             },
             {
               "name": "x-trace-span",
-              "value": "54e57df8ce90c561"
+              "value": "0fbac69875ab703e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6df0bdce020eb91a7d5dec37c33d2e9c"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f2e92694504e0cc9ec4fc3e59ea708c1"
             },
             {
               "name": "x-xss-protection",
@@ -4838,7 +4838,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4df78ef156c4-OSL"
+              "value": "840b616daffc1c12-OSL"
             }
           ],
           "headersSize": 1289,
@@ -4847,8 +4847,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.756Z",
-        "time": 1316,
+        "startedDateTime": "2024-01-05T11:28:55.873Z",
+        "time": 1745,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4856,639 +4856,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1316
-        }
-      },
-      {
-        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 739,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "739"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 322,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "5aff150f-d9be-4999-9570-0562958a8fad"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ywBH5Cqu4jClDxME9t65IW7qYLoCzK5Izs4ICiRwwT8-1704453340-1-AaowMDZ/HcEu/KtFjD55U8F1zO++irntKkUl9SJbkLreeopgMQtSGcLze/Cxu6afgBeoOhB2MA+IISh+oiYRwDk="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "GGDwm6rPy7xZR8zzJaxTU7PHTd1luUnQ5GocAeD.zdg-1704453340624-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5aff150f-d9be-4999-9570-0562958a8fad; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ywBH5Cqu4jClDxME9t65IW7qYLoCzK5Izs4ICiRwwT8-1704453340-1-AaowMDZ/HcEu/KtFjD55U8F1zO++irntKkUl9SJbkLreeopgMQtSGcLze/Cxu6afgBeoOhB2MA+IISh+oiYRwDk=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=GGDwm6rPy7xZR8zzJaxTU7PHTd1luUnQ5GocAeD.zdg-1704453340624-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "69d179f465e846e9f50b63ab623ecba3"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "35c17a69546f400b"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/69d179f465e846e9f50b63ab623ecba3"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01b8bf56b5-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:40.369Z",
-        "time": 242,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 242
-        }
-      },
-      {
-        "_id": "fa14556b8a98cd3158e1f395bbfae82b",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 753,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "753"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 322,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a6d97f07-3869-4a59-93d1-b11da72f3c8e"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "0f439L0y70wWhoKrK9A05guqtS8LxFdyhJE9uC7Y4Nc-1704453340-1-AfldW3f6lQINyfbti/04uz+xp4ypFs1ez0sTVP4SttdZy6eVS9kKnFq6E4TLrmkR4ZJDFfwuNEXwsyw6iA/jf5s="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "IA5ZaMt17J6GkM6YIIvLnQi7xe4ER12.IBr8UJ5mWRo-1704453340634-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a6d97f07-3869-4a59-93d1-b11da72f3c8e; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=0f439L0y70wWhoKrK9A05guqtS8LxFdyhJE9uC7Y4Nc-1704453340-1-AfldW3f6lQINyfbti/04uz+xp4ypFs1ez0sTVP4SttdZy6eVS9kKnFq6E4TLrmkR4ZJDFfwuNEXwsyw6iA/jf5s=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=IA5ZaMt17J6GkM6YIIvLnQi7xe4ER12.IBr8UJ5mWRo-1704453340634-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "96207a9503abe5f8451d77978e121964"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e3a8d4b576f50ae5"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/96207a9503abe5f8451d77978e121964"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01cf6eb51d-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:40.366Z",
-        "time": 254,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 254
-        }
-      },
-      {
-        "_id": "3b9f0cc55d63ad6a017ac63464de0a20",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 347,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "347"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 327,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e74d9552-809f-4193-bae7-b044c594bdba"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "WvVCWzuHPGcIr7j0On_R3dJ8daWmrWwuHIkv.oELD2M-1704453340-1-AVe/Rx5rcNPOl1EsVn85i0+sSk6SZz/V/mki4miMvs0UyQdGLJ8oqrjmHthuDbV2x5XsQZBoKccSAq6hzADBH9E="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "x0x3kYD8MbPZprh96590x3JAKYQJlFS90u32uZPsqCc-1704453340667-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e74d9552-809f-4193-bae7-b044c594bdba; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=WvVCWzuHPGcIr7j0On_R3dJ8daWmrWwuHIkv.oELD2M-1704453340-1-AVe/Rx5rcNPOl1EsVn85i0+sSk6SZz/V/mki4miMvs0UyQdGLJ8oqrjmHthuDbV2x5XsQZBoKccSAq6hzADBH9E=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=x0x3kYD8MbPZprh96590x3JAKYQJlFS90u32uZPsqCc-1704453340667-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "fcf0f99cc12ff5777247e22aa6388c94"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "542ae572e67c7aec"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fcf0f99cc12ff5777247e22aa6388c94"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01db3e56c3-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:40.371Z",
-        "time": 294,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 294
+          "wait": 1745
         }
       },
       {
@@ -5565,20 +4933,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:40.000Z",
+              "expires": "2025-01-05T11:28:57.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "732bd36b-6075-496a-b8b8-d47cda3f4f0c"
+              "value": "83b7e1ac-7a6d-4752-9a9a-12a7b464ecbc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
+              "expires": "2024-01-05T11:58:57.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": ".j.TLgVLqhbM_g8iyafIxDCqc4B0yvQ8itVAILNIop0-1704453340-1-AWE+mWCYkKhAM9oLNrLJCWa9VQbN7T9UmUNhU6503QGyCmZZCMQsR2KpEeuBwUSZeiuKtQl32A0ubDhQb5W2HXw="
+              "value": "dljJBnLJZIvOQrqdgm96F3adVft90W9Vr3.HTSAn2Jg-1704454137-1-AW09t3bk8wyPaEQjRuA/jgDCJ9aSpRz0lnzunNGMmcAPRDQcSK8cLTKObPfYEAo7MRhEz4H3H6m8jun2Vg/KINg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5587,13 +4955,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "pd_BJg3387IRXayBR89mQ5YqqvhWBK2bkIvdbms3slY-1704453340668-0-604800000"
+              "value": "znzleVb_NhQn4X.RQ7VNBYKxsiB3W2mdMFnj46HMG3I-1704454137889-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
             },
             {
               "name": "content-type",
@@ -5622,17 +4990,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=732bd36b-6075-496a-b8b8-d47cda3f4f0c; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
+              "value": "sourcegraphDeviceId=83b7e1ac-7a6d-4752-9a9a-12a7b464ecbc; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=.j.TLgVLqhbM_g8iyafIxDCqc4B0yvQ8itVAILNIop0-1704453340-1-AWE+mWCYkKhAM9oLNrLJCWa9VQbN7T9UmUNhU6503QGyCmZZCMQsR2KpEeuBwUSZeiuKtQl32A0ubDhQb5W2HXw=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=dljJBnLJZIvOQrqdgm96F3adVft90W9Vr3.HTSAn2Jg-1704454137-1-AW09t3bk8wyPaEQjRuA/jgDCJ9aSpRz0lnzunNGMmcAPRDQcSK8cLTKObPfYEAo7MRhEz4H3H6m8jun2Vg/KINg=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=pd_BJg3387IRXayBR89mQ5YqqvhWBK2bkIvdbms3slY-1704453340668-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=znzleVb_NhQn4X.RQ7VNBYKxsiB3W2mdMFnj46HMG3I-1704454137889-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5648,15 +5016,15 @@
             },
             {
               "name": "x-trace",
-              "value": "fac8ef303c769b080178353ab92aa946"
+              "value": "c86232045d22e55f93fb4c4be4646b01"
             },
             {
               "name": "x-trace-span",
-              "value": "5e3a474df74517b3"
+              "value": "a9d1e6e1033066a8"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fac8ef303c769b080178353ab92aa946"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c86232045d22e55f93fb4c4be4646b01"
             },
             {
               "name": "x-xss-protection",
@@ -5680,7 +5048,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4e01cca456ca-OSL"
+              "value": "840b6178a9e9b4f3-OSL"
             },
             {
               "name": "content-encoding",
@@ -5693,8 +5061,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:40.370Z",
-        "time": 295,
+        "startedDateTime": "2024-01-05T11:28:57.658Z",
+        "time": 223,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5702,7 +5070,639 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 295
+          "wait": 223
+        }
+      },
+      {
+        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 739,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "739"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 322,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:57.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "2eb56f6f-ab37-424a-9de3-99470a4dc358"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:57.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "aeGg3Hmvvj7IbWVwK3L3WeH9TjRhLzpkaqxOLXfRFJ0-1704454137-1-ARthvA8y8V3IwgcRBMtWNtmSd17M4Z0vZ5rhshyRWAWrzBIcig6CipO5fG1DGRQtwj2/5ERgH/x/U0fRbiRWYA4="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "OAxsvOEQyxjNML.mrRuch5WxrmtEpJD5eqkKI_8kODE-1704454137898-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=2eb56f6f-ab37-424a-9de3-99470a4dc358; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=aeGg3Hmvvj7IbWVwK3L3WeH9TjRhLzpkaqxOLXfRFJ0-1704454137-1-ARthvA8y8V3IwgcRBMtWNtmSd17M4Z0vZ5rhshyRWAWrzBIcig6CipO5fG1DGRQtwj2/5ERgH/x/U0fRbiRWYA4=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=OAxsvOEQyxjNML.mrRuch5WxrmtEpJD5eqkKI_8kODE-1704454137898-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "76bf9250dd3aac15b9b9cf9c07321016"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "96ee392257b30ed4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/76bf9250dd3aac15b9b9cf9c07321016"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b6178a9e656b7-OSL"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:57.657Z",
+        "time": 229,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 229
+        }
+      },
+      {
+        "_id": "3b9f0cc55d63ad6a017ac63464de0a20",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 347,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "347"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.completion\",\"action\":\"accepted\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 112,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:57.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "5590c55a-f519-4c46-b146-786fb282d955"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:57.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "zfTA_UqvlUrYuggks8XM96qsQvwbwy.LRNoZkOjEMUY-1704454137-1-AZV4AHckNXUXWwxN6lnPuvSxTeaCXxHWHU1duPpiqk1w0OSg+pLXndVy7obaSPV5LoJ5bqvvWDQezlmT5zDFqSA="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "loG6SmoPYUScEZMi93AAzWkZ6sW3C7.Fo1.RxYcBcD0-1704454137908-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=5590c55a-f519-4c46-b146-786fb282d955; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=zfTA_UqvlUrYuggks8XM96qsQvwbwy.LRNoZkOjEMUY-1704454137-1-AZV4AHckNXUXWwxN6lnPuvSxTeaCXxHWHU1duPpiqk1w0OSg+pLXndVy7obaSPV5LoJ5bqvvWDQezlmT5zDFqSA=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=loG6SmoPYUScEZMi93AAzWkZ6sW3C7.Fo1.RxYcBcD0-1704454137908-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "11f22b881fd2d93e96ac5ba8c8ccd054"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "ee016fe6d29efd90"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/11f22b881fd2d93e96ac5ba8c8ccd054"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b6178a8fd56b5-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:57.658Z",
+        "time": 255,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 255
+        }
+      },
+      {
+        "_id": "fa14556b8a98cd3158e1f395bbfae82b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 753,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "753"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 322,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:28:57.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "1fc1549f-6238-4095-822f-9f67725db029"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T11:58:57.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "k_PJrBC38.t7VbItAxVxvDkHfjZmH4f.kGnsskyhrMo-1704454137-1-AYaq9WaLb+06NgqMUceWVFz6e9CUP8Wft262f7KxZnMJvXhOiWTJphl78zBuUJ64GxlkVzHA0dwDEh+li5XeoXY="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "2RWo40rKtRi0hOIsIrrYxspVZgzyG_ZqnOXHd.mxjFY-1704454137930-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=1fc1549f-6238-4095-822f-9f67725db029; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=k_PJrBC38.t7VbItAxVxvDkHfjZmH4f.kGnsskyhrMo-1704454137-1-AYaq9WaLb+06NgqMUceWVFz6e9CUP8Wft262f7KxZnMJvXhOiWTJphl78zBuUJ64GxlkVzHA0dwDEh+li5XeoXY=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=2RWo40rKtRi0hOIsIrrYxspVZgzyG_ZqnOXHd.mxjFY-1704454137930-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "5bf2764f8aa47d5b5db8212f0e8b04b2"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0af36f995b2c96bf"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5bf2764f8aa47d5b5db8212f0e8b04b2"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b6178a843b4ee-OSL"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:28:57.656Z",
+        "time": 266,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 266
         }
       },
       {
@@ -5779,20 +5779,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:40.000Z",
+              "expires": "2025-01-05T11:28:58.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "33cb90f1-300b-45a2-b1b9-2e37d16633e0"
+              "value": "fe765008-6a22-46d9-bbd9-9e659cd376ea"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:41.000Z",
+              "expires": "2024-01-05T11:58:58.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "HtRVBC4OqKS6dlvh3hUdx8vH3xkVYoO_XtBh02A_s1U-1704453341-1-AYYE0QmpsAEH73vhdwgELBQLSqqO9TpcuXITPyaXY/L7nJ4a3B2D4pRe3kjoxQm3M0Owxa6M8tRE5B2ndfSl2Ms="
+              "value": "9FCBKjeOcRJ_U2RgmBJnQRPMRYjebEyH3qcD2BUvdUc-1704454138-1-ATrp4S9htlNnE2jXjNi9cLKs6AvEY51cJSJUmBhVTg37+4lXNq2t2JC0OaRzUB8WO9qDrRoerUlahyT4u/q9beY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5801,13 +5801,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "sFxC.5XWrEgosDUQPfVh.g3IMhsC7LrXXI8GuXSfRQ0-1704453341180-0-604800000"
+              "value": "hy3xBuSHH09bYr54kNFj1s6yLnG.K9xTxYupNuqJ2yE-1704454138406-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:41 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:58 GMT"
             },
             {
               "name": "content-type",
@@ -5840,17 +5840,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=33cb90f1-300b-45a2-b1b9-2e37d16633e0; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
+              "value": "sourcegraphDeviceId=fe765008-6a22-46d9-bbd9-9e659cd376ea; Expires=Sun, 05 Jan 2025 11:28:58 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=HtRVBC4OqKS6dlvh3hUdx8vH3xkVYoO_XtBh02A_s1U-1704453341-1-AYYE0QmpsAEH73vhdwgELBQLSqqO9TpcuXITPyaXY/L7nJ4a3B2D4pRe3kjoxQm3M0Owxa6M8tRE5B2ndfSl2Ms=; path=/; expires=Fri, 05-Jan-24 11:45:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=9FCBKjeOcRJ_U2RgmBJnQRPMRYjebEyH3qcD2BUvdUc-1704454138-1-ATrp4S9htlNnE2jXjNi9cLKs6AvEY51cJSJUmBhVTg37+4lXNq2t2JC0OaRzUB8WO9qDrRoerUlahyT4u/q9beY=; path=/; expires=Fri, 05-Jan-24 11:58:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=sFxC.5XWrEgosDUQPfVh.g3IMhsC7LrXXI8GuXSfRQ0-1704453341180-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=hy3xBuSHH09bYr54kNFj1s6yLnG.K9xTxYupNuqJ2yE-1704454138406-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5866,15 +5866,15 @@
             },
             {
               "name": "x-trace",
-              "value": "16fa9c51612bda5a83e806aaa5cf53a0"
+              "value": "355f9f73059fe50fa3b6be126b69972a"
             },
             {
               "name": "x-trace-span",
-              "value": "f921fce1d2e04f96"
+              "value": "5f112f8472d7ed5d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/16fa9c51612bda5a83e806aaa5cf53a0"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/355f9f73059fe50fa3b6be126b69972a"
             },
             {
               "name": "x-xss-protection",
@@ -5898,7 +5898,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4e037ff1569a-OSL"
+              "value": "840b617a698256cc-OSL"
             }
           ],
           "headersSize": 1318,
@@ -5907,8 +5907,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:40.666Z",
-        "time": 498,
+        "startedDateTime": "2024-01-05T11:28:57.924Z",
+        "time": 474,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5916,7 +5916,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 498
+          "wait": 474
         }
       },
       {
@@ -5993,20 +5993,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:41.000Z",
+              "expires": "2025-01-05T11:28:58.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "7195f001-4878-4c8a-8952-043f64c743ff"
+              "value": "1f07a6ab-5d9c-4e03-8ea3-cd117a265fcc"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:41.000Z",
+              "expires": "2024-01-05T11:58:58.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "NVWkiv7GKO5X8mqBIqVIVE4smZGgelH1bLs1imuydFk-1704453341-1-AR/vw9kMBKv8mvR0nwav2THb+avznuTgn0zAWvx3fWFUxZikZZcLjKIFOPBGueEmJxA4+vLXyTv+IqqxJuZVIBg="
+              "value": "oq.FdTDnyDJcEqdBNfY2kgfGORJjsYGglsjGi8TJYwY-1704454138-1-Ab+arxPZ2Q/KrLOLHvAMlI0QmwuXBDdcke1VeVTvHy+razACLyxilu5qcKMJRPtTJ7zLySLRVNUJv0xe3zBWJA8="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6015,13 +6015,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "4IUratgqxUEuzug2Ni8gWnFo5A2CM1MEmwWG8yK2DiE-1704453341459-0-604800000"
+              "value": "ohJw8oTm7KLewOiVAnBh8NPMGsnzOCQ55fWTItnQ7mo-1704454138660-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:41 GMT"
+              "value": "Fri, 05 Jan 2024 11:28:58 GMT"
             },
             {
               "name": "content-type",
@@ -6050,17 +6050,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7195f001-4878-4c8a-8952-043f64c743ff; Expires=Sun, 05 Jan 2025 11:15:41 GMT; Secure"
+              "value": "sourcegraphDeviceId=1f07a6ab-5d9c-4e03-8ea3-cd117a265fcc; Expires=Sun, 05 Jan 2025 11:28:58 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=NVWkiv7GKO5X8mqBIqVIVE4smZGgelH1bLs1imuydFk-1704453341-1-AR/vw9kMBKv8mvR0nwav2THb+avznuTgn0zAWvx3fWFUxZikZZcLjKIFOPBGueEmJxA4+vLXyTv+IqqxJuZVIBg=; path=/; expires=Fri, 05-Jan-24 11:45:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=oq.FdTDnyDJcEqdBNfY2kgfGORJjsYGglsjGi8TJYwY-1704454138-1-Ab+arxPZ2Q/KrLOLHvAMlI0QmwuXBDdcke1VeVTvHy+razACLyxilu5qcKMJRPtTJ7zLySLRVNUJv0xe3zBWJA8=; path=/; expires=Fri, 05-Jan-24 11:58:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=4IUratgqxUEuzug2Ni8gWnFo5A2CM1MEmwWG8yK2DiE-1704453341459-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=ohJw8oTm7KLewOiVAnBh8NPMGsnzOCQ55fWTItnQ7mo-1704454138660-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6076,15 +6076,15 @@
             },
             {
               "name": "x-trace",
-              "value": "68ab7cbbe398a64cb2f93f5cc95f03db"
+              "value": "e76c10e51893a4f37ac942665433f2ba"
             },
             {
               "name": "x-trace-span",
-              "value": "918293d3d1cd2e60"
+              "value": "dc0ddf001dad4656"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/68ab7cbbe398a64cb2f93f5cc95f03db"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e76c10e51893a4f37ac942665433f2ba"
             },
             {
               "name": "x-xss-protection",
@@ -6108,7 +6108,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4e06cea9712d-OSL"
+              "value": "840b617d791756a2-OSL"
             },
             {
               "name": "content-encoding",
@@ -6121,8 +6121,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:41.195Z",
-        "time": 249,
+        "startedDateTime": "2024-01-05T11:28:58.428Z",
+        "time": 222,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6130,7 +6130,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 249
+          "wait": 222
         }
       },
       {
@@ -6182,20 +6182,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:15:41.000Z",
+              "expires": "2025-01-05T11:28:58.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6bd93bac-aca3-4ba3-b71b-a27368462903"
+              "value": "cc281c22-e0bc-44b0-a7b5-a6718e1766d7"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:44.000Z",
+              "expires": "2024-01-05T11:59:01.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "nCOknERsHWzpV288jWXhCJaYEo_.d3XDMRCm4b.BipA-1704453344-1-AUxgs9/TF4WV6b8UUcivi51aorqy1AR3UMV9H2Aen8A79i+jfIU0yVE+2FHTE+xSC3klYNULwipYsLpFOFD5va8="
+              "value": "1SS6bR1KMORM_uFzk97BASC_R6CJ3wV8oJuHNY.Lzwg-1704454141-1-AdMgL9B0kxBeFaDrYSKpgzjUX418FcMiVgjVBHyJ2P0n7o51TiFMGwv/jcqlLoUEGGfmSiaQakHsW5z0YZSG8cc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6204,13 +6204,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "SreICQpCCTEuuOdvqC4aQWPce3BT3lHO5jYYaG62_SE-1704453344561-0-604800000"
+              "value": "BU64HzY_oxA1oz5Eo_f.sCIFhLfCDCg6HApxXO_bmks-1704454141750-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:44 GMT"
+              "value": "Fri, 05 Jan 2024 11:29:01 GMT"
             },
             {
               "name": "content-type",
@@ -6239,17 +6239,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6bd93bac-aca3-4ba3-b71b-a27368462903; Expires=Sun, 05 Jan 2025 11:15:41 GMT; Secure"
+              "value": "sourcegraphDeviceId=cc281c22-e0bc-44b0-a7b5-a6718e1766d7; Expires=Sun, 05 Jan 2025 11:28:58 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=nCOknERsHWzpV288jWXhCJaYEo_.d3XDMRCm4b.BipA-1704453344-1-AUxgs9/TF4WV6b8UUcivi51aorqy1AR3UMV9H2Aen8A79i+jfIU0yVE+2FHTE+xSC3klYNULwipYsLpFOFD5va8=; path=/; expires=Fri, 05-Jan-24 11:45:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=1SS6bR1KMORM_uFzk97BASC_R6CJ3wV8oJuHNY.Lzwg-1704454141-1-AdMgL9B0kxBeFaDrYSKpgzjUX418FcMiVgjVBHyJ2P0n7o51TiFMGwv/jcqlLoUEGGfmSiaQakHsW5z0YZSG8cc=; path=/; expires=Fri, 05-Jan-24 11:59:01 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=SreICQpCCTEuuOdvqC4aQWPce3BT3lHO5jYYaG62_SE-1704453344561-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=BU64HzY_oxA1oz5Eo_f.sCIFhLfCDCg6HApxXO_bmks-1704454141750-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6265,15 +6265,15 @@
             },
             {
               "name": "x-trace",
-              "value": "26d0ee969e86f021da461b9a39abca50"
+              "value": "b9938320ace7bf4591d0d464b32a2945"
             },
             {
               "name": "x-trace-span",
-              "value": "ed6e7ab0d6041cae"
+              "value": "a3832ca8c821f362"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/26d0ee969e86f021da461b9a39abca50"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b9938320ace7bf4591d0d464b32a2945"
             },
             {
               "name": "x-xss-protection",
@@ -6297,7 +6297,7 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b4e06ceb4712d-OSL"
+              "value": "840b617d7da07127-OSL"
             }
           ],
           "headersSize": 1289,
@@ -6306,8 +6306,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:41.186Z",
-        "time": 3642,
+        "startedDateTime": "2024-01-05T11:28:58.420Z",
+        "time": 3627,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6315,7 +6315,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3642
+          "wait": 3627
         }
       }
     ],

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -72,29 +72,29 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteProductVersion"
         },
         "response": {
-          "bodySize": 136,
+          "bodySize": 139,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 136,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZuYGhvFGBkYmugaGugam8aZ6RrpGxiamqSkWacnGRiZKtbW1AAAAAP//AwC7GWWbSQAAAA==\"]"
+            "size": 139,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZuYGhvFGBkYmugaGugam8aZ6RrpGxiamqSkWacnGRiZKtbW1AAAAAP//\",\"AwC7GWWbSQAAAA==\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:52.000Z",
+              "expires": "2025-01-05T11:30:09.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "24259cb3-4476-4a4a-b993-45a4e1f1290a"
+              "value": "e38bc61b-5ac8-4064-ae85-ce67ffaedaed"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:52.000Z",
+              "expires": "2024-01-05T12:00:09.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "t5rHcj_bO6yfX.e7O_x6lwiN5VAcP2HW.Cn.43GDV3k-1704454132-1-AdXHrrh4bXtYW3IuvcQEVNmtXydvq6OtCv6p00GdyOV+OIVgMd13CvIz+qtBnb7Y0OTkh8ujrXQkaJnAQer5gVQ="
+              "value": "LYnchXMHqXbnULfdLZNkVRqpWHjtyV8bLaurUwD.tTM-1704454209-1-AfyJJSbynkFRDv9blBfwvigmLuPOoPCiYSvMohR5qj+E2phbaWrvyxrjUWPYtf/rOjjiMy0/CIfHHcLaBVfI1v0="
             },
             {
               "domain": ".sourcegraph.com",
@@ -103,13 +103,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "_1THriXLBkaHi.w9UXc7DbrzLMuJdn.Jan8RDRTRirA-1704454132370-0-604800000"
+              "value": "3jK8ssBOpOmK4Bb3EpnXIfVQ8AfjLbngl0LrO4unNF4-1704454209897-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:52 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:09 GMT"
             },
             {
               "name": "content-type",
@@ -122,6 +122,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "575"
             },
             {
               "name": "access-control-allow-credentials",
@@ -138,17 +150,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=24259cb3-4476-4a4a-b993-45a4e1f1290a; Expires=Sun, 05 Jan 2025 11:28:52 GMT; Secure"
+              "value": "sourcegraphDeviceId=e38bc61b-5ac8-4064-ae85-ce67ffaedaed; Expires=Sun, 05 Jan 2025 11:30:09 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=t5rHcj_bO6yfX.e7O_x6lwiN5VAcP2HW.Cn.43GDV3k-1704454132-1-AdXHrrh4bXtYW3IuvcQEVNmtXydvq6OtCv6p00GdyOV+OIVgMd13CvIz+qtBnb7Y0OTkh8ujrXQkaJnAQer5gVQ=; path=/; expires=Fri, 05-Jan-24 11:58:52 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=LYnchXMHqXbnULfdLZNkVRqpWHjtyV8bLaurUwD.tTM-1704454209-1-AfyJJSbynkFRDv9blBfwvigmLuPOoPCiYSvMohR5qj+E2phbaWrvyxrjUWPYtf/rOjjiMy0/CIfHHcLaBVfI1v0=; path=/; expires=Fri, 05-Jan-24 12:00:09 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=_1THriXLBkaHi.w9UXc7DbrzLMuJdn.Jan8RDRTRirA-1704454132370-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=3jK8ssBOpOmK4Bb3EpnXIfVQ8AfjLbngl0LrO4unNF4-1704454209897-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -164,15 +176,15 @@
             },
             {
               "name": "x-trace",
-              "value": "de815d1d248be73392f29ec10c32cb80"
+              "value": "12aceeb2a2ceff4d9d8dfbd5e90924b9"
             },
             {
               "name": "x-trace-span",
-              "value": "999595203fb232e3"
+              "value": "31f60c5cb4ef5c02"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/de815d1d248be73392f29ec10c32cb80"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/12aceeb2a2ceff4d9d8dfbd5e90924b9"
             },
             {
               "name": "x-xss-protection",
@@ -196,21 +208,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b61563adb0b4d-OSL"
+              "value": "840b633a8d41b51e-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:52.118Z",
-        "time": 248,
+        "startedDateTime": "2024-01-05T11:30:09.625Z",
+        "time": 270,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -218,7 +230,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 248
+          "wait": 270
         }
       },
       {
@@ -286,29 +298,29 @@
           "url": "https://sourcegraph.com/.api/graphql?Repository"
         },
         "response": {
-          "bodySize": 158,
+          "bodySize": 148,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 158,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8=\",\"AwD/h5WCVAAAAA==\"]"
+            "size": 148,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:52.000Z",
+              "expires": "2025-01-05T11:30:10.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1facf2c0-9d13-4dff-8b0a-ca76da7a0a33"
+              "value": "adf18bee-8695-45c9-8865-529294af8454"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:52.000Z",
+              "expires": "2024-01-05T12:00:10.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "bfbiAfcoO6Xw291GgsS1vyODrULSG0Mtxwkf2Vs5xQU-1704454132-1-AfeKIk53aSIVSHnCFY09O/2QijSVSD0ormC5fGKBW5gujYDbAF8M4dEZPNwZmUYyjXoTcxh+GRhhJCnrOw61GjY="
+              "value": "HM3vHCbwB1HsTWdoOlw29CE25o5TJYzYG7JJ1H7ydhQ-1704454210-1-Ae+U+7KE1lGK9aAZDkkZdH7chY9v6LSRQiFqEDenxtZCem6UNuhNnR76CfBto3uwTrQaoYo2rMX8Bwxr/xQkGX0="
             },
             {
               "domain": ".sourcegraph.com",
@@ -317,13 +329,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "7JnHbgEJQnH1d2qx2MuudoSR41F4Gj3EWzw4d3X_j_w-1704454132850-0-604800000"
+              "value": "mbhVtr7XTNbFQG92rO7Pfy48xoQXxnZ_HNMx_gdRjiU-1704454210351-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:52 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:10 GMT"
             },
             {
               "name": "content-type",
@@ -336,6 +348,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
             },
             {
               "name": "access-control-allow-credentials",
@@ -352,17 +376,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1facf2c0-9d13-4dff-8b0a-ca76da7a0a33; Expires=Sun, 05 Jan 2025 11:28:52 GMT; Secure"
+              "value": "sourcegraphDeviceId=adf18bee-8695-45c9-8865-529294af8454; Expires=Sun, 05 Jan 2025 11:30:10 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=bfbiAfcoO6Xw291GgsS1vyODrULSG0Mtxwkf2Vs5xQU-1704454132-1-AfeKIk53aSIVSHnCFY09O/2QijSVSD0ormC5fGKBW5gujYDbAF8M4dEZPNwZmUYyjXoTcxh+GRhhJCnrOw61GjY=; path=/; expires=Fri, 05-Jan-24 11:58:52 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=HM3vHCbwB1HsTWdoOlw29CE25o5TJYzYG7JJ1H7ydhQ-1704454210-1-Ae+U+7KE1lGK9aAZDkkZdH7chY9v6LSRQiFqEDenxtZCem6UNuhNnR76CfBto3uwTrQaoYo2rMX8Bwxr/xQkGX0=; path=/; expires=Fri, 05-Jan-24 12:00:10 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=7JnHbgEJQnH1d2qx2MuudoSR41F4Gj3EWzw4d3X_j_w-1704454132850-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=mbhVtr7XTNbFQG92rO7Pfy48xoQXxnZ_HNMx_gdRjiU-1704454210351-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -378,15 +402,15 @@
             },
             {
               "name": "x-trace",
-              "value": "2d4507ef453c255ef4bd4f93fb1dd04d"
+              "value": "89057a303ea0cd3fae6014b17b29b26a"
             },
             {
               "name": "x-trace-span",
-              "value": "7a64de49e245b2fd"
+              "value": "50f03f63d401133f"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2d4507ef453c255ef4bd4f93fb1dd04d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/89057a303ea0cd3fae6014b17b29b26a"
             },
             {
               "name": "x-xss-protection",
@@ -410,21 +434,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b61593c9756b1-OSL"
+              "value": "840b633d9e5e0b51-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:52.629Z",
-        "time": 211,
+        "startedDateTime": "2024-01-05T11:30:10.125Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -432,435 +456,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 211
-        }
-      },
-      {
-        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 164,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "164"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 324,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "SiteIdentification",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
-        },
-        "response": {
-          "bodySize": 212,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:53.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6fd0c956-540f-4744-9821-f62a40d3cce3"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "7xHvHejNKpXyYAvKjrCX2UhTP9qaWPJCC3Ts6s8eICc-1704454133-1-AekpFMnYDAh/4/IH6m7UnLxqp1hv+QHrZoj1s/8cbRSKBH4XcvGb+b5Z7Xa7LLhVphFQD1B3geGzoAkCs5Y5KyA="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "qyJRb0_fEiAed07UDpy7N9wNsoVVZeIL6X0Bv_pDBZ8-1704454133081-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6fd0c956-540f-4744-9821-f62a40d3cce3; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=7xHvHejNKpXyYAvKjrCX2UhTP9qaWPJCC3Ts6s8eICc-1704454133-1-AekpFMnYDAh/4/IH6m7UnLxqp1hv+QHrZoj1s/8cbRSKBH4XcvGb+b5Z7Xa7LLhVphFQD1B3geGzoAkCs5Y5KyA=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=qyJRb0_fEiAed07UDpy7N9wNsoVVZeIL6X0Bv_pDBZ8-1704454133081-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "8886653aeb5a4547efe8d82ec4af6add"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "71b68f645f35e040"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/8886653aeb5a4547efe8d82ec4af6add"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b615abdca568f-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:52.867Z",
-        "time": 204,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 204
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 337,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 128,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 128,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:53.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "4e23d54a-d88a-4cc2-845e-5adc2ed9965e"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xAAl.RLAkDL6KGBSbQZH04HqeA0jT4nu7xi2P8KKQ5o-1704454133-1-AZFmTC27vRvSEF0+7cB2VLZo0T/27aLGq1J+N8zM1N/szQfgHSaXNsLs0FVT7iDj70999GRY6td5gOWPDd8bXg0="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ehHexxlPnkLCRdM10V34lpbr2UOZZmbGLJfIhz_NQrE-1704454133091-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=4e23d54a-d88a-4cc2-845e-5adc2ed9965e; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=xAAl.RLAkDL6KGBSbQZH04HqeA0jT4nu7xi2P8KKQ5o-1704454133-1-AZFmTC27vRvSEF0+7cB2VLZo0T/27aLGq1J+N8zM1N/szQfgHSaXNsLs0FVT7iDj70999GRY6td5gOWPDd8bXg0=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=ehHexxlPnkLCRdM10V34lpbr2UOZZmbGLJfIhz_NQrE-1704454133091-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "ef22a5e116b2dda6873d772c37212c54"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "3f8bed4e42749a97"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ef22a5e116b2dda6873d772c37212c54"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b615abb8856c5-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:52.870Z",
-        "time": 210,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 210
+          "wait": 218
         }
       },
       {
@@ -937,20 +533,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:53.000Z",
+              "expires": "2025-01-05T11:30:10.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "0fa8eae4-9f38-470e-b29b-502a9853d320"
+              "value": "d8c00974-2a1b-4627-993d-90b40b912e55"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
+              "expires": "2024-01-05T12:00:10.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "L37C2N2IsIW5PNpisELylYLlX7Ylhzg4ACkBRiM4z7c-1704454133-1-AT3uMKyJKllsvfVVrWDjfef5Zs1z3Qp5l0zjKU+mJdzuKmcZHkPaUw5Ja1quHPSz+r87TExOgTPsrHPR1CuAktk="
+              "value": "jA0c9Hvi5ufZA6ml.uIJZRwwva0TMBly4kZ8Kw_FExE-1704454210-1-Ac+dXD9S1/3lsolUfgapNJw+2EcCLe+zThljiVYQ6K9fldmowvQmp+Udmc1C715m/TyTJ+UYuIjBBfi9IrzKJoQ="
             },
             {
               "domain": ".sourcegraph.com",
@@ -959,13 +555,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "2OzIbCd8eChZ0G_F0IuPs5dIoNSuExNA1XALwiyNgeY-1704454133105-0-604800000"
+              "value": "8s_sJOf3B7NiKix0XeuipqwtFRY_gLaeaw2eCb1RRGI-1704454210585-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:10 GMT"
             },
             {
               "name": "content-type",
@@ -978,6 +574,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
             },
             {
               "name": "access-control-allow-credentials",
@@ -994,17 +602,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0fa8eae4-9f38-470e-b29b-502a9853d320; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+              "value": "sourcegraphDeviceId=d8c00974-2a1b-4627-993d-90b40b912e55; Expires=Sun, 05 Jan 2025 11:30:10 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=L37C2N2IsIW5PNpisELylYLlX7Ylhzg4ACkBRiM4z7c-1704454133-1-AT3uMKyJKllsvfVVrWDjfef5Zs1z3Qp5l0zjKU+mJdzuKmcZHkPaUw5Ja1quHPSz+r87TExOgTPsrHPR1CuAktk=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=jA0c9Hvi5ufZA6ml.uIJZRwwva0TMBly4kZ8Kw_FExE-1704454210-1-Ac+dXD9S1/3lsolUfgapNJw+2EcCLe+zThljiVYQ6K9fldmowvQmp+Udmc1C715m/TyTJ+UYuIjBBfi9IrzKJoQ=; path=/; expires=Fri, 05-Jan-24 12:00:10 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=2OzIbCd8eChZ0G_F0IuPs5dIoNSuExNA1XALwiyNgeY-1704454133105-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=8s_sJOf3B7NiKix0XeuipqwtFRY_gLaeaw2eCb1RRGI-1704454210585-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1020,15 +628,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5b750df8ab11502c9eefacab0a2ede51"
+              "value": "dddb0bbd91574a859e888d9f9034b6e2"
             },
             {
               "name": "x-trace-span",
-              "value": "81ecc08d7e8e13f0"
+              "value": "f64eb2b19eb98e36"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5b750df8ab11502c9eefacab0a2ede51"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/dddb0bbd91574a859e888d9f9034b6e2"
             },
             {
               "name": "x-xss-protection",
@@ -1052,21 +660,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b615abd6256c1-OSL"
+              "value": "840b633f1b755688-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:52.869Z",
-        "time": 224,
+        "startedDateTime": "2024-01-05T11:30:10.375Z",
+        "time": 204,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1074,7 +682,459 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 224
+          "wait": 204
+        }
+      },
+      {
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 164,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "164"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 324,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "SiteIdentification",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:10.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "7968e4bd-13aa-4842-b3db-916e83acecd2"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:10.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "ov.CW3d9oIoykYKp4Cid0KBqKQiiyJbxy5Pspqy32dc-1704454210-1-AR02Y4Hr/Ia17bf/PX2RA1tTB42PdOdZuGnhuEkEFt3TXPT40RIUWa7GfWcjFRyTYVHNg+ce2exGmX30qHl7HjY="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "pRVrmfPCjupc6aifpJJw6TXXRplqB4NdERPFUac8q1M-1704454210600-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:10 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=7968e4bd-13aa-4842-b3db-916e83acecd2; Expires=Sun, 05 Jan 2025 11:30:10 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=ov.CW3d9oIoykYKp4Cid0KBqKQiiyJbxy5Pspqy32dc-1704454210-1-AR02Y4Hr/Ia17bf/PX2RA1tTB42PdOdZuGnhuEkEFt3TXPT40RIUWa7GfWcjFRyTYVHNg+ce2exGmX30qHl7HjY=; path=/; expires=Fri, 05-Jan-24 12:00:10 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=pRVrmfPCjupc6aifpJJw6TXXRplqB4NdERPFUac8q1M-1704454210600-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "e13c4136bdea0df4d8657172e4a9fcf6"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "c37b25c5bbb1f0d4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e13c4136bdea0df4d8657172e4a9fcf6"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b633f1cf1712b-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:10.373Z",
+        "time": 216,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 216
+        }
+      },
+      {
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 155,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "155"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 337,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 128,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 128,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:10.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "0c4b1bbe-4759-42e6-8647-8d74634a0f7c"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:10.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "9EdYoD4hjFUCJWOTQZNp4nYizDIiId1EVWn5BaYnqHI-1704454210-1-AYENgtGBSn903RquDOzdvunGe74eR1IEG+Q6norUPVz8CFt5jxJKN4X6kT7PA+6aIKHk4m85Z5eMbxuFddeydRw="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "un19uqdM5GpVbA0evi6A8136dWi34No8Zsnomy2gibo-1704454210624-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:10 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=0c4b1bbe-4759-42e6-8647-8d74634a0f7c; Expires=Sun, 05 Jan 2025 11:30:10 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=9EdYoD4hjFUCJWOTQZNp4nYizDIiId1EVWn5BaYnqHI-1704454210-1-AYENgtGBSn903RquDOzdvunGe74eR1IEG+Q6norUPVz8CFt5jxJKN4X6kT7PA+6aIKHk4m85Z5eMbxuFddeydRw=; path=/; expires=Fri, 05-Jan-24 12:00:10 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=un19uqdM5GpVbA0evi6A8136dWi34No8Zsnomy2gibo-1704454210624-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "ade51194760eae9b38df1ffc28065127"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a2b4f1802a654c86"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ade51194760eae9b38df1ffc28065127"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b633f1bd2568b-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:10.376Z",
+        "time": 237,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 237
         }
       },
       {
@@ -1151,20 +1211,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:53.000Z",
+              "expires": "2025-01-05T11:30:10.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "116cf52b-3ad4-4349-808a-6d60586aef63"
+              "value": "925be0da-1af3-4b90-be43-dd4645cfb34f"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
+              "expires": "2024-01-05T12:00:10.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "jQa1bsIzD6Z2JfN0R00mwOg_mj_iSBqV55ZTGQ65N_s-1704454133-1-AQkFpfy/nfZPlsAK4F78LNVLEIL9DDQMtZKbnNk+lN8ucsORy3fpXtlTLfPnMY/rjuVHcAC15Su9HeCwRTZyI+Q="
+              "value": "BMXR7Xusdkmivp4FNI_q0mZa5pgPMuO5XCtSi_nz7xo-1704454210-1-Adi2cB22ulF9ObDX+tE/qi/qcCpwfvkKFnAXKkQJBqn0JShGgkmXa/onzVC+w6vIssLJiz8wHcYVpWbYTr4YCkc="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1173,13 +1233,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "cGo9KcwXRjD3KR8YE9NxwQYK1y0UMPdq_vmQWDTywdY-1704454133323-0-604800000"
+              "value": "BtSrGvjEtCawinGXt.ap8HjeNhPqkTPQYdaDnhXlMLM-1704454210843-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:10 GMT"
             },
             {
               "name": "content-type",
@@ -1192,6 +1252,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1208,17 +1280,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=116cf52b-3ad4-4349-808a-6d60586aef63; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+              "value": "sourcegraphDeviceId=925be0da-1af3-4b90-be43-dd4645cfb34f; Expires=Sun, 05 Jan 2025 11:30:10 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=jQa1bsIzD6Z2JfN0R00mwOg_mj_iSBqV55ZTGQ65N_s-1704454133-1-AQkFpfy/nfZPlsAK4F78LNVLEIL9DDQMtZKbnNk+lN8ucsORy3fpXtlTLfPnMY/rjuVHcAC15Su9HeCwRTZyI+Q=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=BMXR7Xusdkmivp4FNI_q0mZa5pgPMuO5XCtSi_nz7xo-1704454210-1-Adi2cB22ulF9ObDX+tE/qi/qcCpwfvkKFnAXKkQJBqn0JShGgkmXa/onzVC+w6vIssLJiz8wHcYVpWbYTr4YCkc=; path=/; expires=Fri, 05-Jan-24 12:00:10 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=cGo9KcwXRjD3KR8YE9NxwQYK1y0UMPdq_vmQWDTywdY-1704454133323-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=BtSrGvjEtCawinGXt.ap8HjeNhPqkTPQYdaDnhXlMLM-1704454210843-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1234,15 +1306,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f27c783272fa975e2b29178d407d7d49"
+              "value": "65e94f3d2705ba4e546c26c969ee6eb4"
             },
             {
               "name": "x-trace-span",
-              "value": "56c8878738916b41"
+              "value": "e2d2b721f3d244c2"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f27c783272fa975e2b29178d407d7d49"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/65e94f3d2705ba4e546c26c969ee6eb4"
             },
             {
               "name": "x-xss-protection",
@@ -1266,21 +1338,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b615c2d9d0b06-OSL"
+              "value": "840b6340a87056a8-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:53.103Z",
-        "time": 211,
+        "startedDateTime": "2024-01-05T11:30:10.622Z",
+        "time": 214,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1288,7 +1360,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 211
+          "wait": 214
         }
       },
       {
@@ -1364,20 +1436,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:53.000Z",
+              "expires": "2025-01-05T11:30:11.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "26894eaa-cbd2-44a6-a186-66a7400c1c9c"
+              "value": "b94309a1-ab6c-4b4d-9d83-ad1f9b84628c"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
+              "expires": "2024-01-05T12:00:11.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "4aovktl8_GePSee6tM6INsk0ar.3jNxuMBL6.NbqANw-1704454133-1-AZ1eYDbz0AUml+zQIfzCd+l8/R0OS1ikpHicuDSv3ulcfaOc8u2ShvBJvpHbuJctVuqhmzEO+PoORUfKybomhkE="
+              "value": "kIA6moHKKoOrqeXwyTRb5uXNJdYK.4sdWra0nc_J9qo-1704454211-1-ATrqODYSagvlWdxk2qVlmNJEwI3cuCnPdhIVwgNhxXukwHTTUGnBvapiGrSO4nIKC4K/vxebQP3xkdhAQ6b6sLY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1386,13 +1458,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "QSSsrMye9n0vqkq2vspss5nqs3VVYw3Pz.IBBNBkXT8-1704454133578-0-604800000"
+              "value": "7Qub3Hof29VBUjPBQNu7Q2RxleUO5W6w7d4nQCiSvrk-1704454211101-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:11 GMT"
             },
             {
               "name": "content-type",
@@ -1407,6 +1479,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -1421,17 +1505,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=26894eaa-cbd2-44a6-a186-66a7400c1c9c; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+              "value": "sourcegraphDeviceId=b94309a1-ab6c-4b4d-9d83-ad1f9b84628c; Expires=Sun, 05 Jan 2025 11:30:11 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=4aovktl8_GePSee6tM6INsk0ar.3jNxuMBL6.NbqANw-1704454133-1-AZ1eYDbz0AUml+zQIfzCd+l8/R0OS1ikpHicuDSv3ulcfaOc8u2ShvBJvpHbuJctVuqhmzEO+PoORUfKybomhkE=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=kIA6moHKKoOrqeXwyTRb5uXNJdYK.4sdWra0nc_J9qo-1704454211-1-ATrqODYSagvlWdxk2qVlmNJEwI3cuCnPdhIVwgNhxXukwHTTUGnBvapiGrSO4nIKC4K/vxebQP3xkdhAQ6b6sLY=; path=/; expires=Fri, 05-Jan-24 12:00:11 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=QSSsrMye9n0vqkq2vspss5nqs3VVYw3Pz.IBBNBkXT8-1704454133578-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=7Qub3Hof29VBUjPBQNu7Q2RxleUO5W6w7d4nQCiSvrk-1704454211101-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1447,15 +1531,15 @@
             },
             {
               "name": "x-trace",
-              "value": "3d84e33a56a80f7f29986527b99d19d2"
+              "value": "5f9a25fc547c620d4fccdb37d7521878"
             },
             {
               "name": "x-trace-span",
-              "value": "4e494f5e6f808758"
+              "value": "1e7f255e72cee754"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3d84e33a56a80f7f29986527b99d19d2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5f9a25fc547c620d4fccdb37d7521878"
             },
             {
               "name": "x-xss-protection",
@@ -1479,17 +1563,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b615dcf44b4f4-OSL"
+              "value": "840b63424f6956be-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:53.341Z",
-        "time": 226,
+        "startedDateTime": "2024-01-05T11:30:10.875Z",
+        "time": 218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1497,221 +1581,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 226
-        }
-      },
-      {
-        "_id": "cc9b1f585edf9183417f56a2c258ba17",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 147,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "147"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 318,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "FeatureFlags",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
-        },
-        "response": {
-          "bodySize": 799,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 799,
-            "text": "[\"H4sIAAAAAAAA/5xVXW7zOAy8i5/LC+QAvcRiH2g=\",\"irG5kSWVpJJ4i979g5wiaNPabr83A+bvzHD02gV07A6vHZ8xVnQOz4xelZ8jDtYd/nntEk7cHTrKYQasnilPJbIzuCJJGrqnruVydzhiNH57uqdwwj4ymCvjJGmAQRz62H7ec1zrx5SXKnQCc1QHz1XhmLV1HTm5UJsPqrHaetNBC8H/mU++2qSFrP5c9qQRHaZMJ3C29UJfMQlzwkkIphpdoiSG91+S08bQS6GiGf5j7xXlY+xDT+zhLCae9QbQRXyElJ37nE/rad+Mykes0RewKQdWGOdeJayWMEalESgn5+TQo3GAiGmAwM7UVtzZ8FP/pc7VoT8OMMmVw3qyc+SJXWfga8m6Q8iFe8AY9/aQVKqDjfkCo5hnnbfL8rWwysTJcb120RwqOVjtjVTKwjsoY8PXWM9CDEiUa/JtsPbGz5fEaqOU7amL5l9oorFZcWgfzol2h0h8gRPPl6wb7Cm2yjKJG/CVmAOH5a7bbW0ayJ1ODovglUkK/0rkYosHKdNMsXlQPkJRPkuujZeXyuYbh9nH3ENpiNhFnEZAZbSmGnWqvj7KO0CB+7qxIIZJEmDCOLuQwc0x10+w3Yyi+c1VBJODzcnxCqMMY5Rh3Ab0e3n+Spc/MxGwXJV4UCzj35hCzIRxzxYe0SOk8U75Rp7JkGoBq3rm+SvmX8JvVP7MHRXT6RMFj/ZNxGbSNHmU2B5RXn8N7/o3Cdyj7ge2h+sh6t+3tz8BAAD//5ZBG6LnBwAA\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:53.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6a21b3ee-2150-467d-ba69-efee5137fdad"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "6jlngUlIKjZ42sP882ZdtA7Z63p7s5iWvytaKK4M9Vw-1704454133-1-Ab0PGH+tJWkloWM4NfSWgsGGhg5I7l/gAT/p2lMkIGKEKdkJCE3qKm1IzP5eGm7C74tkDlrpwOfiAamPUGMSPNk="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "a9bHiLe5wpPzOwQ3oP5kv9cm8MUoyxECgCwREGDdIdU-1704454133595-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6a21b3ee-2150-467d-ba69-efee5137fdad; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=6jlngUlIKjZ42sP882ZdtA7Z63p7s5iWvytaKK4M9Vw-1704454133-1-Ab0PGH+tJWkloWM4NfSWgsGGhg5I7l/gAT/p2lMkIGKEKdkJCE3qKm1IzP5eGm7C74tkDlrpwOfiAamPUGMSPNk=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=a9bHiLe5wpPzOwQ3oP5kv9cm8MUoyxECgCwREGDdIdU-1704454133595-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4a8f7c1f92bd5593b5ec594419433a29"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "91ecd81b357a721c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4a8f7c1f92bd5593b5ec594419433a29"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b615dc902b4f9-OSL"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:53.333Z",
-        "time": 251,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 251
+          "wait": 218
         }
       },
       {
@@ -1788,20 +1658,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:53.000Z",
+              "expires": "2025-01-05T11:30:11.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "19b84fd6-7aa9-4d45-b709-cf60105294f7"
+              "value": "fac4628a-775d-4fd2-88c0-4e1bf5a9393a"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:53.000Z",
+              "expires": "2024-01-05T12:00:11.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "qLp_4mHTrzAeRgzFk9u_qLk.9it1V5j7kS77.hpAYiU-1704454133-1-AaLkfoR4MNvmF8HiO8vxBupamPrtODqaWx1Fre2x5rVj53VpfBj0JlOZXdJXmEy2ElPzrL4dhySYtwCNB8vpGXU="
+              "value": "wAPrMXHdThkc0pstjivcKn0zydGuP2nzb_6_ADgYV1M-1704454211-1-AXqHClJnkxMxysSLy08dExLx2pbIFjU1vZGdWurFscUyTzwR8gRXGawM4bNQ+spNZ0bg3kJv2+JkXQfQRjbaR9M="
             },
             {
               "domain": ".sourcegraph.com",
@@ -1810,13 +1680,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "giLgU5eM1qDYm722l7tFy72c8LLvH35gq5pd5iLXJ8Y-1704454133629-0-604800000"
+              "value": "cZl0VUhuB8_ZPUMbwow7L3kND0FgfpZ8rv9_uoLz7Vg-1704454211109-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:53 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:11 GMT"
             },
             {
               "name": "content-type",
@@ -1829,6 +1699,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
             },
             {
               "name": "access-control-allow-credentials",
@@ -1845,17 +1727,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=19b84fd6-7aa9-4d45-b709-cf60105294f7; Expires=Sun, 05 Jan 2025 11:28:53 GMT; Secure"
+              "value": "sourcegraphDeviceId=fac4628a-775d-4fd2-88c0-4e1bf5a9393a; Expires=Sun, 05 Jan 2025 11:30:11 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=qLp_4mHTrzAeRgzFk9u_qLk.9it1V5j7kS77.hpAYiU-1704454133-1-AaLkfoR4MNvmF8HiO8vxBupamPrtODqaWx1Fre2x5rVj53VpfBj0JlOZXdJXmEy2ElPzrL4dhySYtwCNB8vpGXU=; path=/; expires=Fri, 05-Jan-24 11:58:53 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=wAPrMXHdThkc0pstjivcKn0zydGuP2nzb_6_ADgYV1M-1704454211-1-AXqHClJnkxMxysSLy08dExLx2pbIFjU1vZGdWurFscUyTzwR8gRXGawM4bNQ+spNZ0bg3kJv2+JkXQfQRjbaR9M=; path=/; expires=Fri, 05-Jan-24 12:00:11 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=giLgU5eM1qDYm722l7tFy72c8LLvH35gq5pd5iLXJ8Y-1704454133629-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=cZl0VUhuB8_ZPUMbwow7L3kND0FgfpZ8rv9_uoLz7Vg-1704454211109-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -1871,15 +1753,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b8bc2cee7c5b8a6bdd04783309a2964a"
+              "value": "c6d212789d44ec45fe00c5a9159398a4"
             },
             {
               "name": "x-trace-span",
-              "value": "43f036b8d9eaa863"
+              "value": "17529658bb9873cf"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b8bc2cee7c5b8a6bdd04783309a2964a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c6d212789d44ec45fe00c5a9159398a4"
             },
             {
               "name": "x-xss-protection",
@@ -1903,21 +1785,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b615dc9350b31-OSL"
+              "value": "840b63424d33b512-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:53.339Z",
-        "time": 278,
+        "startedDateTime": "2024-01-05T11:30:10.869Z",
+        "time": 233,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1925,7 +1807,233 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 278
+          "wait": 233
+        }
+      },
+      {
+        "_id": "cc9b1f585edf9183417f56a2c258ba17",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 147,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "147"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 318,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query FeatureFlags {\\n        evaluatedFeatureFlags() {\\n            name\\n            value\\n          }\\n    }\\n\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "FeatureFlags",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
+        },
+        "response": {
+          "bodySize": 804,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 804,
+            "text": "[\"H4sIAAAAAAAA/6yVYW7bMAyF7+Lf5QVygF5i2A9KerG5yJJLUUm8oncf5GTAksZOC+xfAJHWR73Hl/cusHG3e+9w5FjZEF7BVhWvkfvS7X68d4lHdLvO5zATV8s+j1OEgcKceBRPY40mURLoeiQ5le6la19Et9tzLPh4uf3QCY4QxLKSwsuEfxpM66d6P7DRmP2BDMW2a28gTdlL6rdwkikXu8ALJ6MyJ+MzDdIPUfrBNvsLWP1A+ZSgZZBplc0QMcJ0JpynrN8ZInLqK/fthyH5ebX1CpNwogPmU9awDs6OjlIWCSxXpZPYQCkbXM6HdTmuV7RnQzJyXBAWQAow+Cb+xp1hlEScOM4mvpBnP4CCFHYRG6zLk+A8QWVEMo6reL1OfvWQvUcp4iJoL7GZA1gvvmNFuoO8fxjpU52oVD1i/lz9cKQblZcnPRvF7DnSKOet9klzqN6oVFe8yrQsHSk4QKlAj+JB7H2uyZ6aV9JUjcqQTzRIsazrDluwJ830C+aUJa075a2KP1AxVrs4bJ+1TTwgmfiWNVQLdCMqrnjK6XCzg3cXuZgdTW0/yknMD8QKLm0eNV/tSbS0KGrxsmkp+p1xWC+5gga4uhEVjzX7sliN9huh8ddObt8/M9ODbL+sZAvn2UdJPeU9TYqj5Nps9lZRbEM55RZbMooVwtkDAWHRv8X3kzy+GOy5aBzXY+DBRNhzjbb40ee2JcPsVAKVXNWjV56GL/xpFQlwrP/h4mdmelJ1CRgqpuCxCdSLkYvt8Lbl58fHnwAAAP//6DBFDecHAAA=\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:11.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "690b00f0-ad1d-429b-897e-cbfd923c9308"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:11.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "bSg2n.rb4aWWPCRoRS.ahLSctGaFPF4sledXPlmDG_o-1704454211-1-ATdlkWQ0CHXgXn2z/pdwDWrwpLLKJGfZc/iepxKfi98wBicICKsx6U5p02RkjDafoTw+IX7Y4KeNTD83Yb7pmBI="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "TP20LQrzzPeBhT0b.dg2Y.EFMNpzkcsybNC3x_2gB28-1704454211130-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "574"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=690b00f0-ad1d-429b-897e-cbfd923c9308; Expires=Sun, 05 Jan 2025 11:30:11 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=bSg2n.rb4aWWPCRoRS.ahLSctGaFPF4sledXPlmDG_o-1704454211-1-ATdlkWQ0CHXgXn2z/pdwDWrwpLLKJGfZc/iepxKfi98wBicICKsx6U5p02RkjDafoTw+IX7Y4KeNTD83Yb7pmBI=; path=/; expires=Fri, 05-Jan-24 12:00:11 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=TP20LQrzzPeBhT0b.dg2Y.EFMNpzkcsybNC3x_2gB28-1704454211130-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "5cbe1799942ee40458a4459b6929d1cb"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "74a156f78715d8c4"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5cbe1799942ee40458a4459b6929d1cb"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b63424fea5697-OSL"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:10.873Z",
+        "time": 270,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 270
         }
       },
       {
@@ -2001,20 +2109,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:54.000Z",
+              "expires": "2025-01-05T11:30:11.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8edfba7f-9e28-4326-a9b1-1de70b39419e"
+              "value": "ef0bd174-2010-44b9-9cfd-f6c0b348b3ea"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
+              "expires": "2024-01-05T12:00:11.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8MheeIRP6uf8arsbmeV3slbG6Yp.92R6pFUnu2yfSPo-1704454134-1-AW8w++6Esj3tYyosX7RqUk/mSXaZSLNDurHk75jxdOXN7QBp53pO8F/2x62hTqIdOzPbsPfKNKEPuy/igQnjGHc="
+              "value": "fglW77_2eT7B5Lxn0._P6pavF_mAZMXZ9xzrggZVQhA-1704454211-1-AYy3yWUKmHuB8GFX91XoCgp5RV6mFVDCIeV2cgAxfoNGWxEe10DD8awsD+6UKi+HPEez5oUseLyBbJJvgbyzIRM="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2023,13 +2131,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "0VbiBRyz5R0WgZz4GkNbLdjgS3EbHYJ5nY6Pk9YPd6s-1704454134122-0-604800000"
+              "value": "1ayyubXP_bknc2_KBixin4aL35tOdjasHYVQYsczxd0-1704454211662-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:11 GMT"
             },
             {
               "name": "content-type",
@@ -2042,6 +2150,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "573"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2058,17 +2178,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8edfba7f-9e28-4326-a9b1-1de70b39419e; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+              "value": "sourcegraphDeviceId=ef0bd174-2010-44b9-9cfd-f6c0b348b3ea; Expires=Sun, 05 Jan 2025 11:30:11 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=8MheeIRP6uf8arsbmeV3slbG6Yp.92R6pFUnu2yfSPo-1704454134-1-AW8w++6Esj3tYyosX7RqUk/mSXaZSLNDurHk75jxdOXN7QBp53pO8F/2x62hTqIdOzPbsPfKNKEPuy/igQnjGHc=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=fglW77_2eT7B5Lxn0._P6pavF_mAZMXZ9xzrggZVQhA-1704454211-1-AYy3yWUKmHuB8GFX91XoCgp5RV6mFVDCIeV2cgAxfoNGWxEe10DD8awsD+6UKi+HPEez5oUseLyBbJJvgbyzIRM=; path=/; expires=Fri, 05-Jan-24 12:00:11 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=0VbiBRyz5R0WgZz4GkNbLdjgS3EbHYJ5nY6Pk9YPd6s-1704454134122-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=1ayyubXP_bknc2_KBixin4aL35tOdjasHYVQYsczxd0-1704454211662-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2084,15 +2204,15 @@
             },
             {
               "name": "x-trace",
-              "value": "ab4b602f5dc2e3480ce43cb2f4340527"
+              "value": "c966411868ca580dcaddb469282f6850"
             },
             {
               "name": "x-trace-span",
-              "value": "475e00651eefcfaa"
+              "value": "c86963355bbeb877"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/ab4b602f5dc2e3480ce43cb2f4340527"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c966411868ca580dcaddb469282f6850"
             },
             {
               "name": "x-xss-protection",
@@ -2116,17 +2236,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b61612a1356c9-OSL"
+              "value": "840b6345ca0cb4f9-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:53.895Z",
-        "time": 215,
+        "startedDateTime": "2024-01-05T11:30:11.431Z",
+        "time": 221,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2134,216 +2254,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 215
-        }
-      },
-      {
-        "_id": "f183d7475b363dc45d23134c3118a915",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 180,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "180"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:54.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "065ad317-8678-4f76-9d43-46940619e4f5"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Ilj7KSb1JT.HYCswK_.uG_5nneomFd2fYt_hNfVAa_o-1704454134-1-AbY1L9UEr10ghw8NB9qsdJmOhIewU4NRFC2jhK8WwpDQFOt1wFmX41DuTSh7AhC4CkGnHXCRV8QjkQ8cQ60EmWQ="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ob8M0drlCn_NIi3GTGDlL0oz0igUYWTK4NIjsP9kK7w-1704454134124-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=065ad317-8678-4f76-9d43-46940619e4f5; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=Ilj7KSb1JT.HYCswK_.uG_5nneomFd2fYt_hNfVAa_o-1704454134-1-AbY1L9UEr10ghw8NB9qsdJmOhIewU4NRFC2jhK8WwpDQFOt1wFmX41DuTSh7AhC4CkGnHXCRV8QjkQ8cQ60EmWQ=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=ob8M0drlCn_NIi3GTGDlL0oz0igUYWTK4NIjsP9kK7w-1704454134124-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "83287e47b7c302d83b2c307c8739c82a"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "00238d33e61c89c8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83287e47b7c302d83b2c307c8739c82a"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b61613d055694-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:53.905Z",
-        "time": 211,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 211
+          "wait": 221
         }
       },
       {
@@ -2419,20 +2330,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:54.000Z",
+              "expires": "2025-01-05T11:30:11.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "cb32d239-6a1e-4a4f-9433-7e2d26e9a562"
+              "value": "a8ea32d1-f0ec-470c-bc96-3c114939c928"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
+              "expires": "2024-01-05T12:00:11.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "jUoj5TO3os2G5BnbDzOB6v8VzqefW4Zbvj5fnl6wMcE-1704454134-1-AZYU2TOJoYLiGpBRZqTw6ju8UmKEZWaMT6Z8S4pHmfk+HWCAYHeeP4SLjP8aHpw60tJD/19d2XV6Ei5yvYWlWqg="
+              "value": "HJKoLnS2e6.bC3KvNFkKfZE52PHFcOpU4lrDjtP9JC0-1704454211-1-AVDXudNqgSrznIvKtG77rKTQ8hhg+V7DLeUoyc6mQyCGVfeFd+zhR6DA+UQsH038Rsw/J88+ilaQKg3ZPGWE3gU="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2441,13 +2352,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "8Rj.HsgXhEko8HaYQaBdFN8ueDt0YEecrCljnpmKXmU-1704454134131-0-604800000"
+              "value": "Ec3j0OnUA38aJ197LSiCou4.YN2dMNv6qHtzR5pfemA-1704454211668-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:11 GMT"
             },
             {
               "name": "content-type",
@@ -2460,6 +2371,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "573"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2476,17 +2399,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cb32d239-6a1e-4a4f-9433-7e2d26e9a562; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+              "value": "sourcegraphDeviceId=a8ea32d1-f0ec-470c-bc96-3c114939c928; Expires=Sun, 05 Jan 2025 11:30:11 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=jUoj5TO3os2G5BnbDzOB6v8VzqefW4Zbvj5fnl6wMcE-1704454134-1-AZYU2TOJoYLiGpBRZqTw6ju8UmKEZWaMT6Z8S4pHmfk+HWCAYHeeP4SLjP8aHpw60tJD/19d2XV6Ei5yvYWlWqg=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=HJKoLnS2e6.bC3KvNFkKfZE52PHFcOpU4lrDjtP9JC0-1704454211-1-AVDXudNqgSrznIvKtG77rKTQ8hhg+V7DLeUoyc6mQyCGVfeFd+zhR6DA+UQsH038Rsw/J88+ilaQKg3ZPGWE3gU=; path=/; expires=Fri, 05-Jan-24 12:00:11 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=8Rj.HsgXhEko8HaYQaBdFN8ueDt0YEecrCljnpmKXmU-1704454134131-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Ec3j0OnUA38aJ197LSiCou4.YN2dMNv6qHtzR5pfemA-1704454211668-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2502,15 +2425,15 @@
             },
             {
               "name": "x-trace",
-              "value": "448bfbb57713ba516e53df0036dcab93"
+              "value": "64e0d375e2738818d2bc04ff5cc75216"
             },
             {
               "name": "x-trace-span",
-              "value": "1e5982e3bf404077"
+              "value": "a9c89f0379ea8cb1"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/448bfbb57713ba516e53df0036dcab93"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/64e0d375e2738818d2bc04ff5cc75216"
             },
             {
               "name": "x-xss-protection",
@@ -2534,17 +2457,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b616129dc5688-OSL"
+              "value": "840b6345c8270afe-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:53.904Z",
-        "time": 229,
+        "startedDateTime": "2024-01-05T11:30:11.436Z",
+        "time": 222,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2552,7 +2475,228 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 229
+          "wait": 222
+        }
+      },
+      {
+        "_id": "f183d7475b363dc45d23134c3118a915",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 180,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "180"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-hot-streak\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:11.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "dd1839d9-f3f1-4c2a-9bc2-136ae6ec4401"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:11.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "30YoJeL_jXoaeOlloIrIfsjTMyFRokS9BMOUNWYrCUc-1704454211-1-Ad9UzfCvONcrDK2hRmkOLXtZwqWmNLRcjbeyn/bEtKQSOVBBWcJ01VVQxc7mfnq36MHyKznuD0yogu0F2Hep5aI="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "vBtJGD9QQ.sK296F1_Jix_I5FhW0zVGAUqsS0ea0qUE-1704454211717-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "573"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=dd1839d9-f3f1-4c2a-9bc2-136ae6ec4401; Expires=Sun, 05 Jan 2025 11:30:11 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=30YoJeL_jXoaeOlloIrIfsjTMyFRokS9BMOUNWYrCUc-1704454211-1-Ad9UzfCvONcrDK2hRmkOLXtZwqWmNLRcjbeyn/bEtKQSOVBBWcJ01VVQxc7mfnq36MHyKznuD0yogu0F2Hep5aI=; path=/; expires=Fri, 05-Jan-24 12:00:11 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=vBtJGD9QQ.sK296F1_Jix_I5FhW0zVGAUqsS0ea0qUE-1704454211717-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "757520f87f40ca90a4726ea2c759ab9a"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "40685d06909c873e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/757520f87f40ca90a4726ea2c759ab9a"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b6345cb36712e-OSL"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:11.440Z",
+        "time": 266,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 266
         }
       },
       {
@@ -2628,20 +2772,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:54.000Z",
+              "expires": "2025-01-05T11:30:12.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "8436fd71-f727-4ce6-9c5c-e3fe30bd01b5"
+              "value": "208b7200-3b71-4b09-9d51-daed355e0147"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
+              "expires": "2024-01-05T12:00:12.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "R1iFNzwg47RHbMlnkluQjYhRdHDTvdFqOWn1SimRFZo-1704454134-1-AUhxi540qYnuJvdJVlnZX+QTAndGE4sa6yLNiJVQgzvvd1QzqrWAOQy2jeup6o0Ye/q0HsFW3duaQ/4e8S4dQL8="
+              "value": "fnIYWA8186jlMftFKximB9oosfIjy7_vHlaR66e3BKg-1704454212-1-AciO9c0F3tOA6WPVP4ZmE7TjAruqqcRBUfmX3nIjR79zapHhOMifaf3Uv7R6zc5Xkt6scKX4xWz5/hn2BBj/sQE="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2650,13 +2794,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "tLZeBpxGi4YKaz1yjsX2p_YRxbFE2msCG6UwDTSpbGs-1704454134609-0-604800000"
+              "value": "wE8QyyuAnyRNcDXNeaHByt.yjjNAR3xII8eHHjXfE6M-1704454212189-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:12 GMT"
             },
             {
               "name": "content-type",
@@ -2669,6 +2813,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "573"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2685,17 +2841,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8436fd71-f727-4ce6-9c5c-e3fe30bd01b5; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+              "value": "sourcegraphDeviceId=208b7200-3b71-4b09-9d51-daed355e0147; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=R1iFNzwg47RHbMlnkluQjYhRdHDTvdFqOWn1SimRFZo-1704454134-1-AUhxi540qYnuJvdJVlnZX+QTAndGE4sa6yLNiJVQgzvvd1QzqrWAOQy2jeup6o0Ye/q0HsFW3duaQ/4e8S4dQL8=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=fnIYWA8186jlMftFKximB9oosfIjy7_vHlaR66e3BKg-1704454212-1-AciO9c0F3tOA6WPVP4ZmE7TjAruqqcRBUfmX3nIjR79zapHhOMifaf3Uv7R6zc5Xkt6scKX4xWz5/hn2BBj/sQE=; path=/; expires=Fri, 05-Jan-24 12:00:12 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=tLZeBpxGi4YKaz1yjsX2p_YRxbFE2msCG6UwDTSpbGs-1704454134609-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=wE8QyyuAnyRNcDXNeaHByt.yjjNAR3xII8eHHjXfE6M-1704454212189-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2711,15 +2867,15 @@
             },
             {
               "name": "x-trace",
-              "value": "886859cb9043d5b84d2dbe5ca871eef2"
+              "value": "716b076b6cf5fa14ca40336e66f7a006"
             },
             {
               "name": "x-trace-span",
-              "value": "7beab3fe95fa2272"
+              "value": "d48143fd35ab520f"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/886859cb9043d5b84d2dbe5ca871eef2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/716b076b6cf5fa14ca40336e66f7a006"
             },
             {
               "name": "x-xss-protection",
@@ -2743,17 +2899,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b61643b610b55-OSL"
+              "value": "840b63491b15568d-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:54.390Z",
-        "time": 221,
+        "startedDateTime": "2024-01-05T11:30:11.960Z",
+        "time": 217,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2761,7 +2917,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 221
+          "wait": 217
         }
       },
       {
@@ -2837,20 +2993,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:54.000Z",
+              "expires": "2025-01-05T11:30:12.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6eb3f9e3-6ee1-4ed4-b533-7f7026898eab"
+              "value": "04393fa7-7030-45d1-8a87-7e9f6014558f"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
+              "expires": "2024-01-05T12:00:12.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "nraJ2FEsjqluiVbNKME_LKmR74fHistigS6E0ZcLmhs-1704454134-1-ATPHVaa1q39s14JevW4qsclvWOmcJAC+thghZGOZWCWo/6MttJKJ0G+/Gk6WPlDr23KWAUWZXoBRr3ENQtrAhxY="
+              "value": "oiyKz4PUMGT0Q4zQupmnE8czYCY.7yN8BK.0L.ctbpY-1704454212-1-ASrnHaWMse1FIN6UbkSFkBnHO0ZnSPBZimP8UvjzXFeeMbI9acrPyd1FIT2e/8yXQ+nJpROSUFI/rhShFmDbiys="
             },
             {
               "domain": ".sourcegraph.com",
@@ -2859,13 +3015,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "xqUMwFjlVAlak9BEgS0_IrTELCD9F65sNP2Xqx9qnxk-1704454134621-0-604800000"
+              "value": "uOheBrNV001ZFjTZFQwZ8hp5QMPjssfK2ndc_ZHaHEY-1704454212201-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:12 GMT"
             },
             {
               "name": "content-type",
@@ -2878,6 +3034,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "573"
             },
             {
               "name": "access-control-allow-credentials",
@@ -2894,17 +3062,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6eb3f9e3-6ee1-4ed4-b533-7f7026898eab; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+              "value": "sourcegraphDeviceId=04393fa7-7030-45d1-8a87-7e9f6014558f; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=nraJ2FEsjqluiVbNKME_LKmR74fHistigS6E0ZcLmhs-1704454134-1-ATPHVaa1q39s14JevW4qsclvWOmcJAC+thghZGOZWCWo/6MttJKJ0G+/Gk6WPlDr23KWAUWZXoBRr3ENQtrAhxY=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=oiyKz4PUMGT0Q4zQupmnE8czYCY.7yN8BK.0L.ctbpY-1704454212-1-ASrnHaWMse1FIN6UbkSFkBnHO0ZnSPBZimP8UvjzXFeeMbI9acrPyd1FIT2e/8yXQ+nJpROSUFI/rhShFmDbiys=; path=/; expires=Fri, 05-Jan-24 12:00:12 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=xqUMwFjlVAlak9BEgS0_IrTELCD9F65sNP2Xqx9qnxk-1704454134621-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=uOheBrNV001ZFjTZFQwZ8hp5QMPjssfK2ndc_ZHaHEY-1704454212201-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -2920,15 +3088,15 @@
             },
             {
               "name": "x-trace",
-              "value": "86db7f12c4567a69994701dbe715384d"
+              "value": "16e72f8d72c4a24d09928674f7d13ad2"
             },
             {
               "name": "x-trace-span",
-              "value": "288c02e34e2d1f05"
+              "value": "138e0749941981a5"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/86db7f12c4567a69994701dbe715384d"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/16e72f8d72c4a24d09928674f7d13ad2"
             },
             {
               "name": "x-xss-protection",
@@ -2952,17 +3120,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b61643d69b524-OSL"
+              "value": "840b634908f75691-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:54.389Z",
-        "time": 225,
+        "startedDateTime": "2024-01-05T11:30:11.958Z",
+        "time": 238,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2970,7 +3138,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 225
+          "wait": 238
         }
       },
       {
@@ -3046,20 +3214,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:54.000Z",
+              "expires": "2025-01-05T11:30:12.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "6d3f320f-d2ff-406c-8bf7-3c718b9a8ef0"
+              "value": "698b406a-7315-49bb-b9ad-e7099013eb59"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
+              "expires": "2024-01-05T12:00:12.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "TZHZ7BIOZ6mCfijc6pkOpk8KVSkMWDH4KxKQwB1YW8M-1704454134-1-AY6jWmcAx8DDcE2dj6x/4j+9so21DNjyucEQLbHpwGqsqNL2px42nWR4rdQn4qKbzGK9o169jgqqvx54vEPMcic="
+              "value": "XLeastlRNELNcSgOlhy3U5dNebylq4.eyAWkkwSJVJM-1704454212-1-ARfGqucydBE1i91/MQP7dGvHOJbjXBanaWrOU9EG0odddxbWXnkpU56tngvOmgn0CBMXXcNMvZpnOmSZVvtv9Zg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3068,13 +3236,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "bDxMHh1Bxk17B30zVfnRe6mrq2cXdsgfz6uzRuImYN4-1704454134859-0-604800000"
+              "value": "4zx_NE0IVpxk8CI5fBVmpaeNOxiuGAb9wkAzFtT9Ovg-1704454212511-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:12 GMT"
             },
             {
               "name": "content-type",
@@ -3087,6 +3255,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
             },
             {
               "name": "access-control-allow-credentials",
@@ -3103,17 +3283,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6d3f320f-d2ff-406c-8bf7-3c718b9a8ef0; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+              "value": "sourcegraphDeviceId=698b406a-7315-49bb-b9ad-e7099013eb59; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=TZHZ7BIOZ6mCfijc6pkOpk8KVSkMWDH4KxKQwB1YW8M-1704454134-1-AY6jWmcAx8DDcE2dj6x/4j+9so21DNjyucEQLbHpwGqsqNL2px42nWR4rdQn4qKbzGK9o169jgqqvx54vEPMcic=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=XLeastlRNELNcSgOlhy3U5dNebylq4.eyAWkkwSJVJM-1704454212-1-ARfGqucydBE1i91/MQP7dGvHOJbjXBanaWrOU9EG0odddxbWXnkpU56tngvOmgn0CBMXXcNMvZpnOmSZVvtv9Zg=; path=/; expires=Fri, 05-Jan-24 12:00:12 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=bDxMHh1Bxk17B30zVfnRe6mrq2cXdsgfz6uzRuImYN4-1704454134859-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=4zx_NE0IVpxk8CI5fBVmpaeNOxiuGAb9wkAzFtT9Ovg-1704454212511-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3129,15 +3309,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f6ac6812868758d9047f4a79f7af5acd"
+              "value": "cd24b1d5db2a99c3d2140241a8a04af4"
             },
             {
               "name": "x-trace-span",
-              "value": "5e229c51115f923b"
+              "value": "cc53b4583ec37bb2"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f6ac6812868758d9047f4a79f7af5acd"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cd24b1d5db2a99c3d2140241a8a04af4"
             },
             {
               "name": "x-xss-protection",
@@ -3161,17 +3341,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b6165af6c5691-OSL"
+              "value": "840b634aff0556bf-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:54.619Z",
-        "time": 227,
+        "startedDateTime": "2024-01-05T11:30:12.268Z",
+        "time": 273,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3179,7 +3359,233 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 227
+          "wait": 273
+        }
+      },
+      {
+        "_id": "c63cf23de38703e896ef70b35a6908a4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 342,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "342"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 327,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
+          },
+          "queryString": [
+            {
+              "name": "RecordTelemetryEvents",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+        },
+        "response": {
+          "bodySize": 119,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 119,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:12.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "4e590b6b-8c89-4b14-bdd3-7db9b832f876"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:12.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "L.BIwfkvxn.hxYKbHRALN0FFfjSFDrXFpv6d_I5VIrg-1704454212-1-AS02XTCEnSa3LBPiz0fEbyOCv/bVLBE15QmQHN9s7N9y1PIQGcqWLh8/Blk23txh39Tts4k+pyA3Z7MTQ2gNw6o="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "V9X7lZ0aUA7AAdKibphHFabxxV6nMXPpei4KipJHoE0-1704454212514-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:12 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=4e590b6b-8c89-4b14-bdd3-7db9b832f876; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=L.BIwfkvxn.hxYKbHRALN0FFfjSFDrXFpv6d_I5VIrg-1704454212-1-AS02XTCEnSa3LBPiz0fEbyOCv/bVLBE15QmQHN9s7N9y1PIQGcqWLh8/Blk23txh39Tts4k+pyA3Z7MTQ2gNw6o=; path=/; expires=Fri, 05-Jan-24 12:00:12 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=V9X7lZ0aUA7AAdKibphHFabxxV6nMXPpei4KipJHoE0-1704454212514-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "b9cdf44c014ee0e9a0e66a4ec295025d"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a792e4aa6f93808a"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b9cdf44c014ee0e9a0e66a4ec295025d"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b634b099a56c7-OSL"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1425,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:12.269Z",
+        "time": 272,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 272
         }
       },
       {
@@ -3256,20 +3662,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:54.000Z",
+              "expires": "2025-01-05T11:30:12.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5e0a32c6-4c5b-4562-b946-23d758ce41cc"
+              "value": "4ba47472-b8d6-4ec1-b7ea-cfdda76cabff"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:54.000Z",
+              "expires": "2024-01-05T12:00:12.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "t7Vyb28.3_Bd5d8jd7GpUOgY07bVmiVW76QSYwPD4sw-1704454134-1-Aa1N6flLCeVPi9ibJ/5DCy5jNRXTrOgPlJDObvxW8WzMhuT9hsppDu6jGzn240+7EBnbDN+Ey/8XaWUQAJY04wk="
+              "value": "GNwCmO9ujWNYVCfmN00O2X.jvTWrb7Zfmq4KlcUcl9A-1704454212-1-AZMizQHJpPqdNmUYaCGYMpXICUQjkFiskde2Wh4g5L9Uz5P2TVvZazfdWZSCUonk/fvN3x4tffO2+zNFyeLb9xI="
             },
             {
               "domain": ".sourcegraph.com",
@@ -3278,13 +3684,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": ".uZP9Uv4b2sXak1qjX04QW2BvobskP9h4Y4HPfDRU9w-1704454134862-0-604800000"
+              "value": "6CbhPRm_U2Ayzb1noEivaELdMkvFWIMIafdQn04t_kw-1704454212542-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:54 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:12 GMT"
             },
             {
               "name": "content-type",
@@ -3299,6 +3705,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -3313,17 +3731,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5e0a32c6-4c5b-4562-b946-23d758ce41cc; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
+              "value": "sourcegraphDeviceId=4ba47472-b8d6-4ec1-b7ea-cfdda76cabff; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=t7Vyb28.3_Bd5d8jd7GpUOgY07bVmiVW76QSYwPD4sw-1704454134-1-Aa1N6flLCeVPi9ibJ/5DCy5jNRXTrOgPlJDObvxW8WzMhuT9hsppDu6jGzn240+7EBnbDN+Ey/8XaWUQAJY04wk=; path=/; expires=Fri, 05-Jan-24 11:58:54 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=GNwCmO9ujWNYVCfmN00O2X.jvTWrb7Zfmq4KlcUcl9A-1704454212-1-AZMizQHJpPqdNmUYaCGYMpXICUQjkFiskde2Wh4g5L9Uz5P2TVvZazfdWZSCUonk/fvN3x4tffO2+zNFyeLb9xI=; path=/; expires=Fri, 05-Jan-24 12:00:12 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=.uZP9Uv4b2sXak1qjX04QW2BvobskP9h4Y4HPfDRU9w-1704454134862-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=6CbhPRm_U2Ayzb1noEivaELdMkvFWIMIafdQn04t_kw-1704454212542-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -3339,15 +3757,15 @@
             },
             {
               "name": "x-trace",
-              "value": "2000e5c9c94c47c01fb1f8e028a146c2"
+              "value": "287cd80105f8b15804524166e9eaf23a"
             },
             {
               "name": "x-trace-span",
-              "value": "ce9465de58f8c45e"
+              "value": "459aa2c3318a6037"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/2000e5c9c94c47c01fb1f8e028a146c2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/287cd80105f8b15804524166e9eaf23a"
             },
             {
               "name": "x-xss-protection",
@@ -3371,21 +3789,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b6165aa0456be-OSL"
+              "value": "840b634a889756b4-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:54.622Z",
-        "time": 228,
+        "startedDateTime": "2024-01-05T11:30:12.200Z",
+        "time": 341,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3393,848 +3811,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 228
-        }
-      },
-      {
-        "_id": "c63cf23de38703e896ef70b35a6908a4",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 342,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "342"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 327,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
-          },
-          "queryString": [
-            {
-              "name": "RecordTelemetryEvents",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
-        },
-        "response": {
-          "bodySize": 112,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:54.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "57ad26c3-3484-4462-880f-ebee04d942cf"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:55.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "iqT9tuzCYI89WO2CVLiRw_IfqTOvbxkrRlyEhZze8Ag-1704454135-1-AU54+E4rNtW3BKN89lz5zBBq7bfQ5f+JHifpK5mxc6dR04edDnqOhTcnotBglCzXj2Ypk7h7FyNpdYTZt9aXOSI="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "UGcwFwGC8LiAI47unvyyf7mkNcC39.7dFrkG0kdR_dI-1704454135068-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=57ad26c3-3484-4462-880f-ebee04d942cf; Expires=Sun, 05 Jan 2025 11:28:54 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=iqT9tuzCYI89WO2CVLiRw_IfqTOvbxkrRlyEhZze8Ag-1704454135-1-AU54+E4rNtW3BKN89lz5zBBq7bfQ5f+JHifpK5mxc6dR04edDnqOhTcnotBglCzXj2Ypk7h7FyNpdYTZt9aXOSI=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=UGcwFwGC8LiAI47unvyyf7mkNcC39.7dFrkG0kdR_dI-1704454135068-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "fea652cab62db7cd2da126a6f94e633b"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "8b6b651f9e20914d"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fea652cab62db7cd2da126a6f94e633b"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b616708657129-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:54.840Z",
-        "time": 218,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 218
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:55.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c533f712-503e-4ec5-b5c4-f8b14bb75d91"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:55.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "dRoN.i9AWDwbZ9khGUjPWZlbuIy5FoYyFDzYZOii0F4-1704454135-1-AVLUI4PFcwEki5TTvRRoJrOEy34amZ0o3NEXO/b26hOFhKLPhvut/rxNhozfkekk3LAkQ7n/vtzpSdzpf317XHw="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "JscS2MV.Pjg8DMroV8JY2mvTwdh8nCqT_mvZlTrx6.s-1704454135418-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c533f712-503e-4ec5-b5c4-f8b14bb75d91; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=dRoN.i9AWDwbZ9khGUjPWZlbuIy5FoYyFDzYZOii0F4-1704454135-1-AVLUI4PFcwEki5TTvRRoJrOEy34amZ0o3NEXO/b26hOFhKLPhvut/rxNhozfkekk3LAkQ7n/vtzpSdzpf317XHw=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=JscS2MV.Pjg8DMroV8JY2mvTwdh8nCqT_mvZlTrx6.s-1704454135418-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d902466064aabf9fa73b1e75953d12f7"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "9438532a37fe74c8"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d902466064aabf9fa73b1e75953d12f7"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b61694d39b511-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:55.198Z",
-        "time": 210,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 210
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:55.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "8e268b8d-c7cb-453c-bc43-a2bfc1881988"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:55.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ys6y7LL_8EsCLnlGIgDRy8qPZrSEGQJp0actYroeDdM-1704454135-1-AVEiSFTJZTsuemt6enJ0XZNr71Db32eUzZpvhDAdG30K08SEkOH2gpHMdn8zGfAkxzb1ZqRP+BawRDqVgSpall0="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Ci1aJkTRbkHIc5sJFa3C9mWMYaJgJSajIqAEl5IpYD4-1704454135422-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8e268b8d-c7cb-453c-bc43-a2bfc1881988; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ys6y7LL_8EsCLnlGIgDRy8qPZrSEGQJp0actYroeDdM-1704454135-1-AVEiSFTJZTsuemt6enJ0XZNr71Db32eUzZpvhDAdG30K08SEkOH2gpHMdn8zGfAkxzb1ZqRP+BawRDqVgSpall0=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=Ci1aJkTRbkHIc5sJFa3C9mWMYaJgJSajIqAEl5IpYD4-1704454135422-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "025347d508d662bc7edbb550757f4f15"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "4cfe5adb8bebf4e0"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/025347d508d662bc7edbb550757f4f15"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b61694d30b521-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:55.200Z",
-        "time": 218,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 218
-        }
-      },
-      {
-        "_id": "2bbf280183fdae3c39a73013105339ae",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 199,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "199"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:55.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "901a817e-7133-4ae7-af48-04085efdc465"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:55.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "sg5XHGrf5ajd1835XctQQSR.q_W69xuDMqMFnKoIxlc-1704454135-1-AYbUNA690OQJlrM00BobzcyuLKoZt8twIJtou63BrIQ2Hqvg7sUdwLfOWYggHb8vFyrEaN4UH1BzwzMHktjDn+w="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "48t8yKSdCB.1nIK6bnBfaT2k68b1ql9CZH00zYCM6o4-1704454135426-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=901a817e-7133-4ae7-af48-04085efdc465; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=sg5XHGrf5ajd1835XctQQSR.q_W69xuDMqMFnKoIxlc-1704454135-1-AYbUNA690OQJlrM00BobzcyuLKoZt8twIJtou63BrIQ2Hqvg7sUdwLfOWYggHb8vFyrEaN4UH1BzwzMHktjDn+w=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=48t8yKSdCB.1nIK6bnBfaT2k68b1ql9CZH00zYCM6o4-1704454135426-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "e41e1b9c85d27284ed4c209a84fc4e1c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "6cdd807efbadd71e"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e41e1b9c85d27284ed4c209a84fc4e1c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b61695efa568f-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:55.201Z",
-        "time": 221,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 221
+          "wait": 341
         }
       },
       {
@@ -4310,20 +3887,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:55.000Z",
+              "expires": "2025-01-05T11:30:12.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "de4ed741-3eed-4eef-a878-28fc9c539276"
+              "value": "cadb4b54-75cd-4f50-b321-eafcbefdb636"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:55.000Z",
+              "expires": "2024-01-05T12:00:13.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "3cjPI6NTJzLeVkM9RWB72n7Yk_Vz24FJjbhk0P8pCug-1704454135-1-AfWcS7OVYwanMIL5FzaAb124WDgVSyNZ8MY36/ctBXyL9VcBM8Mz8X45MLjZC6r1+AG5PpMVw3hSgzdEqqwC4Y8="
+              "value": "AFixe_GnOBBlcskRhK6aQopvCAQKl.w6U1q5ATkDQ0E-1704454213-1-ASlN+rIqxNgNcqqo1PPRdpoiGR7TZOFTUJABU1l2xoVnREfEvYl9zawWZ/Pv1SWAobRDEkJWFMd/+gezU5V/BgY="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4332,13 +3909,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "D59CMWk8SkjQ6VmoofK5dQ4qB5y52hLgV2O4969xMdc-1704454135429-0-604800000"
+              "value": "nbpH1PShVrjEhEdRcfXpEEKDqXmjvZlY6PjkYnGhruE-1704454213005-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:13 GMT"
             },
             {
               "name": "content-type",
@@ -4351,6 +3928,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4367,17 +3956,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=de4ed741-3eed-4eef-a878-28fc9c539276; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
+              "value": "sourcegraphDeviceId=cadb4b54-75cd-4f50-b321-eafcbefdb636; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=3cjPI6NTJzLeVkM9RWB72n7Yk_Vz24FJjbhk0P8pCug-1704454135-1-AfWcS7OVYwanMIL5FzaAb124WDgVSyNZ8MY36/ctBXyL9VcBM8Mz8X45MLjZC6r1+AG5PpMVw3hSgzdEqqwC4Y8=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=AFixe_GnOBBlcskRhK6aQopvCAQKl.w6U1q5ATkDQ0E-1704454213-1-ASlN+rIqxNgNcqqo1PPRdpoiGR7TZOFTUJABU1l2xoVnREfEvYl9zawWZ/Pv1SWAobRDEkJWFMd/+gezU5V/BgY=; path=/; expires=Fri, 05-Jan-24 12:00:13 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=D59CMWk8SkjQ6VmoofK5dQ4qB5y52hLgV2O4969xMdc-1704454135429-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=nbpH1PShVrjEhEdRcfXpEEKDqXmjvZlY6PjkYnGhruE-1704454213005-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4393,15 +3982,15 @@
             },
             {
               "name": "x-trace",
-              "value": "cfaf8eddc61a8a4f0ec4ea069f314ebb"
+              "value": "e3469e9d93bf05b998e5abf92d986d1d"
             },
             {
               "name": "x-trace-span",
-              "value": "e6391675590980ad"
+              "value": "6fd62f47ec07f7b8"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cfaf8eddc61a8a4f0ec4ea069f314ebb"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e3469e9d93bf05b998e5abf92d986d1d"
             },
             {
               "name": "x-xss-protection",
@@ -4425,17 +4014,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b61694e9db529-OSL"
+              "value": "840b634e4ace56be-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:55.200Z",
-        "time": 223,
+        "startedDateTime": "2024-01-05T11:30:12.790Z",
+        "time": 210,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4443,7 +4032,670 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 223
+          "wait": 210
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:12.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "6422b256-c03f-4971-a909-35bc97c4ad05"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:13.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Zaa0nsP6dhez5K9ywongCx1eP_shRhQPzUjDZCRqYQo-1704454213-1-AR70b7BHEyuJy4O565ESi6qT2jUyOjyGLHqIqbT/t3/XWsA0PzjNaKzd1m3NzPawdpUMXaQ3QHNDKxyFk3RsHqM="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "T7tDdCGbrV1Vi1iq31e3FM6__0LgVDw8aeDG__Og7XA-1704454213009-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:13 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=6422b256-c03f-4971-a909-35bc97c4ad05; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Zaa0nsP6dhez5K9ywongCx1eP_shRhQPzUjDZCRqYQo-1704454213-1-AR70b7BHEyuJy4O565ESi6qT2jUyOjyGLHqIqbT/t3/XWsA0PzjNaKzd1m3NzPawdpUMXaQ3QHNDKxyFk3RsHqM=; path=/; expires=Fri, 05-Jan-24 12:00:13 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=T7tDdCGbrV1Vi1iq31e3FM6__0LgVDw8aeDG__Og7XA-1704454213009-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "4cb67eeb3261a3effc0a9ed392b91f25"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "97d1ddae11eabd0e"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4cb67eeb3261a3effc0a9ed392b91f25"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b634e3acd56be-OSL"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:12.788Z",
+        "time": 213,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 213
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:12.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "af81a7ca-e41d-4567-ac50-af8288f5e1c5"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:13.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "XntOeqjufSZNh_TK6L7tWDLPC6E8lQq6l6iVy1Y5DGM-1704454213-1-AaMi3uaJBcQWdkuWqe5YN1gCkkZ6RiRBqTgNWD8m4putq/S8Mdg9Ak1yIqJvJUvH4WcLJND+l19NPzuUe5X+ylI="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "9aiuRHI2pQLEZfML53a2GoAqUmAZfEd0YkGL4HbIjd4-1704454213011-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:13 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=af81a7ca-e41d-4567-ac50-af8288f5e1c5; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=XntOeqjufSZNh_TK6L7tWDLPC6E8lQq6l6iVy1Y5DGM-1704454213-1-AaMi3uaJBcQWdkuWqe5YN1gCkkZ6RiRBqTgNWD8m4putq/S8Mdg9Ak1yIqJvJUvH4WcLJND+l19NPzuUe5X+ylI=; path=/; expires=Fri, 05-Jan-24 12:00:13 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=9aiuRHI2pQLEZfML53a2GoAqUmAZfEd0YkGL4HbIjd4-1704454213011-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "83ad18ba3d3bbc5cd30ea7306cc49795"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "182e4f1c0afff676"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83ad18ba3d3bbc5cd30ea7306cc49795"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b634e48b256cc-OSL"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:12.789Z",
+        "time": 222,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 222
+        }
+      },
+      {
+        "_id": "2bbf280183fdae3c39a73013105339ae",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 199,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "199"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 325,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-dynamic-multiline-completions\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:12.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "ef741696-7cce-4779-b5c5-50992690a1b0"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:13.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "2kbZY.yfgPvq8NyfiH6fSJ1YJ7CmK9SwU0UIMYbdtUY-1704454213-1-AQdpVFuoWDV11T0OB6MAXVb1esYkK3nGGjEkrnVgk+bt22OwCha8anfRd3Byq29aZZLoqbB0FFgIWD0nFxtgetQ="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "gxq5NrTVM_VqNt9n9Hu2XG1mDrPiX7u.51IPvpg_xjI-1704454213016-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:13 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "93c64da34dda4e9089a4aff7b686e50b"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "572"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=ef741696-7cce-4779-b5c5-50992690a1b0; Expires=Sun, 05 Jan 2025 11:30:12 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=2kbZY.yfgPvq8NyfiH6fSJ1YJ7CmK9SwU0UIMYbdtUY-1704454213-1-AQdpVFuoWDV11T0OB6MAXVb1esYkK3nGGjEkrnVgk+bt22OwCha8anfRd3Byq29aZZLoqbB0FFgIWD0nFxtgetQ=; path=/; expires=Fri, 05-Jan-24 12:00:13 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=gxq5NrTVM_VqNt9n9Hu2XG1mDrPiX7u.51IPvpg_xjI-1704454213016-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "06d322fa37b6e02d4e5326fccc67fd88"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "a75c454cd869ec1b"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/06d322fa37b6e02d4e5326fccc67fd88"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b634e4e4256c5-OSL"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:12.790Z",
+        "time": 239,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 239
         }
       },
       {
@@ -4519,20 +4771,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:55.000Z",
+              "expires": "2025-01-05T11:30:13.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "cfb4124b-d835-40b4-9993-336bcb3f8498"
+              "value": "fed0683b-0176-4f69-a85a-b5dbb80d2b88"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:55.000Z",
+              "expires": "2024-01-05T12:00:13.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "cHo6ZfSRYazxO6nGIH8wD3nYbBxWwR2vd73d58kiYek-1704454135-1-AZHS/kQ3ABAbcQDStWZN9wBCWnF7M266pt2KIiSW4ujLG6tJPkxBT+Xxusc+99ovk83p6nuX7PQYQjW/u2Vu7TI="
+              "value": "NKykY841pOJTT.nilWYJvBZJAKnvAqCgGo76P1g0e0I-1704454213-1-ASZH5Rv1XD1SwFGJ0NVtrrfU36RrUc0MzbJdQ7xEZLNFKo5LwQAkaDKI7PfHOYvPTJTZr5f71fI2HvuzofMIUm4="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4541,13 +4793,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "TPJb.qj4XANAlJkAwGPmBubZ_QyQiqRpoQzhKvHQ2Dg-1704454135858-0-604800000"
+              "value": "xCgOt5u3XHbtObhnJQm9beAaSqnnq3le076blkIcV34-1704454213481-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:55 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:13 GMT"
             },
             {
               "name": "content-type",
@@ -4560,6 +4812,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "600"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4576,17 +4840,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cfb4124b-d835-40b4-9993-336bcb3f8498; Expires=Sun, 05 Jan 2025 11:28:55 GMT; Secure"
+              "value": "sourcegraphDeviceId=fed0683b-0176-4f69-a85a-b5dbb80d2b88; Expires=Sun, 05 Jan 2025 11:30:13 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=cHo6ZfSRYazxO6nGIH8wD3nYbBxWwR2vd73d58kiYek-1704454135-1-AZHS/kQ3ABAbcQDStWZN9wBCWnF7M266pt2KIiSW4ujLG6tJPkxBT+Xxusc+99ovk83p6nuX7PQYQjW/u2Vu7TI=; path=/; expires=Fri, 05-Jan-24 11:58:55 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=NKykY841pOJTT.nilWYJvBZJAKnvAqCgGo76P1g0e0I-1704454213-1-ASZH5Rv1XD1SwFGJ0NVtrrfU36RrUc0MzbJdQ7xEZLNFKo5LwQAkaDKI7PfHOYvPTJTZr5f71fI2HvuzofMIUm4=; path=/; expires=Fri, 05-Jan-24 12:00:13 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=TPJb.qj4XANAlJkAwGPmBubZ_QyQiqRpoQzhKvHQ2Dg-1704454135858-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=xCgOt5u3XHbtObhnJQm9beAaSqnnq3le076blkIcV34-1704454213481-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4602,15 +4866,15 @@
             },
             {
               "name": "x-trace",
-              "value": "a82d3cc530ac67788df83edaa74310ef"
+              "value": "701e262a4e16e343b48fc7c49737ba81"
             },
             {
               "name": "x-trace-span",
-              "value": "32bb49528023cd2e"
+              "value": "6dcdd6a2c54404f0"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/a82d3cc530ac67788df83edaa74310ef"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/701e262a4e16e343b48fc7c49737ba81"
             },
             {
               "name": "x-xss-protection",
@@ -4634,17 +4898,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b616c0accb4ed-OSL"
+              "value": "840b63513ae0568f-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:55.642Z",
-        "time": 204,
+        "startedDateTime": "2024-01-05T11:30:13.246Z",
+        "time": 223,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4652,7 +4916,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 204
+          "wait": 223
         }
       },
       {
@@ -4723,20 +4987,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:56.000Z",
+              "expires": "2025-01-05T11:30:13.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "3e1d8c41-cbc7-42fc-9f3c-d879b814338a"
+              "value": "226098f7-ad9f-4eef-81d8-9164b7650ed9"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:57.000Z",
+              "expires": "2024-01-05T12:00:14.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "9GOSh4aI_bqrridoiY5g.UU9FN3oRFU9tryZ2tq.H60-1704454137-1-ARBHWTvqvezK31jYK//ljcqm3aDVk9GqKNLBtVyHKwgJs2FnvdGejIB3R9KMhi1qXUoWY3kISpixVvIA89q5sF8="
+              "value": "k3Nw5_YVtZ.9q3qPyCGcl_L5M9Ys6z1zaZhVx05FfBw-1704454214-1-AX/9XoAqp5D4WAx+vqdT9BdTBwaDaf4YAIScFN6V1oxwO3UsCCNl8xwVkea1+Afvt6p4Bt0BqQzjNb4ZZOIkVCU="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4745,13 +5009,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "n6LKO5DA5Wck46WPHhPet5NhXiue9LiemZyuhR27yKE-1704454137629-0-604800000"
+              "value": "_lwLACXz5chVx4StNRb.wdTHiUOYvIqm71K1UiP0OeY-1704454214826-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:14 GMT"
             },
             {
               "name": "content-type",
@@ -4764,6 +5028,18 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "600"
             },
             {
               "name": "access-control-allow-credentials",
@@ -4780,17 +5056,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=3e1d8c41-cbc7-42fc-9f3c-d879b814338a; Expires=Sun, 05 Jan 2025 11:28:56 GMT; Secure"
+              "value": "sourcegraphDeviceId=226098f7-ad9f-4eef-81d8-9164b7650ed9; Expires=Sun, 05 Jan 2025 11:30:13 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=9GOSh4aI_bqrridoiY5g.UU9FN3oRFU9tryZ2tq.H60-1704454137-1-ARBHWTvqvezK31jYK//ljcqm3aDVk9GqKNLBtVyHKwgJs2FnvdGejIB3R9KMhi1qXUoWY3kISpixVvIA89q5sF8=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=k3Nw5_YVtZ.9q3qPyCGcl_L5M9Ys6z1zaZhVx05FfBw-1704454214-1-AX/9XoAqp5D4WAx+vqdT9BdTBwaDaf4YAIScFN6V1oxwO3UsCCNl8xwVkea1+Afvt6p4Bt0BqQzjNb4ZZOIkVCU=; path=/; expires=Fri, 05-Jan-24 12:00:14 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=n6LKO5DA5Wck46WPHhPet5NhXiue9LiemZyuhR27yKE-1704454137629-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=_lwLACXz5chVx4StNRb.wdTHiUOYvIqm71K1UiP0OeY-1704454214826-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -4806,15 +5082,15 @@
             },
             {
               "name": "x-trace",
-              "value": "f2e92694504e0cc9ec4fc3e59ea708c1"
+              "value": "4550d2846ce5e6bafd08373619174684"
             },
             {
               "name": "x-trace-span",
-              "value": "0fbac69875ab703e"
+              "value": "ebeb427009afc6bf"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/f2e92694504e0cc9ec4fc3e59ea708c1"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4550d2846ce5e6bafd08373619174684"
             },
             {
               "name": "x-xss-protection",
@@ -4838,17 +5114,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b616daffc1c12-OSL"
+              "value": "840b63527a307130-OSL"
             }
           ],
-          "headersSize": 1289,
+          "headersSize": 1396,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:55.873Z",
-        "time": 1745,
+        "startedDateTime": "2024-01-05T11:30:13.476Z",
+        "time": 1339,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4856,7 +5132,228 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1745
+          "wait": 1339
+        }
+      },
+      {
+        "_id": "fa14556b8a98cd3158e1f395bbfae82b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 753,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "753"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 322,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [
+            {
+              "expires": "2025-01-05T11:30:15.000Z",
+              "name": "sourcegraphDeviceId",
+              "secure": true,
+              "value": "64537cd2-89c1-4d6f-acad-7e16b97bfdfc"
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "expires": "2024-01-05T12:00:15.000Z",
+              "httpOnly": true,
+              "name": "__cf_bm",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "Nj6XUOinhWDd.g3mTlUay.O1ViJYodCng71LDozak2I-1704454215-1-ASRI0yLga/fEt5Nh/lMOXGtU5XV025gG6ZsRzIpJSOKz1abRzaZj6PlmRvafJ+AmT7mSKN1Jaj9BLB36ptjVB4E="
+            },
+            {
+              "domain": ".sourcegraph.com",
+              "httpOnly": true,
+              "name": "_cfuvid",
+              "path": "/",
+              "sameSite": "None",
+              "secure": true,
+              "value": "7M4gpQxxW9iyq9P5xi4sIcsQh0_R2q9rEXbbNvy8y74-1704454215202-0-604800000"
+            }
+          ],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:30:15 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "sourcegraphDeviceId=64537cd2-89c1-4d6f-acad-7e16b97bfdfc; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "__cf_bm=Nj6XUOinhWDd.g3mTlUay.O1ViJYodCng71LDozak2I-1704454215-1-ASRI0yLga/fEt5Nh/lMOXGtU5XV025gG6ZsRzIpJSOKz1abRzaZj6PlmRvafJ+AmT7mSKN1Jaj9BLB36ptjVB4E=; path=/; expires=Fri, 05-Jan-24 12:00:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "_cfuvid=7M4gpQxxW9iyq9P5xi4sIcsQh0_R2q9rEXbbNvy8y74-1704454215202-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-trace",
+              "value": "7b45e80ee8651c3ad78eb0041d09975e"
+            },
+            {
+              "name": "x-trace-span",
+              "value": "0b387e4455513f41"
+            },
+            {
+              "name": "x-trace-url",
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7b45e80ee8651c3ad78eb0041d09975e"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "via",
+              "value": "1.1 google, 1.1 google"
+            },
+            {
+              "name": "cf-cache-status",
+              "value": "DYNAMIC"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "server",
+              "value": "cloudflare"
+            },
+            {
+              "name": "cf-ray",
+              "value": "840b635bdbcab4f9-OSL"
+            }
+          ],
+          "headersSize": 1393,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2024-01-05T11:30:14.945Z",
+        "time": 247,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 247
         }
       },
       {
@@ -4933,20 +5430,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:57.000Z",
+              "expires": "2025-01-05T11:30:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "83b7e1ac-7a6d-4752-9a9a-12a7b464ecbc"
+              "value": "7769aaf8-c968-4e5f-87ff-ff0dc5de1ce4"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:57.000Z",
+              "expires": "2024-01-05T12:00:15.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "dljJBnLJZIvOQrqdgm96F3adVft90W9Vr3.HTSAn2Jg-1704454137-1-AW09t3bk8wyPaEQjRuA/jgDCJ9aSpRz0lnzunNGMmcAPRDQcSK8cLTKObPfYEAo7MRhEz4H3H6m8jun2Vg/KINg="
+              "value": "FFp9bFVnpM1vOcPeI7ReKH1NfUqL3kaix7uOJ3r4ozA-1704454215-1-AbpdxmARURdVGVHgxqoaDunQ5QO1KriJ4ml5SB2uY0G2zdydmh/mxivKXpC/VQ2iSLkKstKMd7mGBUTB/u73/gM="
             },
             {
               "domain": ".sourcegraph.com",
@@ -4955,13 +5452,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "znzleVb_NhQn4X.RQ7VNBYKxsiB3W2mdMFnj46HMG3I-1704454137889-0-604800000"
+              "value": "KFop6X67gkmSihjlxWu4RXOrSLx70UW0RGiGzgQhSwE-1704454215218-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:15 GMT"
             },
             {
               "name": "content-type",
@@ -4976,6 +5473,18 @@
               "value": "close"
             },
             {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
+            },
+            {
               "name": "access-control-allow-credentials",
               "value": "true"
             },
@@ -4990,17 +5499,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=83b7e1ac-7a6d-4752-9a9a-12a7b464ecbc; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
+              "value": "sourcegraphDeviceId=7769aaf8-c968-4e5f-87ff-ff0dc5de1ce4; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=dljJBnLJZIvOQrqdgm96F3adVft90W9Vr3.HTSAn2Jg-1704454137-1-AW09t3bk8wyPaEQjRuA/jgDCJ9aSpRz0lnzunNGMmcAPRDQcSK8cLTKObPfYEAo7MRhEz4H3H6m8jun2Vg/KINg=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=FFp9bFVnpM1vOcPeI7ReKH1NfUqL3kaix7uOJ3r4ozA-1704454215-1-AbpdxmARURdVGVHgxqoaDunQ5QO1KriJ4ml5SB2uY0G2zdydmh/mxivKXpC/VQ2iSLkKstKMd7mGBUTB/u73/gM=; path=/; expires=Fri, 05-Jan-24 12:00:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=znzleVb_NhQn4X.RQ7VNBYKxsiB3W2mdMFnj46HMG3I-1704454137889-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=KFop6X67gkmSihjlxWu4RXOrSLx70UW0RGiGzgQhSwE-1704454215218-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5016,15 +5525,15 @@
             },
             {
               "name": "x-trace",
-              "value": "c86232045d22e55f93fb4c4be4646b01"
+              "value": "947682135ae698fcbd213911221a365b"
             },
             {
               "name": "x-trace-span",
-              "value": "a9d1e6e1033066a8"
+              "value": "236f086d7584a28c"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/c86232045d22e55f93fb4c4be4646b01"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/947682135ae698fcbd213911221a365b"
             },
             {
               "name": "x-xss-protection",
@@ -5048,21 +5557,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b6178a9e9b4f3-OSL"
+              "value": "840b635bdf1056cb-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:57.658Z",
-        "time": 223,
+        "startedDateTime": "2024-01-05T11:30:14.947Z",
+        "time": 278,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5070,216 +5579,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 223
-        }
-      },
-      {
-        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 739,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "739"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 322,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:28:57.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2eb56f6f-ab37-424a-9de3-99470a4dc358"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:57.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "aeGg3Hmvvj7IbWVwK3L3WeH9TjRhLzpkaqxOLXfRFJ0-1704454137-1-ARthvA8y8V3IwgcRBMtWNtmSd17M4Z0vZ5rhshyRWAWrzBIcig6CipO5fG1DGRQtwj2/5ERgH/x/U0fRbiRWYA4="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OAxsvOEQyxjNML.mrRuch5WxrmtEpJD5eqkKI_8kODE-1704454137898-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2eb56f6f-ab37-424a-9de3-99470a4dc358; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=aeGg3Hmvvj7IbWVwK3L3WeH9TjRhLzpkaqxOLXfRFJ0-1704454137-1-ARthvA8y8V3IwgcRBMtWNtmSd17M4Z0vZ5rhshyRWAWrzBIcig6CipO5fG1DGRQtwj2/5ERgH/x/U0fRbiRWYA4=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=OAxsvOEQyxjNML.mrRuch5WxrmtEpJD5eqkKI_8kODE-1704454137898-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "76bf9250dd3aac15b9b9cf9c07321016"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "96ee392257b30ed4"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/76bf9250dd3aac15b9b9cf9c07321016"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b6178a9e656b7-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:28:57.657Z",
-        "time": 229,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 229
+          "wait": 278
         }
       },
       {
@@ -5356,20 +5656,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:57.000Z",
+              "expires": "2025-01-05T11:30:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "5590c55a-f519-4c46-b146-786fb282d955"
+              "value": "dd4bea28-037c-4b48-b62e-64a194ea1b12"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:57.000Z",
+              "expires": "2024-01-05T12:00:15.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "zfTA_UqvlUrYuggks8XM96qsQvwbwy.LRNoZkOjEMUY-1704454137-1-AZV4AHckNXUXWwxN6lnPuvSxTeaCXxHWHU1duPpiqk1w0OSg+pLXndVy7obaSPV5LoJ5bqvvWDQezlmT5zDFqSA="
+              "value": "6VEPCAusGp1zUAPtTnIfXiDcMAORjFLeaM.YLHU3Yck-1704454215-1-AcKD1aT4vHZzEF1DYV+NEqrPz1rYT0yVqf2Y7266lWuG5YP3vD93M70cQEkzeupVtJsveyVjTMcNhTlvUNjLZkA="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5378,13 +5678,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "loG6SmoPYUScEZMi93AAzWkZ6sW3C7.Fo1.RxYcBcD0-1704454137908-0-604800000"
+              "value": "P25ZLTuq9IPs5BYQh4mXDmgEMmAe23mSd3TLudyXSUA-1704454215220-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:15 GMT"
             },
             {
               "name": "content-type",
@@ -5397,6 +5697,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5413,17 +5725,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5590c55a-f519-4c46-b146-786fb282d955; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
+              "value": "sourcegraphDeviceId=dd4bea28-037c-4b48-b62e-64a194ea1b12; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=zfTA_UqvlUrYuggks8XM96qsQvwbwy.LRNoZkOjEMUY-1704454137-1-AZV4AHckNXUXWwxN6lnPuvSxTeaCXxHWHU1duPpiqk1w0OSg+pLXndVy7obaSPV5LoJ5bqvvWDQezlmT5zDFqSA=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=6VEPCAusGp1zUAPtTnIfXiDcMAORjFLeaM.YLHU3Yck-1704454215-1-AcKD1aT4vHZzEF1DYV+NEqrPz1rYT0yVqf2Y7266lWuG5YP3vD93M70cQEkzeupVtJsveyVjTMcNhTlvUNjLZkA=; path=/; expires=Fri, 05-Jan-24 12:00:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=loG6SmoPYUScEZMi93AAzWkZ6sW3C7.Fo1.RxYcBcD0-1704454137908-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=P25ZLTuq9IPs5BYQh4mXDmgEMmAe23mSd3TLudyXSUA-1704454215220-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5439,15 +5751,15 @@
             },
             {
               "name": "x-trace",
-              "value": "11f22b881fd2d93e96ac5ba8c8ccd054"
+              "value": "23ad62b8f1d122cc17deb22be6025800"
             },
             {
               "name": "x-trace-span",
-              "value": "ee016fe6d29efd90"
+              "value": "8349bcb631c97511"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/11f22b881fd2d93e96ac5ba8c8ccd054"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/23ad62b8f1d122cc17deb22be6025800"
             },
             {
               "name": "x-xss-protection",
@@ -5471,21 +5783,21 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b6178a8fd56b5-OSL"
+              "value": "840b635bdd6356aa-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:57.658Z",
-        "time": 255,
+        "startedDateTime": "2024-01-05T11:30:14.948Z",
+        "time": 277,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5493,15 +5805,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 255
+          "wait": 277
         }
       },
       {
-        "_id": "fa14556b8a98cd3158e1f395bbfae82b",
+        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 753,
+          "bodySize": 739,
           "cookies": [],
           "headers": [
             {
@@ -5527,7 +5839,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "753"
+              "value": "739"
             },
             {
               "_fromType": "array",
@@ -5550,7 +5862,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:unexpectedNotSuggested\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
           },
           "queryString": [
             {
@@ -5569,20 +5881,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:57.000Z",
+              "expires": "2025-01-05T11:30:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1fc1549f-6238-4095-822f-9f67725db029"
+              "value": "349391b3-d167-42d2-ae67-ca9d8dbcd708"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:57.000Z",
+              "expires": "2024-01-05T12:00:15.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "k_PJrBC38.t7VbItAxVxvDkHfjZmH4f.kGnsskyhrMo-1704454137-1-AYaq9WaLb+06NgqMUceWVFz6e9CUP8Wft262f7KxZnMJvXhOiWTJphl78zBuUJ64GxlkVzHA0dwDEh+li5XeoXY="
+              "value": "K7x05AfuqORI3iNoo0ypzT5mA7duOVOBJBUOE5BdzP8-1704454215-1-AfGWJ9cuT7iznOLQQ7hGgfgnKZfEUQFSb48EfnolM98Ah6VypM6ZeuBriN0NFfULVfXNOhSSRBJF3ci+6wG59Pg="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5591,13 +5903,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "2RWo40rKtRi0hOIsIrrYxspVZgzyG_ZqnOXHd.mxjFY-1704454137930-0-604800000"
+              "value": "96mn25yAPxtGelC6F8wfF7M0MLswsosN2M9CdBr4K2U-1704454215221-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:57 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:15 GMT"
             },
             {
               "name": "content-type",
@@ -5610,6 +5922,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5626,17 +5950,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1fc1549f-6238-4095-822f-9f67725db029; Expires=Sun, 05 Jan 2025 11:28:57 GMT; Secure"
+              "value": "sourcegraphDeviceId=349391b3-d167-42d2-ae67-ca9d8dbcd708; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=k_PJrBC38.t7VbItAxVxvDkHfjZmH4f.kGnsskyhrMo-1704454137-1-AYaq9WaLb+06NgqMUceWVFz6e9CUP8Wft262f7KxZnMJvXhOiWTJphl78zBuUJ64GxlkVzHA0dwDEh+li5XeoXY=; path=/; expires=Fri, 05-Jan-24 11:58:57 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=K7x05AfuqORI3iNoo0ypzT5mA7duOVOBJBUOE5BdzP8-1704454215-1-AfGWJ9cuT7iznOLQQ7hGgfgnKZfEUQFSb48EfnolM98Ah6VypM6ZeuBriN0NFfULVfXNOhSSRBJF3ci+6wG59Pg=; path=/; expires=Fri, 05-Jan-24 12:00:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=2RWo40rKtRi0hOIsIrrYxspVZgzyG_ZqnOXHd.mxjFY-1704454137930-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=96mn25yAPxtGelC6F8wfF7M0MLswsosN2M9CdBr4K2U-1704454215221-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5652,15 +5976,15 @@
             },
             {
               "name": "x-trace",
-              "value": "5bf2764f8aa47d5b5db8212f0e8b04b2"
+              "value": "7d721f9b8f54489f7df195b6b29b668f"
             },
             {
               "name": "x-trace-span",
-              "value": "0af36f995b2c96bf"
+              "value": "2dfcab0b112e095d"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5bf2764f8aa47d5b5db8212f0e8b04b2"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/7d721f9b8f54489f7df195b6b29b668f"
             },
             {
               "name": "x-xss-protection",
@@ -5684,17 +6008,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b6178a843b4ee-OSL"
+              "value": "840b635bd83eb509-OSL"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1393,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:57.656Z",
-        "time": 266,
+        "startedDateTime": "2024-01-05T11:30:14.946Z",
+        "time": 280,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5702,7 +6026,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 266
+          "wait": 280
         }
       },
       {
@@ -5770,29 +6094,29 @@
           "url": "https://sourcegraph.com/.api/graphql?LegacyEmbeddingsSearch"
         },
         "response": {
-          "bodySize": 2234,
+          "bodySize": 2227,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 2234,
-            "text": "[\"H4sIAAAAAAAA/8RX327byPV+lfPjXvziQBRlOX8=\",\"vAKEwvVmkQBBE8RJ08UyWA05h+TAwxl25lCUEBjYZ+hdgQJFe9XnyhP0EYozlCzKsrXuVX0hg2dmznf+fN8Z8mskBYlo9jXCOkMplSn9FQqXV2zLrcQP6FtNPpr9/DUqlMY/iBqjWbT0vJh4lye1UGZMPhpFnoSjt8pgNHsxnY4iNHL79GwU5dYQGopm0U1qopvRQ/48uqXK0ScXLVXvnV0qie5K1Y1WhUJ5CHU+QHo5+Q0grbLEV8KhDGB5JShpnK0b8kkfRBzOryipUDfo/AHgs5cvBojPXp4/LjdCTwlOMSnUqm1iibl1gqwb88IByB7GHYiT4xiFWlHr0Ceddde+ETkmykhcjSuq9T7KZAByOh2CpO1kcpb/3w/vLj/+9P4V8NFgwtT0S2wBLUw5TyM0abRdBQDY7EAhh9bdSo0kIK+E80jzNPr08cf4PI0gObK7Impi/HOrlvM0+lP86SK+tHUjSGUa0wg2gc/T6M2rOcoSf8OdETXO02ipsGusoz0PnZJUzSUyC+PwMAJlFCmhY58LjfPT8eRh/6RIY7/0GrW2cGnlul9KBmvDSiV3S9Wbs+3B/c1D8/b8oD1HpBXYzj8xJ77h/f38+/75gBrf7/GPQ2EOHuFhALN1o5GUNT7RtizxAaZPz4ajYnr2/LFY90nZYa4a9Ak5YbwWhIfqfbYn3gOw1BwfT9rmQt/OCGk7o62QsV/XxQHW6enZUGCnLx6Hxom1apeUMk1LlxvEy0rQm4FhTH61j3o+VPX52V3MLWXOtoR5RGmtxEz43Wis0XtR4uFsPD19vpfxAXG+PCrjj9y+3KmG3hDWhylOp8PCTqcHMMO/k5u7Ek2kWg6FdUuwL6OI8zt+6XVCX1PlbFtWPhEt2Q3TcVzLI+P1dBjjd9/xWEC4GBxPzVbPqi7Bu3yeRjz2/CxJPFknShyX1pYaRaP8OLd14m3rciydaKpYeI/kk0zbMln6OFxl1mRWOL7W40HUfPfE08n0jDet42EKMfnVuFTFbp6n5ooTgs4pUqYE9gvCyDDWoFNaw/YwUIWglUF4Yl14QEPKIRStyXkQnEBhHaxtO4bXioBEBmRB5Dk2FPb7tizR89YxIz99+u1v/4L3zsakGh8Ot56DCNjDuJ8+3dYuc33k33795151ofXoNyDO2dbIvWw2zOZ4lCmsq+/E40fgLaiCoweDKHln2SqJoCgYc2FASAmC61GjIRCZXQ6Ksrbt/zsElKGQ4/sC/mnjp7JLdBB++HjpcD2IhaE9Iggga3UmHNgChCZ0RpBa3glbeOhQa/5vqWK3TVgB3+YVW/v6czUEcHU1QmedBEGMoGo8Gmrr+xTT6KNTPOX3qy4ILlvnrQtXbF1zrckCbfaKvgOD3BjVrAPuaNNtdi+xEK0muMZ1oDT4yjrKW+LcF+9CSgtYpOkCrIFa5O+uQl8XF5p29s/KSNv5MAamL+CtMu1q/OC43xN6oVbH9T25o+8f1Spo/H8ga+GvY7Ixh3xXy7ZGqrionbP8q6hiYrrQh9/BJ49BXN9+/auHNLrw173WyHI++z0s1AoUjcA6wFWjhTKhU42zmcb6IQEXanUrvIDO/u+X75ZitsHe9b///pd/QI2mHfVHhbk3xp7gI8jWUNvllkF5oGEvKmZY0KQtBpEIA+icdYE4O+rtUw4Wl30JFrAYD8hmHSwuHelb8wNcezhNob0Fp8qKINcqv2YnHKgirD1sqptG7/v6+jQKA9QW8Mer/jLhsD1qzOm+sjxIc2nzpMPsv7m94DNmgCtC41mzT3DVoFM89IQ+4cYHZG73NjbluQEODek1WKPXoNibRA==\",\"uRnryBlud/+A/ppsMwJjCX7u4xxLXH55slXOznbCpe8nW4dZzO8pEpbCKWHID8oTCPnadrhExy/05LBREiQuUVv+0NsbZ79Uqqz0GoaZ/cIAg7Q3ICGB8Fq4dcbbt8MLVT90C3brEabACrTSzzieGD60BhaNaWpwrYFOUF7NJC5nHWaL0FGqcCMBzn2W9G+glfU0O5tMJly2IGCOLXO28+jG7PjNbTlHwTVntXgrWpNXt3V+tWvhZ8y4KvD73sXJAiRmLQvVFKpsnbi9lT+0xmy1sStG4Kfy0Ik1N5sbZ4tC5UpozZdXw99ZKLlZfL0GK38PoAwD+MvNzc1/AgAA///BabYujhAAAA==\"]"
+            "size": 2227,
+            "text": "[\"H4sIAAAAAAAA/8RX327byPV+lfPjXvziQBRlOX+8AoTC9WaRAEETxEnTxTJYDTmH5MDDGXbmUJQQGNhn6F2BAkV71efKE/QRijOULMqyte5VfSGDZ2bOd/583xnyayQFiWj2NcI6QymVKf0VCpdXbMutxA/oW00+mv38NSqUxj+IGqNZtPS8mHiXJ7VQZkw+GkWehKO3ymA0ezGdjiI0cvv0bBTl1hAaimbRTWqim9FD/jy6pcrRJxctVe+dXSqJ7krVjVaFQnkIdT5Aejn5DSCtssRXwqEMYHklKGmcrRvySR9EHM6vKKlQN+j8AeCzly8GiM9enj8uN0JPCU4xKdSqbWKJuXWCrBvzwgHIHsYdiJPjGIVaUevQJ511174ROSbKSFyNK6r1PspkAHI6HYKk7WRylv/fD+8uP/70/hXw0WDC1PRLbAEtTDlPIzRptF0FANjsQCGH1t1KjSQgr4TzSPM0+vTxx/g8jSA5srsiamL8c6uW8zT6U/zpIr60dSNIZRrTCDaBz9Pozas5yhJ/w50RNc7TaKmwa6yjPQ+dklTNJTIL4/AwAmUUKaFjnwuN89Px5GH/pEhjv/QatbZwaeW6X0oGa8NKJXdL1Zuz7cH9zUPz9vygPUekFdjOPzEnvuH9/fz7/vmAGt/v8Y9DYQ4e4WEAs3WjkZQ1PtG2LPEBpk/PhqNievb8sVj3Sdlhrhr0CTlhvBaEh+p9tifeA7DUHB9P2uZC384IaTujrZCxX9fFAdbp6dlQYKcvHofGibVql5QyTUuXG8TLStCbgWFMfrWPej5U9fnZXcwtZc62hHlEaa3ETPjdaKzRe1Hi4Ww8PX2+l/EBcb48KuOP3L7cqYbeENaHKU6nw8JOpwcww7+Tm7sSTaRaDoV1S7Avo4jzO37pdUJfU+VsW1Y+ES3ZDdNxXMsj4/V0GON33/FYQLgYHE/NVs+qLsG7fJ5GPPb8LEk8WSdKHJfWlhpFo/w4t3XibetyLJ1oqlh4j+STTNsyWfo4XGXWZFY4vtbjQdR898TTyfSMN63jYQox+dW4VMVunqfmihOCzilSpgT2C8LIMNagU1rD9jBQhaCVQXhiXXhAQ8ohFK3JeRCcQGEdrG07hteKgEQGZEHkOTYU9vu2LNHz1jEjP3367W//gvfOxqQaHw63noMI2MO4nz7d1i5zfeTffv3nXnWh9eg3IM7Z1si9bDbM5niUKayr78TjR+AtqIKjB4MoeWfZKomgKBhzYUBICYLrUaMhEJldDoqytu3/OwSUoZDj+wL+aeOnskt0EH74eOlwPYiFoT0iCCBrdSYc2AKEJnRGkFreCVt46FBr/m+pYrdNWAHf5hVb+/pzNQRwdTVCZ50EQYygajwaauv7FNPoo1M85ferLgguW+etC1dsXXOtyQJt9oq+A4PcGNWsA+5o0212L7EQrSa4xnWgNPjKOspb4twX70JKC1ik6QKsgVrk765CXxcXmnb2z8pI2/kwBqYv4K0y7Wr84LjfE3qhVsf1Pbmj7x/VKmj8fyBr4a9jsjGHfFfLtkaquKids/yrqGJiutCH38Enj0Fc3379q4c0uvDXvdbIcj77PSzUChSNwDrAVaOFMqFTjbOZxvohARdqdSu8gM7+75fvlmK2wd71v//+l39AjaYd9UeFuTfGnuAjyNZQ2+WWQXmgYS8qZljQpC0GkQgD6Jx1gTg76u1TDhaXfQkWsBgPyA==\",\"Zh0sLh3pW/MDXHs4TaG9BafKiiDXKr9mJxyoIqw9bKqbRu/7+vo0CgPUFvDHq/4y4bA9aszpvrI8SHNp86TD7L+5veAzZoArQuNZs09w1aBTPPSEPuHGB2Ru9zY25bkBDg3pNVij16DYm0S5GevIGW53/4D+mmwzAmMJfu7jHEtcfnmyVc7OdsKl7ydbh1nM7ykSlsIpYcgPyhMI+dp2uETHL/TksFESJC5RW/7Q2xtnv1SqrPQahpn9wgCDtDcgIYHwWrh1xtu3wwtVP3QLdusRpsAKtNLPOJ4YPrQGFo1panCtgU5QXs0kLmcdZovQUapwIwHOfZb0b6CV9TQ7m0wmXLYgYI4tc7bz6Mbs+M1tOUfBNWe1eCtak1e3dX61a+FnzLgq8PvexckCJGYtC9UUqmyduL2VP7TGbLWxK0bgp/LQiTU3mxtni0LlSmjNl1fD31kouVl8vQYrfw+gDAP4y83NzX8CAAD//8Fpti6OEAAA\"]"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:58.000Z",
+              "expires": "2025-01-05T11:30:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "fe765008-6a22-46d9-bbd9-9e659cd376ea"
+              "value": "35378e08-3041-46a0-bf67-92ac594a50fe"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:58.000Z",
+              "expires": "2024-01-05T12:00:15.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "9FCBKjeOcRJ_U2RgmBJnQRPMRYjebEyH3qcD2BUvdUc-1704454138-1-ATrp4S9htlNnE2jXjNi9cLKs6AvEY51cJSJUmBhVTg37+4lXNq2t2JC0OaRzUB8WO9qDrRoerUlahyT4u/q9beY="
+              "value": "OGyC19Dx7.Kurmd9U19ulxdP2IeMPxqek0YUOgCsJ0g-1704454215-1-AV0p6rxF8/dZxzf5WsptHDGKRRPfKu+OOwK80mZnwaTGg0gT7+iTAm+9L0N3Gx9wdo4Ib43zLaG/UzpyhKYEMfM="
             },
             {
               "domain": ".sourcegraph.com",
@@ -5801,13 +6125,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "hy3xBuSHH09bYr54kNFj1s6yLnG.K9xTxYupNuqJ2yE-1704454138406-0-604800000"
+              "value": "Pdb_6Lw4qC5FxvsluaUKwVzyFW2JB_V5WoGCmBhCN0w-1704454215689-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:58 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:15 GMT"
             },
             {
               "name": "content-type",
@@ -5820,6 +6144,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
             },
             {
               "name": "access-control-allow-credentials",
@@ -5840,17 +6176,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fe765008-6a22-46d9-bbd9-9e659cd376ea; Expires=Sun, 05 Jan 2025 11:28:58 GMT; Secure"
+              "value": "sourcegraphDeviceId=35378e08-3041-46a0-bf67-92ac594a50fe; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=9FCBKjeOcRJ_U2RgmBJnQRPMRYjebEyH3qcD2BUvdUc-1704454138-1-ATrp4S9htlNnE2jXjNi9cLKs6AvEY51cJSJUmBhVTg37+4lXNq2t2JC0OaRzUB8WO9qDrRoerUlahyT4u/q9beY=; path=/; expires=Fri, 05-Jan-24 11:58:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=OGyC19Dx7.Kurmd9U19ulxdP2IeMPxqek0YUOgCsJ0g-1704454215-1-AV0p6rxF8/dZxzf5WsptHDGKRRPfKu+OOwK80mZnwaTGg0gT7+iTAm+9L0N3Gx9wdo4Ib43zLaG/UzpyhKYEMfM=; path=/; expires=Fri, 05-Jan-24 12:00:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=hy3xBuSHH09bYr54kNFj1s6yLnG.K9xTxYupNuqJ2yE-1704454138406-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=Pdb_6Lw4qC5FxvsluaUKwVzyFW2JB_V5WoGCmBhCN0w-1704454215689-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -5866,15 +6202,15 @@
             },
             {
               "name": "x-trace",
-              "value": "355f9f73059fe50fa3b6be126b69972a"
+              "value": "d20c89614d239332e9e2c61dbd6abb18"
             },
             {
               "name": "x-trace-span",
-              "value": "5f112f8472d7ed5d"
+              "value": "573da6b15ba3b117"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/355f9f73059fe50fa3b6be126b69972a"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d20c89614d239332e9e2c61dbd6abb18"
             },
             {
               "name": "x-xss-protection",
@@ -5898,17 +6234,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b617a698256cc-OSL"
+              "value": "840b635d68b3b4fa-OSL"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:57.924Z",
-        "time": 474,
+        "startedDateTime": "2024-01-05T11:30:15.222Z",
+        "time": 466,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5916,7 +6252,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 474
+          "wait": 466
         }
       },
       {
@@ -5993,20 +6329,20 @@
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:58.000Z",
+              "expires": "2025-01-05T11:30:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "1f07a6ab-5d9c-4e03-8ea3-cd117a265fcc"
+              "value": "c1424c7e-eed7-4f62-aa5f-85d5ece49363"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:58:58.000Z",
+              "expires": "2024-01-05T12:00:15.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "oq.FdTDnyDJcEqdBNfY2kgfGORJjsYGglsjGi8TJYwY-1704454138-1-Ab+arxPZ2Q/KrLOLHvAMlI0QmwuXBDdcke1VeVTvHy+razACLyxilu5qcKMJRPtTJ7zLySLRVNUJv0xe3zBWJA8="
+              "value": "0hRd5W6DipjTVI6KPh8gDkgtaxXaNN7Zq88EXWHXuAQ-1704454215-1-ARQoDJLrBHduaZdUe7nPytMYNDTjzlP4JxMATnEcatUbl4QRmbLV7OGtU4/YwbFP1ekdoffPBQCOZsMOBE7bI50="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6015,13 +6351,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "ohJw8oTm7KLewOiVAnBh8NPMGsnzOCQ55fWTItnQ7mo-1704454138660-0-604800000"
+              "value": "CGsIhxjJ9YlasLW9KNRMADsDiCtaDim3I9_K.o2mjg4-1704454215937-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:28:58 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:15 GMT"
             },
             {
               "name": "content-type",
@@ -6034,6 +6370,18 @@
             {
               "name": "connection",
               "value": "close"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6050,17 +6398,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1f07a6ab-5d9c-4e03-8ea3-cd117a265fcc; Expires=Sun, 05 Jan 2025 11:28:58 GMT; Secure"
+              "value": "sourcegraphDeviceId=c1424c7e-eed7-4f62-aa5f-85d5ece49363; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=oq.FdTDnyDJcEqdBNfY2kgfGORJjsYGglsjGi8TJYwY-1704454138-1-Ab+arxPZ2Q/KrLOLHvAMlI0QmwuXBDdcke1VeVTvHy+razACLyxilu5qcKMJRPtTJ7zLySLRVNUJv0xe3zBWJA8=; path=/; expires=Fri, 05-Jan-24 11:58:58 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=0hRd5W6DipjTVI6KPh8gDkgtaxXaNN7Zq88EXWHXuAQ-1704454215-1-ARQoDJLrBHduaZdUe7nPytMYNDTjzlP4JxMATnEcatUbl4QRmbLV7OGtU4/YwbFP1ekdoffPBQCOZsMOBE7bI50=; path=/; expires=Fri, 05-Jan-24 12:00:15 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=ohJw8oTm7KLewOiVAnBh8NPMGsnzOCQ55fWTItnQ7mo-1704454138660-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=CGsIhxjJ9YlasLW9KNRMADsDiCtaDim3I9_K.o2mjg4-1704454215937-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6076,15 +6424,15 @@
             },
             {
               "name": "x-trace",
-              "value": "e76c10e51893a4f37ac942665433f2ba"
+              "value": "49d81a095100e005393b068eab8cce26"
             },
             {
               "name": "x-trace-span",
-              "value": "dc0ddf001dad4656"
+              "value": "62e293079df2d98e"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e76c10e51893a4f37ac942665433f2ba"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/49d81a095100e005393b068eab8cce26"
             },
             {
               "name": "x-xss-protection",
@@ -6108,20 +6456,20 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b617d791756a2-OSL"
+              "value": "840b636068bd5684-OSL"
             },
             {
               "name": "content-encoding",
               "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1425,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:58.428Z",
+        "startedDateTime": "2024-01-05T11:30:15.704Z",
         "time": 222,
         "timings": {
           "blocked": -1,
@@ -6134,11 +6482,11 @@
         }
       },
       {
-        "_id": "cf731964ced2b68f61a0517e5a2b0807",
+        "_id": "53745732e068932b67a08d011abced38",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 5366,
+          "bodySize": 5371,
           "cookies": [],
           "headers": [
             {
@@ -6168,34 +6516,34 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n                )}\\n        </div>\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/chat/chat-view/prompt.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/vscode-context/helpers.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/main.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"\\\"My selected Typescript code from file `/src/animal.ts`:\\n<selected>\\n\\n</selected>\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n                )}\\n        </div>\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/chat/chat-view/prompt.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/vscode-context/helpers.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/main.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
           },
           "queryString": [],
           "url": "https://sourcegraph.com/.api/completions/stream"
         },
         "response": {
-          "bodySize": 6607,
+          "bodySize": 232,
           "content": {
             "mimeType": "text/event-stream",
-            "size": 6607,
-            "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "size": 232,
+            "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
           "cookies": [
             {
-              "expires": "2025-01-05T11:28:58.000Z",
+              "expires": "2025-01-05T11:30:15.000Z",
               "name": "sourcegraphDeviceId",
               "secure": true,
-              "value": "cc281c22-e0bc-44b0-a7b5-a6718e1766d7"
+              "value": "0a861bba-4681-44e7-8726-b861719dfa62"
             },
             {
               "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:59:01.000Z",
+              "expires": "2024-01-05T12:00:17.000Z",
               "httpOnly": true,
               "name": "__cf_bm",
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "1SS6bR1KMORM_uFzk97BASC_R6CJ3wV8oJuHNY.Lzwg-1704454141-1-AdMgL9B0kxBeFaDrYSKpgzjUX418FcMiVgjVBHyJ2P0n7o51TiFMGwv/jcqlLoUEGGfmSiaQakHsW5z0YZSG8cc="
+              "value": "c21hY9eCwUC69v.ppvJyR8VNddyfEIjAYkA2miitMVI-1704454217-1-Ab1oo5XoaepM5tc3tdrTf0NYCPTd9z3nH587vgwxshva9dV1M4IE/7MJeJkoCeHxX+AzC2BPGYPItf5RtJqi7zA="
             },
             {
               "domain": ".sourcegraph.com",
@@ -6204,13 +6552,13 @@
               "path": "/",
               "sameSite": "None",
               "secure": true,
-              "value": "BU64HzY_oxA1oz5Eo_f.sCIFhLfCDCg6HApxXO_bmks-1704454141750-0-604800000"
+              "value": "MtL9g9PrWFZwuAmTKSB__h79rHLDa45muPkSgQ8rSHE-1704454217901-0-604800000"
             }
           ],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:29:01 GMT"
+              "value": "Fri, 05 Jan 2024 11:30:17 GMT"
             },
             {
               "name": "content-type",
@@ -6223,6 +6571,18 @@
             {
               "name": "connection",
               "value": "keep-alive"
+            },
+            {
+              "name": "cf-rate-limit-rule-id",
+              "value": "cd9639e1577149368cf0cc6767aa9ce8"
+            },
+            {
+              "name": "cf-rate-limit-action",
+              "value": "simulate"
+            },
+            {
+              "name": "retry-after",
+              "value": "598"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6239,17 +6599,17 @@
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "sourcegraphDeviceId=cc281c22-e0bc-44b0-a7b5-a6718e1766d7; Expires=Sun, 05 Jan 2025 11:28:58 GMT; Secure"
+              "value": "sourcegraphDeviceId=0a861bba-4681-44e7-8726-b861719dfa62; Expires=Sun, 05 Jan 2025 11:30:15 GMT; Secure"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "__cf_bm=1SS6bR1KMORM_uFzk97BASC_R6CJ3wV8oJuHNY.Lzwg-1704454141-1-AdMgL9B0kxBeFaDrYSKpgzjUX418FcMiVgjVBHyJ2P0n7o51TiFMGwv/jcqlLoUEGGfmSiaQakHsW5z0YZSG8cc=; path=/; expires=Fri, 05-Jan-24 11:59:01 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "__cf_bm=c21hY9eCwUC69v.ppvJyR8VNddyfEIjAYkA2miitMVI-1704454217-1-Ab1oo5XoaepM5tc3tdrTf0NYCPTd9z3nH587vgwxshva9dV1M4IE/7MJeJkoCeHxX+AzC2BPGYPItf5RtJqi7zA=; path=/; expires=Fri, 05-Jan-24 12:00:17 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "_fromType": "array",
               "name": "set-cookie",
-              "value": "_cfuvid=BU64HzY_oxA1oz5Eo_f.sCIFhLfCDCg6HApxXO_bmks-1704454141750-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "value": "_cfuvid=MtL9g9PrWFZwuAmTKSB__h79rHLDa45muPkSgQ8rSHE-1704454217901-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
             },
             {
               "name": "vary",
@@ -6265,15 +6625,15 @@
             },
             {
               "name": "x-trace",
-              "value": "b9938320ace7bf4591d0d464b32a2945"
+              "value": "9565f75d15c2b8b1e8436e00b1280c36"
             },
             {
               "name": "x-trace-span",
-              "value": "a3832ca8c821f362"
+              "value": "effbff3fffc52fdb"
             },
             {
               "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b9938320ace7bf4591d0d464b32a2945"
+              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9565f75d15c2b8b1e8436e00b1280c36"
             },
             {
               "name": "x-xss-protection",
@@ -6297,17 +6657,17 @@
             },
             {
               "name": "cf-ray",
-              "value": "840b617d7da07127-OSL"
+              "value": "840b63607f19b51e-OSL"
             }
           ],
-          "headersSize": 1289,
+          "headersSize": 1396,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:28:58.420Z",
-        "time": 3627,
+        "startedDateTime": "2024-01-05T11:30:15.702Z",
+        "time": 2187,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6315,7 +6675,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3627
+          "wait": 2187
         }
       }
     ],

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -234,9 +234,9 @@ describe('Agent', () => {
             `
           {
             "contextFiles": [],
-            "displayText": " Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.",
+            "displayText": " Hello!",
             "speaker": "assistant",
-            "text": " Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.",
+            "text": " Hello!",
           }
         `
         )

--- a/lib/shared/src/chat/context-filter.ts
+++ b/lib/shared/src/chat/context-filter.ts
@@ -7,7 +7,7 @@ export const ignores = new IgnoreHelper()
 /**
  * Checks if a file should be ignored by Cody based on the ignore rules.
  *
- * Takes URI with file scheme to ensure absolute file paths are ignored correctly across workspaces
+ * Takes URI to ensure absolute file paths are ignored correctly across workspaces
  */
 export function isCodyIgnoredFile(uri: URI): boolean {
     return ignores.isIgnored(uri)

--- a/lib/shared/src/chat/prompts/index.ts
+++ b/lib/shared/src/chat/prompts/index.ts
@@ -20,13 +20,13 @@ export function getDefaultCommandsMap(editorCommands: CodyPrompt[] = []): Map<st
     }
 
     // Add default commands
-    const commands = defaultPrompts.commands as Record<string, unknown>
-    for (const key in commands) {
-        if (Object.prototype.hasOwnProperty.call(commands, key)) {
-            const command = commands[key] as CodyPrompt
-            command.type = 'default'
-            command.slashCommand = toSlashCommand(key)
-            map.set(command.slashCommand, command)
+    const prompts = defaultPrompts.commands as Record<string, unknown>
+    for (const key in prompts) {
+        if (Object.prototype.hasOwnProperty.call(prompts, key)) {
+            const prompt = prompts[key] as CodyPrompt
+            prompt.type = 'default'
+            prompt.slashCommand = toSlashCommand(key)
+            map.set(prompt.slashCommand, prompt)
         }
     }
 

--- a/lib/shared/src/chat/prompts/vscode-context/helpers.ts
+++ b/lib/shared/src/chat/prompts/vscode-context/helpers.ts
@@ -60,13 +60,9 @@ export function isInWorkspace(fileToCheck: URI): boolean {
 
 function createFileContextResponseMessage(context: string, filePath: string): ContextMessage[] {
     const fileName = createVSCodeRelativePath(filePath)
-    const uri = vscode.Uri.file(filePath)
     const truncatedContent = truncateText(context, MAX_CURRENT_FILE_TOKENS)
     return getContextMessageWithResponse(populateCodeContextTemplate(truncatedContent, fileName), {
         fileName,
-        uri,
-        content: truncatedContent,
-        source: 'editor',
     })
 }
 
@@ -278,13 +274,11 @@ export async function getCurrentDirFilteredContext(
         try {
             const decoded = await decodeVSCodeTextDoc(fileUri)
             const truncatedContent = truncateText(decoded, MAX_CURRENT_FILE_TOKENS)
-            // From line 0 to the end of truncatedContent
-            const range = new vscode.Range(0, 0, truncatedContent.split('\n').length, 0)
 
             const templateText = 'Codebase context from file path {fileName}: '
             const contextMessage = getContextMessageWithResponse(
                 populateContextTemplateFromText(templateText, truncatedContent, fileName),
-                { fileName, uri: fileUri, content: truncatedContent, source: 'editor', range }
+                { fileName }
             )
             contextMessages.push(...contextMessage)
         } catch (error) {
@@ -360,12 +354,11 @@ export async function getDirContextMessages(
         try {
             const decoded = await decodeVSCodeTextDoc(fileUri)
             const truncatedContent = truncateText(decoded, MAX_CURRENT_FILE_TOKENS)
-            const range = new vscode.Range(0, 0, truncatedContent.split('\n').length, 0)
 
             const templateText = 'Codebase context from file path {fileName}: '
             const contextMessage = getContextMessageWithResponse(
                 populateContextTemplateFromText(templateText, truncatedContent, fileName),
-                { fileName, uri: fileUri, content: truncatedContent, source: 'editor', range }
+                { fileName }
             )
             contextMessages.push(...contextMessage)
         } catch (error) {

--- a/lib/shared/src/chat/recipes/custom-prompt.ts
+++ b/lib/shared/src/chat/recipes/custom-prompt.ts
@@ -1,0 +1,191 @@
+import { CodebaseContext } from '../../codebase-context'
+import { ContextFile, ContextMessage } from '../../codebase-context/messages'
+import { ActiveTextEditorSelection, Editor } from '../../editor'
+import { MAX_HUMAN_INPUT_TOKENS, NUM_CODE_RESULTS, NUM_TEXT_RESULTS } from '../../prompt/constants'
+import { truncateText } from '../../prompt/truncation'
+import { CodyPromptContext, defaultCodyPromptContext, getCommandEventSource } from '../prompts'
+import { createDisplayTextWithFileLinks, createDisplayTextWithFileSelection } from '../prompts/display-text'
+import {
+    extractTestType,
+    getHumanLLMText,
+    isOnlySelectionRequired,
+    newInteraction,
+    newInteractionWithError,
+} from '../prompts/utils'
+import { VSCodeEditorContext } from '../prompts/vscode-context/VSCodeEditorContext'
+import { Interaction } from '../transcript/interaction'
+
+import { ChatQuestion } from './chat-question'
+import { numResults } from './helpers'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
+
+/**
+ * ======================================================
+ * Recipe for running custom prompts from the cody.json files
+ * Works with VS Code only
+====================================================== *
+ */
+export class CustomPrompt implements Recipe {
+    public id: RecipeID = 'custom-prompt'
+    public title = 'Custom Prompt'
+
+    /**
+     * Retrieves an Interaction object based on the humanChatInput and RecipeContext provided.
+     * The Interaction object contains messages from both the human and the assistant, as well as context information.
+     */
+    public async getInteraction(commandRunnerID: string, context: RecipeContext): Promise<Interaction | null> {
+        const command = context.editor.controllers?.command?.getCommand(commandRunnerID)
+        if (!command) {
+            return createInteractionForError('command')
+        }
+        const isChatQuestion = command?.slashCommand === '/ask'
+
+        const contextConfig = command?.context || defaultCodyPromptContext
+        // If selection is required, ensure not to accept visible content as selection
+        const selection = contextConfig?.selection
+            ? await context.editor.getActiveTextEditorSmartSelection()
+            : context.editor.getActiveTextEditorSelectionOrVisibleContent()
+
+        // Get prompt text from the editor command or from the human input
+        const commandAdditionalInput = command.additionalInput
+        const promptText = commandAdditionalInput ? `${command.prompt}\n${commandAdditionalInput}` : command.prompt
+        const commandName = isChatQuestion ? promptText : command.slashCommand || promptText
+
+        // Log all custom commands under 'custom'
+        const source = getCommandEventSource(command)
+
+        if (!promptText) {
+            return createInteractionForError('prompt', promptText)
+        }
+
+        if (contextConfig?.selection && !selection?.selectedText) {
+            return createInteractionForError('selection', commandName)
+        }
+
+        const text = getHumanLLMText(promptText, selection?.fileName)
+
+        const commandOutput = command.context?.output
+        const contextFiles = command.contextFiles
+
+        // Add selection file name as display when available
+        const displayText = contextFiles?.length
+            ? createDisplayTextWithFileLinks(contextFiles, promptText)
+            : contextConfig.currentFile || contextConfig.selection
+            ? createDisplayTextWithFileSelection(
+                  commandAdditionalInput ? `${commandName} ${commandAdditionalInput}` : commandName,
+                  selection
+              )
+            : `${commandName} ${commandAdditionalInput}`.trim()
+
+        const truncatedText = truncateText(text, MAX_HUMAN_INPUT_TOKENS)
+
+        const editorContext = new VSCodeEditorContext(context.editor, selection)
+
+        // Attach code selection to prompt text if only selection is needed as context
+        if (selection && isOnlySelectionRequired(contextConfig)) {
+            const contextMessages = Promise.resolve(editorContext.getCurrentFileContextFromEditorSelection())
+            return newInteraction({ text, displayText, contextMessages, source })
+        }
+
+        const contextMessages = this.getContextMessages(
+            editorContext,
+            promptText,
+            context.editor,
+            context.codebaseContext,
+            contextConfig,
+            selection,
+            context.userInputContextFiles,
+            commandOutput
+        )
+
+        return newInteraction({ text: truncatedText, displayText, contextMessages, source })
+    }
+
+    private async getContextMessages(
+        editorContext: VSCodeEditorContext,
+        promptText: string,
+        editor: Editor,
+        codebaseContext: CodebaseContext,
+        contextConfig: CodyPromptContext,
+        selection?: ActiveTextEditorSelection | null,
+        contextFiles?: ContextFile[],
+        commandOutput?: string | null
+    ): Promise<ContextMessage[]> {
+        const contextMessages: ContextMessage[] = []
+        const workspaceRootUri = editor.getWorkspaceRootUri()
+        const isUnitTestRequest = extractTestType(promptText) === 'unit'
+
+        if (contextConfig.none) {
+            return []
+        }
+
+        if (contextConfig.codebase) {
+            const codebaseMessages = await codebaseContext.getContextMessages(promptText, numResults)
+            contextMessages.push(...codebaseMessages)
+        }
+
+        if (contextConfig.openTabs) {
+            const openTabsMessages = await editorContext.getEditorOpenTabsContext()
+            contextMessages.push(...openTabsMessages)
+        }
+
+        if (contextConfig.currentDir) {
+            const currentDirMessages = await editorContext.getCurrentDirContext(isUnitTestRequest)
+            contextMessages.push(...currentDirMessages)
+        }
+
+        if (contextConfig.directoryPath) {
+            const dirMessages = await editorContext.getEditorDirContext(
+                contextConfig.directoryPath,
+                selection?.fileName
+            )
+            contextMessages.push(...dirMessages)
+        }
+
+        if (contextConfig.filePath) {
+            const fileMessages = await editorContext.getFilePathContext(contextConfig.filePath)
+            contextMessages.push(...fileMessages)
+        }
+
+        // Context for unit tests requests
+        if (isUnitTestRequest && contextMessages.length === 0) {
+            if (selection?.fileName) {
+                const importsContext = await editorContext.getUnitTestContextMessages(selection, workspaceRootUri)
+                contextMessages.push(...importsContext)
+            }
+        }
+
+        if (contextConfig.currentFile || contextConfig.selection !== false) {
+            const currentFileMessages = editorContext.getCurrentFileContextFromEditorSelection()
+            contextMessages.push(...currentFileMessages)
+        }
+
+        if (contextConfig.command && commandOutput) {
+            const outputMessages = editorContext.getTerminalOutputContext(commandOutput)
+            contextMessages.push(...outputMessages)
+        }
+
+        if (contextFiles?.length) {
+            const contextFileMessages = await ChatQuestion.getContextFilesContext(editor, contextFiles)
+            contextMessages.push(...contextFileMessages)
+        }
+
+        // Return sliced results
+        const maxResults = Math.floor((NUM_CODE_RESULTS + NUM_TEXT_RESULTS) / 2) * 2
+        return contextMessages.slice(-maxResults * 2)
+    }
+}
+
+function createInteractionForError(errorType: 'command' | 'prompt' | 'selection', args?: string): Promise<Interaction> {
+    switch (errorType) {
+        case 'command':
+            return newInteractionWithError('Invalid command -- command not found.')
+        case 'prompt':
+            return newInteractionWithError('Please enter a valid prompt for the custom command.', args || '')
+        case 'selection':
+            return newInteractionWithError(
+                `__${args}__ requires highlighted code. Please select some code in your editor and try again.`,
+                args
+            )
+    }
+}

--- a/lib/shared/src/chat/recipes/recipe.ts
+++ b/lib/shared/src/chat/recipes/recipe.ts
@@ -28,6 +28,7 @@ export type RecipeID =
     | 'generate-unit-test'
     | 'git-history'
     | 'improve-variable-names'
+    | 'custom-prompt'
     | 'next-questions'
     | 'pr-description'
     | 'release-notes'

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -8,17 +8,7 @@ import { Message } from '../sourcegraph-api'
 // user: context file provided by the user explicitly via chat input
 // keyword: the context file returned from local keyword search
 // editor: context file retrieved from the current editor
-// selection: selected code from the current editor
-// terminal: output from shell terminal
-export type ContextFileSource =
-    | 'embeddings'
-    | 'user'
-    | 'keyword'
-    | 'editor'
-    | 'filename'
-    | 'unified'
-    | 'selection'
-    | 'terminal'
+export type ContextFileSource = 'embeddings' | 'user' | 'keyword' | 'editor' | 'filename' | 'unified'
 
 export type ContextFileType = 'file' | 'symbol'
 

--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -1,5 +1,8 @@
 import { URI } from 'vscode-uri'
 
+import { CodyPrompt } from '../chat/prompts'
+import { ContextFile } from '../codebase-context/messages'
+
 export interface ActiveTextEditor {
     content: string
     filePath: string
@@ -79,6 +82,8 @@ export interface VsCodeFixupController {
 }
 
 export interface VsCodeCommandsController {
+    addCommand(key: string, input?: string, contextFiles?: ContextFile[], addEnhancedContext?: boolean): Promise<string>
+    getCommand(commandRunnerId: string): CodyPrompt | null
     menu(type: 'custom' | 'config' | 'default', showDesc?: boolean): Promise<void>
 }
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,9 +8,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Display the source and range of enhanced context correctly in UI. [pull/2542](https://github.com/sourcegraph/cody/pull/2542)
-- Context from directory for commands and custom commands now shows up correctly under enhanced context. [issues/2548](https://github.com/sourcegraph/cody/issues/2548)/[pull/2542](https://github.com/sourcegraph/cody/pull/2542)
-
 ### Changed
 
 ## [1.0.5]

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -2,12 +2,16 @@ import * as vscode from 'vscode'
 
 import { ChatModelProvider } from '@sourcegraph/cody-shared'
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
+import { CustomCommandType } from '@sourcegraph/cody-shared/src/chat/prompts'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
+import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import {
     FeatureFlagProvider,
     featureFlagProvider,
 } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 
+import { View } from '../../../webviews/NavBar'
 import { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import { SymfRunner } from '../../local-context/symf'
 import { logDebug } from '../../log'
@@ -21,6 +25,7 @@ import { chatHistory } from './ChatHistoryManager'
 import { CodyChatPanelViewType } from './ChatManager'
 import { SidebarViewOptions } from './SidebarViewController'
 import { SimpleChatPanelProvider } from './SimpleChatPanelProvider'
+import { SimpleChatRecipeAdapter } from './SimpleChatRecipeAdapter'
 
 type ChatID = string
 
@@ -36,10 +41,28 @@ export interface ChatPanelProviderOptions extends MessageProviderOptions {
     featureFlagProvider: FeatureFlagProvider
 }
 
+/**
+ * An interface to swap out SimpleChatPanelProvider for ChatPanelProvider
+ */
+export interface IChatPanelProvider extends vscode.Disposable {
+    executeRecipe(recipeID: RecipeID, chatID: ChatID, context: any): Promise<void>
+    executeCustomCommand(title: string, type?: CustomCommandType): Promise<void>
+    clearAndRestartSession(): Promise<void>
+    handleChatTitle(title: string): void
+    triggerNotice(notice: { key: string }): void
+    webviewPanel?: vscode.WebviewPanel
+    webview?: ChatViewProviderWebview
+    sessionID: string
+    setWebviewView(view: View): Promise<void>
+    restoreSession(chatID: string): Promise<void>
+    setConfiguration?: (config: Config) => void
+    revive: (panel: vscode.WebviewPanel, chatID: string) => Promise<void>
+}
+
 export class ChatPanelsManager implements vscode.Disposable {
     // Chat views in editor panels
-    private activePanelProvider: SimpleChatPanelProvider | undefined = undefined
-    private panelProvidersMap: Map<ChatID, SimpleChatPanelProvider> = new Map()
+    private activePanelProvider: IChatPanelProvider | undefined = undefined
+    private panelProvidersMap: Map<ChatID, IChatPanelProvider> = new Map()
 
     private options: ChatPanelProviderOptions
 
@@ -101,7 +124,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         await this.updateTreeViewHistory()
     }
 
-    public async getChatPanel(): Promise<SimpleChatPanelProvider> {
+    public async getChatPanel(): Promise<IChatPanelProvider> {
         const provider = await this.createWebviewPanel()
         // Check if any existing panel is available
         return this.activePanelProvider || provider
@@ -114,7 +137,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         chatID?: string,
         chatQuestion?: string,
         panel?: vscode.WebviewPanel
-    ): Promise<SimpleChatPanelProvider> {
+    ): Promise<IChatPanelProvider> {
         if (chatID && this.panelProvidersMap.has(chatID)) {
             const provider = this.panelProvidersMap.get(chatID)
             if (provider?.webviewPanel) {
@@ -194,6 +217,12 @@ export class ChatPanelsManager implements vscode.Disposable {
             embeddingsClient: this.embeddingsClient,
             localEmbeddings: this.localEmbeddings,
             symf: this.symf,
+            recipeAdapter: new SimpleChatRecipeAdapter(
+                this.options.editor,
+                this.options.intentDetector,
+                this.options.contextProvider,
+                this.options.platform
+            ),
             models,
         })
     }
@@ -210,6 +239,30 @@ export class ChatPanelsManager implements vscode.Disposable {
         if (chat) {
             void this.treeView?.reveal(chat, { select: true, focus: false })
         }
+    }
+
+    /**
+     * Executes a recipe in the chat view.
+     */
+    public async executeRecipe(recipeId: RecipeID, humanChatInput: string, source?: ChatEventSource): Promise<void> {
+        logDebug('ChatPanelsManager:executeRecipe', recipeId)
+
+        // Run command in a new webview to avoid conflicts with context from exisiting chat
+        // Only applies when commands are run outside of chat input box
+        const chatProvider = await this.getChatPanel()
+        await chatProvider.executeRecipe(recipeId, humanChatInput, source)
+    }
+
+    public async executeCustomCommand(title: string, type?: CustomCommandType): Promise<void> {
+        logDebug('ChatPanelsManager:executeCustomCommand', title)
+        const customPromptActions = ['add', 'get', 'menu']
+        if (!customPromptActions.includes(title)) {
+            await this.executeRecipe('custom-prompt', title, 'custom-commands')
+            return
+        }
+
+        const chatProvider = await this.getChatPanel()
+        await chatProvider.executeCustomCommand(title, type)
     }
 
     private async updateTreeViewHistory(): Promise<void> {

--- a/vscode/src/chat/chat-view/SimpleChatRecipeAdapter.ts
+++ b/vscode/src/chat/chat-view/SimpleChatRecipeAdapter.ts
@@ -1,0 +1,116 @@
+import { ChatError, ContextFile } from '@sourcegraph/cody-shared'
+import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
+import { Interaction } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
+import { Editor } from '@sourcegraph/cody-shared/src/editor'
+import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
+import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
+
+import { PlatformContext } from '../../extension.common'
+import { ContextProvider } from '../ContextProvider'
+
+import { contextMessageToContextItem } from './chat-helpers'
+import { ContextItem, MessageWithContext } from './SimpleChatModel'
+
+/**
+ * SimpleChatRecipeAdapter is a class that adapts the old recipes for use by the new
+ * SimpleChatPanelProvider
+ */
+export class SimpleChatRecipeAdapter {
+    constructor(
+        private editor: Editor,
+        private intentDetector: IntentDetector,
+        private contextProvider: ContextProvider,
+        private platform: Pick<PlatformContext, 'recipes'>
+    ) {}
+
+    public async computeRecipeMessages(
+        requestID: string,
+        recipeID: RecipeID,
+        humanChatInput: string,
+        userInputContextFiles?: ContextFile[],
+        addEnhancedContext: boolean = true
+    ): Promise<{
+        humanMessage: MessageWithContext
+        prompt: Message[]
+        error?: string | ChatError
+    } | null> {
+        const recipe = this.platform.recipes.find(recipe => recipe.id === recipeID)
+        if (!recipe) {
+            throw new Error(`command ${recipeID} is unsupported`)
+        }
+
+        let recipeInput = humanChatInput
+        if (recipeID === 'custom-prompt') {
+            const commandRunnerID = this.editor.controllers?.command?.getCommand(humanChatInput)
+            if (!commandRunnerID) {
+                const newCommandRunnerID = await this.editor.controllers?.command?.addCommand(
+                    humanChatInput,
+                    requestID,
+                    userInputContextFiles,
+                    addEnhancedContext
+                )
+                if (newCommandRunnerID === 'invalid') {
+                    throw new Error(`did not find valid command from user input "${humanChatInput}"`)
+                }
+                if (newCommandRunnerID) {
+                    recipeInput = newCommandRunnerID
+                }
+            }
+        }
+
+        const interaction = await recipe.getInteraction(recipeInput, {
+            editor: this.editor,
+            intentDetector: this.intentDetector,
+            codebaseContext: this.contextProvider.context,
+            addEnhancedContext,
+            userInputContextFiles,
+        })
+        if (!interaction) {
+            return null
+        }
+
+        const { humanMessage, prompt } = await interactionToHumanMessageAndPrompt(interaction)
+        const preambleMessages = getSimplePreamble()
+        return {
+            humanMessage,
+            prompt: preambleMessages.concat(prompt),
+            error: interaction?.getAssistantMessage()?.error,
+        }
+    }
+}
+
+/**
+ * Converts a legacy Interaction instance into a corresponding humanMessage and prompt.
+ * The humanMessage is what is stored in the new chat model, while the prompt is what
+ * is sent to the LLM.
+ *
+ * Note that the fact that this function does not return any assistant message means
+ * that any assistant message prefixes defined by the recipe are ignored.
+ */
+async function interactionToHumanMessageAndPrompt(interaction: Interaction): Promise<{
+    humanMessage: MessageWithContext
+    prompt: Message[]
+}> {
+    const humanInteractionMessage = interaction.getHumanMessage()
+    const fullContext = await interaction.getFullContext()
+    const prompt: Message[] = fullContext.concat([humanInteractionMessage] as Message[])
+
+    const contextItems = fullContext
+        .map(m => contextMessageToContextItem(m))
+        .filter((m): m is ContextItem => m !== null)
+    const displayText = humanInteractionMessage.prefix
+        ? humanInteractionMessage.prefix + (humanInteractionMessage.displayText || '')
+        : humanInteractionMessage.displayText
+    return {
+        humanMessage: {
+            message: {
+                speaker: humanInteractionMessage.speaker,
+                text: humanInteractionMessage.text,
+            },
+            displayText,
+            newContextUsed: contextItems,
+        },
+        prompt,
+    }
+}

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import * as vscode from 'vscode'
 
 import { ActiveTextEditorSelectionRange } from '@sourcegraph/cody-shared'
-import { createVSCodeRelativePath } from '@sourcegraph/cody-shared/src/chat/prompts/vscode-context/helpers'
 import { ContextFile, ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { EmbeddingsSearchResult } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
@@ -58,8 +57,8 @@ export function rangeToFragment(range: ActiveTextEditorSelectionRange): string {
 }
 
 export function fragmentToRange(fragment: string): ActiveTextEditorSelectionRange | undefined {
-    const match = fragment?.match(/^L(\d+)-(\d+)$/)
-    if (!fragment || !match) {
+    const match = fragment.match(/^L(\d+)-(\d+)$/)
+    if (!match) {
         return undefined
     }
     return {
@@ -136,18 +135,14 @@ export async function openFile(
     range?: ActiveTextEditorSelectionRange,
     currentViewColumn?: vscode.ViewColumn
 ): Promise<void> {
-    try {
-        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(absPath))
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(absPath))
 
-        let viewColumn = vscode.ViewColumn.Beside
-        if (currentViewColumn) {
-            viewColumn = currentViewColumn - 1 || currentViewColumn + 1
-        }
-        const selection = range ? new vscode.Range(range.start.line, 0, range.end.line, 0) : range
-        await vscode.window.showTextDocument(doc, { selection, viewColumn, preserveFocus: true, preview: true })
-    } catch (error) {
-        console.error(error)
+    let viewColumn = vscode.ViewColumn.Beside
+    if (currentViewColumn) {
+        viewColumn = currentViewColumn - 1 || currentViewColumn + 1
     }
+    const selection = range ? new vscode.Range(range.start.line, 0, range.end.line, 0) : range
+    await vscode.window.showTextDocument(doc, { selection, viewColumn, preserveFocus: true, preview: true })
 }
 
 // The approximate inverse of CodebaseContext.makeContextMessageWithResponse
@@ -211,8 +206,8 @@ export function contextItemsToContextFiles(items: ContextItem[]): ContextFile[] 
         }
         contextFiles.push({
             uri: item.uri,
-            fileName: createVSCodeRelativePath(item.uri),
-            source: item.source || 'embeddings',
+            fileName: relFsPath,
+            source: 'embeddings',
             range: rangeToActiveTextEditorSelectionRange(item.range),
             content: item.text,
         })

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -22,7 +22,6 @@ describe('DefaultPrompter', () => {
             {
                 getExplicitContext: () => [],
                 getEnhancedContext: () => Promise.resolve([]),
-                getCommandContext: () => Promise.resolve([]),
             },
             true,
             100000
@@ -69,7 +68,6 @@ describe('DefaultPrompter', () => {
             {
                 getExplicitContext: () => [],
                 getEnhancedContext: () => Promise.resolve([]),
-                getCommandContext: () => Promise.resolve([]),
             },
             true,
             100000

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -1,13 +1,9 @@
 import * as vscode from 'vscode'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
-import { CodyPrompt, CodyPromptContext } from '@sourcegraph/cody-shared/src/chat/prompts'
 import {
     isMarkdownFile,
     populateCodeContextTemplate,
-    populateContextTemplateFromText,
-    populateCurrentSelectedCodeContextTemplate,
     populateMarkdownContextTemplate,
 } from '@sourcegraph/cody-shared/src/prompt/templates'
 import { Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
@@ -22,8 +18,6 @@ export interface IContextProvider {
 
     // Relevant context pulled from the editor state and broader repository
     getEnhancedContext(query: string): Promise<ContextItem[]>
-
-    getCommandContext(promptText: string, contextConfig: CodyPromptContext): Promise<ContextItem[]>
 }
 
 export interface IPrompter {
@@ -31,8 +25,7 @@ export interface IPrompter {
         chat: SimpleChatModel,
         contextProvider: IContextProvider,
         useEnhancedContext: boolean,
-        byteLimit: number,
-        command?: CodyPrompt
+        byteLimit: number
     ): Promise<{
         prompt: Message[]
         contextLimitWarnings: string[]
@@ -50,8 +43,7 @@ export class DefaultPrompter implements IPrompter {
         chat: SimpleChatModel,
         contextProvider: IContextProvider,
         useEnhancedContext: boolean,
-        byteLimit: number,
-        command?: CodyPrompt
+        byteLimit: number
     ): Promise<{
         prompt: Message[]
         contextLimitWarnings: string[]
@@ -117,11 +109,9 @@ export class DefaultPrompter implements IPrompter {
         if (lastMessage.message.speaker === 'assistant') {
             throw new Error('Last message in prompt needs speaker "human", but was "assistant"')
         }
-        if (useEnhancedContext || command) {
+        if (useEnhancedContext) {
             // Add additional context from current editor or broader search
-            const additionalContextItems = command
-                ? await contextProvider.getCommandContext(command.prompt, command.context || { codebase: false })
-                : await contextProvider.getEnhancedContext(lastMessage.message.text)
+            const additionalContextItems = await contextProvider.getEnhancedContext(lastMessage.message.text)
             const { limitReached, used, ignored } = promptBuilder.tryAddContext(
                 additionalContextItems,
                 (item: ContextItem) => this.renderContextItem(item)
@@ -144,14 +134,7 @@ export class DefaultPrompter implements IPrompter {
 
     private renderContextItem(contextItem: ContextItem): Message[] {
         let messageText: string
-        if (contextItem.source === 'selection') {
-            messageText = populateCurrentSelectedCodeContextTemplate(contextItem.text, contextItem.uri.fsPath)
-        } else if (contextItem.source === 'editor') {
-            // This template text works well with prompts in our commands
-            // Using populateCodeContextTemplate here will cause confusion to Cody
-            const templateText = 'Codebase context from file path {fileName}: '
-            messageText = populateContextTemplateFromText(templateText, contextItem.text, contextItem.uri.fsPath)
-        } else if (isMarkdownFile(contextItem.uri.fsPath)) {
+        if (isMarkdownFile(contextItem.uri.fsPath)) {
             messageText = populateMarkdownContextTemplate(contextItem.text, contextItem.uri.fsPath)
         } else {
             messageText = populateCodeContextTemplate(contextItem.text, contextItem.uri.fsPath)
@@ -226,10 +209,6 @@ class PromptBuilder {
         const ignored: ContextItem[] = []
         const duplicate: ContextItem[] = []
         for (const contextItem of contextItems) {
-            if (contextItem.uri.scheme === 'file' && isCodyIgnoredFile(contextItem.uri)) {
-                ignored.push(contextItem)
-                continue
-            }
             const id = contextItemId(contextItem)
             if (this.seenContext.has(id)) {
                 duplicate.push(contextItem)

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -39,16 +39,33 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
     public commandRunners = new Map<string, CommandRunner>()
 
-    constructor(extensionPath: string) {
-        this.tools = new ToolsProvider()
+    constructor(context: vscode.ExtensionContext) {
+        this.tools = new ToolsProvider(context)
         const user = this.tools.getUserInfo()
 
-        this.custom = new CustomPromptsStore(this.isEnabled, extensionPath, user?.workspaceRoot, user.homeDir)
+        this.custom = new CustomPromptsStore(this.isEnabled, context.extensionPath, user?.workspaceRoot, user.homeDir)
         this.disposables.push(this.custom)
 
         this.lastUsedCommands = new Set(localStorage.getLastUsedCommands())
         this.custom.activate()
         this.fileWatcherInit()
+    }
+
+    /**
+     * Gets a CodyPrompt object for the given command runner ID.
+     * @param commandRunnerId - The ID of the command runner to get the prompt for.
+     * @returns The CodyPrompt object for the command runner, or null if not found.
+     *
+     * Looks up the command runner instance in the commandRunners map by the given ID.
+     * If found, returns the CodyPrompt associated with that runner. Otherwise returns null.
+     */
+    public getCommand(commandRunnerId: string): CodyPrompt | null {
+        const commandRunner = this.commandRunners.get(commandRunnerId)
+        if (!commandRunner) {
+            return null
+        }
+        this.commandRunners.delete(commandRunnerId)
+        return commandRunner?.codyCommand
     }
 
     public isCommand(text: string): boolean {
@@ -59,11 +76,14 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         return !!this.default.get(commandKey)
     }
 
-    public async findCommand(
-        text: string,
-        requestID?: string,
-        contextFiles?: ContextFile[]
-    ): Promise<CodyPrompt | null> {
+    /**
+     * Adds a new command to the commands map.
+     *
+     * Looks up the command prompt using the given key in the default prompts map.
+     * If found, creates a new Cody command runner instance for that prompt and input.
+     * Returns the ID of the created runner, or 'invalid' if not found.
+     */
+    public async addCommand(text: string, requestID?: string, contextFiles?: ContextFile[]): Promise<string> {
         const commandSplit = text.split(' ')
         // The unique key for the command. e.g. /test
         const commandKey = commandSplit.shift() || text
@@ -72,47 +92,56 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
         const command = this.default.get(commandKey)
         if (!command) {
-            return null
+            return 'invalid'
         }
+
         if (command.slashCommand === '/ask') {
-            command.prompt = command.prompt.replace('/ask', '')
+            command.prompt = text
         }
+
         command.additionalInput = commandInput
-        command.mode = command.prompt.startsWith('/edit') ? 'edit' : command.mode || 'ask'
         command.requestID = requestID
         command.contextFiles = contextFiles
-        await this.createCodyCommandRunner(command, commandInput)
-        return command
+        return this.createCodyCommandRunner(command, commandInput)
     }
 
-    private async createCodyCommandRunner(command: CodyPrompt, input = ''): Promise<CommandRunner | undefined> {
+    /**
+     * Creates a new Cody command runner instance and returns the ID.
+     *
+     * This creates a new CommandRunner instance with the given CodyPrompt, input text,
+     * and fixup request flag. It adds the runner to the commandRunners map, sets it
+     * as the current prompt in progress, and logs the command usage.
+     *
+     * If the prompt has a shell command in its context, it will execute that command.
+     *
+     * Finally, it returns the unique ID for the created CommandRunner instance.
+     */
+    private async createCodyCommandRunner(command: CodyPrompt, input = ''): Promise<string> {
         const commandKey = command.slashCommand
-        const defaultEditCommands = new Set(['/edit', '/doc'])
-        const isFixupRequest = defaultEditCommands.has(commandKey) || command.mode !== 'ask'
+        const defaultEditCommands = new Set(['/edit', '/fix', '/doc'])
+        const isFixupRequest = defaultEditCommands.has(commandKey) || command.prompt.startsWith('/edit')
 
         logDebug('CommandsController:createCodyCommandRunner:creating', commandKey)
 
         // Start the command runner
-        const runner = new CommandRunner(command, input, isFixupRequest)
-        this.commandRunners.set(runner.id, runner)
+        const codyCommand = new CommandRunner(command, input, isFixupRequest)
+        this.commandRunners.set(codyCommand.id, codyCommand)
 
         // Save command to command history
         this.lastUsedCommands.add(command.slashCommand)
 
         // Fixup request will be taken care by the fixup recipe in the CommandRunner
-        if (isFixupRequest) {
-            return undefined
+        if (isFixupRequest || command.mode !== 'ask') {
+            return ''
         }
 
         // Run shell command if any
         const shellCommand = command.context?.command
         if (shellCommand) {
-            await runner.runShell(this.tools.exeCommand(shellCommand))
+            await codyCommand.runShell(this.tools.exeCommand(shellCommand))
         }
 
-        this.commandRunners.delete(runner.id)
-
-        return runner
+        return codyCommand.id
     }
 
     /**

--- a/vscode/src/commands/PromptsProvider.ts
+++ b/vscode/src/commands/PromptsProvider.ts
@@ -10,7 +10,6 @@ const editorCommands: CodyPrompt[] = [
         description: ASK_QUESTION_COMMAND.description,
         prompt: ASK_QUESTION_COMMAND.slashCommand,
         slashCommand: ASK_QUESTION_COMMAND.slashCommand,
-        context: { codebase: true },
     },
     {
         description: EDIT_COMMAND.description,

--- a/vscode/src/commands/utils/ToolsProvider.ts
+++ b/vscode/src/commands/utils/ToolsProvider.ts
@@ -1,6 +1,6 @@
-import { exec } from 'node:child_process'
-import { promisify } from 'node:util'
+import { exec } from 'child_process'
 import os from 'os'
+import { promisify } from 'util'
 
 import * as vscode from 'vscode'
 
@@ -22,7 +22,7 @@ export class ToolsProvider {
     private user: UserWorkspaceInfo
     private shell = vscode.env.shell
 
-    constructor() {
+    constructor(public context: vscode.ExtensionContext) {
         this.user = this.getUserInfo()
     }
 

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 import { ChatQuestion } from '@sourcegraph/cody-shared/src/chat/recipes/chat-question'
 import { ContextSearch } from '@sourcegraph/cody-shared/src/chat/recipes/context-search'
+import { CustomPrompt } from '@sourcegraph/cody-shared/src/chat/recipes/custom-prompt'
 import { ExplainCodeDetailed } from '@sourcegraph/cody-shared/src/chat/recipes/explain-code-detailed'
 import { ExplainCodeHighLevel } from '@sourcegraph/cody-shared/src/chat/recipes/explain-code-high-level'
 import { FindCodeSmells } from '@sourcegraph/cody-shared/src/chat/recipes/find-code-smells'
@@ -31,6 +32,7 @@ export const VSCODE_WEB_RECIPES: Recipe[] = [
     new GenerateDocstring(),
     new GenerateTest(),
     new ImproveVariableNames(),
+    new CustomPrompt(),
     new NextQuestions(),
     new TranslateToLanguage(),
     new ContextSearch(),

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { FixupIntent } from '@sourcegraph/cody-shared/src/editor'
@@ -44,6 +45,7 @@ import { createOrUpdateEventLogger, telemetryService } from './services/telemetr
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
 import { workspaceActionsOnConfigChange } from './services/utils/workspace-action'
+import { TestSupport } from './test-support'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 
 /**
@@ -106,12 +108,13 @@ const register = async (
     // Controller for Non-Stop Cody
     const fixup = new FixupController()
     disposables.push(fixup)
-
-    const commandsController = platform.createCommandsController?.(context.extensionPath)
+    if (TestSupport.instance) {
+        TestSupport.instance.fixupController.set(fixup)
+    }
 
     const editor = new VSCodeEditor({
         fixups: fixup,
-        command: commandsController,
+        command: platform.createCommandsController?.(context),
     })
 
     // Could we use the `initialConfig` instead?
@@ -274,20 +277,13 @@ const register = async (
     // Sync initial auth status
     await chatManager.syncAuthStatus(authProvider.getAuthStatus())
 
-    // Execute Cody Commands and Cody Custom Commands
-    const executeCommand = async (commandKey: string, source: ChatEventSource = 'editor'): Promise<void> => {
-        const command = await commandsController?.findCommand(commandKey)
-        if (!command) {
-            return
-        }
-        // If it's not a ask command, it's a fixup command. If it's a fixup request, we can exit early
-        // This is because findCommand will start the CommandRunner,
-        // which would send all fixup requests to the FixupController
-        if (command.mode !== 'ask') {
-            return
-        }
-
-        return chatManager.executeCommand(command, source)
+    const executeRecipeInChatView = async (
+        recipe: RecipeID,
+        openChatView = true,
+        humanInput = '',
+        source: ChatEventSource = 'editor'
+    ): Promise<void> => {
+        await chatManager.executeRecipe(recipe, humanInput, openChatView, source)
     }
 
     const executeFixup = async (
@@ -374,9 +370,9 @@ const register = async (
             vscode.commands.executeCommand('workbench.action.openSettings', { query: '@ext:sourcegraph.cody-ai chat' })
         ),
         // Recipes
-        vscode.commands.registerCommand('cody.action.chat', async (input: string, source?: ChatEventSource) =>
-            executeCommand(`/ask ${input}`, source)
-        ),
+        vscode.commands.registerCommand('cody.action.chat', async (input: string, source?: ChatEventSource) => {
+            await executeRecipeInChatView('chat-question', true, input, source)
+        }),
         vscode.commands.registerCommand('cody.action.commands.menu', async () => {
             await editor.controllers.command?.menu('default')
         }),
@@ -385,11 +381,24 @@ const register = async (
             () => editor.controllers.command?.menu('custom')
         ),
         vscode.commands.registerCommand('cody.settings.commands', () => editor.controllers.command?.menu('config')),
-        vscode.commands.registerCommand('cody.action.commands.exec', async title => executeCommand(title)),
-        vscode.commands.registerCommand('cody.command.explain-code', async () => executeCommand('/explain')),
-        vscode.commands.registerCommand('cody.command.generate-tests', async () => executeCommand('/test')),
-        vscode.commands.registerCommand('cody.command.document-code', async () => executeCommand('/doc')),
-        vscode.commands.registerCommand('cody.command.smell-code', async () => executeCommand('/smell')),
+        vscode.commands.registerCommand('cody.action.commands.exec', async title => {
+            await chatManager.executeCustomCommand(title)
+        }),
+        vscode.commands.registerCommand('cody.command.explain-code', async () => {
+            await executeRecipeInChatView('custom-prompt', true, '/explain')
+        }),
+        vscode.commands.registerCommand('cody.command.generate-tests', async () => {
+            await executeRecipeInChatView('custom-prompt', true, '/test')
+        }),
+        vscode.commands.registerCommand('cody.command.document-code', async () => {
+            await executeRecipeInChatView('custom-prompt', false, '/doc')
+        }),
+        vscode.commands.registerCommand('cody.command.smell-code', async () => {
+            await executeRecipeInChatView('custom-prompt', true, '/smell')
+        }),
+        vscode.commands.registerCommand('cody.command.context-search', () =>
+            executeRecipeInChatView('context-search', true)
+        ),
 
         // Account links
         vscode.commands.registerCommand('cody.show-page', (page: string) => {

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
 import { logDebug, logError } from '../log'
-import { TestSupport } from '../test-support'
 
 export const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
 
@@ -16,12 +15,8 @@ export async function getAccessToken(): Promise<string | null> {
         logError('VSCodeSecretStorage:getAccessToken', 'failed', { verbose: error })
         // Remove corrupted token from secret storage
         await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
-
-        if (!TestSupport.instance) {
-            // Display system notification because the error was caused by system storage
-            console.error(`Failed to retrieve access token for Cody from secret storage: ${error}`)
-        }
-
+        // Display system notification because the error was caused by system storage
+        console.error(`Failed to retrieve access token for Cody from secret storage: ${error}`)
         return null
     }
 }

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -2,7 +2,9 @@ import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messag
 import { MockReranker, Reranker } from '@sourcegraph/cody-shared/src/codebase-context/rerank'
 import { ContextResult } from '@sourcegraph/cody-shared/src/local-context'
 
-import { SimpleChatPanelProvider } from './chat/chat-view/SimpleChatPanelProvider'
+import { MessageProvider } from './chat/MessageProvider'
+import { FixupController } from './non-stop/FixupController'
+import { FixupTask } from './non-stop/FixupTask'
 
 // A one-slot channel which lets readers block on a value being
 // available from a writer. Tests use this to wait for the
@@ -37,7 +39,9 @@ class Rendezvous<T> {
 // integration test.
 export class TestSupport {
     public static instance: TestSupport | undefined
-    public chatPanelProvider = new Rendezvous<SimpleChatPanelProvider>()
+
+    public messageProvider = new Rendezvous<MessageProvider>()
+    public fixupController = new Rendezvous<FixupController>()
 
     public reranker: Reranker | undefined
 
@@ -50,7 +54,11 @@ export class TestSupport {
         return this.reranker
     }
 
-    public async chatMessages(): Promise<ChatMessage[]> {
-        return (await this.chatPanelProvider.get()).transcriptForTesting(this)
+    public async chatTranscript(): Promise<ChatMessage[]> {
+        return (await this.messageProvider.get()).transcriptForTesting(this)
+    }
+
+    public async fixupTasks(): Promise<FixupTask[]> {
+        return (await this.messageProvider.get()).fixupTasksForTesting(this)
     }
 }

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -89,8 +89,8 @@ test('@-file empty state', async ({ page, sidebar }) => {
         )
     ).toBeVisible()
 
-    // Also ensure explicitly @-included context is not showing up as enhanced context
-    await expect(chatPanelFrame.getByText(/^✨ Context:/)).not.toBeVisible()
+    // Also ensure we have the right number of files in the context.
+    await expect(chatPanelFrame.getByText('Context: 2 files')).toBeVisible()
 
     // Check pressing tab after typing a complete filename.
     // https://github.com/sourcegraph/cody/issues/2200

--- a/vscode/test/e2e/command.test.ts
+++ b/vscode/test/e2e/command.test.ts
@@ -24,7 +24,7 @@ test('submit command from command palette', async ({ page, sidebar }) => {
     const chatPanelFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
 
     // Check if the command shows up with the current file name
-    await chatPanelFrame.getByText('✨ Context: 13 lines from 1 file').click()
+    await chatPanelFrame.getByText('✨ Context: 1 file').click()
 
     // Check if assistant responsed
     await expect(chatPanelFrame.getByText('hello from the assistant')).toBeVisible()

--- a/vscode/test/integration/chat.test.ts
+++ b/vscode/test/integration/chat.test.ts
@@ -2,19 +2,12 @@ import * as assert from 'assert'
 
 import * as vscode from 'vscode'
 
-import { SimpleChatPanelProvider } from '../../src/chat/chat-view/SimpleChatPanelProvider'
+import { MessageProvider } from '../../src/chat/MessageProvider'
 
-import {
-    afterIntegrationTest,
-    beforeIntegrationTest,
-    getExtensionAPI,
-    getTextEditorWithSelection,
-    getTranscript,
-    waitUntil,
-} from './helpers'
+import { afterIntegrationTest, beforeIntegrationTest, getExtensionAPI, getTranscript, waitUntil } from './helpers'
 
-async function getChatViewProvider(): Promise<SimpleChatPanelProvider> {
-    const chatViewProvider = await getExtensionAPI().exports.testing?.chatPanelProvider.get()
+async function getChatViewProvider(): Promise<MessageProvider> {
+    const chatViewProvider = await getExtensionAPI().exports.testing?.messageProvider.get()
     assert.ok(chatViewProvider)
     return chatViewProvider
 }
@@ -23,24 +16,14 @@ suite('Chat', function () {
     this.beforeEach(() => beforeIntegrationTest())
     this.afterEach(() => afterIntegrationTest())
 
-    test('sends and receives a message', async () => {
+    // TODO Fix test - passes locally but failing in CI
+
+    test.skip('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.panel.new')
         const chatView = await getChatViewProvider()
-        await chatView.handleHumanMessageSubmitted('test', 'hello from the human', 'user', [], false)
+        await chatView.executeRecipe('chat-question', 'hello from the human', 'test')
 
         assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)
-        await waitUntil(async () => /^hello from the assistant$/.test((await getTranscript(1)).displayText || ''))
-    })
-
-    // display filename when there is a selection in active editor
-    test('append current file link to display text on editor selection', async () => {
-        await getTextEditorWithSelection()
-        await vscode.commands.executeCommand('cody.chat.panel.new')
-        const chatView = await getChatViewProvider()
-        await chatView.handleHumanMessageSubmitted('test', 'hello from the human', 'user', [], false)
-
-        // Display text should include file link at the end of message
-        assert.match((await getTranscript(0)).displayText || '', /^hello from the human \[_@Main.java/)
         await waitUntil(async () => /^hello from the assistant$/.test((await getTranscript(1)).displayText || ''))
     })
 })

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -7,8 +7,7 @@ import { getVSCodeAPI } from '../utils/VSCodeApi'
 import styles from './FileLink.module.css'
 
 export const FileLink: React.FunctionComponent<FileLinkProps> = ({ uri, path, range, source }) => {
-    const fileName = path || uri?.fsPath
-    const pathWithRange = range?.end.line ? `${fileName}:${range?.start.line + 1}-${range?.end.line - 1}` : fileName
+    const pathWithRange = range?.end.line ? `${path}:${range?.start.line + 1}-${range?.end.line - 1}` : path
 
     return (
         <button


### PR DESCRIPTION
The agent tests started failing after merging the PR #2542 when you re-record the HTTP requests. The tests were passing in replay mode for some reason, and we suspect it's due to a buggy merge in `recording.har`. When you `rm -rf agent/recordings` and record from scratch then the tests fail.

To prevent this from happening again, we're planning to provide scripts to cleanly update the recordings.

## Test plan

Green CI.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
