### PR TITLE
Agent: add symf support and enabled keyword context by default

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -118,6 +118,20 @@ pass after recording. Worst case, feel free to disable the agent tests by
 uncommenting the block of code in `index.test.ts`. See comment in the code for
 more details about how to disable agent tests.
 
+## Iterating on agent tests
+
+For a fast edit/test/debug feedback loop when iterating on agent tests, use the `CODY_RECORD_IF_MISSING=true` mode.
+
+```sh
+CODY_RECORD_IF_MISSING=true pnpm run test agent/src/index.test.ts
+```
+
+The benefit of this workflow is that the agent replays from the HTTP recording
+for tests that haven't changed, and only sends HTTP requests for new tests.
+
+When you are happy with the result, make sure to run `pnpm
+update-agent-recordings` to clean unused recordings.
+
 ## Miscellaneous notes
 
 - By the nature of using JSON-RPC via stdin/stdout, both the agent server and

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -144,8 +144,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -219,50 +217,18 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 641
-          text: >+
+          size: 232
+          text: |+
             event: completion
-
             data: {"completion":" Hello","stopReason":""}
 
-
             event: completion
-
             data: {"completion":" Hello!","stopReason":""}
 
-
             event: completion
-
-            data: {"completion":" Hello! Nice","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Hello! Nice to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Hello! Nice to meet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Hello! Nice to meet you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Hello! Nice to meet you.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Hello! Nice to meet you.","stopReason":"stop_sequence"}
-
+            data: {"completion":" Hello!","stopReason":"stop_sequence"}
 
             event: done
-
             data: {}
 
         cookies: []
@@ -275,8 +241,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -350,7 +314,7 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 102558
+          size: 107784
           text: >+
             event: completion
 
