### PR TITLE
Autocomplete: Add a new 16b exclusive experiment and document existing flags

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -7,15 +7,30 @@ export enum FeatureFlag {
     // product code
     TestFlagDoNotUse = 'test-flag-do-not-use',
 
+    // Enable both-client side and server-side tracing
     CodyAutocompleteTracing = 'cody-autocomplete-tracing',
+    // This flag is used to track the overall eligibility to use the StarCoder model. The `-hybrid`
+    // suffix is no longer relevant
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
+    // Force all StarCoder traffic (controlled by the above flag) to point to the 16b model.
+    CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
+    // Enables the bfg-mixed context retriever that will combine BFG with the default local editor
+    // context.
     CodyAutocompleteContextBfgMixed = 'cody-autocomplete-context-bfg-mixed',
+    // Enable latency adjustments based on accept/reject streaks
     CodyAutocompleteUserLatency = 'cody-autocomplete-user-latency',
+    // Dynamically decide wether to show a single line or multiple lines for completions.
     CodyAutocompleteDynamicMultilineCompletions = 'cody-autocomplete-dynamic-multiline-completions',
+    // Continue generations after a single-line completion and use the response to see the next line
+    // if the first completion is accepted.
     CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
 
+    // Enable Cody PLG features
     CodyPro = 'cody-pro',
+    // Enable Cody PLG features on JetBrains
     CodyProJetBrains = 'cody-pro-jetbrains',
+
+    // A feature flag to test potential chat experiments. No functionality is gated by it.
     CodyChatMockTest = 'cody-chat-mock-test',
 }
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -22,6 +22,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Folders named 'bin/' are no longer filtered out from chat `@`-mentions but instead ranked lower. [pull/2472](https://github.com/sourcegraph/cody/pull/2472)
 - Files ignored in `.cody/ignore` (if the internal experiment is enabled) will no longer show up in chat `@`-mentions. [pull/2472](https://github.com/sourcegraph/cody/pull/2472)
+- Adds a new experiment to test a higher parameter StarCoder model for single-line completions. [pull/2632](https://github.com/sourcegraph/cody/pull/2632)
 
 ## [1.0.5]
 

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -106,10 +106,13 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(configuredPr
         return { provider: configuredProvider }
     }
 
-    const starCoderHybrid = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid)
+    const [starCoder, starCoder16B] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
+    ])
 
-    if (starCoderHybrid) {
-        return { provider: 'fireworks', model: 'starcoder-hybrid' }
+    if (starCoder) {
+        return { provider: 'fireworks', model: starCoder16B ? 'starcoder-16b' : 'starcoder-hybrid' }
     }
 
     return null

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -106,12 +106,12 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(configuredPr
         return { provider: configuredProvider }
     }
 
-    const [starCoder, starCoder16B] = await Promise.all([
+    const [starCoderHybrid, starCoder16B] = await Promise.all([
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
     ])
 
-    if (starCoder) {
+    if (starCoderHybrid) {
         return { provider: 'fireworks', model: starCoder16B ? 'starcoder-16b' : 'starcoder-hybrid' }
     }
 


### PR DESCRIPTION
For https://docs.google.com/document/d/1P-Hb8BTbz-vMNFXw3gbAvphArsNvS1_8u4ID-phn8gI/edit, we are considereing moving all traffic to the 16b model. When we first run an experiment for this, the single-line CAR was better with the faster model. Part of this might be due to latency (which will improve with the ST deployment) but parts of this might also just no longer be relevant since we have made so many changes.

This PR adds a new client side feature flag that we can run in the short term to gather data on 16b exclusive setups. It will only have an affect if the user is already inside the `CodyAutocompleteStarCoderHybrid` experiment, which is currently our main StarCoder enablement flag.

## Test plan

- Be inside `CodyAutocompleteStarCoderHybrid`
- Be inside `CodyAutocompleteStarCoder16B`
- Observe that single-line completions use the 16b model identifier: 
<img width="904" alt="Screenshot 2024-01-09 at 11 46 51" src="https://github.com/sourcegraph/cody/assets/458591/801682a5-6626-4767-9898-b9fe9cd3be27">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
