### PR TITLE
Fixing Steal Cursor Issue

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -274,7 +274,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
         if (autoFocus) {
             inputRef.current?.focus()
         }
-    }, [autoFocus, value, chatModels])
+    }, [autoFocus, value])
 
     // Focus the textarea when the webview gains focus (unless there is text selected). This makes
     // it so that the user can immediately start typing to Cody after invoking `Cody: Focus on Chat


### PR DESCRIPTION
Issue: https://github.com/sourcegraph/cody/issues/2669

The current build of Cody has an issue where the cursor is stolen many times because of a rerendering of some sort for auth, this makes cody very hard to use for anything as you can barely type.

Original PR that introduced this https://github.com/sourcegraph/cody/pull/2665

I actually do not know how the PR works so I added a throttle mechanism to stop the rerendering for 5 minutes(300 seconds) so that it doesn't make a super terrible UX. 

My aim is to merge this HACK for now and then do a proper fix later with @abeatrix 



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
