### PR TITLE
Don't skip setting ignore files when not in a codebase

### DIFF
--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -101,16 +101,14 @@ async function refresh(uri: vscode.Uri): Promise<void> {
         })
     )
 
-    if (codebaseName) {
-        ignores.setIgnoreFiles(wf.uri.fsPath, filesWithContent, codebaseName)
-        logDebug('CodyIgnore:refresh:workspace', wf.uri.fsPath)
-        return
-    }
+    logDebug('CodyIgnore:refresh:workspace', wf.uri.fsPath)
 
+    // Main workspace root
+    ignores.setIgnoreFiles(wf.uri.fsPath, filesWithContent, codebaseName)
+    // Nested codebases
     for (const cb of codebases) {
         ignores.setIgnoreFiles(cb[1], filesWithContent, cb[0])
     }
-    logDebug('CodyIgnore:refresh:workspace', wf.uri.fsPath)
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/2586


## Test plan

- Open a folder that is not a Git repo / codebase
- Set `"cody.internal.unstable": true` to enable ignore functionality
- Create a `.cody/ignore` file containing "*.ignore"
- Create files "foo.not" and "foo.ignore"
- Type "@foo" in chat and ensure the `.ignore` file is not shown

![image](https://github.com/sourcegraph/cody/assets/1078012/ce8dea8b-93fa-44b8-aa9d-dcd9cf55c5e9)
