### PR TITLE
agent: return client-provided anonymous user ID from localStorage

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -20,6 +20,7 @@ import { type TelemetryEventParameters } from '@sourcegraph/telemetry'
 import { type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
 import { activate } from '../../vscode/src/extension.node'
 import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
+import { localStorage } from '../../vscode/src/services/LocalStorageProvider'
 
 import { newTextEditor } from './AgentTextEditor'
 import { AgentWebPanel, AgentWebPanels } from './AgentWebPanel'
@@ -65,7 +66,15 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
         globalState: {
             keys: () => [...globalStorage.keys()],
             get: key => {
-                return globalStorage.get(key)
+                if (globalStorage.has(key)) {
+                    return globalStorage.get(key)
+                }
+                switch (key) {
+                    case localStorage.ANONYMOUS_USER_ID_KEY:
+                        return vscode_shim.extensionConfiguration?.anonymousUserID
+                    default:
+                        return undefined
+                }
             },
             update: (key, value) => {
                 globalStorage.set(key, value)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -66,14 +66,11 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
         globalState: {
             keys: () => [...globalStorage.keys()],
             get: key => {
-                if (globalStorage.has(key)) {
-                    return globalStorage.get(key)
-                }
                 switch (key) {
                     case localStorage.ANONYMOUS_USER_ID_KEY:
                         return vscode_shim.extensionConfiguration?.anonymousUserID
                     default:
-                        return undefined
+                        return globalStorage.get(key)
                 }
             },
             update: (key, value) => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -64,7 +64,7 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
         extensionPath: paths.config,
         extensionUri: vscode.Uri.file(paths.config),
         globalState: {
-            keys: () => [...globalStorage.keys()],
+            keys: () => [localStorage.ANONYMOUS_USER_ID_KEY, ...globalStorage.keys()],
             get: key => {
                 switch (key) {
                     case localStorage.ANONYMOUS_USER_ID_KEY:

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -69,6 +69,8 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
                 switch (key) {
                     case localStorage.ANONYMOUS_USER_ID_KEY:
                         return vscode_shim.extensionConfiguration?.anonymousUserID
+                    case localStorage.LAST_USED_ENDPOINT:
+                        return vscode_shim.extensionConfiguration?.serverEndpoint
                     default:
                         return globalStorage.get(key)
                 }

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -22,7 +22,7 @@ export class LocalStorage {
     // Bump this on storage changes so we don't handle incorrectly formatted data
     protected readonly KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'
     public readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
-    protected readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
+    public readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
     protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected readonly KEY_LAST_USED_RECIPES = 'SOURCEGRAPH_CODY_LAST_USED_RECIPE_NAMES'
 

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -21,7 +21,7 @@ type AccountKeyedChatHistory = {
 export class LocalStorage {
     // Bump this on storage changes so we don't handle incorrectly formatted data
     protected readonly KEY_LOCAL_HISTORY = 'cody-local-chatHistory-v2'
-    protected readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
+    public readonly ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
     protected readonly LAST_USED_ENDPOINT = 'SOURCEGRAPH_CODY_ENDPOINT'
     protected readonly CODY_ENDPOINT_HISTORY = 'SOURCEGRAPH_CODY_ENDPOINT_HISTORY'
     protected readonly KEY_LAST_USED_RECIPES = 'SOURCEGRAPH_CODY_LAST_USED_RECIPE_NAMES'


### PR DESCRIPTION
(From https://github.com/sourcegraph/jetbrains/issues/281#issuecomment-1884680142) 

The [telemetry logger](https://sourcegraph.com/github.com/sourcegraph/cody@85355f1ca72073518ab7adeb1dcc14d14fc1449a/-/blob/vscode/src/services/telemetry.ts?L48-49) was not being created with the anonymous user ID provided by the agent client for events that were created using a singleton [globalAnonymousUserID](https://sourcegraph.com/github.com/sourcegraph/cody@nsc/global-anonymous-user-id/-/blob/vscode/src/services/telemetry.ts?L16). The recipe events dont https://sourcegraph.com/github.com/sourcegraph/cody@85355f1ca72073518ab7adeb1dcc14d14fc1449a/-/blob/agent/src/agent.ts?L327, as well as events created on the jetbrains plugin side (e.g. `CodyInstalled`), but `CodyJetBrainsPlugin:Auth:connected` and others do.

As a result, each agent startup would create a new ID and use that for most of its events instead of the one created by clients.

Disclaimer: no ☕ has been had yet, but I think I've gotten the situation correct here

## Test plan

`console.log` showed `created === true` [here](https://sourcegraph.com/github.com/sourcegraph/cody@85355f1ca72073518ab7adeb1dcc14d14fc1449a/-/blob/vscode/src/services/telemetry.ts?L48) before the change, and false after the change
