### PR TITLE
Clean up Polly recordings to reduce diffs when re-recording

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@pollyjs/adapter-node-http": "^6.0.6",
     "@pollyjs/core": "^6.0.6",
+    "@pollyjs/persister": "^6.0.6",
     "@pollyjs/persister-fs": "^6.0.6",
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/telemetry": "^0.16.0",

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -55,7 +55,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 324,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -79,37 +79,11 @@
             "size": 136,
             "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZuYGhvFGBkYmugaGugam8aZ6RrpGxiamqSkWacnGRiZKtbW1AAAAAP//AwC7GWWbSQAAAA==\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:33.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "0bd4f5e9-8e29-4668-984e-55eac01c7e5d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:34.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "E.ksRsElgdGMMsW_3o_Ujcuc2AXsXNtq6Hrf4u86Tfw-1704453334-1-ATyfIZztohmcTQQxQIbsQXPduJupUZxoohu8xrF9BzwuYZkkbhKFV1Klb9kBBzfBxtKLoanW2z27nVhlXRZDahM="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "_IlQxRyfOE7MIIbCngyjqnxn7t3tYuVm2qi6akSGYEA-1704453334059-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:34 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -136,21 +110,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0bd4f5e9-8e29-4668-984e-55eac01c7e5d; Expires=Sun, 05 Jan 2025 11:15:33 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=E.ksRsElgdGMMsW_3o_Ujcuc2AXsXNtq6Hrf4u86Tfw-1704453334-1-ATyfIZztohmcTQQxQIbsQXPduJupUZxoohu8xrF9BzwuYZkkbhKFV1Klb9kBBzfBxtKLoanW2z27nVhlXRZDahM=; path=/; expires=Fri, 05-Jan-24 11:45:34 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=_IlQxRyfOE7MIIbCngyjqnxn7t3tYuVm2qi6akSGYEA-1704453334059-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -163,40 +122,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "d523249f9a03ebf83cc826c202bba3fb"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "8f34ffd4f18ad065"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d523249f9a03ebf83cc826c202bba3fb"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4dd5f9ab7127-OSL"
             },
             {
               "name": "content-encoding",
@@ -209,8 +140,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:33.369Z",
-        "time": 682,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -218,7 +149,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 682
+          "wait": 0
         }
       },
       {
@@ -269,7 +200,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 316,
+          "headersSize": 333,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -293,251 +224,11 @@
             "size": 148,
             "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:34.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "2fefd71b-4e68-40c3-b638-d8ddaaa38344"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "psAIBzPss9JwEmssO9RmrsZ7YNraVOyMLPMqcGeebC0-1704453335-1-AQCdURgkSzaogEqdxi5I7gBbPemmzdOIJ5eVx+G2a92Tn+NDM3dNjoCebzQczfNnJr+EPOJ8jA+1N7MKoIg6W0k="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Ooaxb4_6Wb1UZStp50iz7WPQdk5RPhd0Fw_k9lOfEus-1704453335427-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=2fefd71b-4e68-40c3-b638-d8ddaaa38344; Expires=Sun, 05 Jan 2025 11:15:34 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=psAIBzPss9JwEmssO9RmrsZ7YNraVOyMLPMqcGeebC0-1704453335-1-AQCdURgkSzaogEqdxi5I7gBbPemmzdOIJ5eVx+G2a92Tn+NDM3dNjoCebzQczfNnJr+EPOJ8jA+1N7MKoIg6W0k=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=Ooaxb4_6Wb1UZStp50iz7WPQdk5RPhd0Fw_k9lOfEus-1704453335427-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "205a8b667877fbd2399b08c64d6b26dd"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c6928d630cba1e44"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/205a8b667877fbd2399b08c64d6b26dd"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4ddd4d84b523-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:34.552Z",
-        "time": 864,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 864
-        }
-      },
-      {
-        "_id": "c382115f0629fc6dabc67adfd72f2923",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 155,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "155"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 337,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 128,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 128,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:35.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "01923998-c17e-4d6e-9650-8d2f768625bb"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9KVVn_uX6STXh_VOxZbXGoWbe70mMRUAhS2AyWL.KAk-1704453335-1-AfRqApx3fGF0dEuM8snw8mjNbI6UXMp8AubfO0Da/zgu433VP2OLyHUHBiYvz3gDluIAM38EVYGRqaqaGtFkD1c="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "Eqn8gTRwKiFlZE22K3bPIwX2CeBrB1eQbRgJvypToR4-1704453335657-0-604800000"
-            }
-          ],
-          "headers": [
-            {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -564,21 +255,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=01923998-c17e-4d6e-9650-8d2f768625bb; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=9KVVn_uX6STXh_VOxZbXGoWbe70mMRUAhS2AyWL.KAk-1704453335-1-AfRqApx3fGF0dEuM8snw8mjNbI6UXMp8AubfO0Da/zgu433VP2OLyHUHBiYvz3gDluIAM38EVYGRqaqaGtFkD1c=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=Eqn8gTRwKiFlZE22K3bPIwX2CeBrB1eQbRgJvypToR4-1704453335657-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -591,40 +267,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "5b30b5b71799ebb7eb439d6951536a98"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2df00778b1e52155"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/5b30b5b71799ebb7eb439d6951536a98"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de2cccf7128-OSL"
             },
             {
               "name": "content-encoding",
@@ -637,8 +285,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:35.443Z",
-        "time": 204,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -646,221 +294,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 204
-        }
-      },
-      {
-        "_id": "26f7093bcc1d125e7768f46a33e590e8",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 318,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "318"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 337,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
-          },
-          "queryString": [
-            {
-              "name": "CurrentSiteCodyLlmConfiguration",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
-        },
-        "response": {
-          "bodySize": 215,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 215,
-            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UF\",\"jiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:35.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6366d665-4903-4052-851f-2d0948e6d77a"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "AJyUAqqYNi670gFuSMaQPAt0_CqVt5Qm_mS1U9R5CM0-1704453335-1-AfEqanrGzN3esXYW8PlBE/QHOoR7z8qjMSUcTm16UEKSpT3K8+sxnHRXiT7ijk3j7IdnMMYa49nrw2wjKlkOskA="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "pHH3t5eFTfoU6mH2bS4wySDO0uKUjXlC8sFluYyCQa0-1704453335664-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6366d665-4903-4052-851f-2d0948e6d77a; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=AJyUAqqYNi670gFuSMaQPAt0_CqVt5Qm_mS1U9R5CM0-1704453335-1-AfEqanrGzN3esXYW8PlBE/QHOoR7z8qjMSUcTm16UEKSpT3K8+sxnHRXiT7ijk3j7IdnMMYa49nrw2wjKlkOskA=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=pHH3t5eFTfoU6mH2bS4wySDO0uKUjXlC8sFluYyCQa0-1704453335664-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "e29879e358f991ce00b8444d1859dede"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "391387ba26229f33"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/e29879e358f991ce00b8444d1859dede"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de2db4c5685-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:35.442Z",
-        "time": 219,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 219
+          "wait": 0
         }
       },
       {
@@ -911,7 +345,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 324,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -928,44 +362,18 @@
           "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
         },
         "response": {
-          "bodySize": 222,
+          "bodySize": 212,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 222,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaR\",\"wfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8=\",\"AwBhzrhaoAAAAA==\"]"
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:35.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "60d00a83-6609-4cf8-8c70-9b2f1e4cfbb7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:35.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9WI1H8qnpeHl7r3n9Bj6NrywTOz2lOcSqkuACx6GmwY-1704453335-1-AdOI8w0ae3wmjJYSql7CxKRjF3mexgOvLSkX+LbmR+ojYxG3tJbWc057PY2kBWa2zXFNVlUYNAjtkk/c3ClyUFM="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ufe2Obh2yyxIere2YW9LAeKmV.635_dG4hhhmd7IIww-1704453335944-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:35 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -992,19 +400,149 @@
               "value": "no-cache, max-age=0"
             },
             {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "c382115f0629fc6dabc67adfd72f2923",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 155,
+          "cookies": [],
+          "headers": [
+            {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=60d00a83-6609-4cf8-8c70-9b2f1e4cfbb7; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=9WI1H8qnpeHl7r3n9Bj6NrywTOz2lOcSqkuACx6GmwY-1704453335-1-AdOI8w0ae3wmjJYSql7CxKRjF3mexgOvLSkX+LbmR+ojYxG3tJbWc057PY2kBWa2zXFNVlUYNAjtkk/c3ClyUFM=; path=/; expires=Fri, 05-Jan-24 11:45:35 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=ufe2Obh2yyxIere2YW9LAeKmV.635_dG4hhhmd7IIww-1704453335944-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "155"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            provider\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 128,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 128,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
             },
             {
               "name": "vary",
@@ -1019,40 +557,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "26c2201a8aec5d98eebed69ca3436b0c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "2fabd3c039c51ced"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/26c2201a8aec5d98eebed69ca3436b0c"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de2cae156b5-OSL"
             },
             {
               "name": "content-encoding",
@@ -1065,8 +575,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:35.438Z",
-        "time": 491,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1074,7 +584,152 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 491
+          "wait": 0
+        }
+      },
+      {
+        "_id": "26f7093bcc1d125e7768f46a33e590e8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 318,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "318"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 354,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
+          },
+          "queryString": [
+            {
+              "name": "CurrentSiteCodyLlmConfiguration",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+        },
+        "response": {
+          "bodySize": 212,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 212,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
         }
       },
       {
@@ -1125,7 +780,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 317,
+          "headersSize": 334,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1142,258 +797,18 @@
           "url": "https://sourcegraph.com/.api/graphql?CurrentUser"
         },
         "response": {
-          "bodySize": 304,
+          "bodySize": 288,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 304,
-            "text": "[\"H4sIAAAAAAAAAzSOQWrDMBRErxJmbWKXptAKSrtoyCaYUEholz/Sj60iS+ZLCrjGp+gJepZcrLhpdzNvMfNGGEoENUJnEfZpH1nmag0UDm+10x/hs355v0OBluKBxZ4sm3VH1kElyVzA2Ng7GmrqGAqXL0enLIvd5du5xYatxBg8CtCZEsn+dQuFNqU+qrK8slgtG5vafMyRRQef2KelDl2Zy5tVdV893D6dH1cooIMZdhLWno6Ozf9/L7YjGf6cRvA1IPyK9M1zM4N5ENM0TT8AAAD//wMAYDFO0fQAAAA=\"]"
+            "size": 288,
+            "text": "[\"H4sIAAAAAAAAAzSOQUvDQBSE/4rMOTStCMpC0UNz0ypii9fX7KtZSXaXt2+L25D/LiF6m5nD980IS0owI9oswl4PiWWuzsLg+Lnv2+/w83Jtrq+7ZosKHaUjizs7ts1ArodRyVzBuhR7KnsaGAY78r7cfOQY2RdUoAspyeH9GQadakymrpctrb6cdvmUE0sbvLLXVRuGOteb9f3DenP7eNneoUIbbHmT0Hg69Wz/rVHcQFL+nozgJcDO/idd/DMP0zRNvwAAAP//AwB6VIJ87QAAAA==\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:35.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "135a35d0-e6a5-46a4-ac8e-cdcf1ffab215"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "YirGbPk4atdUeb5GaVPDeO3OHjJOUxMYmjdL89kFWxE-1704453336-1-AbWngC5ctJhnfcBdwoPDAlZ/p4Nq2LU3p+9lrOs3DSSuJ0Serbp5TntgbjU//bcesjbjK1HPhuHHKP4LRkOc6vA="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "gqSn4h9e0irpeml4tUWz0RCv8kF3y5.AbD.lsD7EGmk-1704453336338-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=135a35d0-e6a5-46a4-ac8e-cdcf1ffab215; Expires=Sun, 05 Jan 2025 11:15:35 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=YirGbPk4atdUeb5GaVPDeO3OHjJOUxMYmjdL89kFWxE-1704453336-1-AbWngC5ctJhnfcBdwoPDAlZ/p4Nq2LU3p+9lrOs3DSSuJ0Serbp5TntgbjU//bcesjbjK1HPhuHHKP4LRkOc6vA=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=gqSn4h9e0irpeml4tUWz0RCv8kF3y5.AbD.lsD7EGmk-1704453336338-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "4cb68afcacfa0b9a189569c720df66dd"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "0c1b046f9b476eb7"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4cb68afcacfa0b9a189569c720df66dd"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de4380956c5-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:35.671Z",
-        "time": 653,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 653
-        }
-      },
-      {
-        "_id": "72193840b9935c6cf7c7a9606eac4c6e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 144,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "144"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 316,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery Repository($name: String!) {\\n\\trepository(name: $name) {\\n\\t\\tid\\n\\t}\\n}\",\"variables\":{\"name\":\"github.com/sourcegraph/cody\"}}"
-          },
-          "queryString": [
-            {
-              "name": "Repository",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?Repository"
-        },
-        "response": {
-          "bodySize": 120,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 120,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA==\"]"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "aae4d3df-4b9c-4bcb-937a-9da692d9bff7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "HpYML10w6m_7BucTYrb9J4lkSRXLhszrUHE2sTw4bww-1704453336-1-AXVVNXoalpk+qne8g5scu0uxKH1fFZGl5wTrioFf/K0JQiQWihf7PD57Gmr0syz03vCo+k/w7kP1aTU8vZ81XcI="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "xx356VYP3H8VSI9Br_Z_a7.iOoK6Dcm071GpziqiV6U-1704453336569-0-604800000"
-            }
-          ],
-          "headers": [
-            {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -1420,21 +835,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=aae4d3df-4b9c-4bcb-937a-9da692d9bff7; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=HpYML10w6m_7BucTYrb9J4lkSRXLhszrUHE2sTw4bww-1704453336-1-AXVVNXoalpk+qne8g5scu0uxKH1fFZGl5wTrioFf/K0JQiQWihf7PD57Gmr0syz03vCo+k/w7kP1aTU8vZ81XcI=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=xx356VYP3H8VSI9Br_Z_a7.iOoK6Dcm071GpziqiV6U-1704453336569-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -1447,40 +847,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "044b7f321d39e2c6b11c131461d4bf7d"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "6cc41912e0d1d8ce"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/044b7f321d39e2c6b11c131461d4bf7d"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de87913b4fd-OSL"
             },
             {
               "name": "content-encoding",
@@ -1493,8 +865,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.348Z",
-        "time": 207,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1502,7 +874,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 207
+          "wait": 0
         }
       },
       {
@@ -1553,7 +925,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1576,37 +948,11 @@
             "size": 38,
             "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e5835af2-9cdd-4488-a96e-611e696daa9d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "OX_GcrirqGf64OsWZxMrDL_FeUwfkTq8goutUYKBuEs-1704453336-1-AbZv1cMMP2SQPh99ZnPGO5u04ObFZTHIOHBTDhwNrvhW/96uUJYdmDdEa3PmIFRS4FSiObrHBzuQ8w3bZYk6pTQ="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -1633,19 +979,145 @@
               "value": "no-cache, max-age=0"
             },
             {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "72193840b9935c6cf7c7a9606eac4c6e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 144,
+          "cookies": [],
+          "headers": [
+            {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e5835af2-9cdd-4488-a96e-611e696daa9d; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=OX_GcrirqGf64OsWZxMrDL_FeUwfkTq8goutUYKBuEs-1704453336-1-AbZv1cMMP2SQPh99ZnPGO5u04ObFZTHIOHBTDhwNrvhW/96uUJYdmDdEa3PmIFRS4FSiObrHBzuQ8w3bZYk6pTQ=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "144"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 333,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery Repository($name: String!) {\\n\\trepository(name: $name) {\\n\\t\\tid\\n\\t}\\n}\",\"variables\":{\"name\":\"github.com/sourcegraph/cody\"}}"
+          },
+          "queryString": [
+            {
+              "name": "Repository",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?Repository"
+        },
+        "response": {
+          "bodySize": 126,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 126,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//\",\"AwDHAhygPQAAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
             },
             {
               "name": "vary",
@@ -1660,50 +1132,26 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "cf90da919caa30b2423cd60862354d0c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ca3248552ef49a56"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/cf90da919caa30b2423cd60862354d0c"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
             },
             {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de87a1c069b-OSL"
+              "name": "content-encoding",
+              "value": "gzip"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.351Z",
-        "time": 248,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1711,7 +1159,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 248
+          "wait": 0
         }
       },
       {
@@ -1762,7 +1210,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 318,
+          "headersSize": 335,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -1779,44 +1227,18 @@
           "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
         },
         "response": {
-          "bodySize": 800,
+          "bodySize": 532,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 800,
-            "text": "[\"H4sIAAAAAAAA/5RVUXLbOgy8i76DC/gAucSb9wGCsISaIhUAtK1mcvcObU/aOqFV/2mG4GKJXazeh4iOw+594COmis7xldGr8mvC0Ybdf+9DxpmH3UAlrsPL0Mp42LlW/nj5PBx1oe5huwknDmASOaB2C41RaQIq2Tk7BDSOkDCPENmZXEr+fXePyb504fPCKjNnx/SAT3ZFc6AyL0kwO9iaHc8wyTglGSeXPG50wurlcp+dr4zPDqkQJpjlzPGZ6+2JFcf24ZypP+bPSWJ69Lx7/Mh7rMnBHJVKZIVpDSoRrFQlHhWXaYNva0oT+uOuixb4wR4UJVu3dNESKzlYDUYqS9PVwFiPQgxIVGr2Ph/nxDO7XtQu2qd0s5NiPvyl510ZBjiKiRcFL1XhJD5BLs6hlEP/FUjEZhISw14SgyvzFhXJS3WwqZxgEvOifam/H5IyNvn+eVbfeGHNOAvBXJNLksxwO2r4fSCMs2TAjGl1IQPOGNKfLv/ODs0wMBc6gLP1dbrHJqSJIYrdtbjnZDLmuoBVPfL6ldF9ecso+Fn40GdyxQBzZZwljzCKQ0jtcEPZzCc48HoqurX5bZM4XuymTLJw32L9oAn7cStmbsSum765ts+kyVWYxn6l1KZU9rAoH6XU5tC3yuYPrPRWhQ6XLPLrwu2Ltg4TZxdqvyCoxvoAQbGFpsziBnwm5sjxgtJs9jC6QyoBlha1dhKnCVAZrW2kOlXvS3GbZjllVptkeWJerkgPSd2wI4f61F+nF+t33P7/+PgVAAD//2e0EsLnBwAA\"]"
+            "size": 532,
+            "text": "[\"H4sIAAAAAAAAA5yTQY7bMAxF76L18AI5wFyi6IKSvmUhsuhS1MRGkLsPnAYo2sL2tDsBFD8fyc+7i2zsLneHDy6dDfEdbF3xXjg1d/l2d5UnuIsLElfibhJkmgsMFNfKUw409WK55Ap6hbLU5t7cpgh3Gbg0PN4OhEw55Jr2UxpYw0jj6jXHX99M+7FwkGpYjPyQaMoL4n4J1Ei9QUmqF9b4G89poYiBezFqxhokQv+ftUjg8iftOUBu7AtIEdZQck0kA82Kjyy9keJHR7ODpRgKJpiuhGUWtd3Sr1Uo1+u/jahwTZ3T9jDUsB6nzipnCM+BVSPPDfEpTxGGsNlvv1FfxNO8cbRbtjASK7hRG0UtdDv0bTXlZj9dnrkatbUaLzTmNJacRjs08dddQ026BiTledzXU96mmqdsjbAEICLSIEqGZl85p4obXbHeROMJdRjZaJJwfWofHdHThM0UPG0mTNnIly24t0yZUbfeT5p9IUf4/ldj3x+PTwAAAP//AwCN1YgKyAQAAA==\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "fed647a3-6658-4320-83bc-485078f0dc02"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:36.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "GXS6BO6345MQSWIj8kuIG64Fv.oGTkuH__L1p4VNgRk-1704453336-1-AWcpS+/qWgOTyDwAbfcL6NSPiRKXeAmt9DLJ3Ps5YbgIjXN5/zluvywmeeZ39Rlt/05nFze1paXzGQmZ+O8c8gs="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:36 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -1843,25 +1265,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=fed647a3-6658-4320-83bc-485078f0dc02; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=GXS6BO6345MQSWIj8kuIG64Fv.oGTkuH__L1p4VNgRk-1704453336-1-AWcpS+/qWgOTyDwAbfcL6NSPiRKXeAmt9DLJ3Ps5YbgIjXN5/zluvywmeeZ39Rlt/05nFze1paXzGQmZ+O8c8gs=; path=/; expires=Fri, 05-Jan-24 11:45:36 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=vwrEoYm3jyIMFUVq_yN570qqGETwNv3A_x0qUHNysAM-1704453336579-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -1874,40 +1277,16 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "b9786baff4f1f2ae61544359bd49090e"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "375da26d6b47e476"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/b9786baff4f1f2ae61544359bd49090e"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
             },
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
             },
             {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4de87fd75697-OSL"
+              "name": "content-encoding",
+              "value": "gzip"
             }
           ],
           "headersSize": 1318,
