### PR TITLE
fix: remove codyProEnabled field from GraphQL API call

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -144,6 +144,8 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -244,6 +246,8 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1273,6 +1277,8 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2293,6 +2299,8 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2728,6 +2736,8 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2841,6 +2851,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2929,8 +2941,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 134
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmV","Pj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//","AwAfFAXARQAAAA=="]'
+          size: 128
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  provider: sourcegraph
         cookies: []
         headers:
           - name: date
@@ -2941,6 +2958,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2975,7 +2994,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4ae74ba5fbde655d9886623eddcc0d04
+    - _id: b97b51a84cc5c39d12d228fd1e107fa1
       _order: 0
       cache: {}
       request:
@@ -2995,7 +3014,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "251"
+            value: "227"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -3020,7 +3039,6 @@ log:
                       displayName
                       username
                       avatarURL
-                      codyProEnabled
                       primaryEmail {
                           email
                       }
@@ -3035,19 +3053,18 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 312
-          text: '["H4sIAAAAAAAAAzxOXUrDQBi8Spnn0ESsoAtiHyx9kVCEFn38mv2abNnshm93CzHkFJ7As/RiEqO+zQzzN0BTJKgBVRJhF/eBZaJGQ+HwVtrq7D/K5/c7ZGgoHFjMybDetGQsVJTEGbQJnaW+pJahcP20dEqy2F2/rF1s2UgI3iFDCixu9vgfS1cjA10okuxfX6DQxNgFleezFoplbWKTjlOw8i6yi8vKt3nKb1bFffFw+3R5XCFD5XW/E79xdLSs/151YlqS/vfpAJ7B//a6noSpEOM4jt8AAAD//wMAddiLlAoBAAA="]'
+          size: 228
+          text: '["H4sIAAAAAAAAA2SMywrCMBRE/2XWURB3gYIu3NkuhBa3l+TapiRNuWmEUvrv4gsEd3OGM7PA0kTQC0wW4WGqE8sTnYVGc6286eO+7NtdeSwKKHSUGhZ3c2xPgZyHniSzgnVp9DRXFBh6yN4r5MQyvBgpZjHcCo3dxkaToEB3mkjqy/mrj+ICyfx5XcDv8Lc9/BRbEwPWdV0fAAAA//8DAGZSkGHIAAAA"]'
           textDecoded:
             data:
               currentUser:
-                avatarURL: https://avatars0.githubusercontent.com/u/1408093?v=4
-                codyProEnabled: true
-                displayName: Ólafur Páll Geirsson
+                avatarURL: null
+                displayName: null
                 hasVerifiedEmail: true
-                id: VXNlcjozNDY5
+                id: VXNlcjo3Mjg1MA==
                 primaryEmail:
-                  email: olafurpg@gmail.com
-                username: olafurpg
+                  email: sourcegraph-docs@sourcegraph.com
+                username: sourcegraph-docs
         cookies: []
         headers:
           - name: date
