### PR TITLE
fix: duplicate edit handling in chat

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -568,10 +568,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
                 return this.postError(new Error('Command failed. Please open a file and try again.'), 'transcript')
             }
         }
-        const promptText = [command.prompt, command.additionalInput].join(' ')?.trim()
-        // Check for edit commands
+        // Returns early if it's an edit command as edit command is redirected to edits in findCommand
         if (command.mode !== 'ask') {
-            return executeEdit({ instruction: promptText }, source)
+            return
         }
         const inputText = [command.slashCommand, command.additionalInput].join(' ')?.trim()
 


### PR DESCRIPTION
CLOES https://github.com/sourcegraph/cody/issues/2610

Fix issues where starting edit commands from chat would create two edits

Edit commands are already redirected to the executeEdit function in findCommand, so we should exist early in the command execution flow in chat for edit commands. 

This avoids duplicate handling of edit commands.

- No changelog required as the bug does not exist in released version

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Start the doc command from chat input box
- only one edit should be executed


https://github.com/sourcegraph/cody/assets/68532117/7736cdc4-b65c-4d72-a351-de0c350e5c2b