@@ -1916,8 +1295,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.341Z",
-        "time": 259,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -1925,425 +1304,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 259
-        }
-      },
-      {
-        "_id": "9d54881b484bd8da117ebff3b4a20983",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 181,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "181"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b92b91d5-fe2b-43ed-b886-3b9b8a610a90"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "RDTunnXaEjzsZcXxarYYhoeNDU0M0ezCjc1B27j_V.E-1704453337-1-AZDhh6MAyg4Pw5YuLy36YXl6JzjQUOR4mkmmUNKxE87IZmrEPHU+krg4//WF1UufbH/OvV5dCQSOs2FplBtIjFU="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "z2F613RBPJtHDGdKAUeiaXPp4E99yFx84WblqeT0dJM-1704453337053-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b92b91d5-fe2b-43ed-b886-3b9b8a610a90; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=RDTunnXaEjzsZcXxarYYhoeNDU0M0ezCjc1B27j_V.E-1704453337-1-AZDhh6MAyg4Pw5YuLy36YXl6JzjQUOR4mkmmUNKxE87IZmrEPHU+krg4//WF1UufbH/OvV5dCQSOs2FplBtIjFU=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=z2F613RBPJtHDGdKAUeiaXPp4E99yFx84WblqeT0dJM-1704453337053-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "d67c85d5f612a4ab6ce8323e8dfa9421"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "13f5622f7939e8fe"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d67c85d5f612a4ab6ce8323e8dfa9421"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4deb8e600b49-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:36.836Z",
-        "time": 202,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 202
-        }
-      },
-      {
-        "_id": "a7479b7cd643db7ddd3b295802d79130",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "b0f952d0-6f34-48eb-88ac-e18b2e088639"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "enNL8TpbfrwgWxg62kaJVO826gjfE2v93EQNjPFEunI-1704453337-1-AXOUFGPqX368wZ4KGzubRsDRbHvVcHZlYPAScKEnqLyA1vQ8HeJvBtgFprQSKK/3Cc9viIuHzroAVMURtzHHh9Q="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "pF6QjGNdmemUwX9ZllAwShOrBSgaIvPrFat8_oc0qJ4-1704453337060-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=b0f952d0-6f34-48eb-88ac-e18b2e088639; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=enNL8TpbfrwgWxg62kaJVO826gjfE2v93EQNjPFEunI-1704453337-1-AXOUFGPqX368wZ4KGzubRsDRbHvVcHZlYPAScKEnqLyA1vQ8HeJvBtgFprQSKK/3Cc9viIuHzroAVMURtzHHh9Q=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=pF6QjGNdmemUwX9ZllAwShOrBSgaIvPrFat8_oc0qJ4-1704453337060-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "66ac1a4c81ff012cddf33c08dd701f9f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "8fe48d85f9ecbd7a"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/66ac1a4c81ff012cddf33c08dd701f9f"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4deb8a5a56c0-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:36.834Z",
-        "time": 213,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 213
+          "wait": 0
         }
       },
       {
@@ -2394,7 +1355,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2417,37 +1378,11 @@
             "size": 37,
             "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:36.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "8c63ae46-045b-4824-911c-8ac0b9a36a0c"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "QcDyftBVhmlZKGe.mecoqZhzRMUTCzgKVwgwilU5Xyo-1704453337-1-AcfPI1U7ohn7TyoFFPg0B7pD5eJCb0ZzvXTR3lSFEaPoJfeWawI6J8wNfxMonZO0EfShX3k3zmDPyr1WbkDYEkY="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "20F_BTYGn6ciZXFcC0HthscL_qO69gZoWKweoggdePc-1704453337095-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -2474,19 +1409,144 @@
               "value": "no-cache, max-age=0"
             },
             {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "a7479b7cd643db7ddd3b295802d79130",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=8c63ae46-045b-4824-911c-8ac0b9a36a0c; Expires=Sun, 05 Jan 2025 11:15:36 GMT; Secure"
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=QcDyftBVhmlZKGe.mecoqZhzRMUTCzgKVwgwilU5Xyo-1704453337-1-AcfPI1U7ohn7TyoFFPg0B7pD5eJCb0ZzvXTR3lSFEaPoJfeWawI6J8wNfxMonZO0EfShX3k3zmDPyr1WbkDYEkY=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=20F_BTYGn6ciZXFcC0HthscL_qO69gZoWKweoggdePc-1704453337095-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-lsp-light\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
             },
             {
               "name": "vary",
@@ -2501,40 +1561,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "17a563402cdb7d5385d3c9da2bd50e38"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e2a24625d6600f0c"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/17a563402cdb7d5385d3c9da2bd50e38"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4deb8b6056b7-OSL"
             }
           ],
           "headersSize": 1286,
