### PR TITLE
DX: add `pnpm -C vscode run release:dry-run` to the CI build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm -C vscode run build
+      - run: pnpm -C vscode run release:dry-run
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm -C vscode run build
-      - run: pnpm -C vscode run release:dry-run
+      - run: CODY_RELEASE_TYPE=stable pnpm -C vscode run release:dry-run
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

- Adds vscode release dry-run command to the CI build check to ensure it always succeeds on main.

## Test plan

CI
