### PR TITLE
Do not require a root build for agent unit tests

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -12,7 +12,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "cd .. && pnpm build && cd agent && node src/esbuild.mjs",
+    "build:root": "cd .. && pnpm build && cd agent",
+    "build:agent": "node src/esbuild.mjs",
+    "build": "pnpm run build:root && pnpm run build:agent",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
     "agent:debug": "pnpm run build && node --inspect --enable-source-maps ./dist/index.js",

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -201,7 +201,7 @@ describe('Agent', () => {
     const rateLimitedClient = new TestClient('rateLimitedClient', process.env.SRC_ACCESS_TOKEN_WITH_RATE_LIMIT)
 
     // Bundle the agent. When running `pnpm run test`, vitest doesn't re-run this step.
-    execSync('pnpm run build', { cwd: client.getAgentDir(), stdio: 'inherit' })
+    execSync('pnpm run build:agent', { cwd: client.getAgentDir(), stdio: 'inherit' })
 
     // Initialize inside beforeAll so that subsequent tests are skipped if initialization fails.
     beforeAll(async () => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -182,7 +182,7 @@ describe('Agent', () => {
     const explainPollyError = `
 
     ===================================================[ NOTICE ]=======================================================
-    If you get PollyError or unexpeced diff, you might need to update recordings to match your changes.
+    If you get PollyError or unexpected diff, you might need to update recordings to match your changes.
     Please check https://github.com/sourcegraph/cody/tree/main/agent#updating-the-polly-http-recordings for the details.
     ====================================================================================================================
 
@@ -201,6 +201,11 @@ describe('Agent', () => {
     const rateLimitedClient = new TestClient('rateLimitedClient', process.env.SRC_ACCESS_TOKEN_WITH_RATE_LIMIT)
 
     // Bundle the agent. When running `pnpm run test`, vitest doesn't re-run this step.
+    //
+    // ⚠️ If this line fails when running unit tests, chances are that the error is being swallowed.
+    // To see the full error, run this file in isolation:
+    //
+    //   pnpm test agent/src/index.test.ts
     execSync('pnpm run build:agent', { cwd: client.getAgentDir(), stdio: 'inherit' })
 
     // Initialize inside beforeAll so that subsequent tests are skipped if initialization fails.


### PR DESCRIPTION
See thread in https://sourcegraph.slack.com/archives/C05AGQYD528/p1704748857378909

This makes it so that the unit tests for agent only runs the esbuild portion of the script and not the full build of the workspace root (which can fail for any TS issue in the codebase and leads to confusion)

It does seem like the stdio inheriting does not work because of how vitests isolates different test workers (i.e if the test is run in isolation, the stdio won't be cleared? maybe another test file uses `console.clear`?) In any case it doesn't appear trivial to fix the reporting, so leaving this as-is (Plus I added a comment in the code that is displayed on error on how to get more logs).

## Test plan

- Have a change that does not typecheck, e.g.

```
diff --git a/vscode/src/configuration.ts b/vscode/src/configuration.ts
index ffa6e1a9..f1e0bc95 100644
--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -67,6 +67,8 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         autocompleteExperimentalGraphContext = 'lsp-light'
     }

+    const foo = getHiddenSetting('experimental.symfContext', false)
+
     return {
         proxy: config.get<string | null>(CONFIG_KEY.proxy, null),
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
```

- Run `pnpm test` in the workspace root
- Observe no issues

And when you make the build command error:

<img width="1188" alt="Screenshot 2024-01-09 at 15 55 48" src="https://github.com/sourcegraph/cody/assets/458591/6c921b6c-d13f-48f2-811e-94913850b101">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
