### PR TITLE
Autocomplete: hide ollama settings

### DIFF
--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -7,8 +7,6 @@ import type {
 } from '@sourcegraph/cody-shared/src/configuration'
 import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 
-import packageJson from '../package.json'
-
 import { CONFIG_KEY, getConfigEnumValues, type ConfigKeys, type ConfigurationKeysMap } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'
 import { getAccessToken } from './services/SecretStorageProvider'
@@ -116,10 +114,10 @@ export function getConfiguration(config: ConfigGetter = vscode.workspace.getConf
         ),
 
         autocompleteExperimentalHotStreak: getHiddenSetting('autocomplete.experimental.hotStreak', false),
-        autocompleteExperimentalOllamaOptions: config.get(
-            CONFIG_KEY.autocompleteExperimentalOllamaOptions,
-            packageJson.contributes.configuration.properties['cody.autocomplete.experimental.ollamaOptions'].default
-        ),
+        autocompleteExperimentalOllamaOptions: getHiddenSetting('autocomplete.experimental.ollamaOptions', {
+            url: 'http://localhost:11434',
+            model: 'codellama:7b-code',
+        }),
 
         // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
         // We currently use this flag for the agent to provide more helpful error messages


### PR DESCRIPTION
## Context

- The stable release Typescript build fails because we remove experimental settings from the `package.json`. 
- Follow-up: we need to run a dry-run release as a CI check.

## Test plan

`cd vscode && CODY_RELEASE_TYPE=stable pnpm release:dry-run`
