### PR TITLE
Autocomplete: use `NodeResponse` in the autocomplete client

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -41,6 +41,7 @@
     "@types/highlight.js": "^9.12.4",
     "@types/isomorphic-fetch": "^0.0.39",
     "@types/lodash": "^4.14.195",
+    "@types/node-fetch": "^2.6.4",
     "@types/marked": "^5.0.0",
     "@types/vscode": "^1.80.0"
   }

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -2,6 +2,8 @@ import { differenceInDays, format, formatDistanceStrict, formatRelative } from '
 
 import { isError } from '../utils'
 
+import { BrowserOrNodeResponse } from './graphql/client'
+
 function formatRetryAfterDate(retryAfterDate: Date): string {
     const now = new Date()
     if (differenceInDays(retryAfterDate, now) < 7) {
@@ -73,7 +75,7 @@ export class NetworkError extends Error {
     public readonly status: number
 
     constructor(
-        response: Response,
+        response: BrowserOrNodeResponse,
         content: string,
         public traceId: string | undefined
     ) {
@@ -92,7 +94,7 @@ export function isAuthError(error: unknown): boolean {
 
 export class AbortError extends Error {}
 
-export function isAbortError(error: unknown): boolean {
+export function isAbortError(error: unknown): error is AbortError {
     return (
         isError(error) &&
         // custom abort error

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -92,13 +92,16 @@ export function isAuthError(error: unknown): boolean {
     return error instanceof NetworkError && (error.status === 401 || error.status === 403)
 }
 
-export class AbortError extends Error {}
+export class AbortError extends Error {
+    // Added to make Typescript understand that AbortError is not the same as Error.
+    public readonly isAbortError = true
+}
 
-export function isAbortError(error: unknown): error is AbortError {
+export function isAbortError(error: any): error is AbortError {
     return (
         isError(error) &&
         // custom abort error
-        (error instanceof AbortError ||
+        ((error instanceof AbortError && error.isAbortError) ||
             // http module
             error.message === 'aborted' ||
             // fetch

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1,4 +1,5 @@
 import fetch from 'isomorphic-fetch'
+import type { Response as NodeResponse } from 'node-fetch'
 
 import { TelemetryEventInput } from '@sourcegraph/telemetry'
 
@@ -34,6 +35,12 @@ import {
     SEARCH_EMBEDDINGS_QUERY,
 } from './queries'
 import { buildGraphQLUrl } from './url'
+
+export type BrowserOrNodeResponse = Response | NodeResponse
+
+export function isNodeResponse(response: BrowserOrNodeResponse): response is NodeResponse {
+    return Boolean(response.body && !('getReader' in response.body))
+}
 
 const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       '@types/marked':
         specifier: ^5.0.0
         version: 5.0.0
+      '@types/node-fetch':
+        specifier: ^2.6.4
+        version: 2.6.4
       '@types/vscode':
         specifier: ^1.80.0
         version: 1.80.0

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -15,6 +15,7 @@ import {
     TimeoutError,
     TracedError,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { isNodeResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 import { fetch } from '../fetch'
@@ -94,7 +95,7 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
             headers.set('Accept-Encoding', 'gzip;q=0')
         }
 
-        const response: Response = await fetch(url, {
+        const response = await fetch(url, {
             method: 'POST',
             body: JSON.stringify({
                 ...params,
@@ -136,16 +137,10 @@ export function createClient(config: CompletionsClientConfig, logger?: Completio
         // regular JSON payload. This ensures that the request also works against older backends
         const isStreamingResponse = response.headers.get('content-type') === 'text/event-stream'
 
-        if (isStreamingResponse) {
+        if (isStreamingResponse && isNodeResponse(response)) {
             let lastResponse: CompletionResponse | undefined
             try {
-                // The any cast is necessary because `node-fetch` (The polyfill for fetch we use via
-                // `isomorphic-fetch`) does not implement a proper ReadableStream interface but
-                // instead exposes a Node Stream.
-                //
-                // Since we directly require from `isomporphic-fetch` and gate this branch out from
-                // non Node environments, the response.body will always be a Node Stream instead
-                const iterator = createSSEIterator(response.body as any as AsyncIterableIterator<BufferSource>)
+                const iterator = createSSEIterator(response.body)
                 let chunkIndex = 0
 
                 for await (const { event, data } of iterator) {
@@ -221,13 +216,12 @@ interface SSEMessage {
 }
 
 const SSE_TERMINATOR = '\n\n'
-export async function* createSSEIterator(iterator: AsyncIterableIterator<BufferSource>): AsyncGenerator<SSEMessage> {
+export async function* createSSEIterator(iterator: NodeJS.ReadableStream): AsyncGenerator<SSEMessage> {
     let buffer = ''
     for await (const event of iterator) {
         const messages: SSEMessage[] = []
 
-        const data = new TextDecoder().decode(event)
-        buffer += data
+        buffer += event.toString()
 
         let index: number
         while ((index = buffer.indexOf(SSE_TERMINATOR)) >= 0) {

--- a/vscode/src/fetch.ts
+++ b/vscode/src/fetch.ts
@@ -6,7 +6,11 @@ import type { Agent } from 'http'
  */
 import isomorphicFetch from 'isomorphic-fetch'
 
-import { addCustomUserAgent, customUserAgent } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import {
+    addCustomUserAgent,
+    BrowserOrNodeResponse,
+    customUserAgent,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 /**
  * In node environments, it might be necessary to set up a custom agent to control the network
@@ -21,13 +25,14 @@ import { addCustomUserAgent, customUserAgent } from '@sourcegraph/cody-shared/sr
 export const agent: { current: ((url: URL) => Agent) | undefined } = { current: undefined }
 
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<BrowserOrNodeResponse> {
     if (customUserAgent) {
         init = init ?? {}
         const headers = new Headers(init?.headers)
         addCustomUserAgent(headers)
         init.headers = headers
     }
+
     return isomorphicFetch(input, {
         ...init,
         agent: agent.current,


### PR DESCRIPTION
## Context

- This PR applies part of the changes from @sqs's Ollama PR: https://github.com/sourcegraph/cody/pull/905, which is not specific to Ollama support.
- Differentiate between HTTP responses on the web and in node.js on the type level. 
- This allows dropping redundant type casting in the autocomplete HTTP client code.

## Test plan

- CI
- Manually tested autocomplete locally.
