### PR TITLE
Edit: Reflect functionality and scope in quick pick

### DIFF
--- a/vscode/src/commands/utils/menu.ts
+++ b/vscode/src/commands/utils/menu.ts
@@ -82,14 +82,12 @@ const openIconButton = { iconPath: new ThemeIcon('go-to-file'), tooltip: 'Open o
 const trashIconButton = { iconPath: new ThemeIcon('trash'), tooltip: 'Delete Settings File', id: 'delete' }
 const gearIconButton = { iconPath: new ThemeIcon('gear'), tooltip: 'Configure Custom Commands...', id: 'config' }
 const backIconButton = QuickInputButtons.Back
-const codyIconButton = { iconPath: new ThemeIcon('cody-logo'), tooltip: 'Cody Edit' }
 
 export const menu_buttons = {
     open: openIconButton,
     trash: trashIconButton,
     back: backIconButton,
     gear: gearIconButton,
-    cody: codyIconButton,
 }
 
 export const CustomCommandTypes = {

--- a/vscode/src/commands/utils/menu.ts
+++ b/vscode/src/commands/utils/menu.ts
@@ -82,12 +82,14 @@ const openIconButton = { iconPath: new ThemeIcon('go-to-file'), tooltip: 'Open o
 const trashIconButton = { iconPath: new ThemeIcon('trash'), tooltip: 'Delete Settings File', id: 'delete' }
 const gearIconButton = { iconPath: new ThemeIcon('gear'), tooltip: 'Configure Custom Commands...', id: 'config' }
 const backIconButton = QuickInputButtons.Back
+const codyIconButton = { iconPath: new ThemeIcon('cody-logo'), tooltip: 'Cody Edit' }
 
 export const menu_buttons = {
     open: openIconButton,
     trash: trashIconButton,
     back: backIconButton,
     gear: gearIconButton,
+    cody: codyIconButton,
 }
 
 export const CustomCommandTypes = {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1007,6 +1007,8 @@ export class FixupController
 
         // Prompt the user for a new instruction, and create a new fixup
         const input = await this.typingUI.getInputFromQuickPick({
+            filePath: task.fixupFile.filePath,
+            range: previousRange,
             initialValue: previousInstruction,
             initialSelectedContextFiles: previousUserContextFiles,
         })

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1011,6 +1011,7 @@ export class FixupController
             range: previousRange,
             initialValue: previousInstruction,
             initialSelectedContextFiles: previousUserContextFiles,
+            source: 'code-lens',
         })
         if (!input) {
             return

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -113,7 +113,7 @@ export class FixupTypingUI {
         filePath,
         range,
         source,
-        placeholder = 'Edit instructions (@ to include code)',
+        placeholder = 'Instructions (@ to include code)',
         initialValue = '',
         initialSelectedContextFiles = [],
         prefix = EDIT_COMMAND.slashCommand,
@@ -122,7 +122,7 @@ export class FixupTypingUI {
         userContextFiles: ContextFile[]
     } | null> {
         const quickPick = vscode.window.createQuickPick()
-        quickPick.title = `${vscode.workspace.asRelativePath(filePath)}:${getTitleRange(range)}`
+        quickPick.title = `Edit ${vscode.workspace.asRelativePath(filePath)}:${getTitleRange(range)} with Cody`
         quickPick.placeholder = placeholder
         quickPick.value = initialValue
 
@@ -140,9 +140,8 @@ export class FixupTypingUI {
         // Property not currently documented, open issue: https://github.com/microsoft/vscode/issues/73904
         ;(quickPick as any).sortByLabel = false
 
-        quickPick.buttons = [menu_buttons.cody]
         if (source === 'menu') {
-            quickPick.buttons = [menu_buttons.cody, menu_buttons.back]
+            quickPick.buttons = [menu_buttons.back]
             quickPick.onDidTriggerButton((target: vscode.QuickInputButton) => {
                 if (target === menu_buttons.back) {
                     void vscode.commands.executeCommand('cody.action.commands.menu')

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -29,6 +29,18 @@ function getLabelForContextFile(file: ContextFile): string {
     return `${file.path?.relative}${rangeLabel}#${file.fileName}`
 }
 
+/**
+ * Returns a string representation of the given range, formatted as "{startLine}:{endLine}".
+ * If startLine and endLine are the same, returns just the line number.
+ */
+function getTitleRange(range: vscode.Range): string {
+    const endLine = range.end.character === 0 ? range.end.line - 1 : range.end.line
+    if (range.start.line === endLine) {
+        return `${range.start.line + 1}`
+    }
+    return `${range.start.line + 1}:${endLine + 1}`
+}
+
 /* Match strings that end with a '@' followed by any characters except a space */
 const MATCHING_CONTEXT_FILE_REGEX = /@(\S+)$/
 
@@ -103,9 +115,7 @@ export class FixupTypingUI {
         userContextFiles: ContextFile[]
     } | null> {
         const quickPick = vscode.window.createQuickPick()
-        quickPick.title = `${vscode.workspace.asRelativePath(filePath)}:${
-            range.start.line === range.end.line ? `${range.start.line}` : `${range.start.line}-${range.end.line}`
-        }`
+        quickPick.title = `${vscode.workspace.asRelativePath(filePath)}:${getTitleRange(range)}`
         quickPick.placeholder = placeholder
         quickPick.value = initialValue
 

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -34,10 +34,17 @@ function getLabelForContextFile(file: ContextFile): string {
  * If startLine and endLine are the same, returns just the line number.
  */
 function getTitleRange(range: vscode.Range): string {
-    const endLine = range.end.character === 0 ? range.end.line - 1 : range.end.line
-    if (range.start.line === endLine) {
+    if (range.isEmpty) {
+        // No selected range, return just active line
         return `${range.start.line + 1}`
     }
+
+    const endLine = range.end.character === 0 ? range.end.line - 1 : range.end.line
+    if (range.start.line === endLine) {
+        // Range only encompasses a single line
+        return `${range.start.line + 1}`
+    }
+
     return `${range.start.line + 1}:${endLine + 1}`
 }
 

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -140,11 +140,14 @@ export class FixupTypingUI {
         // Property not currently documented, open issue: https://github.com/microsoft/vscode/issues/73904
         ;(quickPick as any).sortByLabel = false
 
+        quickPick.buttons = [menu_buttons.cody]
         if (source === 'menu') {
-            quickPick.buttons = [menu_buttons.back]
-            quickPick.onDidTriggerButton(() => {
-                void vscode.commands.executeCommand('cody.action.commands.menu')
-                quickPick.hide()
+            quickPick.buttons = [menu_buttons.cody, menu_buttons.back]
+            quickPick.onDidTriggerButton((target: vscode.QuickInputButton) => {
+                if (target === menu_buttons.back) {
+                    void vscode.commands.executeCommand('cody.action.commands.menu')
+                    quickPick.hide()
+                }
             })
         }
 


### PR DESCRIPTION
## Description

Updates the Edit quick pick title to better reflect functionality and scope:

Changes:
- Update placeholder text
- Add title that shows relative path and range selected
- Remove back button from edit QP when triggered directly. Back button still shows when edit input triggered from command palette

<img width="814" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/b0bd116c-76ed-4aec-b142-2729fadd911b">

## Test plan

Check QP title and placeholder

Check QP title and placeholder matches original when retrying

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