@@ -974,382 +938,412 @@ log:
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main,","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method,","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\");","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\");","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n-","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n-","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The print","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The print","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary,","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `jav","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello World program","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello World program in","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello World program in Java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java`","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello World program in Java.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside the main method, we call System.out.println(\"Hello World\"); to print the text \"Hello World!\" to the console. \n\n- The println method prints the text and a newline character.\n\nSo in summary, this program defines a Main class with a static main method that prints \"Hello World!\" when executed. This is the simplest Hello World program in Java.","stopReason":"stop_sequence"}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then run","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then run `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then run `java","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then run `java Main","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then run `java Main`.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be inside a class.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- Inside main, we call System.out.println(\"Hello World!\"); to print the text \"Hello World!\" to the console. \n\n- The println method handles printing the text and moving to a new line after.\n\nSo this simple program prints \"Hello World!\" when run. To run it from the command line you would compile with `javac Main.java` and then run `java Main`.","stopReason":"stop_sequence"}
 
 
             event: done
@@ -1366,8 +1360,441 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7e7da1e2728766fa5abd6b1665484997
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Only show the code, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0.2
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 15726
+          text: >+
+            event: completion
+
+            data: {"completion":" Here","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\");","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }\n\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }\n\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }\n\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1459,8 +1886,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 219
-          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//w==","AwCpmMLNBAEAAA=="]'
+          size: 222
+          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UF","jiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//w==","AwCpmMLNBAEAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1471,8 +1898,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1561,8 +1986,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 131
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//","AwAfFAXARQAAAA=="]'
+          size: 134
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmV","Pj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//","AwAfFAXARQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1573,8 +1998,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1690,8 +2113,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1788,8 +2209,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1884,8 +2303,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1980,8 +2397,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2076,104 +2491,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 50b031b05a8f064cbb7c320d4adb6bdc
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "208"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-autocomplete-disable-recycling-of-previous-requests
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        content:
-          mimeType: application/json
-          size: 38
-          text: '{"data":{"evaluateFeatureFlag":false}}'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2268,8 +2585,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2364,8 +2679,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2451,87 +2764,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 760
-          text: '["H4sIAAAAAAAA/5RVUW7rOAy8i7/LC+QAvcRiP2hpYnMjSy5JJfEWvfuD3OKh7Xu2m78AHg2HQ3Ly2kV27k6vHa6cKjviM9ir4jnxYN3pn9cu84Tu1IUSF+LqJZRpTnBQXDJPEmiqySVJBn18kpKte+oaI7rTmZPh7WmHKJTsuDv154EmuSM+8jjizDU5mbOGEqE0Lr3KJw7X+pnCwBrG96LZqWdDpMR5oAhHaOoP6t/Qk0lEz7pZZQXOWvYBuM9QmZCd0z7yS8+uHCQPD9kkxn0CKcISkuSByplmxVVKNVK8VJjvTI3jJJk4c1pcghFyozt0OaKvRzqbnZwO+m8gRPGirQWZYcf4MLIfDoj+g/fKkg8IGxlNJVzIYdu0H31n3OiC5VZ0Z5k/sMr58mWaf6eUPFcnG8uNRjEvujywMW2/Kw/thyOH7afKDS2TuBHuAYiIdC66dr27c30qPc2tht3Ew0isYGuC1UP1A3t/dNNkpWrAoDyP20JeqoTL+tbJS9VVPlcfkV1CyziqBn1g2QOH8fcJHQ/0IIBmLbEGJ6u9BZV5zUsy6FUCiEMoNfuOuJ6uYuslrN3dxEfKxdGXctl3+UFJCm7e/1xZCDCTFjNnSS2mgO2tliHXmazqFcufcfKd25EwwXXNzKLbBzjoHI5Oqdwy1EaZN4HveshcwVNLy0Gc+tQ+bhucXdn8/V9QODvZkp3vNMowJhnG/ftpwun/gsv33v59e/sVAAD//+dsoHqoBwAA"]'
-          textDecoded:
-            data:
-              evaluatedFeatureFlags:
-                - name: cody-autocomplete-dynamic-multiline-completions
-                  value: false
-                - name: cody-autocomplete-context-bfg-mixed
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid
-                  value: true
-                - name: search-content-based-lang-detection
-                  value: false
-                - name: cody-web-sidebar
-                  value: true
-                - name: cody-pro
-                  value: true
-                - name: cody-experimental
-                  value: true
-                - name: cody-autocomplete-tracing
-                  value: false
-                - name: cody-autocomplete-disable-recycling-of-previous-requests
-                  value: false
-                - name: admin-analytics-enabled
-                  value: true
-                - name: search-debug
-                  value: false
-                - name: cody-web-all
-                  value: true
-                - name: cody-web-editor-recipes
-                  value: true
-                - name: cody-web-chat
-                  value: true
-                - name: cody-pro-jetbrains
-                  value: true
-                - name: cody-chat-mock-test
-                  value: true
-                - name: search-new-keyword
-                  value: false
-                - name: search-ranking
-                  value: true
-                - name: search-input-show-history
-                  value: true
-                - name: cody-autocomplete-language-latency
-                  value: true
-                - name: rate-limits-exceeded-for-testing
-                  value: false
-                - name: blob-page-switch-areas-shortcuts
-                  value: true
-                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
-                  value: false
-                - name: quick-start-tour-for-authenticated-users
-                  value: false
-                - name: admin-analytics-cache-disabled
-                  value: false
-                - name: search-hybrid
-                  value: true
-                - name: product-subscriptions-service-account
-                  value: false
-                - name: ab-visitor-tour-with-notebooks
-                  value: true
-                - name: cody
-                  value: true
-                - name: product-subscriptions-reader-service-account
-                  value: false
-                - name: accessible-file-tree
-                  value: true
-                - name: signup-survey-enabled
-                  value: false
-                - name: telemetry-export
-                  value: true
-                - name: grpc
-                  value: true
-                - name: search-ownership
-                  value: true
-                - name: enable-streaming-git-blame
-                  value: true
-                - name: contrast-compliant-syntax-highlighting
-                  value: false
-                - name: grpc-zoekt
-                  value: true
+          size: 807
+          text: '["H4sIAAAAAAAA/5RVUZLrOAi8i7+HC+QAc4mt/UA=","iNhsZMkDKI53au6+JU+q9iXv2Z78qUqAmoZufXYRHbvTZ8dXTBWd4zujV+X3hL11p78+u4wjd6eOSlxg0gL/sAdFyda9dS2Ju5Nr5a+3h9Ddy1ZnPwCrFyrjlNgZIp+xJgdzVCqRFYYlqESwUpW4V5yG/8udMdmv9XqdaPMxzhgSg7kyjpJ76MUhpHa5lYJxlAyYMS0uZPBdIm7GG6PScIe8HSV9rhNY1Ssvv9d8buoZBCENDFHsIG8ld+YAHMWLgjLJxNujnLTESg5Wg5HK5FKygTK2KRjrVYgBiUrNvv3qnQLJU3WwocwwiHnRgy2hAR3GQhdwNt+PbT21+Bc7ebWFyKH2P6DXJHJAPVqKzDNceJmL7s4su6I5rIIQzA62ZMcbDNIPSfrBJR+BehTUknEUgrEmlySZ4X7VOHmlUMLcV+zbwTnTwTwfUl2RdmGXiXNT+5O8/0xkmTOrDTJty5aIzaSp/Sypvc/bGldszckobsA3Yo4c4Vx0XcRd1M1t4N/Cl+1NvENWzJeHUoeUtUXgm0M49zDK7VDnPzLRHWuMUI0VSg4FNe5hxQBXsdVRvFSFWXyAXJxDKZf9jwL4NrHKyNkxbUY6Jx7ZdQ0vuk3uRxW6rE36N5Q2Naw+cHah9sGtTb205XdbbWa5UGq/RDnDpHyVUpsZflQ236l4H/g6vuwQ0Diu0oHIztRUt50cUgkwNY3ZLE4DoDJac1F1qn5AbvMiTM+8/v319V8AAAD//8psKTL6BwAA"]'
         cookies: []
         headers:
           - name: date
@@ -2542,8 +2776,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2552,119 +2784,6 @@ log:
             value: no-cache, max-age=0
           - name: content-encoding
             value: gzip
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: d7720d62932d2de21ea1f187e1bf5135
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "734"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: >-
-              
-              mutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {
-                  logEvent(
-              		event: $event
-              		userCookieID: $userCookieID
-              		url: $url
-              		source: $source
-              		argument: $argument
-              		publicArgument: $publicArgument
-              		client: $client
-              		connectedSiteID: $connectedSiteID
-              		hashedLicenseKey: $hashedLicenseKey
-                  ) {
-              		alwaysNil
-              	}
-              }
-            variables:
-              client: VSCODE_CODY_EXTENSION
-              connectedSiteID: SourcegraphWeb
-              event: CodyVSCodeExtension:Auth:connected
-              source: IDEEXTENSION
-              url: ""
-              userCookieID: ANONYMOUS_USER_COOKIE_ID
-        queryString:
-          - name: LogEventMutation
-            value: null
-        url: https://sourcegraph.com/.api/graphql?LogEventMutation
-      response:
-        content:
-          mimeType: application/json
-          size: 26
-          text: '{"data":{"logEvent":null}}'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "26"
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
@@ -2770,8 +2889,117 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: d7720d62932d2de21ea1f187e1bf5135
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "734"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >-
+              
+              mutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {
+                  logEvent(
+              		event: $event
+              		userCookieID: $userCookieID
+              		url: $url
+              		source: $source
+              		argument: $argument
+              		publicArgument: $publicArgument
+              		client: $client
+              		connectedSiteID: $connectedSiteID
+              		hashedLicenseKey: $hashedLicenseKey
+                  ) {
+              		alwaysNil
+              	}
+              }
+            variables:
+              client: VSCODE_CODY_EXTENSION
+              connectedSiteID: SourcegraphWeb
+              event: CodyVSCodeExtension:Auth:connected
+              source: IDEEXTENSION
+              url: ""
+              userCookieID: ANONYMOUS_USER_COOKIE_ID
+        queryString:
+          - name: LogEventMutation
+            value: null
+        url: https://sourcegraph.com/.api/graphql?LogEventMutation
+      response:
+        content:
+          mimeType: application/json
+          size: 26
+          text: '{"data":{"logEvent":null}}'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "26"
+          - name: connection
+            value: close
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2883,8 +3111,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2996,8 +3222,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3015,117 +3239,6 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: c63cf23de38703e896ef70b35a6908a4
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: defaultClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "342"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
-              	telemetry {
-              		recordEvents(events: $events) {
-              			alwaysNil
-              		}
-              	}
-              }
-            variables:
-              events:
-                - action: connected
-                  feature: cody.auth
-                  parameters:
-                    privateMetadata: {}
-                    version: 0
-                  source:
-                    client: VSCode.Cody
-                    clientVersion: 1.0.5
-        queryString:
-          - name: RecordTelemetryEvents
-            value: null
-        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
-      response:
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
         headersSize: 0
         httpVersion: HTTP/1.1
         redirectURL: ""
@@ -3221,8 +3334,115 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: c63cf23de38703e896ef70b35a6908a4
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "342"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: connected
+                  feature: cody.auth
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.0.5
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3337,8 +3557,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3453,8 +3671,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3489,7 +3705,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1a71934de7e17499fc6950eb40367602
+    - _id: 8b1d3e6611c711a5af2e145069c311ac
       _order: 0
       cache: {}
       request:
@@ -3509,7 +3725,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "360"
+            value: "350"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -3536,8 +3752,8 @@ log:
               }
             variables:
               events:
-                - action: recipe-used
-                  feature: cody.recipe.chat-question
+                - action: executed
+                  feature: cody.chat-question
                   parameters:
                     privateMetadata: {}
                     version: 0
@@ -3552,8 +3768,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -3564,8 +3780,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3663,13 +3877,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 112
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -3680,8 +3889,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3770,13 +3977,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 148
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
-          textDecoded:
-            data:
-              repository:
-                embeddingExists: true
-                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
+          size: 151
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q","BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
         cookies: []
         headers:
           - name: date
@@ -3787,8 +3989,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3892,8 +4092,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4004,8 +4202,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4093,11 +4289,11 @@ log:
           encoding: base64
           mimeType: application/json
           size: 136
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZhaGFvFGBkYmugaGugZm8aZ6RrqWiSZppkbJKSZGhilKtbW1AAAAAP//AwCkSWFZSQAAAA=="]'
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5gbmFvFGBkYmugaGugaW8aZ6RrppKcZGxmYWqYaWpklKtbW1AAAAAP//AwCEdlSPSQAAAA=="]'
           textDecoded:
             data:
               site:
-                productVersion: 256818_2024-01-06_5.2-9a4f52cd421d
+                productVersion: 257078_2024-01-09_5.2-fd32368e195b
         cookies: []
         headers:
           - name: date
@@ -4108,8 +4304,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin

--- a/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
+++ b/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
@@ -57,21 +57,21 @@ log:
             value: "0"
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: retry-after
+            value: "0"
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
           - name: x-cloud-trace-context
-            value: a8e6a387e9141b770d6ad9a7d3ae86fd
+            value: 8021f57f24a9cc23d041b6fbcf88a00d
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -180,8 +180,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -287,8 +285,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -404,8 +400,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -502,8 +496,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -598,8 +590,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -694,8 +684,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -790,104 +778,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 50b031b05a8f064cbb7c320d4adb6bdc
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: rateLimitedClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "208"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-autocomplete-disable-recycling-of-previous-requests
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        content:
-          mimeType: application/json
-          size: 38
-          text: '{"data":{"evaluateFeatureFlag":false}}'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -982,8 +872,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1070,40 +958,40 @@ log:
           encoding: base64
           mimeType: application/json
           size: 444
-          text: '["H4sIAAAAAAAAA5SSUU4kMQxE75JvfIE5AJdAfLiT6sSQTnptZ6Zbo7k7AiEEu4Jevl1+dpV9DYmdw+kacOY62JHuwT4U95WzhdPDNTReEE7BJLexkg09Yyc0nipSuAuvfQinmavhdvchjz3txMN77Mta4aAk9tpDirjHKi1Tn2lVnKUPI8WfAXM7IMbCTkuPz+Qw/17sqFjguhO2tesnpes42BMzj+pkzhp7glLZJ5X0C0TszbE5TXOmRbbDnFbt39Kn2idaOYPsIh4LsYKNrHT1OA4D+y9rZH1oRFZey294rhyl5WN39ASflKXZDyk2VzanN7pwc7K9OW9UJJcqufjxqK9u98aLRFpGdanSQO8l6e2H2JQdVGURN8IWgYREc9e3j/uywl8ODKyxUMOFnrFfuv5z9sfb7QUAAP//AwBsUsNwcgMAAA=="]'
+          text: '["H4sIAAAAAAAAA6xRW24bMQy8i77DC/gAuUTRD640KzHRShuSsndh+O6BjQKFW9hBgHxzXpw5h8TO4XAOOHId7EivYB+K18rZwuHXOTReEA4h9rRTLOy09PhODvPwEq4shMPM1XB5uQfz8B77slY4KPbm2JymOdMiG9Jj8lT7RCtnkJ3EYyFWsJGVrh6H22OmSW5jJRt6xE5oPNVnRreUq/a/CNdxpwfWWKjhRO/YT12fiCk7qMoiboQtAgmJ5q63pqTlhyaOigWuO2Fbu/pD4P+lJrHri6SIe6zSMvWZVsVR+jBSfAzYs76uoyib001RuDnZ3pw3KpJLlVzuk389syvHb1ISZh7VyZw19gSlsk8qiawPjcjKa/l6Q3qDT8rS7Dv97Y0XibSM6lKlgf6cpDf7iR/+yfL7cvkEAAD//wMASs0t4XIDAAA="]'
           textDecoded:
             data:
               evaluatedFeatureFlags:
-                - name: signup-survey-enabled
-                  value: false
-                - name: cody-autocomplete-disable-recycling-of-previous-requests
-                  value: false
                 - name: cody-chat-mock-test
                   value: false
-                - name: telemetry-export
-                  value: true
-                - name: cody-autocomplete-default-starcoder-hybrid
-                  value: true
                 - name: cody-autocomplete-context-bfg-mixed
+                  value: false
+                - name: blob-page-switch-areas-shortcuts
+                  value: false
+                - name: signup-survey-enabled
                   value: false
                 - name: cody-pro
                   value: true
-                - name: blob-page-switch-areas-shortcuts
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
-                  value: false
-                - name: cody-autocomplete-tracing
-                  value: false
-                - name: cody-pro-jetbrains
-                  value: true
-                - name: contrast-compliant-syntax-highlighting
-                  value: false
-                - name: cody-autocomplete-dynamic-multiline-completions
+                - name: search-new-keyword
                   value: false
                 - name: rate-limits-exceeded-for-testing
                   value: true
-                - name: search-new-keyword
+                - name: telemetry-export
+                  value: true
+                - name: cody-autocomplete-disable-recycling-of-previous-requests
                   value: false
+                - name: contrast-compliant-syntax-highlighting
+                  value: false
+                - name: cody-autocomplete-tracing
+                  value: false
+                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
+                  value: false
+                - name: cody-pro-jetbrains
+                  value: true
+                - name: cody-autocomplete-dynamic-multiline-completions
+                  value: false
+                - name: cody-autocomplete-default-starcoder-hybrid
+                  value: true
         cookies: []
         headers:
           - name: date
@@ -1114,8 +1002,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1229,8 +1115,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1248,6 +1132,120 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 8b1d3e6611c711a5af2e145069c311ac
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "350"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.chat-question
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.0.5
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
         headersSize: 0
         httpVersion: HTTP/1.1
         redirectURL: ""
@@ -1379,117 +1377,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1a71934de7e17499fc6950eb40367602
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: rateLimitedClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "360"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
-              	telemetry {
-              		recordEvents(events: $events) {
-              			alwaysNil
-              		}
-              	}
-              }
-            variables:
-              events:
-                - action: recipe-used
-                  feature: cody.recipe.chat-question
-                  parameters:
-                    privateMetadata: {}
-                    version: 0
-                  source:
-                    client: VSCode.Cody
-                    clientVersion: 1.0.5
-        queryString:
-          - name: RecordTelemetryEvents
-            value: null
-        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
-      response:
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: f8951b1429c774d692bea21c67602015
       _order: 0
       cache: {}
@@ -1544,8 +1431,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 155
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8=","AwD/h5WCVAAAAA=="]'
+          size: 148
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
+          textDecoded:
+            data:
+              repository:
+                embeddingExists: true
+                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
         cookies: []
         headers:
           - name: date
@@ -1556,8 +1448,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1645,12 +1535,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 120
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
-          textDecoded:
-            data:
-              repository:
-                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
+          size: 123
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q","BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1661,8 +1547,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1773,8 +1657,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1861,12 +1743,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 136
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkamZhaGFvFGBkYmugaGugZm8aZ6RrqWiSZppkbJKSZGhilKtbW1AAAAAP//AwCkSWFZSQAAAA=="]'
-          textDecoded:
-            data:
-              site:
-                productVersion: 256818_2024-01-06_5.2-9a4f52cd421d
+          size: 142
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp","pcklYalFxZn5eUpWSkam5gbmFvFGBkYmugaGugaW8aZ6RrppKcZGxmYWqYaWpklKtbW1AAAAAP//","AwCEdlSPSQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1877,8 +1755,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -2,6 +2,8 @@ import type * as vscode from 'vscode'
 
 import type { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 
+import { defaultConfigurationValue } from '../../vscode/src/configuration-keys'
+
 import { type ClientInfo, type ExtensionConfiguration } from './protocol-alias'
 
 export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguration {
@@ -25,7 +27,7 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
         if (this.prefix.length === 0) {
             return section
         }
-        return [section, ...this.prefix].join('.')
+        return [...this.prefix, section].join('.')
     }
 
     private clientNameToIDE(value: string): Configuration['agentIDE'] | undefined {
@@ -82,16 +84,18 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
             case 'cody.autocomplete.experimental.syntacticPostProcessing':
                 // False because we don't embed WASM with the agent yet.
                 return false
-            case 'cody.experimental.symfContext':
-                // Symf is disabled because the tests fail with the following error when symf is enabled:
-                //   EvalError: symf index creation failed: Error: spawn Unknown system error -8
-                return false
+            case 'cody.useContext':
+                // Disable embeddings by default.
+                return 'keyword'
             case 'cody.codebase':
                 return extensionConfig?.codebase
             case 'cody.advanced.agent.ide':
                 return this.clientNameToIDE(this.clientInfo()?.name ?? '')
             default:
-                return defaultValue
+                // VS Code picks up default value in package.json, and only uses
+                // the `defaultValue` parameter if package.json provides no
+                // default.
+                return defaultConfigurationValue(section) ?? defaultValue
         }
     }
 

--- a/agent/src/__tests__/example-ts/src/animal.ts
+++ b/agent/src/__tests__/example-ts/src/animal.ts
@@ -1,6 +1,7 @@
 /* SELECTION_START */
 export interface Animal {
     name: string
-    sound(): string
+    makeAnimalSound(): string
+    isMammal: boolean
 }
 /* SELECTION_END */

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -173,9 +173,11 @@ export class Agent extends MessageHandler {
         this.registerRequest('initialize', async clientInfo => {
             this.workspace.workspaceRootUri = vscode.Uri.parse(clientInfo.workspaceRootUri)
             vscode_shim.setWorkspaceDocuments(this.workspace)
-            process.stderr.write(
-                `Cody Agent: handshake with client '${clientInfo.name}' (version '${clientInfo.version}') at workspace root path '${clientInfo.workspaceRootUri}'\n`
-            )
+            if (process.env.CODY_DEBUG === 'true') {
+                process.stderr.write(
+                    `Cody Agent: handshake with client '${clientInfo.name}' (version '${clientInfo.version}') at workspace root path '${clientInfo.workspaceRootUri}'\n`
+                )
+            }
 
             vscode_shim.setClientInfo(clientInfo)
             // Register client info

--- a/agent/src/cli/base64.ts
+++ b/agent/src/cli/base64.ts
@@ -2,6 +2,6 @@ import pako from 'pako'
 
 export function decodeCompressedBase64(text: string): any {
     const bytes = Buffer.from(text, 'base64')
-    const inflated = pako.ungzip(bytes)
-    return JSON.parse(Buffer.from(inflated).toString('utf-8'))
+    const unzipped = pako.ungzip(bytes)
+    return JSON.parse(Buffer.from(unzipped).toString('utf-8'))
 }

--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -166,11 +166,10 @@ class CodyPersister extends FSPersister {
                 // in in pull requests.
                 try {
                     const text = JSON.parse(responseContent.text)[0]
-                    console.log({ text })
                     const decodedBase64 = decodeCompressedBase64(text)
                     ;(responseContent as any).textDecoded = decodedBase64
-                } catch (error) {
-                    console.error('base64 decode error', error)
+                } catch {
+                    // console.error('base64 decode error', error)
                 }
             }
         }
@@ -266,12 +265,15 @@ export const jsonrpcCommand = new Command('jsonrpc')
             // because we don't want to record the binary downloads for
             // macOS/Windows/Linux
             polly.server.get('https://github.com/sourcegraph/bfg/*path').passthrough()
+            polly.server.get('https://github.com/sourcegraph/symf/*path').passthrough()
         } else if (options.recordingMode) {
             console.error('CODY_RECORDING_DIRECTORY is required when CODY_RECORDING_MODE is set.')
             process.exit(1)
         }
 
-        process.stderr.write('Starting Cody Agent...\n')
+        if (process.env.CODY_DEBUG === 'true') {
+            process.stderr.write('Starting Cody Agent...\n')
+        }
 
         const agent = new Agent({ polly })
 

--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -169,6 +169,9 @@ class CodyPersister extends FSPersister {
                     const decodedBase64 = decodeCompressedBase64(text)
                     ;(responseContent as any).textDecoded = decodedBase64
                 } catch {
+                    // Ignored: uncomment below to debug. It's fine to ignore this error because we only
+                    // make a best-effort to decode the gzip+base64 encoded JSON payload. It's not needed
+                    // for the HTTP replay to work correctly because we leave the `.text` property unchanged.
                     // console.error('base64 decode error', error)
                 }
             }

--- a/lib/shared/src/chat/typewriter.ts
+++ b/lib/shared/src/chat/typewriter.ts
@@ -119,7 +119,6 @@ export class Typewriter implements IncrementalTextConsumer {
         // Clean up the consumer, finished promise.
         if (this.upstreamClosed) {
             if (error) {
-                console.error('Typewriter stopped', error)
                 if (this.consumer.error) {
                     this.consumer.error(error)
                     return

--- a/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts
+++ b/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts
@@ -63,7 +63,7 @@ export class GraphQLTelemetryExporter implements TelemetryExporter {
             } else {
                 this.exportMode = 'legacy'
             }
-            console.log('telemetry: evaluated export mode:', this.exportMode)
+            // console.log('telemetry: evaluated export mode:', this.exportMode)
         }
         if (this.exportMode === 'legacy' && this.legacySiteIdentification === undefined) {
             const siteIdentification = await this.client.getSiteIdentification()

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -143,6 +143,7 @@ export class DefaultPrompter implements IPrompter {
     }
 
     private renderContextItem(contextItem: ContextItem): Message[] {
+        console.log(new Error(JSON.stringify(contextItem)))
         // Do not create context item for empty file
         if (!contextItem.text?.trim()?.length) {
             return []

--- a/vscode/src/configuration-keys.ts
+++ b/vscode/src/configuration-keys.ts
@@ -4,6 +4,11 @@ import packageJson from '../package.json'
 
 const { properties } = packageJson.contributes.configuration
 
+export function defaultConfigurationValue(key: string): any {
+    const value = (properties as any)[key as any]?.default
+    return value
+}
+
 export type ConfigurationKeysMap = {
     // Use key remapping to get a nice typescript interface with the correct keys.
     // https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -52,7 +52,7 @@ describe('getConfiguration', () => {
                     case 'cody.experimental.simpleChatContext':
                         return true
                     case 'cody.experimental.symfContext':
-                        return false
+                        return true
                     case 'cody.experimental.tracing':
                         return true
                     case 'cody.debug.enable':
@@ -112,7 +112,7 @@ describe('getConfiguration', () => {
             experimentalChatPredictions: true,
             commandCodeLenses: true,
             experimentalSimpleChatContext: true,
-            experimentalSymfContext: false,
+            experimentalSymfContext: true,
             experimentalTracing: true,
             editorTitleCommandIcon: true,
             experimentalGuardrails: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -102,7 +102,7 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         autocompleteExperimentalGraphContext,
         experimentalChatPredictions: getHiddenSetting('experimental.chatPredictions', isTesting),
         experimentalSimpleChatContext: getHiddenSetting('experimental.simpleChatContext', true),
-        experimentalSymfContext: getHiddenSetting('experimental.symfContext', false),
+        experimentalSymfContext: getHiddenSetting('experimental.symfContext', true),
 
         experimentalGuardrails: getHiddenSetting('experimental.guardrails', isTesting),
         experimentalLocalSymbols: getHiddenSetting('experimental.localSymbols', false),

--- a/vscode/src/rg.ts
+++ b/vscode/src/rg.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 import * as vscode from 'vscode'
 
+import { logDebug } from './log'
+
 /**
  * Get the path to `rg` (ripgrep) that is bundled with VS Code.
  */
@@ -24,6 +26,6 @@ export async function getRgPath(): Promise<string | null> {
         }
     }
 
-    console.log('Did not find bundled `rg`.')
+    logDebug('getRgPath', 'Did not find bundled `rg`.')
     return null
 }

--- a/vscode/src/services/SecretStorageProvider.ts
+++ b/vscode/src/services/SecretStorageProvider.ts
@@ -19,7 +19,7 @@ export async function getAccessToken(): Promise<string | null> {
 
         if (!TestSupport.instance) {
             // Display system notification because the error was caused by system storage
-            console.error(`Failed to retrieve access token for Cody from secret storage: ${error}`)
+            logDebug('getAccessToken', `Failed to retrieve access token for Cody from secret storage: ${error}`)
         }
 
         return null

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -816,7 +816,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     experimentalGuardrails: false,
     experimentalLocalSymbols: false,
     experimentalSimpleChatContext: true,
-    experimentalSymfContext: false,
+    experimentalSymfContext: true,
     experimentalTracing: false,
     codeActions: true,
     isRunningInsideAgent: false,

--- a/vscode/test/e2e/install-deps.ts
+++ b/vscode/test/e2e/install-deps.ts
@@ -27,8 +27,18 @@ export function installChromium(): Promise<void> {
     const proc = spawn('pnpm', ['exec', 'playwright', 'install', 'chromium'], { shell: true })
     return new Promise<void>((resolve, reject) => {
         proc.on('error', e => console.error(e))
-        proc.stderr.on('data', e => console.error(e.toString()))
-        proc.stdout.on('data', e => console.log(e.toString()))
+        proc.stderr.on('data', e => {
+            const message = e.toString()
+            if (message) {
+                console.error(message)
+            }
+        })
+        proc.stdout.on('data', e => {
+            const message = e.toString()
+            if (message) {
+                console.log(message)
+            }
+        })
         proc.on('close', code => {
             if (code) {
                 reject(new Error(`Process failed: ${code}}`))


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/256

Previously, symf was disabled in the agent because the download+unzip logic was failing in Node.js. This PR fixes that problem (along with
    several other small issues), and adds a test case to stress the code
path where the user submits a chat message with enhanced context enabled. This test case is disabled for now because symf sends an LLM request that we can't record/replay (since symf is written in Go). The test can be manually enabled locally to test the functionality. It's still useful to merge this PR because it unblocks testing symf context with JetBrains.

**Important**: this PR changes the default context to be keyword-based instead of embeddings-based. This is aligned with our plans for February GA. It's possible to change it back to be embeddings-based by adding the custom configuration:

```json
{
  "cody.useContext": "embeddings"
}
```

Additionally (and optionally), use the following setting to disable symf to get the old default before this PR:

```json
{
  "cody.experimental.symfContext": false
}
```


## Test plan


* Green CI
* (optional) Manually enable the enhanced context test case to see it running locally. Even in replay mode, it still takes ~2 seconds to run because it does an LLM request for query expansion inside symf. Also, the assertion doesn't stress the context functionality because the workspace folder is a tmp directory without git repo.
* Manually test with JetBrains in a real-world git repository and see if the context is any more intelligent.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
