### PR TITLE
skip (instead of hanging indefinitely on) non-text context files

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+import { URI } from 'vscode-uri'
+
+import { type Editor } from '@sourcegraph/cody-shared/src/editor'
+
+import { type ContextItem } from './SimpleChatModel'
+import { contextFilesToContextItems } from './SimpleChatPanelProvider'
+
+import '../../testutils/vscode'
+
+describe('contextFilesToContextItems', () => {
+    test('omits files that could not be read', async () => {
+        // Fixes https://github.com/sourcegraph/cody/issues/2390.
+        const mockEditor: Partial<Editor> = {
+            getTextEditorContentForFile(uri, range) {
+                if (uri.path === '/a.txt') {
+                    return Promise.resolve('a')
+                }
+                throw new Error('error')
+            },
+        }
+        const contextItems = await contextFilesToContextItems(
+            mockEditor as Editor,
+            [
+                {
+                    uri: URI.parse('file:///a.txt'),
+                    fileName: 'a.txt',
+                },
+                {
+                    uri: URI.parse('file:///error.txt'),
+                    fileName: 'error.txt',
+                },
+            ],
+            true
+        )
+        expect(contextItems).toEqual<ContextItem[]>([{ uri: URI.parse('file:///a.txt'), text: 'a' }])
+    })
+})

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -7,6 +7,7 @@
 // TODO: use implements vscode.XXX on mocked classes to ensure they match the real vscode API.
 import fspromises from 'fs/promises'
 
+import type * as vscode_types from 'vscode'
 import type {
     Disposable as VSCodeDisposable,
     InlineCompletionTriggerKind as VSCodeInlineCompletionTriggerKind,
@@ -14,7 +15,6 @@ import type {
     Position as VSCodePosition,
     Range as VSCodeRange,
 } from 'vscode'
-import type * as vscode_types from 'vscode'
 
 import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
@@ -710,8 +710,12 @@ export const vsCodeMocks = {
     TreeItem,
     WorkspaceEdit,
     UIKind,
+    QuickInputButtons,
     Uri,
     languages,
+    env: {
+        uiKind: 1 satisfies vscode_types.UIKind.Desktop,
+    },
     window: {
         showInformationMessage: () => undefined,
         showWarningMessage: () => undefined,


### PR DESCRIPTION
If a file is `@`-mentioned that is inaccessible or unreadable, Cody chat would hang indefinitely. Now, it skips the file, shows the user an error message, and proceeds with the chat response.

The most likely causes for a file being inaccessible or unreadable are: the file is binary, or the file was removed after the user selected it.

Fix https://github.com/sourcegraph/cody/issues/2390.



## Test plan

Added test case.