@@ -2543,8 +1575,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:36.837Z",
-        "time": 243,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2552,7 +1584,147 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 243
+          "wait": 0
+        }
+      },
+      {
+        "_id": "9d54881b484bd8da117ebff3b4a20983",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 181,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "181"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
         }
       },
       {
@@ -2603,7 +1775,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2626,37 +1798,11 @@
             "size": 37,
             "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:37.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "ce2b3973-a713-4f38-96e1-8876e72a327f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "PTsifwH32icHGzP2SKe6FT1ppDnv3sKPrFVu2IB6rt8-1704453337-1-AXeN8/k7KCiJdDzTzC4yGsvY2Xo64UzMWtJQ5NzW6BvNmYK70hKJD0w6Ery8jnLtBCXfiqqDYzCYvS1dHc0e8JY="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "rh9JVAEpDtufRHV3l9oZjIaysYb9uDVbF8w1Il0I4o4-1704453337554-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -2683,21 +1829,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=ce2b3973-a713-4f38-96e1-8876e72a327f; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=PTsifwH32icHGzP2SKe6FT1ppDnv3sKPrFVu2IB6rt8-1704453337-1-AXeN8/k7KCiJdDzTzC4yGsvY2Xo64UzMWtJQ5NzW6BvNmYK70hKJD0w6Ery8jnLtBCXfiqqDYzCYvS1dHc0e8JY=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=rh9JVAEpDtufRHV3l9oZjIaysYb9uDVbF8w1Il0I4o4-1704453337554-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -2710,40 +1841,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "3f62ee305887689353cb7e500a9bfef6"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "0b018b25a7f97851"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/3f62ee305887689353cb7e500a9bfef6"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4dee987456b7-OSL"
             }
           ],
           "headersSize": 1286,
