### PR TITLE
Agent: add support for client-side progress bars

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -303,6 +303,37 @@ export class Agent extends MessageHandler {
             return thenable
         })
 
+        this.registerRequest('testing/progressCancelation', async ({ title }) => {
+            const message = await vscode.window.withProgress<string>(
+                {
+                    title: 'testing/progressCancelation',
+                    location: vscode.ProgressLocation.Notification,
+                    cancellable: true,
+                },
+                (progress, token) => {
+                    return new Promise<string>((resolve, reject) => {
+                        token.onCancellationRequested(() => {
+                            progress.report({ message: 'before resolution' })
+                            resolve(`request with title '${title}' cancelled`)
+                            progress.report({ message: 'after resolution' })
+                        })
+                        setTimeout(
+                            () =>
+                                reject(
+                                    new Error(
+                                        'testing/progressCancelation did not resolve within 5 seconds. ' +
+                                            'To fix this problem, send a progress/cancel notification with the same ID ' +
+                                            'as the progress/start notification with title "testing/progressCancelation"'
+                                    )
+                                ),
+                            5_000
+                        )
+                    })
+                }
+            )
+            return { result: message }
+        })
+
         this.registerRequest('recipes/list', () =>
             Promise.resolve(
                 Object.values<RecipeInfo>(registeredRecipes).map(({ id, title }) => ({

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -290,6 +290,19 @@ export class Agent extends MessageHandler {
             }
         })
 
+        this.registerRequest('testing/progress', async ({ title }) => {
+            const thenable = await vscode.window.withProgress(
+                { title: 'testing/progress', location: vscode.ProgressLocation.Notification, cancellable: true },
+                progress => {
+                    progress.report({ message: 'message1' })
+                    progress.report({ increment: 50 })
+                    progress.report({ increment: 50 })
+                    return Promise.resolve({ result: `Hello ${title}` })
+                }
+            )
+            return thenable
+        })
+
         this.registerRequest('recipes/list', () =>
             Promise.resolve(
                 Object.values<RecipeInfo>(registeredRecipes).map(({ id, title }) => ({

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -281,6 +281,15 @@ export class Agent extends MessageHandler {
             })
         })
 
+        this.registerNotification('progress/cancel', ({ id }) => {
+            const token = vscode_shim.progressBars.get(id)
+            if (token) {
+                token.cancel()
+            } else {
+                console.error(`progress/cancel: unknown ID ${id}`)
+            }
+        })
+
         this.registerRequest('recipes/list', () =>
             Promise.resolve(
                 Object.values<RecipeInfo>(registeredRecipes).map(({ id, title }) => ({

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -468,47 +468,49 @@ describe('Agent', () => {
             assert(progressID !== undefined, JSON.stringify(client.progressMessages))
             const messages = client.progressMessages
                 .filter(message => message.id === progressID)
-                .map(({ method, message }) => [method, message])
+                .map(({ method, message }) => [method, { ...message, id: 'THE_ID' }])
             expect(messages).toMatchInlineSnapshot(`
-          [
-            [
-              "progress/start",
-              {
-                "id": "ID_0",
-                "options": {
-                  "cancellable": true,
-                  "location": "Notification",
-                  "title": "testing/progress",
-                },
-              },
-            ],
-            [
-              "progress/report",
-              {
-                "id": "ID_0",
-                "message": "message1",
-              },
-            ],
-            [
-              "progress/report",
-              {
-                "id": "ID_0",
-                "increment": 50,
-              },
-            ],
-            [
-              "progress/report",
-              {
-                "id": "ID_0",
-                "increment": 50,
-              },
-            ],
-            [
-              "progress/end",
-              {},
-            ],
-          ]
-        `)
+              [
+                [
+                  "progress/start",
+                  {
+                    "id": "THE_ID",
+                    "options": {
+                      "cancellable": true,
+                      "location": "Notification",
+                      "title": "testing/progress",
+                    },
+                  },
+                ],
+                [
+                  "progress/report",
+                  {
+                    "id": "THE_ID",
+                    "message": "message1",
+                  },
+                ],
+                [
+                  "progress/report",
+                  {
+                    "id": "THE_ID",
+                    "increment": 50,
+                  },
+                ],
+                [
+                  "progress/report",
+                  {
+                    "id": "THE_ID",
+                    "increment": 50,
+                  },
+                ],
+                [
+                  "progress/end",
+                  {
+                    "id": "THE_ID",
+                  },
+                ],
+              ]
+            `)
         })
         it('progress can be cancelled', async () => {
             const disposable = client.progressStartEvents.event(params => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -13,11 +13,32 @@ import type { ExtensionMessage } from '../../vscode/src/chat/protocol'
 
 import { AgentTextDocument } from './AgentTextDocument'
 import { MessageHandler } from './jsonrpc-alias'
-import { type ClientInfo, type ServerInfo } from './protocol-alias'
+import { type ClientInfo, type ProgressReportParams, type ProgressStartParams, type ServerInfo } from './protocol-alias'
+
+type ProgressMessage = ProgressStartMessage | ProgressReportMessage | ProgressEndMessage
+interface ProgressStartMessage {
+    method: 'progress/start'
+    id: string
+    message: ProgressStartParams
+}
+interface ProgressReportMessage {
+    method: 'progress/report'
+    id: string
+    message: ProgressReportParams
+}
+interface ProgressEndMessage {
+    method: 'progress/end'
+    id: string
+    message: {}
+}
 
 export class TestClient extends MessageHandler {
     public info: ClientInfo
     public agentProcess?: ChildProcessWithoutNullStreams
+    // Array of all raw `progress/*` notification. Typed as `any` because
+    // start/end/report have different types.
+    public progressMessages: ProgressMessage[] = []
+    public progressIDs = new Map<string, number>()
 
     constructor(
         public readonly name: string,
@@ -28,10 +49,31 @@ export class TestClient extends MessageHandler {
         this.name = name
         this.info = this.getClientInfo()
 
+        this.registerNotification('progress/start', message => {
+            message.id = this.progressID(message.id)
+            this.progressMessages.push({ method: 'progress/start', id: message.id, message })
+        })
+        this.registerNotification('progress/report', message => {
+            message.id = this.progressID(message.id)
+            this.progressMessages.push({ method: 'progress/report', id: message.id, message })
+        })
+        this.registerNotification('progress/end', ({ id }) => {
+            this.progressMessages.push({ method: 'progress/end', id: this.progressID(id), message: {} })
+        })
         this.registerNotification('debug/message', message => {
             // Uncomment below to see `logDebug` messages.
             // console.log(`${message.channel}: ${message.message}`)
         })
+    }
+
+    private progressID(id: string): string {
+        const fromCache = this.progressIDs.get(id)
+        if (fromCache !== undefined) {
+            return `ID_${fromCache}`
+        }
+        const freshID = this.progressIDs.size
+        this.progressIDs.set(id, freshID)
+        return `ID_${freshID}`
     }
 
     public async initialize() {
@@ -148,6 +190,9 @@ export class TestClient extends MessageHandler {
             version: 'v1',
             workspaceRootUri: workspaceRootUri.toString(),
             workspaceRootPath: workspaceRootUri.fsPath,
+            capabilities: {
+                progressBars: 'enabled',
+            },
             extensionConfiguration: {
                 anonymousUserID: this.name + 'abcde1234',
                 accessToken: this.accessToken ?? 'sgp_RRRRRRRREEEEEEEDDDDDDAAACCCCCTEEEEEEEDDD',
@@ -405,6 +450,62 @@ describe('Agent', () => {
         setTimeout(() => client.notify('$/cancelRequest', { id: client.id - 1 }), 300)
         await client.request('recipes/execute', { id: 'chat-question', humanChatInput: 'How do I implement sum?' })
     }, 600)
+
+    it('progress notifications are sent', async () => {
+        const { result } = await client.request('testing/progress', { title: 'Susan' })
+        expect(result).toStrictEqual('Hello Susan')
+        let progressID: string | undefined
+        for (const message of client.progressMessages) {
+            if (message.method === 'progress/start' && message.message.options.title === 'testing/progress') {
+                progressID = message.message.id
+                break
+            }
+        }
+        assert(progressID !== undefined, JSON.stringify(client.progressMessages))
+        const messages = client.progressMessages
+            .filter(message => message.id === progressID)
+            .map(({ method, message }) => [method, message])
+        expect(messages).toMatchInlineSnapshot(`
+          [
+            [
+              "progress/start",
+              {
+                "id": "ID_0",
+                "options": {
+                  "cancellable": true,
+                  "location": "Notification",
+                  "title": "testing/progress",
+                },
+              },
+            ],
+            [
+              "progress/report",
+              {
+                "id": "ID_0",
+                "message": "message1",
+              },
+            ],
+            [
+              "progress/report",
+              {
+                "id": "ID_0",
+                "increment": 50,
+              },
+            ],
+            [
+              "progress/report",
+              {
+                "id": "ID_0",
+                "increment": 50,
+              },
+            ],
+            [
+              "progress/end",
+              {},
+            ],
+          ]
+        `)
+    })
 
     describe('RateLimitedAgent', () => {
         const rateLimitedClient = new TestClient('rateLimitedClient', process.env.SRC_ACCESS_TOKEN_WITH_RATE_LIMIT)

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -2,6 +2,7 @@
 import { execSync } from 'child_process'
 import path from 'path'
 
+import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 
 // <VERY IMPORTANT - PLEASE READ>
@@ -31,6 +32,7 @@ import {
     ExtensionKind,
     FileType,
     LogLevel,
+    ProgressLocation,
     Range,
     StatusBarAlignment,
     UIKind,
@@ -414,6 +416,8 @@ export function setCreateWebviewPanel(newCreateWebviewPanel: typeof vscode.windo
     shimmedCreateWebviewPanel = newCreateWebviewPanel
 }
 
+export const progressBars = new Map<string, CancellationTokenSource>()
+
 const _window: Partial<typeof vscode.window> = {
     createTreeView: () => defaultTreeView,
     tabGroups,
@@ -443,13 +447,43 @@ const _window: Partial<typeof vscode.window> = {
     registerWebviewViewProvider: () => emptyDisposable,
     createStatusBarItem: () => statusBarItem,
     visibleTextEditors,
-    withProgress: async (_, handler) => {
+    withProgress: async (options, handler) => {
+        const progressClient = clientInfo?.capabilities?.progressBars === 'enabled' ? agent : undefined
+        const id = uuid.v4()
+        const tokenSource = new CancellationTokenSource()
+        const token = tokenSource.token
+        progressBars.set(id, tokenSource)
+        token.onCancellationRequested(() => progressBars.delete(id))
+
+        if (progressClient) {
+            const location = typeof options.location === 'number' ? ProgressLocation[options.location] : undefined
+            const locationViewId = typeof options.location === 'object' ? options.location.viewId : undefined
+            progressClient.notify('progress/start', {
+                id,
+                options: { title: options.title, cancellable: options.cancellable, location, locationViewId },
+            })
+        }
         try {
-            const result = await handler({ report: () => {} }, new CancellationTokenSource().token)
+            const result = await handler(
+                {
+                    report: ({ message, increment }) => {
+                        if (progressClient) {
+                            progressClient.notify('progress/report', { id, message, increment })
+                        }
+                    },
+                },
+                token
+            )
             return result
         } catch (error) {
             console.error('window.withProgress: uncaught error', error)
             throw error
+        } finally {
+            tokenSource.dispose()
+            progressBars.delete(id)
+            if (progressClient) {
+                progressClient.notify('progress/end', { id })
+            }
         }
     },
     onDidChangeActiveTextEditor: onDidChangeActiveTextEditor.event,

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -467,7 +467,7 @@ const _window: Partial<typeof vscode.window> = {
             const result = await handler(
                 {
                     report: ({ message, increment }) => {
-                        if (progressClient) {
+                        if (progressClient && !token.isCancellationRequested) {
                             progressClient.notify('progress/report', { id, message, increment })
                         }
                     },

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -91,6 +91,11 @@ export type Requests = {
     // `chat/submitMessage`.
     'webview/receiveMessage': [{ id: string; message: WebviewMessage }, null]
 
+    // Only used for testing purposes. If you want to write an integration test
+    // for dealing with progress bars then you can send a request to this
+    // endpoint to emulate the scenario where the server creates a progress bar.
+    'testing/progress': [{ title: string }, { result: string }]
+
     // ================
     // Server -> Client
     // ================
@@ -169,7 +174,7 @@ export type Notifications = {
     // on the chat reply.
     'webview/postMessage': [{ id: string; message: ExtensionMessage }]
 
-    'progress/start': [ProgressCreateParams]
+    'progress/start': [ProgressStartParams]
 
     // Update about an ongoing progress bar from progress/create. This
     // notification can only be sent from the server while the progress/create
@@ -378,7 +383,7 @@ export interface DebugMessage {
     message: string
 }
 
-export interface ProgressCreateParams {
+export interface ProgressStartParams {
     /** Unique ID for this operation. */
     id: string
     options: ProgressOptions

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -96,6 +96,10 @@ export type Requests = {
     // endpoint to emulate the scenario where the server creates a progress bar.
     'testing/progress': [{ title: string }, { result: string }]
 
+    // Only used for testing purposes. This operation runs indefinitely unless
+    // the client sends progress/cancel.
+    'testing/progressCancelation': [{ title: string }, { result: string }]
+
     // ================
     // Server -> Client
     // ================

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -150,6 +150,10 @@ export type Notifications = {
     // The chat transcript grows indefinitely if this notification is never sent.
     'transcript/reset': [null]
 
+    // User requested to cancel this progress bar. Only supported for progress
+    // bars with `cancelable: true`.
+    'progress/cancel': [{ id: string }]
+
     // ================
     // Server -> Client
     // ================
@@ -164,6 +168,15 @@ export type Notifications = {
     // chat/new). Subscribe to these messages to get access to streaming updates
     // on the chat reply.
     'webview/postMessage': [{ id: string; message: ExtensionMessage }]
+
+    'progress/start': [ProgressCreateParams]
+
+    // Update about an ongoing progress bar from progress/create. This
+    // notification can only be sent from the server while the progress/create
+    // request has not finished responding.
+    'progress/report': [ProgressReportParams]
+
+    'progress/end': [{ id: string }]
 }
 
 export interface CancelParams {
@@ -224,6 +237,9 @@ export interface ClientCapabilities {
     //  When 'streaming', handles 'chat/updateMessageInProgress' streaming notifications.
     chat?: 'none' | 'streaming'
     git?: 'none' | 'disabled'
+    // If 'enabled', the client must implement the progress/start,
+    // progress/report, and progress/end notification endpoints.
+    progressBars?: 'none' | 'enabled'
 }
 
 export interface ServerInfo {
@@ -360,4 +376,49 @@ export interface ExecuteCommandParams {
 export interface DebugMessage {
     channel: string
     message: string
+}
+
+export interface ProgressCreateParams {
+    /** Unique ID for this operation. */
+    id: string
+    options: ProgressOptions
+}
+export interface ProgressReportParams {
+    /** Unique ID for this operation. */
+    id: string
+    /** (optional) Text message to display in the progress bar */
+    message?: string
+    /**
+     * (optional) increment to indicate how much percentage of the total
+     * operation has been completed since the last report. The total % of the
+     * job that is complete is the sum of all published increments. An increment
+     * of 10 indicates '10%' of the progress has completed since the last
+     * report. Can never be negative, and total can never exceed 100.
+     */
+    increment?: number
+}
+export interface ProgressOptions {
+    /**
+     * A human-readable string which will be used to describe the
+     * operation.
+     */
+    title?: string
+    /**
+     * The location at which progress should show.
+     * Either `location` or `locationViewId` must be set
+     */
+    location?: string // one of: 'SourceControl' | 'Window' | 'Notification'
+    /**
+     * The location at which progress should show.
+     * Either `location` or `locationViewId` must be set
+     */
+    locationViewId?: string
+
+    /**
+     * Controls if a cancel button should show to allow the user to
+     * cancel the long running operation.  Note that currently only
+     * `ProgressLocation.Notification` is supporting to show a cancel
+     * button.
+     */
+    cancellable?: boolean
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/257

Previously, the agent didn't support rendering progress bars on the client. This was problematic because symf symbol uses progress bars to inform the user when symf is indexing, and allows users to cancel indexing. This PR closes this feature gap by adding four new JSON-RPC notification endpoints to the agent protocol to deal with progress bars:

* `progress/start`: server to client.
* `progress/report`: server to client.
* `progress/end`: server to client.
* `progress/end`: client to server. Only valid for cancelable progress bars.

Agent clients must add `progressBars: 'enabled'` to the client capabilities during the `initalize` handshake to receive progress-related notifications.

Additionally, to help clients with testing progress bars, there are two new testing-related JSON-RPC endpoints

* `testing/progress`. Client request to server.
* `testing/progressCancelation`. Client request to server.

This PR adds two test cases that demonstrate how progress bars work, including how to cancel a progress bar.

## Test plan

See two new test cases for progress bars.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
