### PR TITLE
show context files explicitly included (@-mentioned) by user

### DIFF
--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -30,10 +30,6 @@ export const EnhancedContext: React.FunctionComponent<{
         if (uniqueFiles.has(file.fileName)) {
             return false
         }
-        // Skip files added by user. e.g. @-files
-        if (file.source === 'user') {
-            return false
-        }
         uniqueFiles.add(file.fileName)
         return true
     })

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -89,8 +89,8 @@ test('@-file empty state', async ({ page, sidebar }) => {
         )
     ).toBeVisible()
 
-    // Also ensure explicitly @-included context is not showing up as enhanced context
-    await expect(chatPanelFrame.getByText(/^✨ Context:/)).not.toBeVisible()
+    // Ensure explicitly @-included context shows up as enhanced context
+    expect(await chatPanelFrame.getByText(/^✨ Context:/).count()).toEqual(2)
 
     // Check pressing tab after typing a complete filename.
     // https://github.com/sourcegraph/cody/issues/2200


### PR DESCRIPTION
It is confusing if these are not shown because the user thinks that the file they *most* wanted is not included in Cody's context.

Discussion: https://sourcegraph.slack.com/archives/C05AGQYD528/p1704952995626909



## Test plan

- `@`-mention a file and ensure it's mentioned in the EnhancedContext