### PR TITLE
Autocomplete: Tweak user-delay maximum timer and decrease steps

### DIFF
--- a/vscode/src/completions/artificial-delay.test.ts
+++ b/vscode/src/completions/artificial-delay.test.ts
@@ -29,14 +29,16 @@ describe('getArtificialDelay', () => {
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
         // start at default, but gradually increasing latency after 5 rejected suggestions
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1050)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1100)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1150)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1200)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1250)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1300)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1350)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1600)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1800)
-        // max latency at 2000
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
+        // max latency at 1400
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetArtificialDelay()
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
@@ -47,14 +49,17 @@ describe('getArtificialDelay', () => {
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
         // gradually increasing latency after 5 rejected suggestions
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1050)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1100)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1150)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1200)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1250)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1300)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1350)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1600)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1800)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
         // Latency will be reset after 5 minutes
         vi.advanceTimersByTime(5 * 60 * 1000)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
@@ -78,9 +83,10 @@ describe('getArtificialDelay', () => {
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
         // gradually increasing latency after 5 rejected suggestions
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(50)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(100)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(150)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(200)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(400)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(600)
         // after the suggestion was accepted, user latency resets to 0, using baseline only
         resetArtificialDelay()
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
@@ -106,7 +112,7 @@ describe('getArtificialDelay', () => {
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1200)
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1050)
         // Latency will be reset after 5 minutes
         vi.advanceTimersByTime(5 * 60 * 1000)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
@@ -123,22 +129,16 @@ describe('getArtificialDelay', () => {
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(0)
-        // latency should start increasing after 5 rejections, but max at 2000
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(200)
+        // latency should start increasing after 5 rejections, but max at 1400
+        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(50)
         // line is a comment, so latency should be increased where:
         // base is 1000 due to line is a comment, and user latency is 400 as this is the 7th rejection
-        expect(getArtificialDelay(featureFlags, uri, languageId, 'comment')).toBe(1400)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(600)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(800)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1200)
+        expect(getArtificialDelay(featureFlags, uri, languageId, 'comment')).toBe(1100)
+        for (let i = 150; i <= 1400; i += 50) {
+            expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(i)
+        }
+        // max at 1400 after multiple rejection
         expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1400)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1600)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(1800)
-        // max at 2000 after multiple rejection
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
-        expect(getArtificialDelay(featureFlags, uri, languageId)).toBe(2000)
 
         // reset latency on file change to default
         const newUri = 'foo/test.ts'
@@ -151,7 +151,7 @@ describe('getArtificialDelay', () => {
         expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)
         // Latency will not reset before 5 minutes
         vi.advanceTimersByTime(3 * 60 * 1000)
-        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(200)
+        expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(50)
         // reset latency on accepted suggestion
         resetArtificialDelay()
         expect(getArtificialDelay(featureFlags, newUri, languageId)).toBe(0)

--- a/vscode/src/completions/artificial-delay.ts
+++ b/vscode/src/completions/artificial-delay.ts
@@ -6,9 +6,9 @@ export interface LatencyFeatureFlags {
 }
 
 const defaultLatencies = {
-    user: 200,
+    user: 50,
     lowPerformance: 1000,
-    max: 2000,
+    max: 1400,
 }
 
 // Languages with lower performance get additional latency to avoid spamming users with unhelpful


### PR DESCRIPTION
Tweaks the user based delay system to be less aggressive by:

- Reducing the increments from 200ms to 50ms chunks
- Reducing the maximum delay from 2sec to 1.4sec

c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1700829801359009?thread_ts=1700673177.479549&cid=C05AGQYD528

## Test plan

See unit test updates

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