@@ -2752,8 +1855,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.326Z",
-        "time": 212,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -2761,7 +1864,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 212
+          "wait": 0
         }
       },
       {
@@ -2812,7 +1915,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 322,
+          "headersSize": 339,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -2835,246 +1938,11 @@
             "size": 26,
             "text": "{\"data\":{\"logEvent\":null}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:37.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7a1885ab-e18a-4127-9b29-bfc9f8703e99"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "sX8aT.iQXsEH4k32KZLhTMhzJofZwaPbsHaW0Ch3XHE-1704453337-1-AT+7QzjabssfPx5zJ5NM6yD6zbA1z76uwmiTloKpF0lzLbCC0RgYxnhoy3/B6rK6/zYWvJr+eWtDFlh7VwmmMdA="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "uf3mEc.Durx4I5BpVdw8vma2qRvxZ2Lk31dpxsbc2r8-1704453337642-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7a1885ab-e18a-4127-9b29-bfc9f8703e99; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=sX8aT.iQXsEH4k32KZLhTMhzJofZwaPbsHaW0Ch3XHE-1704453337-1-AT+7QzjabssfPx5zJ5NM6yD6zbA1z76uwmiTloKpF0lzLbCC0RgYxnhoy3/B6rK6/zYWvJr+eWtDFlh7VwmmMdA=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=uf3mEc.Durx4I5BpVdw8vma2qRvxZ2Lk31dpxsbc2r8-1704453337642-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "198a643140ece9961f2e025c1d868d8c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "016c17fee191ae5b"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/198a643140ece9961f2e025c1d868d8c"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4dee9f81067b-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:37.324Z",
-        "time": 301,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 301
-        }
-      },
-      {
-        "_id": "d7720d62932d2de21ea1f187e1bf5135",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 734,
           "cookies": [],
           "headers": [
             {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "734"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 322,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:37.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "804623ee-9011-475f-b4d3-059c14c482e3"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "LxCS_Tca_VtRhFnq5dZJcUGreAeHHRKC1yyU986i1T0-1704453337-1-AcuzpjnkOdXEkXPFG49jTY9Q+JS3nme2QPuXsmvNfmL+3O34LgfV2Bo6P1AVxiYvbrR9U8EPN1TqRxiI7XCZv/4="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "9OnM5JKTNeOY1zdXk3igRRvpb..40ADayapp9Y6p0Lw-1704453337798-0-604800000"
-            }
-          ],
-          "headers": [
-            {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -3101,21 +1969,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=804623ee-9011-475f-b4d3-059c14c482e3; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=LxCS_Tca_VtRhFnq5dZJcUGreAeHHRKC1yyU986i1T0-1704453337-1-AcuzpjnkOdXEkXPFG49jTY9Q+JS3nme2QPuXsmvNfmL+3O34LgfV2Bo6P1AVxiYvbrR9U8EPN1TqRxiI7XCZv/4=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=9OnM5JKTNeOY1zdXk3igRRvpb..40ADayapp9Y6p0Lw-1704453337798-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -3128,40 +1981,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "4b4757a9c6b368023b69c7edc0e85d7f"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "8f31ebe753b507ab"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4b4757a9c6b368023b69c7edc0e85d7f"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df00f2b069b-OSL"
             }
           ],
           "headersSize": 1286,
@@ -3170,8 +1995,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.546Z",
-        "time": 268,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3179,7 +2004,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 268
+          "wait": 0
         }
       },
       {
@@ -3230,7 +2055,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3247,44 +2072,18 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 122,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 122,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:37.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7b6e9d04-496d-443d-a8b2-3cd39119cb92"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:37.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "qjO66cuXQnqYqliPV7XF2uQZyJ4JNlgo5BJh_xEHIcw-1704453337-1-Adw8gbbJYxuFqnc3TIvLqFu9ZLEoCKFBOJi7cmfYPzNIRf66iGH7hV7qAg9qSSvYOW4BoGFyr8/0CXGRlJ7Fv9g="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "uK_XY_jdjCZiaoimq1HSjSnOhU6bKI9NMUEVbcLis7c-1704453337826-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:37 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -3311,19 +2110,148 @@
               "value": "no-cache, max-age=0"
             },
             {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "d7720d62932d2de21ea1f187e1bf5135",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 734,
+          "cookies": [],
+          "headers": [
+            {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7b6e9d04-496d-443d-a8b2-3cd39119cb92; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=qjO66cuXQnqYqliPV7XF2uQZyJ4JNlgo5BJh_xEHIcw-1704453337-1-Adw8gbbJYxuFqnc3TIvLqFu9ZLEoCKFBOJi7cmfYPzNIRf66iGH7hV7qAg9qSSvYOW4BoGFyr8/0CXGRlJ7Fv9g=; path=/; expires=Fri, 05-Jan-24 11:45:37 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=uK_XY_jdjCZiaoimq1HSjSnOhU6bKI9NMUEVbcLis7c-1704453337826-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "734"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 339,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:Auth:connected\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
             },
             {
               "name": "vary",
@@ -3338,54 +2266,22 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "9d9b493a87d5e2de6f85ab5ab50e7160"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f95c12c049e07f60"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/9d9b493a87d5e2de6f85ab5ab50e7160"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df049cc56cb-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.587Z",
-        "time": 230,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3393,7 +2289,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 230
+          "wait": 0
         }
       },
       {
@@ -3444,7 +2340,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -3461,44 +2357,18 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 122,
+          "bodySize": 112,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 122,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 112,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:37.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e0fc4749-140b-4dff-bf76-332bc299cecd"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "hSZiEWUIcUJFmRGk7DskWJgYLTnUK.HFz4VAsIntQ_8-1704453338-1-Abz+6YCKNQhSJr9mU4FbwR/E8/0JyjVWKrCJSeZmmal7F/YjYEuEZwbpbjKQmuwF3iF298oBLP5/kgoYymzDJH0="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "n1sMYNGLNvycWx7dmQjWodWsILLg627tpauMczuQkY4-1704453338052-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -3525,21 +2395,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e0fc4749-140b-4dff-bf76-332bc299cecd; Expires=Sun, 05 Jan 2025 11:15:37 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=hSZiEWUIcUJFmRGk7DskWJgYLTnUK.HFz4VAsIntQ_8-1704453338-1-Abz+6YCKNQhSJr9mU4FbwR/E8/0JyjVWKrCJSeZmmal7F/YjYEuEZwbpbjKQmuwF3iF298oBLP5/kgoYymzDJH0=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=n1sMYNGLNvycWx7dmQjWodWsILLg627tpauMczuQkY4-1704453338052-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -3552,40 +2407,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "595604a13f0ec3ec7566601bb415391d"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "22ee63bbb182c9dc"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/595604a13f0ec3ec7566601bb415391d"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df199b756bd-OSL"
             },
             {
               "name": "content-encoding",
@@ -3598,8 +2425,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:37.782Z",
-        "time": 273,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -3607,425 +2434,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 273
-        }
-      },
-      {
-        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 187,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "187"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c93fd369-27e7-4ba8-b8f4-f5f8b11d115f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "zR4zHgcEpvM.B6UWzptR69KmWAxEx2cMS6kfLVBRZVk-1704453338-1-AYret9HqkumfNTq/8YxqqPs8HR6BhnA5ljYGLAOxOPt5q4pBOFVDgdeYKQJQfImDDH7NHHUusfc0Muz5vvrnXa8="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "e7Pe27KtI4W07lbAU.0W6m752ky0fhjG2ECpSkOVoU0-1704453338269-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c93fd369-27e7-4ba8-b8f4-f5f8b11d115f; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=zR4zHgcEpvM.B6UWzptR69KmWAxEx2cMS6kfLVBRZVk-1704453338-1-AYret9HqkumfNTq/8YxqqPs8HR6BhnA5ljYGLAOxOPt5q4pBOFVDgdeYKQJQfImDDH7NHHUusfc0Muz5vvrnXa8=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=e7Pe27KtI4W07lbAU.0W6m752ky0fhjG2ECpSkOVoU0-1704453338269-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "83bb6473d19dab7c6a087a79e94a5bb4"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "fef316eb0eb2de38"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/83bb6473d19dab7c6a087a79e94a5bb4"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df32bbbb521-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:38.049Z",
-        "time": 204,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 204
-        }
-      },
-      {
-        "_id": "243255429fc6f137e796538de9eb469f",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 189,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "189"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 325,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 38,
-          "content": {
-            "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "1b682244-f8d3-4187-ad57-8e4070a1229d"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "037zV3Js2kg32keh0iFFZSxw0mXACkvaa7bT7NfrIO0-1704453338-1-AXiSIJohNRtUcqLIIv6Zho0RUsja8GGAKunwNOIr4SzzM/W8xtnZt6DQXJXcmY1kDSQI2hPvCnC3XaSCI5jYa/E="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "cmyRjffGzNcUGY5kwYnJFLEAin2dAB6LGeSaF9vlN9I-1704453338275-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "38"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=1b682244-f8d3-4187-ad57-8e4070a1229d; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=037zV3Js2kg32keh0iFFZSxw0mXACkvaa7bT7NfrIO0-1704453338-1-AXiSIJohNRtUcqLIIv6Zho0RUsja8GGAKunwNOIr4SzzM/W8xtnZt6DQXJXcmY1kDSQI2hPvCnC3XaSCI5jYa/E=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=cmyRjffGzNcUGY5kwYnJFLEAin2dAB6LGeSaF9vlN9I-1704453338275-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "856fd4b8841b784809f22cb13b1f3282"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "c57368360d8a2ce4"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/856fd4b8841b784809f22cb13b1f3282"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df32a1056af-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:38.050Z",
-        "time": 209,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 209
+          "wait": 0
         }
       },
       {
@@ -4076,7 +2485,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -4099,37 +2508,11 @@
             "size": 38,
             "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "f09f5db0-30ae-4f13-ad85-c6f8ec67f70f"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ZO8zf5QVvzgeC2JArdYgQ6V7Kypyk0RdXIsbx66fkmg-1704453338-1-AeSx+/Ag5hfuxYAqLRRrQuIUhFzOfhfbXXLl4Tn6YLC34wsE3OVHtXDLwcEHyxqI4uVd4vX8jqwrernTOi23f5w="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "JvXdvmgcQaLECFwmreqwsXNOFEo0oCBctUV6ubBBz8c-1704453338278-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -4156,19 +2539,144 @@
               "value": "no-cache, max-age=0"
             },
             {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "243255429fc6f137e796538de9eb469f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 189,
+          "cookies": [],
+          "headers": [
+            {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=f09f5db0-30ae-4f13-ad85-c6f8ec67f70f; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ZO8zf5QVvzgeC2JArdYgQ6V7Kypyk0RdXIsbx66fkmg-1704453338-1-AeSx+/Ag5hfuxYAqLRRrQuIUhFzOfhfbXXLl4Tn6YLC34wsE3OVHtXDLwcEHyxqI4uVd4vX8jqwrernTOi23f5w=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=JvXdvmgcQaLECFwmreqwsXNOFEo0oCBctUV6ubBBz8c-1704453338278-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "189"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-local-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 37,
+          "content": {
+            "mimeType": "application/json",
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "37"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
             },
             {
               "name": "vary",
@@ -4183,40 +2691,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "d3d34e76fc155aba95fab5fe5799259c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "d5f5e31359c157e9"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/d3d34e76fc155aba95fab5fe5799259c"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df32fe3b4f7-OSL"
             }
           ],
           "headersSize": 1286,
@@ -4225,8 +2705,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.050Z",
-        "time": 217,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4234,7 +2714,147 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 217
+          "wait": 0
+        }
+      },
+      {
+        "_id": "7e2cae0c3275084cb257ee48fead6fb9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 187,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "187"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-context-bfg-mixed\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
         }
       },
       {
@@ -4285,7 +2905,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -4308,37 +2928,11 @@
             "size": 38,
             "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "c6ee1c02-b229-45a0-b38b-cc68175a12f7"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "hY.straIut02_Wcb..Xpq59Rc3ynYKvP5gxJ.LYOOAk-1704453338-1-AZX9PtaaxR5xbOrlIfyH9+XoAQytxT6lmV1RHRED6avK/y02M7IK6LLrRcfoPXNQ0xWJlABh6N+cAyne59c+D6w="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "tsYSXo6kZc.7Er2y8tY4pEwun9bmQSUj5xqwgJzrg_Y-1704453338280-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -4365,21 +2959,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=c6ee1c02-b229-45a0-b38b-cc68175a12f7; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=hY.straIut02_Wcb..Xpq59Rc3ynYKvP5gxJ.LYOOAk-1704453338-1-AZX9PtaaxR5xbOrlIfyH9+XoAQytxT6lmV1RHRED6avK/y02M7IK6LLrRcfoPXNQ0xWJlABh6N+cAyne59c+D6w=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=tsYSXo6kZc.7Er2y8tY4pEwun9bmQSUj5xqwgJzrg_Y-1704453338280-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -4392,40 +2971,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "4755c3c117b2651c59096d7cf86dadea"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "cca0dacb4da7d287"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/4755c3c117b2651c59096d7cf86dadea"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df32e520b31-OSL"
             }
           ],
           "headersSize": 1286,
@@ -4434,8 +2985,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.051Z",
-        "time": 231,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4443,7 +2994,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 231
+          "wait": 0
         }
       },
       {
@@ -4494,7 +3045,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 325,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -4517,37 +3068,11 @@
             "size": 37,
             "text": "{\"data\":{\"evaluateFeatureFlag\":null}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "97216359-0d36-4e2f-bc40-d6d6c81f7dc5"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:38.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "rgXRrKSbP3Vdarg5s4ozRivgzqOnYBWnKh2Blmb7Ge8-1704453338-1-AWU34KKOP/hndWjEKqR94obR3ozHqesNbgUb72g1BLEVCQtztcE6M7Fsi/vr/c5goj783M3OgNJnpN1pyyq82E4="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "J6c3XzLoTLo4bMpRE.iJXRL9qRAI8uAr9cPXEZ5n9dk-1704453338742-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:38 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -4574,21 +3099,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=97216359-0d36-4e2f-bc40-d6d6c81f7dc5; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=rgXRrKSbP3Vdarg5s4ozRivgzqOnYBWnKh2Blmb7Ge8-1704453338-1-AWU34KKOP/hndWjEKqR94obR3ozHqesNbgUb72g1BLEVCQtztcE6M7Fsi/vr/c5goj783M3OgNJnpN1pyyq82E4=; path=/; expires=Fri, 05-Jan-24 11:45:38 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=J6c3XzLoTLo4bMpRE.iJXRL9qRAI8uAr9cPXEZ5n9dk-1704453338742-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -4601,40 +3111,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "88ff54d72e660dda662811530cbd3f69"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e7770bdb24d11cd1"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/88ff54d72e660dda662811530cbd3f69"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df61ba8b4fa-OSL"
             }
           ],
           "headersSize": 1286,
