### PR TITLE
fix: respect cody.useContext for context fetching

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - @-mentioning the same file a second time in chat no longer duplicates the filename prefix [issues/2243](https://github.com/sourcegraph/cody/issues/2243)/[pull/2474](https://github.com/sourcegraph/cody/pull/2474)
 - Do not automatically append open file name to display text for chat questions. [pull/2580](https://github.com/sourcegraph/cody/pull/2580)
 - Fixed unresponsive stop button in chat when an error is presented. [pull/2588](https://github.com/sourcegraph/cody/pull/2588)
+- Added existing `cody.useContext` config to chat to control context fetching strategy. [pull/2616](https://github.com/sourcegraph/cody/pull/2616)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -783,11 +783,10 @@
           "enum": [
             "embeddings",
             "keyword",
-            "none",
-            "blended"
+            "none"
           ],
           "default": "embeddings",
-          "markdownDescription": "If 'embeddings' is selected, Cody will prefer to use an embeddings-based index when fetching context to generate responses to user requests. If no such index is found, it will fall back to using keyword-based local context fetching. If 'keyword' is selected, Cody will use keyword context. Selecting 'none' will limit Cody to using only the currently open file."
+          "markdownDescription": "If 'embeddings' is selected, Cody will prefer to use an embeddings-based index when fetching context to generate responses to user requests. If no such index is found, it will fall back to using keyword-based local context fetching. If 'keyword' is selected, Cody will use keyword-based context. Selecting 'none' will limit Cody to using only the currently open file."
         },
         "cody.customHeaders": {
           "order": 4,

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -783,6 +783,7 @@
           "enum": [
             "embeddings",
             "keyword",
+            "blended",
             "none"
           ],
           "default": "embeddings",

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1109,10 +1109,9 @@ class ContextProvider implements IContextProvider {
             return searchContext
         }
 
-        // NOTE: Do not use embeddings if useContext is not set to 'embeddings' specifically
         let hasEmbeddingsContext = false
-        // Get embeddings context if useContext Config is set to 'embeddings'
-        if (useContextConfig === 'embeddings') {
+        // Get embeddings context if useContext Config is not set to 'keyword' only
+        if (useContextConfig !== 'keyword') {
             logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
             const localEmbeddingsResults = this.searchEmbeddingsLocal(text)
             const remoteEmbeddingsResults = this.searchEmbeddingsRemote(text)


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/2615

fix: add config to control context fetching strategy

This adds the exisiting 'cody.useContext' config to SimpleChatPanelProvider that allows selecting between 'embeddings', 'keyword', and 'none' strategies for context fetching.

- 'embeddings' will use embeddings-based indexing if available, falling back to keyword search (symf). 
- 'keyword' will only use keyword search-based (symf) context fetching.
- 'none' will limit context to the user's current open file.

The default is now 'embeddings' 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start build from this branch
2. Set `cody.useContext` to `search` to confirm context from embeddings are not added, and context from symf are added (if any)
3. Set `cody.useContext` to `embeddings` to confirm context from embeddings are added (if any)
4. Set `cody.useContext` to `none` to confirm only context from `open file` (if any) is added