### PR TITLE
Autocomplete: insert missing brackets before completion truncation

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Autocomplete: Improve the stability of multiline completion truncation during streaming by gracefully handling missing brackets in incomplete code segments. [pull/2682](https://github.com/sourcegraph/cody/pull/2682)
+
 ### Changed
 
 - Made the Enterprise login button more prominent. [pull/2672](https://github.com/sourcegraph/cody/pull/2672)

--- a/vscode/src/completions/get-inline-completions-tests/dynamic-multiline.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/dynamic-multiline.test.ts
@@ -15,7 +15,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
     })
 
     it('continues generating a multiline completion if a multiline trigger is found on the first line', async () => {
-        const firstParams = params(
+        const requestParams = params(
             'function █',
             [
                 completion`├myFunction() {
@@ -53,7 +53,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
             }
         )
 
-        const completions = await getInlineCompletions(firstParams)
+        const completions = await getInlineCompletions(requestParams)
         expect(completions?.items[0]?.insertText).toMatchInlineSnapshot(`
             "myFunction() {
                 console.log(1)
@@ -65,7 +65,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
     })
 
     it('does not use dynamic multiline for certain black listed cases', async () => {
-        const firstParams = params(
+        const requestParams = params(
             'class █',
             [
                 completion`├Test {
@@ -106,7 +106,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
             }
         )
 
-        const completions = await getInlineCompletions(firstParams)
+        const completions = await getInlineCompletions(requestParams)
         expect(completions?.items[0]?.insertText).toMatchInlineSnapshot('"Test {"')
     })
 })

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -682,7 +682,7 @@ cases.forEach(isTreeSitterEnabled => {
                 `)
                 })
 
-                it('handles missing brackes gracefully to truncate the completion correctly', async () => {
+                it('handles missing brackets gracefully to truncate the completion correctly', async () => {
                     const requestParams = params('console.log(1); const █', [completion``], {
                         onNetworkRequest(_params, onPartialResponse) {
                             onPartialResponse?.(completion`

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -687,15 +687,13 @@ cases.forEach(isTreeSitterEnabled => {
                         onNetworkRequest(_params, onPartialResponse) {
                             onPartialResponse?.(completion`
                                 ├MyCoolObject = {
-                                constructor() {
-                            ┤`)
+                                constructor() {`)
                             onPartialResponse?.(completion`
                                 ├MyCoolObject = {
                                 constructor() {
                                     console.log(1)
 
-                                    if (false
-                            `)
+                                    if (false`)
                             onPartialResponse?.(completion`
                                 ├MyCoolObject = {
                                 constructor() {
@@ -706,8 +704,7 @@ cases.forEach(isTreeSitterEnabled => {
                                     }
 
                                     const result = {
-                                        value:
-                            `)
+                                        value:`)
                             onPartialResponse?.(completion`
                                 ├MyCoolObject = {
                                 constructor() {

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -681,6 +681,73 @@ cases.forEach(isTreeSitterEnabled => {
                       }"
                 `)
                 })
+
+                it('handles missing brackes gracefully to truncate the completion correctly', async () => {
+                    const requestParams = params('console.log(1); const █', [completion``], {
+                        onNetworkRequest(_params, onPartialResponse) {
+                            onPartialResponse?.(completion`
+                                ├MyCoolObject = {
+                                constructor() {
+                            ┤`)
+                            onPartialResponse?.(completion`
+                                ├MyCoolObject = {
+                                constructor() {
+                                    console.log(1)
+
+                                    if (false
+                            `)
+                            onPartialResponse?.(completion`
+                                ├MyCoolObject = {
+                                constructor() {
+                                    console.log(1)
+
+                                    if (false) {
+                                        console.log(2)
+                                    }
+
+                                    const result = {
+                                        value:
+                            `)
+                            onPartialResponse?.(completion`
+                                ├MyCoolObject = {
+                                constructor() {
+                                    console.log(1)
+
+                                    if (false) {
+                                        console.log(2)
+                                    }
+
+                                    const result = {
+                                        value: true
+                                    }
+
+                                    return result
+                                }
+                            }
+                            console.log(5)┤`)
+                        },
+                        dynamicMultilineCompletions: true,
+                    })
+
+                    const [insertText] = await getInlineCompletionsInsertText(requestParams)
+                    expect(insertText).toMatchInlineSnapshot(`
+                      "MyCoolObject = {
+                          constructor() {
+                              console.log(1)
+
+                              if (false) {
+                                  console.log(2)
+                              }
+
+                              const result = {
+                                  value: true
+                              }
+
+                              return result
+                          }
+                      }"
+                    `)
+                })
             }
         })
     })

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.test.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { insertMissingBrackets } from './truncate-parsed-completion'
+
+describe('insertAllMissingBrackets', () => {
+    it('handles an empty string', () => {
+        expect(insertMissingBrackets('')).toEqual('')
+    })
+
+    it('returns original string if brackets are balanced', () => {
+        const text = 'function balanced() { return [1, 2, 3]; }'
+        expect(insertMissingBrackets(text)).toEqual(text)
+    })
+
+    it('inserts missing single type of bracket', () => {
+        const text = 'function missingCurly() { return [1, 2, 3;'
+        expect(insertMissingBrackets(text)).toEqual(text + ']}')
+    })
+
+    it('correctly handles nested brackets', () => {
+        const text = 'function nested() { if (true) { return [1, 2, 3; '
+        expect(insertMissingBrackets(text)).toEqual(text + ']}}')
+    })
+
+    it('handles mixed types of brackets', () => {
+        const text = 'function mixed() { return [1, 2, 3;'
+        expect(insertMissingBrackets(text)).toEqual(text + ']}')
+    })
+
+    it('returns original string if no brackets are present', () => {
+        const text = 'function noBrackets() return 123;'
+        expect(insertMissingBrackets(text)).toEqual(text)
+    })
+
+    it('does not correct incorrectly ordered brackets', () => {
+        const text = 'function wrongOrder() } return [1, 2, 3; {'
+        expect(insertMissingBrackets(text)).toEqual(text + '}]')
+    })
+})

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.ts
@@ -6,7 +6,7 @@ import { getCachedParseTreeForDocument } from '../../tree-sitter/parse-tree-cach
 import { type DocumentContext } from '../get-current-doc-context'
 
 import { parseCompletion, type ParsedCompletion } from './parse-completion'
-import { BRACKET_PAIR, getFirstLine, type OpeningBracket } from './utils'
+import { BRACKET_PAIR, type OpeningBracket } from './utils'
 
 interface CompletionContext {
     completion: ParsedCompletion
@@ -14,34 +14,33 @@ interface CompletionContext {
     docContext: DocumentContext
 }
 
-interface InsertMissingBracketParams {
-    textToCheck: string
-    textToComplete: string
-    docContext: DocumentContext
-}
-
 /**
- * Inserts a closing bracket if the text to check ends with an opening bracket
- * but the next non-empty line does not start with the corresponding closing bracket.
+ * Inserts missing closing brackets in the completion text.
  * This handles cases where a missing bracket breaks the incomplete parse-tree.
  */
-function insertMissingBracketIfNeeded(params: InsertMissingBracketParams): string {
-    const {
-        textToCheck,
-        textToComplete,
-        docContext: { nextNonEmptyLine },
-    } = params
+export function insertMissingBrackets(text: string): string {
+    const openingStack: OpeningBracket[] = []
+    const bracketPairs = Object.entries(BRACKET_PAIR)
 
-    const openingBracket = Object.keys(BRACKET_PAIR).find(openingBracket =>
-        textToCheck.trimEnd().endsWith(openingBracket)
-    ) as OpeningBracket | undefined
+    for (const char of text) {
+        const bracketPair = bracketPairs.find(([_, closingBracket]) => closingBracket === char)
 
-    const closingBracket = openingBracket && BRACKET_PAIR[openingBracket]
-    if (closingBracket && !nextNonEmptyLine.startsWith(closingBracket) && !textToComplete.endsWith(closingBracket)) {
-        return textToComplete + closingBracket
+        if (bracketPair) {
+            if (openingStack.length > 0 && openingStack.at(-1) === bracketPair[0]) {
+                openingStack.pop()
+            }
+        } else if (Object.keys(BRACKET_PAIR).includes(char)) {
+            openingStack.push(char as OpeningBracket)
+        }
     }
 
-    return textToComplete
+    return (
+        text +
+        openingStack
+            .reverse()
+            .map(openBracket => BRACKET_PAIR[openBracket])
+            .join('')
+    )
 }
 
 interface TruncateParsedCompletionResult {
@@ -68,20 +67,14 @@ export function truncateParsedCompletion(context: CompletionContext): TruncatePa
     })
 
     let fixedCompletion = completion
-    let updatedText = insertMissingBracketIfNeeded({
-        textToCheck: getFirstLine(insertText),
-        textToComplete: insertText,
-        docContext,
-    })
-    updatedText = insertMissingBracketIfNeeded({
-        textToCheck: updatedText,
-        textToComplete: updatedText,
-        docContext,
-    })
 
-    if (updatedText.length !== insertText.length) {
+    const insertTextWithMissingBrackets = insertMissingBrackets(docContext.currentLinePrefix + insertText).slice(
+        docContext.currentLinePrefix.length
+    )
+
+    if (insertTextWithMissingBrackets.length !== insertText.length) {
         const updatedCompletion = parseCompletion({
-            completion: { insertText: updatedText },
+            completion: { insertText: insertTextWithMissingBrackets },
             document,
             docContext,
         })


### PR DESCRIPTION
## Context

- Improves the stability of multiline completion truncation during streaming by gracefully handling missing brackets in incomplete code segments.
- Closes #2387 

## Test plan

Added new unit tests.
