### PR TITLE
VSCode: Remove close button from Enhanced Context Settings popup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,8 +531,8 @@ importers:
         specifier: ^3.7.3
         version: 3.7.3
       '@playwright/test':
-        specifier: ^1.33.0
-        version: 1.33.0
+        specifier: 1.39.0
+        version: 1.39.0
       '@pollyjs/adapter-node-http':
         specifier: ^6.0.6
         version: 6.0.6
@@ -648,8 +648,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       playwright:
-        specifier: ^1.33.0
-        version: 1.33.0
+        specifier: 1.39.0
+        version: 1.39.0
       progress:
         specifier: ^2.0.3
         version: 2.0.3
@@ -4890,14 +4890,12 @@ packages:
       playwright-core: 1.39.0
     dev: true
 
-  /@playwright/test@1.33.0:
-    resolution: {integrity: sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==}
-    engines: {node: '>=14'}
+  /@playwright/test@1.39.0:
+    resolution: {integrity: sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==}
+    engines: {node: '>=16'}
+    hasBin: true
     dependencies:
-      '@types/node': 20.5.7
-      playwright-core: 1.33.0
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright: 1.39.0
     dev: true
 
   /@pollyjs/adapter-node-http@6.0.6:
@@ -13848,26 +13846,16 @@ packages:
       - supports-color
     dev: true
 
-  /playwright-core@1.33.0:
-    resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
-    engines: {node: '>=14'}
-    dev: true
-
   /playwright-core@1.39.0:
     resolution: {integrity: sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==}
     engines: {node: '>=16'}