@@ -4643,8 +3125,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.525Z",
-        "time": 204,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4652,7 +3134,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 204
+          "wait": 0
         }
       },
       {
@@ -4703,7 +3185,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 316,
+          "headersSize": 333,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -4715,43 +3197,17 @@
           "url": "https://sourcegraph.com/.api/completions/code"
         },
         "response": {
-          "bodySize": 702,
+          "bodySize": 619,
           "content": {
             "mimeType": "text/event-stream",
-            "size": 702,
-            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\\n\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\\n\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "size": 619,
+            "text": "event: completion\ndata: {\"completion\":\"\\n \",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a +\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\"\\n  return a + b;\\n}\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:38.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "0fdb380f-2f08-44ae-a7c0-c11b288b7069"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": ".jDHp6mvF5OQktHAFibvrAm8RoctiGaoRNInH5QJ.Xc-1704453340-1-AX1uuB3qzPSd8n6un6aMOrXHjrYrgj/9XsthuUl4bP3PwyM4eq9AWZFI+gjkdAg8cXrmv4eTiHeztMAnbukNBfE="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "CiIPknEXwHWCnHxVCKUc2RcHB0sNijxaotb7SASNpxM-1704453340087-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -4778,21 +3234,6 @@
               "value": "no-cache"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=0fdb380f-2f08-44ae-a7c0-c11b288b7069; Expires=Sun, 05 Jan 2025 11:15:38 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=.jDHp6mvF5OQktHAFibvrAm8RoctiGaoRNInH5QJ.Xc-1704453340-1-AX1uuB3qzPSd8n6un6aMOrXHjrYrgj/9XsthuUl4bP3PwyM4eq9AWZFI+gjkdAg8cXrmv4eTiHeztMAnbukNBfE=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=CiIPknEXwHWCnHxVCKUc2RcHB0sNijxaotb7SASNpxM-1704453340087-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -4805,40 +3246,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "6df0bdce020eb91a7d5dec37c33d2e9c"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "54e57df8ce90c561"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/6df0bdce020eb91a7d5dec37c33d2e9c"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4df78ef156c4-OSL"
             }
           ],
           "headersSize": 1289,
@@ -4847,8 +3260,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:38.756Z",
-        "time": 1316,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -4856,216 +3269,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1316
-        }
-      },
-      {
-        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 739,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "739"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 322,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "5aff150f-d9be-4999-9570-0562958a8fad"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "ywBH5Cqu4jClDxME9t65IW7qYLoCzK5Izs4ICiRwwT8-1704453340-1-AaowMDZ/HcEu/KtFjD55U8F1zO++irntKkUl9SJbkLreeopgMQtSGcLze/Cxu6afgBeoOhB2MA+IISh+oiYRwDk="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "GGDwm6rPy7xZR8zzJaxTU7PHTd1luUnQ5GocAeD.zdg-1704453340624-0-604800000"
-            }
-          ],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=5aff150f-d9be-4999-9570-0562958a8fad; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=ywBH5Cqu4jClDxME9t65IW7qYLoCzK5Izs4ICiRwwT8-1704453340-1-AaowMDZ/HcEu/KtFjD55U8F1zO++irntKkUl9SJbkLreeopgMQtSGcLze/Cxu6afgBeoOhB2MA+IISh+oiYRwDk=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=GGDwm6rPy7xZR8zzJaxTU7PHTd1luUnQ5GocAeD.zdg-1704453340624-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-trace",
-              "value": "69d179f465e846e9f50b63ab623ecba3"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "35c17a69546f400b"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/69d179f465e846e9f50b63ab623ecba3"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01b8bf56b5-OSL"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2024-01-05T11:15:40.369Z",
-        "time": 242,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 242
+          "wait": 0
         }
       },
       {
@@ -5116,7 +3320,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 322,
+          "headersSize": 339,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5139,37 +3343,11 @@
             "size": 26,
             "text": "{\"data\":{\"logEvent\":null}}"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "a6d97f07-3869-4a59-93d1-b11da72f3c8e"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "0f439L0y70wWhoKrK9A05guqtS8LxFdyhJE9uC7Y4Nc-1704453340-1-AfldW3f6lQINyfbti/04uz+xp4ypFs1ez0sTVP4SttdZy6eVS9kKnFq6E4TLrmkR4ZJDFfwuNEXwsyw6iA/jf5s="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "IA5ZaMt17J6GkM6YIIvLnQi7xe4ER12.IBr8UJ5mWRo-1704453340634-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -5196,21 +3374,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=a6d97f07-3869-4a59-93d1-b11da72f3c8e; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=0f439L0y70wWhoKrK9A05guqtS8LxFdyhJE9uC7Y4Nc-1704453340-1-AfldW3f6lQINyfbti/04uz+xp4ypFs1ez0sTVP4SttdZy6eVS9kKnFq6E4TLrmkR4ZJDFfwuNEXwsyw6iA/jf5s=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=IA5ZaMt17J6GkM6YIIvLnQi7xe4ER12.IBr8UJ5mWRo-1704453340634-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -5223,40 +3386,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "96207a9503abe5f8451d77978e121964"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "e3a8d4b576f50ae5"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/96207a9503abe5f8451d77978e121964"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01cf6eb51d-OSL"
             }
           ],
           "headersSize": 1286,
@@ -5265,8 +3400,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:40.366Z",
-        "time": 254,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5274,7 +3409,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 254
+          "wait": 0
         }
       },
       {
@@ -5325,7 +3460,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5349,37 +3484,11 @@
             "size": 112,
             "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "e74d9552-809f-4193-bae7-b044c594bdba"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "WvVCWzuHPGcIr7j0On_R3dJ8daWmrWwuHIkv.oELD2M-1704453340-1-AVe/Rx5rcNPOl1EsVn85i0+sSk6SZz/V/mki4miMvs0UyQdGLJ8oqrjmHthuDbV2x5XsQZBoKccSAq6hzADBH9E="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "x0x3kYD8MbPZprh96590x3JAKYQJlFS90u32uZPsqCc-1704453340667-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -5406,19 +3515,148 @@
               "value": "no-cache, max-age=0"
             },
             {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
+        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 739,
+          "cookies": [],
+          "headers": [
+            {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=e74d9552-809f-4193-bae7-b044c594bdba; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
+              "name": "authorization",
+              "value": "token REDACTED"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=WvVCWzuHPGcIr7j0On_R3dJ8daWmrWwuHIkv.oELD2M-1704453340-1-AVe/Rx5rcNPOl1EsVn85i0+sSk6SZz/V/mki4miMvs0UyQdGLJ8oqrjmHthuDbV2x5XsQZBoKccSAq6hzADBH9E=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
             },
             {
               "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=x0x3kYD8MbPZprh96590x3JAKYQJlFS90u32uZPsqCc-1704453340667-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "739"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 339,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
             },
             {
               "name": "vary",
@@ -5433,54 +3671,22 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "fcf0f99cc12ff5777247e22aa6388c94"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "542ae572e67c7aec"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fcf0f99cc12ff5777247e22aa6388c94"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01db3e56c3-OSL"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:40.371Z",
-        "time": 294,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5488,7 +3694,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 294
+          "wait": 0
         }
       },
       {
@@ -5539,7 +3745,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5563,37 +3769,11 @@
             "size": 112,
             "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "732bd36b-6075-496a-b8b8-d47cda3f4f0c"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:40.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": ".j.TLgVLqhbM_g8iyafIxDCqc4B0yvQ8itVAILNIop0-1704453340-1-AWE+mWCYkKhAM9oLNrLJCWa9VQbN7T9UmUNhU6503QGyCmZZCMQsR2KpEeuBwUSZeiuKtQl32A0ubDhQb5W2HXw="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "pd_BJg3387IRXayBR89mQ5YqqvhWBK2bkIvdbms3slY-1704453340668-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:40 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -5620,21 +3800,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=732bd36b-6075-496a-b8b8-d47cda3f4f0c; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=.j.TLgVLqhbM_g8iyafIxDCqc4B0yvQ8itVAILNIop0-1704453340-1-AWE+mWCYkKhAM9oLNrLJCWa9VQbN7T9UmUNhU6503QGyCmZZCMQsR2KpEeuBwUSZeiuKtQl32A0ubDhQb5W2HXw=; path=/; expires=Fri, 05-Jan-24 11:45:40 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=pd_BJg3387IRXayBR89mQ5YqqvhWBK2bkIvdbms3slY-1704453340668-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -5647,40 +3812,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "fac8ef303c769b080178353ab92aa946"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "5e3a474df74517b3"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/fac8ef303c769b080178353ab92aa946"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e01cca456ca-OSL"
             },
             {
               "name": "content-encoding",
@@ -5693,8 +3830,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:40.370Z",
-        "time": 295,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5702,7 +3839,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 295
+          "wait": 0
         }
       },
       {
@@ -5753,7 +3890,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 328,
+          "headersSize": 345,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5777,37 +3914,11 @@
             "size": 2234,
             "text": "[\"H4sIAAAAAAAA/8RX327byPV+lfPjXvziQBRlOX8=\",\"vAKEwvVmkQBBE8RJ08UyWA05h+TAwxl25lCUEBjYZ+hdgQJFe9XnyhP0EYozlCzKsrXuVX0hg2dmznf+fN8Z8mskBYlo9jXCOkMplSn9FQqXV2zLrcQP6FtNPpr9/DUqlMY/iBqjWbT0vJh4lye1UGZMPhpFnoSjt8pgNHsxnY4iNHL79GwU5dYQGopm0U1qopvRQ/48uqXK0ScXLVXvnV0qie5K1Y1WhUJ5CHU+QHo5+Q0grbLEV8KhDGB5JShpnK0b8kkfRBzOryipUDfo/AHgs5cvBojPXp4/LjdCTwlOMSnUqm1iibl1gqwb88IByB7GHYiT4xiFWlHr0Ceddde+ETkmykhcjSuq9T7KZAByOh2CpO1kcpb/3w/vLj/+9P4V8NFgwtT0S2wBLUw5TyM0abRdBQDY7EAhh9bdSo0kIK+E80jzNPr08cf4PI0gObK7Impi/HOrlvM0+lP86SK+tHUjSGUa0wg2gc/T6M2rOcoSf8OdETXO02ipsGusoz0PnZJUzSUyC+PwMAJlFCmhY58LjfPT8eRh/6RIY7/0GrW2cGnlul9KBmvDSiV3S9Wbs+3B/c1D8/b8oD1HpBXYzj8xJ77h/f38+/75gBrf7/GPQ2EOHuFhALN1o5GUNT7RtizxAaZPz4ajYnr2/LFY90nZYa4a9Ak5YbwWhIfqfbYn3gOw1BwfT9rmQt/OCGk7o62QsV/XxQHW6enZUGCnLx6Hxom1apeUMk1LlxvEy0rQm4FhTH61j3o+VPX52V3MLWXOtoR5RGmtxEz43Wis0XtR4uFsPD19vpfxAXG+PCrjj9y+3KmG3hDWhylOp8PCTqcHMMO/k5u7Ek2kWg6FdUuwL6OI8zt+6XVCX1PlbFtWPhEt2Q3TcVzLI+P1dBjjd9/xWEC4GBxPzVbPqi7Bu3yeRjz2/CxJPFknShyX1pYaRaP8OLd14m3rciydaKpYeI/kk0zbMln6OFxl1mRWOL7W40HUfPfE08n0jDet42EKMfnVuFTFbp6n5ooTgs4pUqYE9gvCyDDWoFNaw/YwUIWglUF4Yl14QEPKIRStyXkQnEBhHaxtO4bXioBEBmRB5Dk2FPb7tizR89YxIz99+u1v/4L3zsakGh8Ot56DCNjDuJ8+3dYuc33k33795151ofXoNyDO2dbIvWw2zOZ4lCmsq+/E40fgLaiCoweDKHln2SqJoCgYc2FASAmC61GjIRCZXQ6Ksrbt/zsElKGQ4/sC/mnjp7JLdBB++HjpcD2IhaE9Iggga3UmHNgChCZ0RpBa3glbeOhQa/5vqWK3TVgB3+YVW/v6czUEcHU1QmedBEGMoGo8Gmrr+xTT6KNTPOX3qy4ILlvnrQtXbF1zrckCbfaKvgOD3BjVrAPuaNNtdi+xEK0muMZ1oDT4yjrKW+LcF+9CSgtYpOkCrIFa5O+uQl8XF5p29s/KSNv5MAamL+CtMu1q/OC43xN6oVbH9T25o+8f1Spo/H8ga+GvY7Ixh3xXy7ZGqrionbP8q6hiYrrQh9/BJ49BXN9+/auHNLrw173WyHI++z0s1AoUjcA6wFWjhTKhU42zmcb6IQEXanUrvIDO/u+X75ZitsHe9b///pd/QI2mHfVHhbk3xp7gI8jWUNvllkF5oGEvKmZY0KQtBpEIA+icdYE4O+rtUw4Wl30JFrAYD8hmHSwuHelb8wNcezhNob0Fp8qKINcqv2YnHKgirD1sqptG7/v6+jQKA9QW8Mer/jLhsD1qzOm+sjxIc2nzpMPsv7m94DNmgCtC41mzT3DVoFM89IQ+4cYHZG73NjbluQEODek1WKPXoNibRA==\",\"uRnryBlud/+A/ppsMwJjCX7u4xxLXH55slXOznbCpe8nW4dZzO8pEpbCKWHID8oTCPnadrhExy/05LBREiQuUVv+0NsbZ79Uqqz0GoaZ/cIAg7Q3ICGB8Fq4dcbbt8MLVT90C3brEabACrTSzzieGD60BhaNaWpwrYFOUF7NJC5nHWaL0FGqcCMBzn2W9G+glfU0O5tMJly2IGCOLXO28+jG7PjNbTlHwTVntXgrWpNXt3V+tWvhZ8y4KvD73sXJAiRmLQvVFKpsnbi9lT+0xmy1sStG4Kfy0Ik1N5sbZ4tC5UpozZdXw99ZKLlZfL0GK38PoAwD+MvNzc1/AgAA///BabYujhAAAA==\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:40.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "33cb90f1-300b-45a2-b1b9-2e37d16633e0"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:41.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "HtRVBC4OqKS6dlvh3hUdx8vH3xkVYoO_XtBh02A_s1U-1704453341-1-AYYE0QmpsAEH73vhdwgELBQLSqqO9TpcuXITPyaXY/L7nJ4a3B2D4pRe3kjoxQm3M0Owxa6M8tRE5B2ndfSl2Ms="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "sFxC.5XWrEgosDUQPfVh.g3IMhsC7LrXXI8GuXSfRQ0-1704453341180-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:41 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -5838,21 +3949,6 @@
               "value": "gzip"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=33cb90f1-300b-45a2-b1b9-2e37d16633e0; Expires=Sun, 05 Jan 2025 11:15:40 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=HtRVBC4OqKS6dlvh3hUdx8vH3xkVYoO_XtBh02A_s1U-1704453341-1-AYYE0QmpsAEH73vhdwgELBQLSqqO9TpcuXITPyaXY/L7nJ4a3B2D4pRe3kjoxQm3M0Owxa6M8tRE5B2ndfSl2Ms=; path=/; expires=Fri, 05-Jan-24 11:45:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=sFxC.5XWrEgosDUQPfVh.g3IMhsC7LrXXI8GuXSfRQ0-1704453341180-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -5865,40 +3961,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "16fa9c51612bda5a83e806aaa5cf53a0"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "f921fce1d2e04f96"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/16fa9c51612bda5a83e806aaa5cf53a0"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e037ff1569a-OSL"
             }
           ],
           "headersSize": 1318,
