### PR TITLE
Specify git merge strategy for HTTP recording file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # code and snapshots assume this.
 * text=auto eol=lf
 CHANGELOG.md merge=union
+agent/recordings/*/*.har merge=ours


### PR DESCRIPTION

## Test plan
I haven't manually tested this change works as expected. I only manually validated the glob pattern is correct
```
❯ ls agent/recordings/*/*.har
agent/recordings/FullConfig_234680970/recording.har
```

This SO answer mentions how to do this https://stackoverflow.com/questions/4515679/git-workflow-can-i-prevent-a-certain-file-from-being-merged-to-another-branch-b
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
