### PR TITLE
VS Code: Disable displaying feature limits

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -34,7 +34,7 @@ export class RateLimitError extends Error {
     ) {
         super(message)
         if (upgradeIsAvailable) {
-            this.userMessage = `You've used all${limit ? ` ${limit}` : ''} ${feature} for the month.`
+            this.userMessage = `You've used all ${feature} for the month.`
         } else {
             // Don't display Pro & Enterprise’s fair use limit numbers, as they're for abuse protection only
             this.userMessage = `You've used all ${feature} for today.`

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -33,12 +33,7 @@ export class RateLimitError extends Error {
         public readonly retryAfter?: string | null
     ) {
         super(message)
-        if (upgradeIsAvailable) {
-            this.userMessage = `You've used all ${feature} for the month.`
-        } else {
-            // Don't display Pro & Enterprise’s fair use limit numbers, as they're for abuse protection only
-            this.userMessage = `You've used all ${feature} for today.`
-        }
+        this.userMessage = `You've used all ${feature} for ${upgradeIsAvailable ? 'the month' : 'today'}.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)
                 ? new Date(Date.now() + parseInt(retryAfter, 10) * 1000)

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -24,7 +24,7 @@ export class RateLimitError extends Error {
     public readonly retryMessage: string | undefined
 
     constructor(
-        public readonly feature: string,
+        public readonly feature: 'autocompletions' | 'chat messages and commands',
         public readonly message: string,
         /* Whether an upgrade is available that would increase rate limits. */
         public readonly upgradeIsAvailable: boolean,

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -615,7 +615,7 @@ describe('InlineCompletionItemProvider', () => {
                     canUpgrade
                         ? expect.objectContaining({
                               title: 'Upgrade to Continue Using Cody Autocomplete',
-                              description: "You've used all 1234 autocompletions for the month.",
+                              description: "You've used all autocompletions for the month.",
                           })
                         : expect.objectContaining({
                               title: 'Cody Autocomplete Disabled Due to Rate Limit',


### PR DESCRIPTION
The problem is that we're displaying 160 chats in the error message:

![image](https://github.com/sourcegraph/cody/assets/2552265/415dc740-6b91-4ee8-9403-fe4f0ad05cd7)

while on the /cody/manage page, we display 20:

![image](https://github.com/sourcegraph/cody/assets/2552265/cd0bbbf9-ee34-4774-8ffc-cc137179d36f)

Cody Gateway only knows the LLM limits (which is 160 for Free users), and that's what it returns in the error header, so that's all the client knows as well. We should display the official limit of 20 instead, but we can't know it for now on the client side.

So my quick solution is just to hide this info on the UI.

## Test plan

Relying on the VS Code team to test this
