### PR TITLE
test: add missing dispose calls for watchers

### DIFF
--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { ContextFile } from '@sourcegraph/cody-shared'
-import { CodyPrompt, CustomCommandType, MyPrompts } from '@sourcegraph/cody-shared/src/chat/prompts'
+import { CodyPrompt, ConfigFileName, CustomCommandType, MyPrompts } from '@sourcegraph/cody-shared/src/chat/prompts'
 import { VsCodeCommandsController } from '@sourcegraph/cody-shared/src/editor'
 
 import { executeEdit } from '../edit/execute'
@@ -425,8 +425,8 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
         }
 
         const user = this.tools.getUserInfo()
-
-        this.wsFileWatcher = createFileWatchers(user?.workspaceRoot)
+        const configFile = ConfigFileName.vscode
+        this.wsFileWatcher = createFileWatchers(configFile, user?.workspaceRoot)
         if (this.wsFileWatcher) {
             this.fileWatcherDisposables.push(
                 this.wsFileWatcher,
@@ -435,7 +435,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
             )
         }
 
-        this.userFileWatcher = createFileWatchers(user?.homeDir)
+        this.userFileWatcher = createFileWatchers(configFile, user?.homeDir)
         if (this.userFileWatcher) {
             this.fileWatcherDisposables.push(
                 this.userFileWatcher,

--- a/vscode/src/commands/utils/helpers.ts
+++ b/vscode/src/commands/utils/helpers.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode'
 
-import { ConfigFileName } from '@sourcegraph/cody-shared/src/chat/prompts'
-
 export function constructFileUri(fileName: string, rootDirPath?: string): vscode.Uri | undefined {
     if (!rootDirPath) {
         return undefined
@@ -35,8 +33,8 @@ export async function saveJSONFile(data: unknown, filePath: vscode.Uri): Promise
 }
 
 // Create a file watcher for each .vscode/cody.json file
-export function createFileWatchers(fsPath?: string): vscode.FileSystemWatcher | null {
-    const fileUri = constructFileUri(ConfigFileName.vscode, fsPath)
+export function createFileWatchers(fileName: string, basePath?: string): vscode.FileSystemWatcher | null {
+    const fileUri = constructFileUri(fileName, basePath)
     if (!fileUri) {
         return null
     }

--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -76,12 +76,19 @@ export async function gitAPIinit(): Promise<vscode.Disposable | undefined> {
         }
     }
     // Update vscodeGitAPI when the extension becomes enabled/disabled
-    return extension?.exports?.onDidChangeEnablement(enabled => {
+    const onDidChangeEnablement = extension?.exports?.onDidChangeEnablement(enabled => {
         if (enabled) {
             return init()
         }
         vscodeGitAPI = undefined
     })
+
+    return {
+        dispose() {
+            setUpCodyIgnore().dispose()
+            onDidChangeEnablement?.dispose()
+        },
+    }
 }
 
 /**

--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode'
 import { ignores } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import { CODY_IGNORE_FILENAME_POSIX_GLOB } from '@sourcegraph/cody-shared/src/chat/ignore-helper'
 
+import { createFileWatchers } from '../commands/utils/helpers'
 import { logDebug } from '../log'
 import { getCodebaseFromWorkspaceUri } from '../repository/repositoryHelpers'
 
@@ -20,10 +21,10 @@ export function setUpCodyIgnore(): vscode.Disposable {
     onConfigChange()
 
     // Refresh ignore rules when any ignore file in the workspace changes.
-    const watcher = vscode.workspace.createFileSystemWatcher(CODY_IGNORE_FILENAME_POSIX_GLOB)
-    watcher.onDidChange(refresh)
-    watcher.onDidCreate(refresh)
-    watcher.onDidDelete(refresh)
+    const watcher = createFileWatchers(CODY_IGNORE_FILENAME_POSIX_GLOB)
+    watcher?.onDidChange(refresh)
+    watcher?.onDidCreate(refresh)
+    watcher?.onDidDelete(refresh)
 
     // Handle any added/removed workspace folders.
     const didChangeSubscription = vscode.workspace.onDidChangeWorkspaceFolders(e => {
@@ -43,7 +44,7 @@ export function setUpCodyIgnore(): vscode.Disposable {
 
     return {
         dispose() {
-            watcher.dispose()
+            watcher?.dispose()
             didChangeSubscription.dispose()
             onDidChangeConfig.dispose()
         },

--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -19,12 +19,11 @@ const utf8 = new TextDecoder('utf-8')
  */
 export function setUpCodyIgnore(): vscode.Disposable {
     onConfigChange()
-
     // Refresh ignore rules when any ignore file in the workspace changes.
     const watcher = createFileWatchers(CODY_IGNORE_FILENAME_POSIX_GLOB)
-    watcher?.onDidChange(refresh)
-    watcher?.onDidCreate(refresh)
-    watcher?.onDidDelete(refresh)
+    const onDidChange = watcher?.onDidChange(refresh)
+    const onDidCreate = watcher?.onDidCreate(refresh)
+    const onDidDelete = watcher?.onDidDelete(refresh)
 
     // Handle any added/removed workspace folders.
     const didChangeSubscription = vscode.workspace.onDidChangeWorkspaceFolders(e => {
@@ -44,6 +43,9 @@ export function setUpCodyIgnore(): vscode.Disposable {
 
     return {
         dispose() {
+            onDidChange?.dispose()
+            onDidCreate?.dispose()
+            onDidDelete?.dispose()
             watcher?.dispose()
             didChangeSubscription.dispose()
             onDidChangeConfig.dispose()

--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -5,7 +5,6 @@ import * as vscode from 'vscode'
 import { ignores } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import { CODY_IGNORE_FILENAME_POSIX_GLOB } from '@sourcegraph/cody-shared/src/chat/ignore-helper'
 
-import { createFileWatchers } from '../commands/utils/helpers'
 import { logDebug } from '../log'
 import { getCodebaseFromWorkspaceUri } from '../repository/repositoryHelpers'
 
@@ -20,10 +19,10 @@ const utf8 = new TextDecoder('utf-8')
 export function setUpCodyIgnore(): vscode.Disposable {
     onConfigChange()
     // Refresh ignore rules when any ignore file in the workspace changes.
-    const watcher = createFileWatchers(CODY_IGNORE_FILENAME_POSIX_GLOB)
-    const onDidChange = watcher?.onDidChange(refresh)
-    const onDidCreate = watcher?.onDidCreate(refresh)
-    const onDidDelete = watcher?.onDidDelete(refresh)
+    const watcher = vscode.workspace.createFileSystemWatcher(CODY_IGNORE_FILENAME_POSIX_GLOB)
+    watcher?.onDidChange(refresh)
+    watcher?.onDidCreate(refresh)
+    watcher?.onDidDelete(refresh)
 
     // Handle any added/removed workspace folders.
     const didChangeSubscription = vscode.workspace.onDidChangeWorkspaceFolders(e => {
@@ -43,9 +42,6 @@ export function setUpCodyIgnore(): vscode.Disposable {
 
     return {
         dispose() {
-            onDidChange?.dispose()
-            onDidCreate?.dispose()
-            onDidDelete?.dispose()
             watcher?.dispose()
             didChangeSubscription.dispose()
             onDidChangeConfig.dispose()


### PR DESCRIPTION
PR for ensuring disposables are properly managed in `repositoryHelpers.ts` and `context-filter.ts` by adding missing dispose calls.

- Improved resource cleanup by ensuring proper disposal of event listeners and watchers in `repositoryHelpers.ts` and `context-filter.ts`.
- Updated file watcher utility to accept dynamic configuration file names for better flexibility across different modules.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Follow the steps listed in this doc to enable logging for watchers: https://github.com/microsoft/vscode/wiki/File-Watcher-Issues#logging-local
