### PR TITLE
refactor: rename chat question events

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -625,12 +625,16 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
                     promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
                     contextSummary,
                 }
-                telemetryService.log('CodyVSCodeExtension:chat-question:recipe-used', properties, {
-                    hasV2Event: true,
-                })
-                telemetryRecorder.recordEvent('cody.recipe.chat-question', 'recipe-used', {
-                    metadata: { ...contextSummary },
-                })
+
+                // Only log chat-question event if it is not a command to avoid double logging for commands
+                if (!command) {
+                    telemetryService.log('CodyVSCodeExtension:chat-question:executed', properties, {
+                        hasV2Event: true,
+                    })
+                    telemetryRecorder.recordEvent('cody.chat-question', 'executed', {
+                        metadata: { ...contextSummary },
+                    })
+                }
             },
             command
         )


### PR DESCRIPTION
refactor: rename chat question events

- Rename chat events 
  - from `chat-question:recipe-used` to `chat-question:executed`
  - from `cody.recipe.chat-question.recipe-used` to `cody.chat-question.executed`
- Avoid logging the chat events when the question is triggered by a command to prevent duplicate events.


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Ask Cody a question and check the log:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat-question:executed VSCode {"properties":{"requestID":"9da457b4-ff82-4304-b3c1-042e4920ac1e","chatModel":"anthropic/claude-2.0","promptText":"hello","contextSummary":{}},"opts":{"hasV2Event":true}}
█ telemetry-v2: recordEvent (no-op): cody.chat-question/executed: {"parameters":{"version":0,"metadata":[]},"timestamp":"2024-01-08T17:46:25.454Z"}
```