### PR TITLE
fix: ignore all non-file uris by default

### DIFF
--- a/lib/shared/src/chat/ignore-helper.test.ts
+++ b/lib/shared/src/chat/ignore-helper.test.ts
@@ -40,6 +40,16 @@ describe('IgnoreHelper', () => {
         ignore.setActiveState(true)
     })
 
+    it('returns true for non-file schemed URLs', () => {
+        const nonFileWorkspaceRoot = workspace1Root.with({ scheme: 'non-file' })
+        expect(ignore.isIgnored(Utils.joinPath(nonFileWorkspaceRoot, 'foo.txt'))).toBe(true)
+    })
+
+    it('returns true for non-file schemed URLs - vscode user settings', () => {
+        const nonFileWorkspaceRoot = workspace1Root.with({ scheme: 'vscode-userdata' })
+        expect(ignore.isIgnored(Utils.joinPath(nonFileWorkspaceRoot, 'settings.json'))).toBe(true)
+    })
+
     it('returns false for an undefined workspace', () => {
         expect(ignore.isIgnored(Utils.joinPath(workspace1Root, 'foo.txt'))).toBe(false)
     })

--- a/lib/shared/src/chat/ignore-helper.ts
+++ b/lib/shared/src/chat/ignore-helper.ts
@@ -116,6 +116,11 @@ export class IgnoreHelper {
             return false
         }
 
+        // Ignore all non-file URIs
+        if (uri.scheme !== 'file') {
+            return true
+        }
+
         this.ensureFileUri('uri', uri)
         this.ensureAbsolute('uri.fsPath', uri.fsPath)
         const workspaceRoot = this.findWorkspaceRoot(uri.fsPath)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,12 +17,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Do not automatically append open file name to display text for chat questions. [pull/2580](https://github.com/sourcegraph/cody/pull/2580)
 - Fixed unresponsive stop button in chat when an error is presented. [pull/2588](https://github.com/sourcegraph/cody/pull/2588)
 - Added existing `cody.useContext` config to chat to control context fetching strategy. [pull/2616](https://github.com/sourcegraph/cody/pull/2616)
+- [Internal] Opening files with non-file schemed URLs no longer breaks Autocomplete when `.cody/ignore` is enabled. [pull/2640](https://github.com/sourcegraph/cody/pull/2640)
 
 ### Changed
 
 - Folders named 'bin/' are no longer filtered out from chat `@`-mentions but instead ranked lower. [pull/2472](https://github.com/sourcegraph/cody/pull/2472)
 - Files ignored in `.cody/ignore` (if the internal experiment is enabled) will no longer show up in chat `@`-mentions. [pull/2472](https://github.com/sourcegraph/cody/pull/2472)
 - Adds a new experiment to test a higher parameter StarCoder model for single-line completions. [pull/2632](https://github.com/sourcegraph/cody/pull/2632)
+- [Internal] All non-file schemed URLs are now ignored by default when `.cody/ignore` is enabled. [pull/2640](https://github.com/sourcegraph/cody/pull/2640)
 
 ## [1.0.5]
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/2585

Add a check to ignore all non-file URIs in the IgnoreHelper class. 

This prevents Cody from using files that cannot be uploaded remotely or defined in ignore files as context, e.g. unsaved files or vs code user configuration files.

This also fixed an issue where opening a non-file URIs would cause autocomplete to stop working

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Open vs code config as tab as described by @philipp-spiess in https://sourcegraph.slack.com/archives/C05AGQYD528/p1704815009033359
2. Switch back to a codebase file to make sure autocomplete is still working (unless the file is ignored)

https://github.com/sourcegraph/cody/assets/68532117/fca1e0e1-205e-4d72-8278-f5101609a1bf