@@ -3058,6 +3075,112 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: fb21b36f1f7c652617e0a9e8c3d194a3
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "101"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUser {
+                  currentUser {
+                      codyProEnabled
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUser
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUser
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 100
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJz81MqA4ryXfMSk3JSU5Ss0hJzilNra2sBAAAA//8DAFJUb/wxAAAA"]'
+          textDecoded:
+            data:
+              currentUser:
+                codyProEnabled: false
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3154,6 +3277,8 @@ log:
             value: "38"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3248,6 +3373,8 @@ log:
             value: "37"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3342,6 +3469,8 @@ log:
             value: "38"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3436,6 +3565,8 @@ log:
             value: "38"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3530,6 +3661,8 @@ log:
             value: "37"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3615,91 +3748,45 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 808
-          text: '["H4sIAAAAAAAA/6xVW3LjOAy8i76DC/gAucTWfoAgLGFNkQoA2tamcvcpyplHHpQnNfOnKoFgo9HdfB4iOg6H54HPmCo6x0dGr8qPCUcbDv88DxlnHg4DlbgCVi9U5iWxM1DJzleHcBxhlivH4WFoXXg4HDEZvzy8PUwTOsyFTuBs/rPYtf5aO+pC8H/hU7/EGJUmiBzq2L+UM4bEYK6Ms+QRRnEIqf3sNf44ZOQj1uRgjkolssK0BpUIVqoSj4rL1IdQFs7t1Luyz269cABM6SvQ1oyzEMw1uSTJbSPbLynZ+pheySuXzGqTLLuL2IfD14VVZs6OfeCv991ou1elmE+Sx24ZErGZtL0eJTG4cn+bGOAsJl4UvFSFi/gEuTiHUk72F0TQbbFoiZUcrAYjlWVbCShjO2usZyEGJCo1+x3XvAGSMI8Vx/bhnGndn2HR0ucmzpIBM6bVhQwIaWKIYs0zd5zcbfpUhU4bS35j/Fi0DTBxdqGWLlCNdUecIZUAS5vQLuI0ASqjgU1Fnar3l/Z+npv57+ot8wVOvF6K7s6cXdH85i/B7GBrdrzCJOOUZJz8jWY7jpO8VG+jXGAS86J9Ij/Xzx8IxxVpF+OPDGopfT+pTCIH1G6hYlOrzOIGfCXmyHFTQ4v+3wPCcXOuMsnCX3LrTcTt5EqpBX85wqJ8llKbCZ8qm+9o0DnxzK5bvhXdeYZkzHUBq3rm9aPiPr5HN/lDyaGgxr2c++5f+I89KEruE/Cqru01zg4BjeMWFBDZmZp03mP69+XlWwAAAP//aJAjBPoHAAA="]'
+          size: 444
+          text: '["H4sIAAAAAAAAA5STXU7DMAzH75Ln+QI9wC6BeHATr7GWxsV26Kppd0eFCdjQOvGcX/z/cHIOCR1Ddw70jqWhU9oTelPaFxwsdC/nUHGk0IUoaYGZeogZPezCylPoDliMLru/GJbyQ7m235ARasxQaYYjLbNoejzwrXE8gjmqg0tTOIgCNs9UnePqGJqR2uMJVL8QkNoLauI6PHT2bd84UY+6AVZXNIco41QYq4Mt1fEEmYdceMh+o3Nvqi/Sw4QDgc3sMQMqoYFlUY/N7UnD2Fw+lckJXDFuijkVGsl1ATpNor4df1J53g8ldlFQijyRbfM3ZtNSceQIYyvOhSvB9YilbqTGNHIFrFgW52gQMWaCxIZ9ofSfttbN0cmhPwww8mnr8vWdylxJLfO0HXP9GDBKPIKT3Xf8erl8AAAA//8DAME7td9tAwAA"]'
           textDecoded:
             data:
               evaluatedFeatureFlags:
-                - name: cody-autocomplete-context-bfg-mixed
+                - name: cody-web-chat
                   value: false
-                - name: cody-chat-mock-test
-                  value: true
-                - name: grpc-zoekt
-                  value: true
-                - name: search-debug
-                  value: false
-                - name: enable-streaming-git-blame
-                  value: true
-                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
-                  value: false
-                - name: opencodegraph
-                  value: true
                 - name: cody-web-all
-                  value: true
-                - name: cody-autocomplete-dynamic-multiline-completions
-                  value: false
-                - name: search-ownership
-                  value: true
-                - name: grpc
-                  value: true
-                - name: cody-experimental
-                  value: true
-                - name: search-hybrid
-                  value: true
-                - name: search-ranking
-                  value: true
-                - name: accessible-file-tree
-                  value: true
-                - name: ab-visitor-tour-with-notebooks
-                  value: true
-                - name: cody-autocomplete-default-starcoder-hybrid
-                  value: true
-                - name: product-subscriptions-reader-service-account
-                  value: false
-                - name: cody-autocomplete-language-latency
-                  value: true
-                - name: cody-pro
-                  value: true
-                - name: admin-analytics-cache-disabled
-                  value: false
-                - name: cody
-                  value: true
-                - name: quick-start-tour-for-authenticated-users
-                  value: false
-                - name: blob-page-switch-areas-shortcuts
-                  value: true
-                - name: admin-analytics-enabled
                   value: true
                 - name: search-new-keyword
                   value: false
-                - name: contrast-compliant-syntax-highlighting
-                  value: false
-                - name: search-input-show-history
-                  value: true
-                - name: product-subscriptions-service-account
-                  value: false
-                - name: cody-autocomplete-tracing
-                  value: false
-                - name: cody-web-chat
-                  value: true
-                - name: cody-web-sidebar
-                  value: true
-                - name: rate-limits-exceeded-for-testing
-                  value: false
-                - name: cody-web-editor-recipes
-                  value: true
-                - name: cody-autocomplete-disable-recycling-of-previous-requests
-                  value: false
-                - name: telemetry-export
-                  value: true
-                - name: signup-survey-enabled
+                - name: quick-start-tour-for-authenticated-users
                   value: false
                 - name: end-user-onboarding
                   value: true
-                - name: cody-pro-jetbrains
+                - name: cody-web-sidebar
                   value: true
-                - name: search-content-based-lang-detection
+                - name: contrast-compliant-syntax-highlighting
                   value: false
+                - name: blob-page-switch-areas-shortcuts
+                  value: false
+                - name: cody-autocomplete-tracing
+                  value: false
+                - name: telemetry-export
+                  value: true
+                - name: cody-pro
+                  value: true
+                - name: cody-web-editor-recipes
+                  value: true
+                - name: cody-autocomplete-dynamic-multiline-completions
+                  value: false
+                - name: admin-analytics-cache-disabled
+                  value: false
+                - name: cody-autocomplete-context-bfg-mixed
+                  value: false
+                - name: search-ownership
+                  value: true
+                - name: cody-chat-mock-test
+                  value: true
         cookies: []
         headers:
           - name: date
@@ -3710,14 +3797,14 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
             value: no-cache, max-age=0
-          - name: content-encoding
-            value: gzip
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
@@ -3729,6 +3816,8 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
         headersSize: 0
         httpVersion: HTTP/1.1
         redirectURL: ""
@@ -3823,6 +3912,8 @@ log:
             value: "26"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3934,6 +4025,8 @@ log:
             value: "26"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4045,6 +4138,8 @@ log:
             value: "26"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4156,6 +4251,8 @@ log:
             value: "26"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4188,7 +4285,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ec06b949e0d75e4eb04074a0df35dff6
+    - _id: 034a673937c6196287e0d760ff5ab207
       _order: 0
       cache: {}
       request:
@@ -4242,7 +4339,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4268,6 +4365,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4302,7 +4401,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c63cf23de38703e896ef70b35a6908a4
+    - _id: 869d103f953a0c3190caf0857cab1466
       _order: 0
       cache: {}
       request:
@@ -4356,7 +4455,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4365,8 +4464,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 115
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          size: 119
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -4377,6 +4476,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4411,7 +4512,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 2ef7fccc71a44596d2ffab65eca5f035
+    - _id: 88de2cce28b0ab84962bfbe9854f95ab
       _order: 0
       cache: {}
       request:
@@ -4465,7 +4566,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4474,13 +4575,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 112
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          size: 119
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -4491,6 +4587,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4525,7 +4623,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 3b9f0cc55d63ad6a017ac63464de0a20
+    - _id: faf7a884bd11f3160cb539ee68fa2173
       _order: 0
       cache: {}
       request:
@@ -4579,7 +4677,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4605,6 +4703,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4639,7 +4739,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8b1d3e6611c711a5af2e145069c311ac
+    - _id: eed92b456f519c7972e07cb5478a1c63
       _order: 0
       cache: {}
       request:
@@ -4693,7 +4793,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4702,8 +4802,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 122
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 119
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -4714,6 +4814,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4748,7 +4850,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e455862587078970fe60174ad1452e99
+    - _id: 49781905e735793580db84a00e44fbdf
       _order: 0
       cache: {}
       request:
@@ -4802,7 +4904,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4811,8 +4913,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 115
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
         cookies: []
         headers:
           - name: date
@@ -4823,6 +4930,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4928,6 +5037,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -5031,6 +5142,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -5141,6 +5254,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -5227,8 +5342,12 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 142
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp","pcklYalFxZn5eUpWSkam5sYmBvFGBkYmugaGuoYG8aZ6RroplmapickGxknGZklKtbW1AAAAAP//","AwArauoHSQAAAA=="]'
+          size: 136
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5sYmBvFGBkYmugaGuoYG8aZ6RroplmapickGxknGZklKtbW1AAAAAP//AwArauoHSQAAAA=="]'
+          textDecoded:
+            data:
+              site:
+                productVersion: 257340_2024-01-10_5.2-d96eac03b36b
         cookies: []
         headers:
           - name: date
@@ -5239,6 +5358,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin

--- a/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
+++ b/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
@@ -57,27 +57,27 @@ log:
             value: "0"
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
             value: no-cache, max-age=0
-          - name: retry-after
-            value: "0"
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
           - name: x-cloud-trace-context
-            value: 761506b7800fcf009150738c61f91f18
+            value: 84a8b2f36bd6a381b80cbf525d971426
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-is-cody-pro-user
-            value: "true"
+            value: "false"
           - name: x-ratelimit-limit
             value: "1"
           - name: x-ratelimit-remaining
@@ -158,8 +158,18 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 222
-          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UF","jiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//w==","AwCpmMLNBAEAAA=="]'
+          size: 212
+          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA="]'
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  chatModel: anthropic/claude-2.0
+                  chatModelMaxTokens: 12000
+                  completionModel: anthropic/claude-instant-1
+                  completionModelMaxTokens: 9000
+                  fastChatModel: anthropic/claude-instant-1
+                  fastChatModelMaxTokens: 9000
         cookies: []
         headers:
           - name: date
@@ -170,6 +180,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -258,8 +270,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 131
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmV","Pj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
+          size: 128
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  provider: sourcegraph
         cookies: []
         headers:
           - name: date
@@ -270,6 +287,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -304,7 +323,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4ae74ba5fbde655d9886623eddcc0d04
+    - _id: b97b51a84cc5c39d12d228fd1e107fa1
       _order: 0
       cache: {}
       request:
@@ -324,7 +343,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "251"
+            value: "227"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -349,7 +368,6 @@ log:
                       displayName
                       username
                       avatarURL
-                      codyProEnabled
                       primaryEmail {
                           email
                       }
@@ -364,19 +382,18 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 360
-          text: '["H4sIAAAAAAAAA2yPy0rEMBSG3+Wse0EchxoYsOgsBqTepkVXw2lybDOmTSdJg23pw/gsvpiU0Z27/8IP3z+BQIfAJuC9MdS63JJZrBTAoHjNFD/qz4d9fpGNfAMB1GgLMvJdktg2KBUwZ3oKQEjbKRwybAgY3H1/eSkggN6Sac+ZQC9F5MmOpLS344eEANCjQ5M/3wOD2rnOsjhW9WVUaV0pWtZct45aF3HdxBint1Wi+S5dhfqgku4U9uExrV/UTl+t9uapcEmxprdy9KemD+tDubHX65BDAFyL4dHobYulIvFH3RnZoBl+n0xAZ/EP6021VAsFzPM8/wAAAP//AwB6yrPiOAEAAA=="]'
+          size: 344
+          text: '["H4sIAAAAAAAAA2yO3U6DQBSE3+Vc8xNtbNpNmkis8a9iokLRu8PuEdYuLNldsIXwMD6LL2YIXno3M18mMwMIdAhsAN4aQ7VLLJnJSgEM0ixW/FMfn16T88dttAEPSrQpGfkhSVxXKBUwZ1ryQEjbKDzFWBEw2P58d1KAB60lU89ZR7YnpTvbH2QgcObYoUOTPO+AQelcY1kYqnIRFFoXiqY217Wj2gVcVyGG0VWx0nx393bfLw5f5ujUyq99yvZF/pKny9s4u3lXuooeLtb5XpyVG7te+hw8aIys0Jz+Pg9As/jn1WUxoWkPxnEcfwEAAP//AwCyKDmxIgEAAA=="]'
           textDecoded:
             data:
               currentUser:
-                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocIA4-o_l8pq-u-jAhSlIo54TrQVt8V6eYbzvqmu-h_b=s96-c
-                codyProEnabled: true
+                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocLIYJz3kwrxtl8-n-eXWgbSbV6HNXGZlomAK59bWd1h=s96-c
                 displayName: Dávid
                 hasVerifiedEmail: true
-                id: VXNlcjoxOTU1Nzc=
+                id: VXNlcjoxOTU2MDA=
                 primaryEmail:
-                  email: david.veszelovszki@gmail.com
-                username: david.veszelovszki
+                  email: veszelovszki.david@gmail.com
+                username: veszelovszki.david
         cookies: []
         headers:
           - name: date
@@ -387,6 +404,112 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: fb21b36f1f7c652617e0a9e8c3d194a3
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "101"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query CurrentUser {
+                  currentUser {
+                      codyProEnabled
+                  }
+              }
+            variables: {}
+        queryString:
+          - name: CurrentUser
+            value: null
+        url: https://sourcegraph.com/.api/graphql?CurrentUser
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 100
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJz81MqA4ryXfMSk3JSU5Ss0hJzilNra2sBAAAA//8DAFJUb/wxAAAA"]'
+          textDecoded:
+            data:
+              currentUser:
+                codyProEnabled: false
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -483,6 +606,8 @@ log:
             value: "38"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -577,6 +702,8 @@ log:
             value: "37"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -671,6 +798,8 @@ log:
             value: "38"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -765,6 +894,8 @@ log:
             value: "38"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -850,40 +981,50 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 452
-          text: '["H4sIAAAAAAAAA6ySW27jMAxF96LvcgNZQDcxmA9aupbYypKHpBIbQfZeNBhgXo2LAvOt++A90DUkdg6na8CZ62BHegb7UDxXzhZO366h8YJwCrGnnXh4j31ZKxwUe3NsTtOcaZENKTyF9xSE08zVcHs6MLtylJYfWxwVC1x3wrZ29V9K1/G7cKp9opUzyC7isRAr2MhKV4/D7XGFSW5jJRt6xk5oPNWvjUiYeVQnc9bYE5TKPqkksj40Iiuv5ZO8WNhp6fGVHOaPxcoOqrKIG2GLQEKiuevd9gfIv/B8cLXY+1JSxD1WaZn6TKviLH0YKX4M2BG2e+KqnV7gk7I0e1huYI2FGi70iv3S9b/gPd66aj8QNFc2p3uHcHOyvTlvVCSXKrn44af84Ma98SKRllFdqjTQzyfp7R+G32+3NwAAAP//AwAy+I6XcgMAAA=="]'
+          size: 524
+          text: '["H4sIAAAAAAAAA6ySUW7cMAxE76Lv8AJ7gFyi6ActjWU1suiS1K6Nxd49cJqkSYrsYoH+CRA5HD7OOSR2DodzwJFrZ0d6BHtXPFbOFg4/zqHxjHAIBtY4UcLQc3gIeznCYeRquDy8V0VJG8WJnWaJT+Qwv1HM3SXKvFQ4KG2N5xJp7tVLLQ30+lWk2T1CUZpjdRrGTHNZke5ygZF7dTJnjZKgNG2DlkQmXSOy8jL9D72/Gq79o8Qr65clmtPAhkSVW6YER9xp3DN/7+yc94ejxe3buY6KGa4bYV1E/ZbBhhM9YTuJXuXbXNn8zykLNyfbmvNKU8lTLXny0vJdPIvxUEGKuMVaWiYZaVEci3Qjxe8O81txWVToF3xQLh+j9WVR5Z1fmYsbYY1AQqJR9CXZn2x/aXyb8T3CkltfyLoesRHavlG6LvcJgivHq9zQEnWDkrRBWNM1t7Kg7cm8Ee2hykDLniQ7FY8TsYKNbBL12P9F/vNyeQYAAP//AwA/9+8XYgQAAA=="]'
           textDecoded:
             data:
               evaluatedFeatureFlags:
-                - name: cody-autocomplete-context-bfg-mixed
-                  value: false
-                - name: cody-autocomplete-tracing
-                  value: false
-                - name: telemetry-export
-                  value: true
-                - name: blob-page-switch-areas-shortcuts
-                  value: false
-                - name: signup-survey-enabled
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
+                - name: search-debug
                   value: false
                 - name: cody-chat-mock-test
                   value: false
-                - name: rate-limits-exceeded-for-testing
+                - name: cody-autocomplete-dynamic-multiline-completions
+                  value: false
+                - name: cody-autocomplete-context-bfg-mixed
+                  value: false
+                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
+                  value: false
+                - name: cody-autocomplete-default-starcoder-hybrid
                   value: true
+                - name: search-content-based-lang-detection
+                  value: false
+                - name: cody-autocomplete-language-latency
+                  value: true
+                - name: telemetry-export
+                  value: true
+                - name: search-new-keyword
+                  value: false
+                - name: contrast-compliant-syntax-highlighting
+                  value: false
                 - name: cody-autocomplete-disable-recycling-of-previous-requests
                   value: false
                 - name: cody-pro-jetbrains
                   value: true
-                - name: search-new-keyword
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid
+                - name: rate-limits-exceeded-for-testing
                   value: true
                 - name: cody-pro
                   value: true
-                - name: contrast-compliant-syntax-highlighting
+                - name: signup-survey-enabled
+                  value: true
+                - name: cody-autocomplete-tracing
                   value: false
-                - name: cody-autocomplete-dynamic-multiline-completions
+                - name: end-user-onboarding
+                  value: true
+                - name: opencodegraph
+                  value: false
+                - name: blob-page-switch-areas-shortcuts
                   value: false
         cookies: []
         headers:
@@ -895,6 +1036,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1008,6 +1151,8 @@ log:
             value: "26"
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1040,7 +1185,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8b1d3e6611c711a5af2e145069c311ac
+    - _id: eed92b456f519c7972e07cb5478a1c63
       _order: 0
       cache: {}
       request:
@@ -1094,7 +1239,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -1120,6 +1265,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1154,7 +1301,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c63cf23de38703e896ef70b35a6908a4
+    - _id: 869d103f953a0c3190caf0857cab1466
       _order: 0
       cache: {}
       request:
@@ -1208,7 +1355,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.0.5
+                    clientVersion: 1.1.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -1217,13 +1364,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 112
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          size: 119
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1324,8 +1466,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 151
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q","BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
+          size: 148
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
+          textDecoded:
+            data:
+              repository:
+                embeddingExists: true
+                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
         cookies: []
         headers:
           - name: date
@@ -1336,6 +1483,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1423,12 +1572,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 120
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
-          textDecoded:
-            data:
-              repository:
-                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
+          size: 123
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//","AwDHAhygPQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1439,6 +1584,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1549,6 +1696,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1635,8 +1784,12 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 142
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp","pcklYalFxZn5eUpWSkam5sYmBvFGBkYmugaGuoYG8aZ6RroplmapickGxknGZklKtbW1AAAAAP//","AwArauoHSQAAAA=="]'
+          size: 136
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5sYmBvFGBkYmugaGuoYG8aZ6RroplmapickGxknGZklKtbW1AAAAAP//AwArauoHSQAAAA=="]'
+          textDecoded:
+            data:
+              site:
+                productVersion: 257340_2024-01-10_5.2-d96eac03b36b
         cookies: []
         headers:
           - name: date
@@ -1647,6 +1800,8 @@ log:
             value: chunked
           - name: connection
             value: close
+          - name: retry-after
+            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -75,7 +75,6 @@ interface CurrentUserInfoResponse {
         displayName?: string
         username: string
         avatarURL: string
-        codyProEnabled: boolean | null
         primaryEmail?: { email: string } | null
     } | null
 }
@@ -186,7 +185,6 @@ export interface CurrentUserInfo {
     username: string
     displayName?: string
     avatarURL: string
-    codyProEnabled: boolean | null
     primaryEmail?: { email: string } | null
 }
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -6,7 +6,7 @@ query CurrentUser {
 }`
 
 export const CURRENT_USER_CODY_PRO_ENABLED_QUERY = `
-query CurrentUser {
+query CurrentUserCodyProEnabled {
     currentUser {
         codyProEnabled
     }

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -20,7 +20,6 @@ query CurrentUser {
         displayName
         username
         avatarURL
-        codyProEnabled
         primaryEmail {
             email
         }

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,12 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## [1.1.1]
+
+### Fixed
+
+- Fixed authentication issue when trying to connect to an enterprise instance. [pull/2667](https://github.com/sourcegraph/cody/pull/2667)
+
 ## [1.1.0]
 
 ### Added

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -271,7 +271,6 @@ export class AuthProvider {
             }
             return { ...unauthenticatedStatus, endpoint }
         }
-
         const userCanUpgrade =
             isDotCom &&
             'codyProEnabled' in proStatus &&

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -262,6 +262,7 @@ export class AuthProvider {
         }
 
         const isCodyEnabled = true
+        const proStatus = await this.client.getCurrentUserCodyProEnabled()
 
         // check first if it's a network error
         if (isError(userInfo)) {
@@ -273,9 +274,9 @@ export class AuthProvider {
 
         const userCanUpgrade =
             isDotCom &&
-            'codyProEnabled' in userInfo &&
-            typeof userInfo.codyProEnabled === 'boolean' &&
-            !userInfo.codyProEnabled
+            'codyProEnabled' in proStatus &&
+            typeof proStatus.codyProEnabled === 'boolean' &&
+            !proStatus.codyProEnabled
 
         return newAuthStatus(
             endpoint,

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -183,6 +183,17 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
                     })
                 )
                 break
+            case 'CurrentUserCodyProEnabled':
+                res.send(
+                    JSON.stringify({
+                        data: {
+                            currentUser: {
+                                codyProEnabled: false,
+                            },
+                        },
+                    })
+                )
+                break
             case 'IsContextRequiredForChatQuery':
                 res.send(JSON.stringify({ data: { isContextRequiredForChatQuery: false } }))
                 break

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -172,7 +172,6 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
                             currentUser: {
                                 id: 'u',
                                 hasVerifiedEmail: true,
-                                codyProEnabled: false,
                                 displayName: 'Person',
                                 username: 'person',
                                 avatarURL: '',


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1704927255975299

Fix issues where enterprise users are unable to login due when on an older version of Sourcegraph.

Remove codyProEnabled field from GraphQL API call as it's used for both enterprise and dot com users, which does not exist in older enterprise instances.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

updating tests