### PR TITLE
fix: model selection on start up

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Do not automatically append open file name to display text for chat questions. [pull/2580](https://github.com/sourcegraph/cody/pull/2580)
 - Fixed unresponsive stop button in chat when an error is presented. [pull/2588](https://github.com/sourcegraph/cody/pull/2588)
 - Added existing `cody.useContext` config to chat to control context fetching strategy. [pull/2616](https://github.com/sourcegraph/cody/pull/2616)
+- Fixed issue with incorrect chat model selected on first chat session for DotCom users after reauthorization. [issues/2648](https://github.com/sourcegraph/cody/issues/2648)
+
 - [Internal] Opening files with non-file schemed URLs no longer breaks Autocomplete when `.cody/ignore` is enabled. [pull/2640](https://github.com/sourcegraph/cody/pull/2640)
 
 ### Changed

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -181,6 +181,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
 
     // Select the chat model to use in Chat
     private selectModel(models: ChatModelProvider[]): string {
+        const authStatus = this.authProvider.getAuthStatus()
+        // Free user can only use the default model
+        if (authStatus.isDotCom && authStatus.userCanUpgrade) {
+            return models[0].model
+        }
         // Check for the last selected model
         const lastSelectedModelID = localStorage.get('model')
         if (lastSelectedModelID) {


### PR DESCRIPTION
Fix https://sourcegraph.slack.com/archives/C05AGQYD528/p1704845125801249
Close https://github.com/sourcegraph/cody/issues/2649

Added a check for user's authentication status and model selection in the SimpleChatPanelProvider class that will get called on start up. The auth provider's getAuthStatus() method is used to determine if the user is on dotcom and can upgrade (not pro users). 

If so, the default model is selected instead of the last used model that does not associate with the current logged in account status.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. log into cody with a pro account
2. select a pro-only chat model from dropdown and ask cody a question
3. log out of the account 
4. log into cody again with a dot com free user
5. open a new chat to confirm the default chat model is selected instead of the chat model that you have last used with the previous logged in account 