@@ -5907,8 +3975,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:40.666Z",
-        "time": 498,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -5916,7 +3984,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 498
+          "wait": 0
         }
       },
       {
@@ -5967,7 +4035,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 327,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -5984,44 +4052,18 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 115,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:41.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "7195f001-4878-4c8a-8952-043f64c743ff"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:41.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "NVWkiv7GKO5X8mqBIqVIVE4smZGgelH1bLs1imuydFk-1704453341-1-AR/vw9kMBKv8mvR0nwav2THb+avznuTgn0zAWvx3fWFUxZikZZcLjKIFOPBGueEmJxA4+vLXyTv+IqqxJuZVIBg="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "4IUratgqxUEuzug2Ni8gWnFo5A2CM1MEmwWG8yK2DiE-1704453341459-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:41 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -6048,21 +4090,6 @@
               "value": "no-cache, max-age=0"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=7195f001-4878-4c8a-8952-043f64c743ff; Expires=Sun, 05 Jan 2025 11:15:41 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=NVWkiv7GKO5X8mqBIqVIVE4smZGgelH1bLs1imuydFk-1704453341-1-AR/vw9kMBKv8mvR0nwav2THb+avznuTgn0zAWvx3fWFUxZikZZcLjKIFOPBGueEmJxA4+vLXyTv+IqqxJuZVIBg=; path=/; expires=Fri, 05-Jan-24 11:45:41 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=4IUratgqxUEuzug2Ni8gWnFo5A2CM1MEmwWG8yK2DiE-1704453341459-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -6075,40 +4102,12 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "68ab7cbbe398a64cb2f93f5cc95f03db"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "918293d3d1cd2e60"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/68ab7cbbe398a64cb2f93f5cc95f03db"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e06cea9712d-OSL"
             },
             {
               "name": "content-encoding",
@@ -6121,8 +4120,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:41.195Z",
-        "time": 249,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6130,7 +4129,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 249
+          "wait": 0
         }
       },
       {
@@ -6162,7 +4161,7 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 244,
+          "headersSize": 261,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -6180,37 +4179,11 @@
             "size": 6607,
             "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
-          "cookies": [
-            {
-              "expires": "2025-01-05T11:15:41.000Z",
-              "name": "sourcegraphDeviceId",
-              "secure": true,
-              "value": "6bd93bac-aca3-4ba3-b71b-a27368462903"
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "expires": "2024-01-05T11:45:44.000Z",
-              "httpOnly": true,
-              "name": "__cf_bm",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "nCOknERsHWzpV288jWXhCJaYEo_.d3XDMRCm4b.BipA-1704453344-1-AUxgs9/TF4WV6b8UUcivi51aorqy1AR3UMV9H2Aen8A79i+jfIU0yVE+2FHTE+xSC3klYNULwipYsLpFOFD5va8="
-            },
-            {
-              "domain": ".sourcegraph.com",
-              "httpOnly": true,
-              "name": "_cfuvid",
-              "path": "/",
-              "sameSite": "None",
-              "secure": true,
-              "value": "SreICQpCCTEuuOdvqC4aQWPce3BT3lHO5jYYaG62_SE-1704453344561-0-604800000"
-            }
-          ],
+          "cookies": [],
           "headers": [
             {
               "name": "date",
-              "value": "Fri, 05 Jan 2024 11:15:44 GMT"
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
             },
             {
               "name": "content-type",
@@ -6222,7 +4195,7 @@
             },
             {
               "name": "connection",
-              "value": "keep-alive"
+              "value": "close"
             },
             {
               "name": "access-control-allow-credentials",
@@ -6237,21 +4210,6 @@
               "value": "no-cache"
             },
             {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "sourcegraphDeviceId=6bd93bac-aca3-4ba3-b71b-a27368462903; Expires=Sun, 05 Jan 2025 11:15:41 GMT; Secure"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "__cf_bm=nCOknERsHWzpV288jWXhCJaYEo_.d3XDMRCm4b.BipA-1704453344-1-AUxgs9/TF4WV6b8UUcivi51aorqy1AR3UMV9H2Aen8A79i+jfIU0yVE+2FHTE+xSC3klYNULwipYsLpFOFD5va8=; path=/; expires=Fri, 05-Jan-24 11:45:44 GMT; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
-              "_fromType": "array",
-              "name": "set-cookie",
-              "value": "_cfuvid=SreICQpCCTEuuOdvqC4aQWPce3BT3lHO5jYYaG62_SE-1704453344561-0-604800000; path=/; domain=.sourcegraph.com; HttpOnly; Secure; SameSite=None"
-            },
-            {
               "name": "vary",
               "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
             },
@@ -6264,50 +4222,22 @@
               "value": "DENY"
             },
             {
-              "name": "x-trace",
-              "value": "26d0ee969e86f021da461b9a39abca50"
-            },
-            {
-              "name": "x-trace-span",
-              "value": "ed6e7ab0d6041cae"
-            },
-            {
-              "name": "x-trace-url",
-              "value": "https://sourcegraph.com/-/debug/jaeger/trace/26d0ee969e86f021da461b9a39abca50"
-            },
-            {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             },
             {
-              "name": "via",
-              "value": "1.1 google, 1.1 google"
-            },
-            {
-              "name": "cf-cache-status",
-              "value": "DYNAMIC"
-            },
-            {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "server",
-              "value": "cloudflare"
-            },
-            {
-              "name": "cf-ray",
-              "value": "840b4e06ceb4712d-OSL"
             }
           ],
-          "headersSize": 1289,
+          "headersSize": 1284,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-01-05T11:15:41.186Z",
-        "time": 3642,
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -6315,7 +4245,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 3642
+          "wait": 0
         }
       }
     ],