-    dev: true
-
-  /playwright@1.33.0:
-    resolution: {integrity: sha512-+zzU3V2TslRX2ETBRgQKsKytYBkJeLZ2xzUj4JohnZnxQnivoUvOvNbRBYWSYykQTO0Y4zb8NwZTYFUO+EpPBQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      playwright-core: 1.33.0
+    hasBin: true
     dev: true
 
   /playwright@1.39.0:
     resolution: {integrity: sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==}
     engines: {node: '>=16'}
+    hasBin: true
     dependencies:
       playwright-core: 1.39.0
     optionalDependencies:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1104,7 +1104,7 @@
   },
   "devDependencies": {
     "@google-cloud/pubsub": "^3.7.3",
-    "@playwright/test": "^1.33.0",
+    "@playwright/test": "1.39.0",
     "@pollyjs/adapter-node-http": "^6.0.6",
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/node-server": "^6.0.6",
@@ -1143,7 +1143,7 @@
     "ovsx": "^0.8.2",
     "pako": "^2.1.0",
     "path-browserify": "^1.0.1",
-    "playwright": "^1.33.0",
+    "playwright": "1.39.0",
     "progress": "^2.0.3",
     "semver": "^7.5.4",
     "yaml": "^2.3.4"

--- a/vscode/src/local-context/enhanced-context-status.test.ts
+++ b/vscode/src/local-context/enhanced-context-status.test.ts
@@ -1,5 +1,4 @@
-import { expect } from '@playwright/test'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
 import type * as status from '@sourcegraph/cody-shared/src/codebase-context/context-status'

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -9,20 +9,20 @@ test('enhanced context selector is keyboard accessible', async ({ page, sidebar 
     const contextSettingsButton = chatFrame.getByTitle('Configure Enhanced Context')
     await contextSettingsButton.focus()
 
-    page.keyboard.press('Space')
+    await page.keyboard.press('Space')
     // Opening the enhanced context settings should focus the checkbox for toggling it.
     const enhancedContextCheckbox = chatFrame.locator('#enhanced-context-checkbox')
     await expect(enhancedContextCheckbox.and(page.locator(':focus'))).toBeVisible()
 
     // Enhanced context should be enabled by default.
     await expect(enhancedContextCheckbox).toBeChecked()
-    page.keyboard.press('Space')
+    await page.keyboard.press('Space')
     // The keyboard should toggle the checkbox, but not dismiss the popup.
     await expect(enhancedContextCheckbox).not.toBeChecked()
     await expect(enhancedContextCheckbox).toBeVisible()
 
     // The popup should be dismiss-able with the keyboard.
-    page.keyboard.press('Escape')
+    await page.keyboard.press('Escape')
     // Closing the enhanced context settings should close the dialog...
     await expect(enhancedContextCheckbox).not.toBeVisible()
     // ... and focus the button which re-opens it.

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -1,0 +1,30 @@
+import { expect } from '@playwright/test'
+
+import { sidebarSignin } from './common'
+import { newChat, test } from './helpers'
+
+test('enhanced context selector is keyboard accessible', async ({ page, sidebar }) => {
+    await sidebarSignin(page, sidebar)
+    const chatFrame = await newChat(page)
+    const contextSettingsButton = chatFrame.getByTitle('Configure Enhanced Context')
+    await contextSettingsButton.focus()
+
+    page.keyboard.press('Space')
+    // Opening the enhanced context settings should focus the checkbox for toggling it.
+    const enhancedContextCheckbox = chatFrame.locator('#enhanced-context-checkbox')
+    await expect(enhancedContextCheckbox.and(page.locator(':focus'))).toBeVisible()
+
+    // Enhanced context should be enabled by default.
+    await expect(enhancedContextCheckbox).toBeChecked()
+    page.keyboard.press('Space')
+    // The keyboard should toggle the checkbox, but not dismiss the popup.
+    await expect(enhancedContextCheckbox).not.toBeChecked()
+    await expect(enhancedContextCheckbox).toBeVisible()
+
+    // The popup should be dismiss-able with the keyboard.
+    page.keyboard.press('Escape')
+    // Closing the enhanced context settings should close the dialog...
+    await expect(enhancedContextCheckbox).not.toBeVisible()
+    // ... and focus the button which re-opens it.
+    await expect(contextSettingsButton.and(page.locator(':focus'))).toBeVisible()
+})

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -1,6 +1,10 @@
 .inner-container {
     height: 100%;
-    overflow: auto;
+
+    /* popups use a screen to capture clicks outside the popups; this is
+       necessary so that the screen can extend to the extent of the view without
+       scrollbars */
+    overflow: clip;
 }
 
 .transcript-item {

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -77,6 +77,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
     },
     render: function Render() {
         const [args, updateArgs] = useArgs()
+        const [isOpen, setIsOpen] = useState<boolean>(args.isOpen)
 
         const eventHandlers: EnhancedContextEventHandlersT = {
             onConsentToEmbeddings(provider: LocalEmbeddingsProvider): void {
@@ -117,7 +118,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
                             right: 20,
                         }}
                     >
-                        <EnhancedContextSettings isOpen={args.isOpen} setOpen={() => {}} />
+                        <EnhancedContextSettings isOpen={isOpen} setOpen={() => setIsOpen(!isOpen)} />
                     </div>
                 </EnhancedContextEventHandlers.Provider>
             </EnhancedContextContext.Provider>
@@ -126,7 +127,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
 }
 
 export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
-    render: () => {
+    render: function Render() {
         const [isOpen, setIsOpen] = useState<boolean>(true)
         return (
             <EnhancedContextContext.Provider
@@ -174,7 +175,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                         right: 20,
                     }}
                 >
-                    <EnhancedContextSettings isOpen={isOpen} setOpen={setIsOpen} />
+                    <EnhancedContextSettings isOpen={isOpen} setOpen={() => setIsOpen(!isOpen)} />
                 </div>
             </EnhancedContextContext.Provider>
         )

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -1,4 +1,4 @@
-import { useArgs } from '@storybook/preview-api'
+import { useArgs, useState } from '@storybook/preview-api'
 import { type Meta, type StoryObj } from '@storybook/react'
 
 import {
@@ -126,54 +126,57 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
 }
 
 export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
-    render: () => (
-        <EnhancedContextContext.Provider
-            value={{
-                groups: [
-                    {
-                        name: '~/projects/foo',
-                        providers: [
-                            { kind: 'embeddings', type: 'local', state: 'unconsented' },
-                            { kind: 'graph', state: 'ready' },
-                            { kind: 'search', state: 'indexing' },
-                        ],
-                    },
-                    {
-                        name: 'gitlab.com/my/repo',
-                        providers: [
-                            {
-                                kind: 'embeddings',
-                                type: 'remote',
-                                remoteName: 'gitlab.com/my/repo',
-                                origin: 'sourcegraph.com',
-                                state: 'ready',
-                            },
-                        ],
-                    },
-                    {
-                        name: 'github.com/sourcegraph/bar',
-                        providers: [
-                            {
-                                kind: 'embeddings',
-                                type: 'remote',
-                                remoteName: 'github.com/sourcegraph/bar',
-                                origin: 'sourcegraph.sourcegraph.com',
-                                state: 'no-match',
-                            },
-                        ],
-                    },
-                ],
-            }}
-        >
-            <div
-                style={{
-                    position: 'absolute',
-                    bottom: 20,
-                    right: 20,
+    render: () => {
+        const [isOpen, setIsOpen] = useState<boolean>(true)
+        return (
+            <EnhancedContextContext.Provider
+                value={{
+                    groups: [
+                        {
+                            name: '~/projects/foo',
+                            providers: [
+                                { kind: 'embeddings', type: 'local', state: 'unconsented' },
+                                { kind: 'graph', state: 'ready' },
+                                { kind: 'search', state: 'indexing' },
+                            ],
+                        },
+                        {
+                            name: 'gitlab.com/my/repo',
+                            providers: [
+                                {
+                                    kind: 'embeddings',
+                                    type: 'remote',
+                                    remoteName: 'gitlab.com/my/repo',
+                                    origin: 'sourcegraph.com',
+                                    state: 'ready',
+                                },
+                            ],
+                        },
+                        {
+                            name: 'github.com/sourcegraph/bar',
+                            providers: [
+                                {
+                                    kind: 'embeddings',
+                                    type: 'remote',
+                                    remoteName: 'github.com/sourcegraph/bar',
+                                    origin: 'sourcegraph.sourcegraph.com',
+                                    state: 'no-match',
+                                },
+                            ],
+                        },
+                    ],
                 }}
             >
-                <EnhancedContextSettings isOpen={true} setOpen={() => {}} />
-            </div>
-        </EnhancedContextContext.Provider>
-    ),
+                <div
+                    style={{
+                        position: 'absolute',
+                        bottom: 20,
+                        right: 20,
+                    }}
+                >
+                    <EnhancedContextSettings isOpen={isOpen} setOpen={setIsOpen} />
+                </div>
+            </EnhancedContextContext.Provider>
+        )
+    },
 }

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -262,16 +262,34 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
         localStorage.setItem(hasOpenedBeforeKey, 'true')
     }
 
+    // Can't point at and use VSCodeCheckBox type with 'ref'
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const autofocusTarget = React.useRef<any>(null)
+    React.useEffect(() => {
+        if (isOpen) {
+            autofocusTarget.current?.focus()
+        }
+    }, [isOpen])
+
+    // Can't point at and use VSCodeButton type with 'ref'
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const restoreFocusTarget = React.useRef<any>(null)
+    const handleDismiss = React.useCallback(() => {
+        setOpen(false)
+        restoreFocusTarget.current?.focus()
+    }, [setOpen, restoreFocusTarget])
+
     return (
         <div className={classNames(popupStyles.popupHost)}>
-            <PopupFrame
-                isOpen={isOpen}
-                onDismiss={() => setOpen(false)}
-                classNames={[popupStyles.popupTrail, styles.popup]}
-            >
+            <PopupFrame isOpen={isOpen} onDismiss={handleDismiss} classNames={[popupStyles.popupTrail, styles.popup]}>
                 <div className={styles.container}>
                     <div>
-                        <VSCodeCheckbox onChange={enabledChanged} checked={enabled} id="enhanced-context-checkbox" />
+                        <VSCodeCheckbox
+                            onChange={enabledChanged}
+                            checked={enabled}
+                            id="enhanced-context-checkbox"
+                            ref={autofocusTarget}
+                        />
                     </div>
                     <div>
                         <label htmlFor="enhanced-context-checkbox">
@@ -295,6 +313,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 type="button"
                 onClick={() => setOpen(!isOpen)}
                 title="Configure Enhanced Context"
+                ref={restoreFocusTarget}
             >
                 <i className="codicon codicon-sparkle" />
                 {isOpen || hasOpenedBefore ? null : <div className={styles.glowyDot} />}

--- a/vscode/webviews/Popups/Popup.module.css
+++ b/vscode/webviews/Popups/Popup.module.css
@@ -1,4 +1,15 @@
+.backdrop {
+    position: absolute;
+    inset: -100vh -100vw;
+    width: 200vw;
+    height: 200vh;
+    z-index: 1;
+    background-color: rgba(0 0 0 0.01);
+}
+
 .popup {
+    z-index: 2;
+
     --notice-border-radius: 6px;
     text-align: left;
     box-sizing: border-box;
@@ -24,6 +35,8 @@
 }
 
 .pointy-bit {
+    z-index: 3;
+
     position: absolute;
     left: calc(50% - 6px);
     bottom: 100%;
@@ -38,8 +51,6 @@
     border-bottom: 1px solid var(--vscode-widget-border);
 
     /* no box shadow on this, it relies on overlapping the rest of the popup */
-
-    z-index: 1;
 }
 
 .popup-host {
@@ -52,14 +63,6 @@
     gap: 4px;
 }
 
-.row > .notice-close {
-    flex-grow: 0;
-}
-
-.row > :not(.notice-close) {
-    flex-grow: 1;
-}
-
 .action-button-container :nth-last-child(-n + 1) {
     background-color: var(--vscode-button-secondaryBackground);
     color: var(--vscode-button-secondaryForeground);
@@ -68,11 +71,6 @@
 
 .action-button-container :nth-last-child(-n + 1):hover {
     background-color: var(--vscode-button-secondaryHoverBackground);
-}
-
-.notice-close {
-    margin-top: -5px;
-    margin-right: -5px;
 }
 
 .popup h1,

--- a/vscode/webviews/Popups/Popup.tsx
+++ b/vscode/webviews/Popups/Popup.tsx
@@ -1,4 +1,4 @@
-import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
+import { VSCodeLink } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
 import styles from './Popup.module.css'
@@ -6,6 +6,23 @@ import styles from './Popup.module.css'
 export interface PopupOpenProps {
     isOpen: boolean
     onDismiss: () => void
+}
+
+interface BackdropProps {
+    dismiss: () => void
+}
+
+export const Backdrop: React.FunctionComponent<React.PropsWithoutRef<BackdropProps>> = ({ dismiss }) => {
+    const handleKeyUp = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+        if (e.key === 'Escape') {
+            dismiss()
+        }
+    }
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+        e.stopPropagation()
+        dismiss()
+    }
+    return <div className={styles.backdrop} onClick={handleClick} onKeyUp={handleKeyUp} role="presentation" />
 }
 
 interface PopupFrameProps {
@@ -25,28 +42,35 @@ interface PopupProps extends Omit<PopupFrameProps, 'classNames'>, PopupOpenProps
 export const PopupFrame: React.FunctionComponent<React.PropsWithChildren<PopupFrameProps & PopupOpenProps>> = ({
     actionButtons,
     classNames: extraClassNames,
-    isOpen,
     onDismiss,
+    isOpen,
     children,
-}) =>
-    isOpen && (
-        <>
-            <div className={classNames(styles.popup, ...(extraClassNames || []))}>
-                <div className={styles.row}>
-                    {children}
-                    <div className={styles.noticeClose}>
-                        <VSCodeButton appearance="icon" onClick={onDismiss}>
-                            <i className="codicon codicon-close" />
-                        </VSCodeButton>
-                    </div>
-                </div>
-                {actionButtons && (
-                    <div className={classNames(styles.actionButtonContainer, styles.row)}>{actionButtons}</div>
-                )}
-            </div>
-            <div className={styles.pointyBit} />
-        </>
+}) => {
+    const handleKeyUp = (e: React.KeyboardEvent<HTMLDialogElement>): void => {
+        if (e.key === 'Escape') {
+            e.stopPropagation()
+            onDismiss()
+        }
+    }
+    return (
+        isOpen && (
+            <>
+                <dialog
+                    open={true}
+                    className={classNames(styles.popup, ...(extraClassNames || []))}
+                    onKeyUp={handleKeyUp}
+                >
+                    <div className={styles.row}>{children}</div>
+                    {actionButtons && (
+                        <div className={classNames(styles.actionButtonContainer, styles.row)}>{actionButtons}</div>
+                    )}
+                </dialog>
+                <div className={styles.pointyBit} />
+                <Backdrop dismiss={onDismiss} />
+            </>
+        )
     )
+}
 
 // Note, if the popup's parent is interactive, the button's event handlers should prevent event
 // propagation.


### PR DESCRIPTION
#2628 will use &times; in the enhanced context settings popup for removing a repository, so we need to remove the close button. This removes the close button. Now, the popup is closed by:

- Clicking outside the popup.
- Pressing Escape.

In addition, this takes care that keyboard focus goes to the enable/disable checkbox when the popup opens, and returns to the enhanced context button when the popup closes.

## Test plan

```
pnpm test:e2e -- context-settings.test.ts
```

Manual test:

1. Sign in and start a chat.
2. Open the enhanced context popup.
3. Press Space a few times, this should toggle the checkbox.
4. Press Escape, this should close the popup.
5. Press Space again, this should re-open the popup.
6. Click somewhere else on the chat. This should close the popup.
