### PR TITLE
send transcript data as `privateMetadata` for v2 telemetry only

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -236,7 +236,7 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                 const responseText = this.isDotComUser ? text : undefined
                 telemetryService.log(
                     'CodyVSCodeExtension:chatResponse:hasCode',
-                    { ...codeCount, ...metadata, requestID, responseText },
+                    { ...codeCount, ...metadata, requestID },
                     { hasV2Event: true }
                 )
 
@@ -247,6 +247,10 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
                         {
                             metadata: {
                                 ...codeCount,
+                            },
+                            privateMetadata: {
+                                ...metadata,
+                                responseText,
                             },
                         }
                     )
@@ -460,9 +464,13 @@ export abstract class MessageProvider extends MessageHandler implements vscode.D
         }
 
         const promptText = this.isDotComUser ? interaction.getHumanMessage().text : undefined
-        const properties = { contextSummary, source, requestID, chatModel: this.chatModel, promptText }
+        const properties = { contextSummary, source, requestID, chatModel: this.chatModel }
         telemetryService.log(`CodyVSCodeExtension:${recipe.id}:recipe-used`, properties, { hasV2Event: true })
-        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'recipe-used', { metadata: { ...contextSummary } })
+        // only include transcript data in v2 telemetry(telemtryRecorder) and as privateMetadata
+        telemetryRecorder.recordEvent(`cody.recipe.${recipe.id}`, 'recipe-used', {
+            metadata: { ...contextSummary },
+            privateMetadata: { promptText },
+        })
     }
 
     protected async runRecipeForSuggestion(

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -646,8 +646,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
                 const properties = {
                     requestID,
                     chatModel: this.chatModel.modelID,
-                    // 🚨 SECURITY: included only for DotCom users.
-                    promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
                     contextSummary,
                 }
 
@@ -658,6 +656,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
                     })
                     telemetryRecorder.recordEvent('cody.chat-question', 'executed', {
                         metadata: { ...contextSummary },
+                        // 🚨 SECURITY: included only for DotCom users.
+                        privateMetadata: {
+                            properties,
+                            promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
+                        },
                     })
                 }
             },
@@ -946,6 +949,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
             telemetryRecorder.recordEvent('cody.chatResponse.new', 'hasCode', {
                 metadata: {
                     ...codeCount,
+                },
+                privateMetadata: {
+                    requestID,
+                    responseText: rawResponse,
                 },
             })
         }

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -60,6 +60,7 @@ function updateGlobalInstances(updatedProvider: TelemetryRecorderProvider & { no
                     event.action
                 }: ${JSON.stringify({
                     parameters: event.parameters,
+                    private: event.privateMetadata,
                     timestamp: event.timestamp,
                 })}`
             )


### PR DESCRIPTION
updates telemetry to only send transcript data on v2 telemetry and removes sending it for v1. This part of a bigger pipeline to isolate these transcripts in their own gcs bucket and subscriptions


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