--- a/agent/recordings/FullConfig_234680970/recording.har
+++ b/agent/recordings/FullConfig_234680970/recording.har
@@ -298,11 +298,11 @@
         }
       },
       {
-        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
+        "_id": "26f7093bcc1d125e7768f46a33e590e8",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 164,
+          "bodySize": 318,
           "cookies": [],
           "headers": [
             {
@@ -328,7 +328,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "164"
+              "value": "318"
             },
             {
               "_fromType": "array",
@@ -345,29 +345,29 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 341,
+          "headersSize": 354,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
+            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
           },
           "queryString": [
             {
-              "name": "SiteIdentification",
+              "name": "CurrentSiteCodyLlmConfiguration",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
+          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
         },
         "response": {
-          "bodySize": 212,
+          "bodySize": 222,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 212,
-            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
+            "size": 222,
+            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UF\",\"jiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//w==\",\"AwCpmMLNBAEAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -588,11 +588,11 @@
         }
       },
       {
-        "_id": "26f7093bcc1d125e7768f46a33e590e8",
+        "_id": "d0677a3181c3b4ee74acabaadc1dc934",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 318,
+          "bodySize": 164,
           "cookies": [],
           "headers": [
             {
@@ -618,7 +618,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "318"
+              "value": "164"
             },
             {
               "_fromType": "array",
@@ -635,21 +635,21 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 354,
+          "headersSize": 341,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nquery CurrentSiteCodyLlmConfiguration {\\n    site {\\n        codyLLMConfiguration {\\n            chatModel\\n            chatModelMaxTokens\\n            fastChatModel\\n            fastChatModelMaxTokens\\n            completionModel\\n            completionModelMaxTokens\\n        }\\n    }\\n}\",\"variables\":{}}"
+            "text": "{\"query\":\"\\nquery SiteIdentification {\\n\\tsite {\\n\\t\\tsiteID\\n\\t\\tproductSubscription {\\n\\t\\t\\tlicense {\\n\\t\\t\\t\\thashedKey\\n\\t\\t\\t}\\n\\t\\t}\\n\\t}\\n}\",\"variables\":{}}"
           },
           "queryString": [
             {
-              "name": "CurrentSiteCodyLlmConfiguration",
+              "name": "SiteIdentification",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration"
+          "url": "https://sourcegraph.com/.api/graphql?SiteIdentification"
         },
         "response": {
           "bodySize": 212,
@@ -657,7 +657,7 @@
             "encoding": "base64",
             "mimeType": "application/json",
             "size": 212,
-            "text": "[\"H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -878,6 +878,151 @@
         }
       },
       {
+        "_id": "72193840b9935c6cf7c7a9606eac4c6e",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 144,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "144"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 333,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nquery Repository($name: String!) {\\n\\trepository(name: $name) {\\n\\t\\tid\\n\\t}\\n}\",\"variables\":{\"name\":\"github.com/sourcegraph/cody\"}}"
+          },
+          "queryString": [
+            {
+              "name": "Repository",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?Repository"
+        },
+        "response": {
+          "bodySize": 123,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json",
+            "size": 123,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 1318,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
         "_id": "68618dc68610496fb5623c6778ea6c25",
         "_order": 0,
         "cache": {},
@@ -1018,151 +1163,6 @@
         }
       },
       {
-        "_id": "72193840b9935c6cf7c7a9606eac4c6e",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 144,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "144"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 333,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nquery Repository($name: String!) {\\n\\trepository(name: $name) {\\n\\t\\tid\\n\\t}\\n}\",\"variables\":{\"name\":\"github.com/sourcegraph/cody\"}}"
-          },
-          "queryString": [
-            {
-              "name": "Repository",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?Repository"
-        },
-        "response": {
-          "bodySize": 126,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json",
-            "size": 126,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q\",\"BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//\",\"AwDHAhygPQAAAA==\"]"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            }
-          ],
-          "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
-        "time": 0,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 0
-        }
-      },
-      {
         "_id": "cc9b1f585edf9183417f56a2c258ba17",
         "_order": 0,
         "cache": {},
@@ -1227,12 +1227,12 @@
           "url": "https://sourcegraph.com/.api/graphql?FeatureFlags"
         },
         "response": {
-          "bodySize": 532,
+          "bodySize": 539,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 532,
-            "text": "[\"H4sIAAAAAAAAA5yTQY7bMAxF76L18AI5wFyi6IKSvmUhsuhS1MRGkLsPnAYo2sL2tDsBFD8fyc+7i2zsLneHDy6dDfEdbF3xXjg1d/l2d5UnuIsLElfibhJkmgsMFNfKUw409WK55Ap6hbLU5t7cpgh3Gbg0PN4OhEw55Jr2UxpYw0jj6jXHX99M+7FwkGpYjPyQaMoL4n4J1Ei9QUmqF9b4G89poYiBezFqxhokQv+ftUjg8iftOUBu7AtIEdZQck0kA82Kjyy9keJHR7ODpRgKJpiuhGUWtd3Sr1Uo1+u/jahwTZ3T9jDUsB6nzipnCM+BVSPPDfEpTxGGsNlvv1FfxNO8cbRbtjASK7hRG0UtdDv0bTXlZj9dnrkatbUaLzTmNJacRjs08dddQ026BiTledzXU96mmqdsjbAEICLSIEqGZl85p4obXbHeROMJdRjZaJJwfWofHdHThM0UPG0mTNnIly24t0yZUbfeT5p9IUf4/ldj3x+PTwAAAP//AwCN1YgKyAQAAA==\"]"
+            "size": 539,
+            "text": "[\"H4sIAAAAAAAAA5xTW27jMAy8i77LC+QAvcRiP2g=\",\"aSwLkUWXohobQe5e2CgW3bSx235z+JgHry6wsTtdHV45NzaEZ7A1xXPmWN3pz9UVHuFOTiYULwFReRrck1vxcKeec8Xt6R/MS1iIm4mXccowkJdimI26PtKYZoSfNAf03LJRNdZ1u9KwdJo+zDBtH0dUsPrhCIXCXQZVU/CYSqSYjLq8Fh+1rDSUq9F2W+JiVJdiPNOQ4pBTHCyVeMDND2w0ij+TodpjcJelo4kjqF6S+YFYwZXqIGq+WX3cacgYYboQ5knUjoQquNAZy0X0Z76kuimo8IvPq4LS06R4TdIqKV4a6t6Znyeasj8W8FvhoCpN/beSOqnsOH6/MHOJbXUls6H45UjcgK7tMHpHbQ9SjDquCNsOCjB4S1J+82hZPOf7V7s7UHmlk8ZklTB7ICBQL7rlctcGlECtQklKJ6zhP/DXMiiX8x7sC2eXwmPyNLZsKacCei8lKZ9S9fd2ewMAAP//AwAPy4VKyAQAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -1728,146 +1728,6 @@
         }
       },
       {
-        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 160,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "160"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 342,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
-          },
-          "queryString": [
-            {
-              "name": "EvaluateFeatureFlag",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
-        },
-        "response": {
-          "bodySize": 37,
-          "content": {
-            "mimeType": "application/json",
-            "size": 37,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "37"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            }
-          ],
-          "headersSize": 1286,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
-        "time": 0,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 0
-        }
-      },
-      {
         "_id": "f2ad82c29e307a41faf523ab25033ae0",
         "_order": 0,
         "cache": {},
@@ -2008,11 +1868,11 @@
         }
       },
       {
-        "_id": "ec06b949e0d75e4eb04074a0df35dff6",
+        "_id": "6da3ef8e96a914f2db1f9ebf28035fb2",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 339,
+          "bodySize": 160,
           "cookies": [],
           "headers": [
             {
@@ -2038,7 +1898,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "339"
+              "value": "160"
             },
             {
               "_fromType": "array",
@@ -2055,29 +1915,28 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 344,
+          "headersSize": 342,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-pro\"}}"
           },
           "queryString": [
             {
-              "name": "RecordTelemetryEvents",
+              "name": "EvaluateFeatureFlag",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
         },
         "response": {
-          "bodySize": 122,
+          "bodySize": 37,
           "content": {
-            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 122,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
+            "size": 37,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":true}}"
           },
           "cookies": [],
           "headers": [
@@ -2090,8 +1949,8 @@
               "value": "application/json"
             },
             {
-              "name": "transfer-encoding",
-              "value": "chunked"
+              "name": "content-length",
+              "value": "37"
             },
             {
               "name": "connection",
@@ -2128,13 +1987,9 @@
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
             }
           ],
-          "headersSize": 1318,
+          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
@@ -2293,11 +2148,11 @@
         }
       },
       {
-        "_id": "c63cf23de38703e896ef70b35a6908a4",
+        "_id": "ec06b949e0d75e4eb04074a0df35dff6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 342,
+          "bodySize": 339,
           "cookies": [],
           "headers": [
             {
@@ -2323,7 +2178,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "342"
+              "value": "339"
             },
             {
               "_fromType": "array",
@@ -2346,7 +2201,7 @@
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"failed\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
           },
           "queryString": [
             {
@@ -2357,12 +2212,12 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 115,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -2438,11 +2293,11 @@
         }
       },
       {
-        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_id": "c63cf23de38703e896ef70b35a6908a4",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 208,
+          "bodySize": 342,
           "cookies": [],
           "headers": [
             {
@@ -2468,7 +2323,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "208"
+              "value": "342"
             },
             {
               "_fromType": "array",
@@ -2485,28 +2340,29 @@
               "value": "sourcegraph.com"
             }
           ],
-          "headersSize": 342,
+          "headersSize": 344,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json; charset=utf-8",
             "params": [],
-            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+            "text": "{\"query\":\"\\nmutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {\\n\\ttelemetry {\\n\\t\\trecordEvents(events: $events) {\\n\\t\\t\\talwaysNil\\n\\t\\t}\\n\\t}\\n}\\n\",\"variables\":{\"events\":[{\"feature\":\"cody.auth\",\"action\":\"connected\",\"source\":{\"client\":\"VSCode.Cody\",\"clientVersion\":\"1.0.5\"},\"parameters\":{\"version\":0,\"privateMetadata\":{}}}]}}"
           },
           "queryString": [
             {
-              "name": "EvaluateFeatureFlag",
+              "name": "RecordTelemetryEvents",
               "value": null
             }
           ],
-          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+          "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 38,
+          "bodySize": 115,
           "content": {
+            "encoding": "base64",
             "mimeType": "application/json",
-            "size": 38,
-            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -2519,8 +2375,8 @@
               "value": "application/json"
             },
             {
-              "name": "content-length",
-              "value": "38"
+              "name": "transfer-encoding",
+              "value": "chunked"
             },
             {
               "name": "connection",
@@ -2557,9 +2413,13 @@
             {
               "name": "strict-transport-security",
               "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
             }
           ],
-          "headersSize": 1286,
+          "headersSize": 1318,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
@@ -2998,6 +2858,146 @@
         }
       },
       {
+        "_id": "50b031b05a8f064cbb7c320d4adb6bdc",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 208,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "208"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 342,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\n    query EvaluateFeatureFlag($flagName: String!) {\\n        evaluateFeatureFlag(flagName: $flagName)\\n    }\\n\",\"variables\":{\"flagName\":\"cody-autocomplete-disable-recycling-of-previous-requests\"}}"
+          },
+          "queryString": [
+            {
+              "name": "EvaluateFeatureFlag",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag"
+        },
+        "response": {
+          "bodySize": 38,
+          "content": {
+            "mimeType": "application/json",
+            "size": 38,
+            "text": "{\"data\":{\"evaluateFeatureFlag\":false}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "38"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
         "_id": "7449140909c921a511332d4c1de94c1f",
         "_order": 0,
         "cache": {},
@@ -3273,6 +3273,146 @@
         }
       },
       {
+        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 739,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "token REDACTED"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "test-client / v1"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "739"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "sourcegraph.com"
+            }
+          ],
+          "headersSize": 339,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json; charset=utf-8",
+            "params": [],
+            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
+          },
+          "queryString": [
+            {
+              "name": "LogEventMutation",
+              "value": null
+            }
+          ],
+          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
+        },
+        "response": {
+          "bodySize": 26,
+          "content": {
+            "mimeType": "application/json",
+            "size": 26,
+            "text": "{\"data\":{\"logEvent\":null}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": "26"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "access-control-allow-credentials",
+              "value": "true"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": ""
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, max-age=0"
+            },
+            {
+              "name": "vary",
+              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "DENY"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            }
+          ],
+          "headersSize": 1286,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
+        "time": 0,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 0
+        }
+      },
+      {
         "_id": "fa14556b8a98cd3158e1f395bbfae82b",
         "_order": 0,
         "cache": {},
@@ -3477,12 +3617,12 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 112,
+          "bodySize": 115,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 112,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 115,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -3540,146 +3680,6 @@
             }
           ],
           "headersSize": 1318,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "Fri, 05 Jan 2024 00:00:00 GMT",
-        "time": 0,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 0
-        }
-      },
-      {
-        "_id": "c4f40aca2c2674f1a13bea041aae71e9",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 739,
-          "cookies": [],
-          "headers": [
-            {
-              "_fromType": "array",
-              "name": "authorization",
-              "value": "token REDACTED"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "_fromType": "array",
-              "name": "user-agent",
-              "value": "test-client / v1"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept",
-              "value": "*/*"
-            },
-            {
-              "_fromType": "array",
-              "name": "content-length",
-              "value": "739"
-            },
-            {
-              "_fromType": "array",
-              "name": "accept-encoding",
-              "value": "gzip,deflate"
-            },
-            {
-              "_fromType": "array",
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "host",
-              "value": "sourcegraph.com"
-            }
-          ],
-          "headersSize": 339,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json; charset=utf-8",
-            "params": [],
-            "text": "{\"query\":\"\\nmutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {\\n    logEvent(\\n\\t\\tevent: $event\\n\\t\\tuserCookieID: $userCookieID\\n\\t\\turl: $url\\n\\t\\tsource: $source\\n\\t\\targument: $argument\\n\\t\\tpublicArgument: $publicArgument\\n\\t\\tclient: $client\\n\\t\\tconnectedSiteID: $connectedSiteID\\n\\t\\thashedLicenseKey: $hashedLicenseKey\\n    ) {\\n\\t\\talwaysNil\\n\\t}\\n}\",\"variables\":{\"event\":\"CodyVSCodeExtension:completion:accepted\",\"userCookieID\":\"ANONYMOUS_USER_COOKIE_ID\",\"source\":\"IDEEXTENSION\",\"url\":\"\",\"client\":\"VSCODE_CODY_EXTENSION\",\"connectedSiteID\":\"SourcegraphWeb\"}}"
-          },
-          "queryString": [
-            {
-              "name": "LogEventMutation",
-              "value": null
-            }
-          ],
-          "url": "https://sourcegraph.com/.api/graphql?LogEventMutation"
-        },
-        "response": {
-          "bodySize": 26,
-          "content": {
-            "mimeType": "application/json",
-            "size": 26,
-            "text": "{\"data\":{\"logEvent\":null}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "date",
-              "value": "Fri, 05 Jan 2024 11:11:11 GMT"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": "26"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": ""
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, max-age=0"
-            },
-            {
-              "name": "vary",
-              "value": "Cookie,Accept-Encoding,Authorization,Cookie, Authorization, X-Requested-With,Cookie"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-frame-options",
-              "value": "DENY"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            }
-          ],
-          "headersSize": 1286,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
@@ -4052,12 +4052,12 @@
           "url": "https://sourcegraph.com/.api/graphql?RecordTelemetryEvents"
         },
         "response": {
-          "bodySize": 115,
+          "bodySize": 122,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json",
-            "size": 115,
-            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+            "size": 122,
+            "text": "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE\",\"cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==\",\"AwCEdn1qOgAAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -4133,11 +4133,11 @@
         }
       },
       {
-        "_id": "cf731964ced2b68f61a0517e5a2b0807",
+        "_id": "53745732e068932b67a08d011abced38",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 5366,
+          "bodySize": 5371,
           "cookies": [],
           "headers": [
             {
@@ -4167,17 +4167,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n                )}\\n        </div>\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/chat/chat-view/prompt.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/vscode-context/helpers.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/main.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"\\\"My selected Typescript code from file `/src/animal.ts`:\\n<selected>\\n\\n</selected>\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
+            "text": "{\"temperature\":0.2,\"maxTokensToSample\":1000,\"topK\":-1,\"topP\":-1,\"model\":\"anthropic/claude-2.0\",\"messages\":[{\"speaker\":\"human\",\"text\":\"You are Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"assistant\",\"text\":\"I am Cody, an AI coding assistant from Sourcegraph.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/doc/web.md`:\\n# Web extension (experimental)\\n\\nCody for VS Code is currently only intended for use in VS Code Desktop, not [vscode.dev](https://vscode.dev) or other web-based variants of VS Code.\\n\\nHowever, intrepid developers can use the _highly experimental_ web extension variant for local development, using either of these 2 methods:\\n\\n- Run `pnpm run watch:dev:web` and then open http://localhost:3000 in your web browser.\\n- In VS Code, run the `Launch VS Code Extension (Web, in Browser)` debug configuration.\\n\\nRunning the extension in this way is not officially supported or formally tested.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/fix.md`:\\n## Fix Code\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-ask-to-fix.gif\\\">\\n\\nSomething wrong with your code? Use Cody’s \\\"Ask Cody to Fix\\\" command to fix it, or explain the problem.\\n\\n**✨ Pro-tips for fixing code with Cody**\\n<br>• You can open the 💡 menu, with an \\\"Ask Cody to Fix\\\" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.\\n<br>• You can also right click on any items in the \\\"Problems\\\" tab of VS Code and select \\\"Ask Cody to Fix\\\"\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use the following text from file `/vscode/walkthroughs/autocomplete.md`:\\n## Code Autocomplete\\n\\n<img src=\\\"https://storage.googleapis.com/sourcegraph-assets/blog/vs-code-onboarding-walkthrough-dec-2023-cody-autocomplete-tsx.gif\\\">\\n\\nStart writing code and Cody will complete the line (or the entire function) for you. Hit tab to accept the suggestion.\\n\\n**✨ Pro-tips for using Cody autocomplete**\\n<br>• Autocomplete uses the surrounding code and context to inform the suggestions, so if you need to guide it you can add a comment above the line you're editing.\\n<br>• You can hover over the grey suggestion to see a toolbar of alternative suggestions, as well as other options such as accepting a single word at a time.\\n<br>• You can use the \\\"Trigger Autocomplete at Cursor\\\" command to trigger a code suggestion at any time, using the default keyboard shortcut of `Option` `\\\\` on macOS and `Alt` `\\\\` on Windows & Linux.\\n\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/TranscriptItem.tsx`:\\n```tsx\\n                )}\\n        </div>\\n    )\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/codebase-context/messages.ts`:\\n```ts\\n    ]\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/ui/src/chat/inputContext/ChatInputContext.tsx`:\\n```tsx\\n    </h3>\\n)\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/local-context/download-symf.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/recipes/translate.ts`:\\n```ts\\n    }\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/completions/logger.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/chat/chat-view/prompt.test.ts`:\\n```ts\\n    })\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/fixtures/workspace/index.html`:\\n```html\\n<!DOCTYPE html>\\n<html lang=\\\"en\\\">\\n    <head>\\n        <meta charset=\\\"UTF-8\\\" />\\n        <meta http-equiv=\\\"X-UA-Compatible\\\" content=\\\"IE=edge\\\" />\\n        <meta name=\\\"viewport\\\" content=\\\"width=device-width, initial-scale=1.0\\\" />\\n        <title>Hello Cody</title>\\n    </head>\\n    <body>\\n    </body>\\n</html>\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/test/e2e/fixup-decorator.test.ts`:\\n```ts\\n})\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/lib/shared/src/chat/prompts/vscode-context/helpers.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/services/AuthProviderSimplified.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `/vscode/src/main.ts`:\\n```ts\\n}\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"speaker\":\"human\",\"text\":\"Use following code snippet from file `cody-vscode-shim-test/src/animal.ts`:\\n```ts\\n\\n```\"},{\"speaker\":\"assistant\",\"text\":\"Ok.\"},{\"text\":\"Hello!\",\"speaker\":\"human\"},{\"speaker\":\"assistant\"}]}"
           },
           "queryString": [],
           "url": "https://sourcegraph.com/.api/completions/stream"
         },
         "response": {
-          "bodySize": 6607,
+          "bodySize": 232,
           "content": {
             "mimeType": "text/event-stream",
-            "size": 6607,
-            "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file,\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello! I don't have any selected code from /src/animal.ts to use. If you provide me with some selected code snippets from that file, I'd be happy to incorporate them into my responses.\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
+            "size": 232,
+            "text": "event: completion\ndata: {\"completion\":\" Hello\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"\"}\n\nevent: completion\ndata: {\"completion\":\" Hello!\",\"stopReason\":\"stop_sequence\"}\n\nevent: done\ndata: {}\n\n"
           },
           "cookies": [],
           "headers": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@pollyjs/core':
         specifier: ^6.0.6
         version: 6.0.6
+      '@pollyjs/persister':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@pollyjs/persister-fs':
         specifier: ^6.0.6
         version: 6.0.6


### PR DESCRIPTION
@olafurpg I still see quite a lot of changes here, I think some of it is because of ordering. I noticed we're setting [disableSortingHarEntries](https://netflix.github.io/pollyjs/#/configuration?id=disablesortingharentries) although after reading the docs it's not clear to me why _not_ sorting would improve diffs - seems like the opposite should be true? 🤔

There are a still a lot of "junk" headers in the HAR file that don't necessarily change on each run, but might be worth removing just to make the file smaller (for example `x-frame-options`). Let me know if you think they should be stripped.

(I haven't looked at the format yet, will do that separately, easy stuff first 🙂)

## Test plan

- Re-record Polly recordings before this change and note large diff that contains many timestamps and cookies that change on each run
- Apply this change
- Re-record and commit
- Re-record and review new diff to ensure it's not full of the same timestamps/etc.

