### PR TITLE
Agent: use `temperature: 0` in HTTP recordings

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -144,8 +144,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -178,7 +176,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 50988e78646b85b75640c96a32734dcf
+    - _id: c8bf41d74bc28382266e30db42fb9889
       _order: 0
       cache: {}
       request:
@@ -211,7 +209,7 @@ log:
                 text: Hello!
               - speaker: assistant
             model: anthropic/claude-2.0
-            temperature: 0.2
+            temperature: 0
             topK: -1
             topP: -1
         queryString: []
@@ -219,21 +217,75 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 315
-          text: |+
+          size: 1187
+          text: >+
             event: completion
+
             data: {"completion":" Hello","stopReason":""}
 
+
             event: completion
+
             data: {"completion":" Hello there","stopReason":""}
 
+
             event: completion
+
             data: {"completion":" Hello there!","stopReason":""}
 
+
             event: completion
-            data: {"completion":" Hello there!","stopReason":"stop_sequence"}
+
+            data: {"completion":" Hello there! How","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help you with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help you with coding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help you with coding today","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help you with coding today?","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Hello there! How can I help you with coding today?","stopReason":"stop_sequence"}
+
 
             event: done
+
             data: {}
 
         cookies: []
@@ -246,8 +298,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -280,7 +330,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 349de092281b6d15b669a4f39e95ead8
+    - _id: cd797ea83fc10a9d27ca3644d207c5d9
       _order: 0
       cache: {}
       request:
@@ -313,7 +363,7 @@ log:
                 text: Generate simple hello world function in java!
               - speaker: assistant
             model: anthropic/claude-2.0
-            temperature: 0.2
+            temperature: 0
             topK: -1
             topP: -1
         queryString: []
@@ -321,7 +371,7 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 91271
+          size: 47761
           text: >+
             event: completion
 
@@ -355,912 +405,647 @@ log:
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[]","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[]","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args)","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args)","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n   ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n   ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\");","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\");","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n-","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method,","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java,","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method,","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n-","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n-","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `jav","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java`","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n-","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when executed","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when executed.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: jav","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to the console","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to the console when","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to the console when executed","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to the console when executed.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nTo break this down:\n\n- The code is wrapped in a class called Main. In Java, code must be contained within classes.\n\n- The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.\n\n- The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.\n\n- System.out.println prints the text \"Hello World!\" to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThis will print \"Hello World!\" to the console when executed.","stopReason":"stop_sequence"}
+            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when executed.","stopReason":"stop_sequence"}
 
 
             event: done
@@ -2333,7 +2118,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7e7da1e2728766fa5abd6b1665484997
+    - _id: c18483fba57ab40b7c31d41f8af01c05
       _order: 0
       cache: {}
       request:
@@ -2367,7 +2152,7 @@ log:
                   Only show the code, no explanation needed.
               - speaker: assistant
             model: anthropic/claude-2.0
-            temperature: 0.2
+            temperature: 0
             topK: -1
             topP: -1
         queryString: []
@@ -2851,8 +2636,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2958,8 +2741,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3053,18 +2834,18 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 228
-          text: '["H4sIAAAAAAAAA2SMywrCMBRE/2XWURB3gYIu3NkuhBa3l+TapiRNuWmEUvrv4gsEd3OGM7PA0kTQC0wW4WGqE8sTnYVGc6286eO+7NtdeSwKKHSUGhZ3c2xPgZyHniSzgnVp9DRXFBh6yN4r5MQyvBgpZjHcCo3dxkaToEB3mkjqy/mrj+ICyfx5XcDv8Lc9/BRbEwPWdV0fAAAA//8DAGZSkGHIAAAA"]'
+          size: 296
+          text: '["H4sIAAAAAAAAAzyOQUrEQBRErzLUuplEHEEbxFkobiSIMIMuv8mfpKXTHX7/HhhDTuEJPMtcTGLEXVXxiqoRDSnBjqizCAfdJZbZugYW+9fK1x/xs7p/u4JBR2nP4g6Om4eenIdVyWzQuDR4OlXUMyzOX54OWVbP52/vV4/sJKUYYJATS1iY+IsMLQzoSEqye3mCRac6JFsUS5bKdeu0y+9zsY5BOei6jn2Ri4tNeV3eXN4dbzcwGMT1JKe/TyN4Ef8r23YO5iqmaZp+AAAA//8DABxxHfX0AAAA"]'
           textDecoded:
             data:
               currentUser:
-                avatarURL: null
-                displayName: null
+                avatarURL: https://avatars0.githubusercontent.com/u/1408093?v=4
+                displayName: Ólafur Páll Geirsson
                 hasVerifiedEmail: true
-                id: VXNlcjo3Mjg1MA==
+                id: VXNlcjozNDY5
                 primaryEmail:
-                  email: sourcegraph-docs@sourcegraph.com
-                username: sourcegraph-docs
+                  email: olafurpg@gmail.com
+                username: olafurpg
         cookies: []
         headers:
           - name: date
@@ -3075,8 +2856,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3111,7 +2890,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fb21b36f1f7c652617e0a9e8c3d194a3
+    - _id: c24c1c5c8d214fde2fe90194baba56ed
       _order: 0
       cache: {}
       request:
@@ -3131,7 +2910,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "101"
+            value: "115"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -3149,26 +2928,22 @@ log:
           textJSON:
             query: |-
               
-              query CurrentUser {
+              query CurrentUserCodyProEnabled {
                   currentUser {
                       codyProEnabled
                   }
               }
             variables: {}
         queryString:
-          - name: CurrentUser
+          - name: CurrentUserCodyProEnabled
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentUser
+        url: https://sourcegraph.com/.api/graphql?CurrentUserCodyProEnabled
       response:
         content:
           encoding: base64
           mimeType: application/json
-          size: 100
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJz81MqA4ryXfMSk3JSU5Ss0hJzilNra2sBAAAA//8DAFJUb/wxAAAA"]'
-          textDecoded:
-            data:
-              currentUser:
-                codyProEnabled: false
+          size: 103
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1O","LQJz81MqA4ryXfMSk3JSU5SsSopKU2trawEAAAD//wMAqqwCpjAAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -3179,8 +2954,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3277,8 +3050,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3373,8 +3144,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3469,8 +3238,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3565,8 +3332,6 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3661,8 +3426,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -3748,45 +3511,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 444
-          text: '["H4sIAAAAAAAAA5STXU7DMAzH75Ln+QI9wC6BeHATr7GWxsV26Kppd0eFCdjQOvGcX/z/cHIOCR1Ddw70jqWhU9oTelPaFxwsdC/nUHGk0IUoaYGZeogZPezCylPoDliMLru/GJbyQ7m235ARasxQaYYjLbNoejzwrXE8gjmqg0tTOIgCNs9UnePqGJqR2uMJVL8QkNoLauI6PHT2bd84UY+6AVZXNIco41QYq4Mt1fEEmYdceMh+o3Nvqi/Sw4QDgc3sMQMqoYFlUY/N7UnD2Fw+lckJXDFuijkVGsl1ATpNor4df1J53g8ldlFQijyRbfM3ZtNSceQIYyvOhSvB9YilbqTGNHIFrFgW52gQMWaCxIZ9ofSfttbN0cmhPwww8mnr8vWdylxJLfO0HXP9GDBKPIKT3Xf8erl8AAAA//8DAME7td9tAwAA"]'
-          textDecoded:
-            data:
-              evaluatedFeatureFlags:
-                - name: cody-web-chat
-                  value: false
-                - name: cody-web-all
-                  value: true
-                - name: search-new-keyword
-                  value: false
-                - name: quick-start-tour-for-authenticated-users
-                  value: false
-                - name: end-user-onboarding
-                  value: true
-                - name: cody-web-sidebar
-                  value: true
-                - name: contrast-compliant-syntax-highlighting
-                  value: false
-                - name: blob-page-switch-areas-shortcuts
-                  value: false
-                - name: cody-autocomplete-tracing
-                  value: false
-                - name: telemetry-export
-                  value: true
-                - name: cody-pro
-                  value: true
-                - name: cody-web-editor-recipes
-                  value: true
-                - name: cody-autocomplete-dynamic-multiline-completions
-                  value: false
-                - name: admin-analytics-cache-disabled
-                  value: false
-                - name: cody-autocomplete-context-bfg-mixed
-                  value: false
-                - name: search-ownership
-                  value: true
-                - name: cody-chat-mock-test
-                  value: true
+          size: 815
+          text: '["H4sIAAAAAAAA/5RVW3LcOAy8i76DC/gAucTWfoA=","ZI+EHYpUAHBmtC7ffYvyVCr2RpLzpyo2H93obr0OiZ2Hl9cBN86NHek72Jvie+bRhpe/XofCM4aXYdQlDt+GDsPw4trw9u3nooE1TlTvBWqTLLvAWNNKi9ZjADevsc5LhoMyl7Hx2D8cJa7HW+8IhCRelRRRFtgu3pExw3UlPJaq/gdvSmvhWSLNLbtkKaDnktTyy4UXzvbrQXVBiTVhVF6m3etCroGWztju4nEiVrCRTVU9Nt8ntL0zTuw013glh+1zek5MytK8H32nScyrnsj7QYVYi+PhFC4jzfJA2mduMpa2kDW9YSUUDvkIzjHCTEIGXSSDXIHzuXPOZ3ynNaikXRSnWQpx4by6RPv/Qz/hfzSJVzJndfLalC5Vu0YTikvscaJm0ANLdA2Vzd8NJFycbC3OD5pknLKMk0sZ9/ejvF9BtYTKmj6ATyfoyvHw+N9YX6xr0tO1xixlpHqhRXGT2owUPxrMDwm/NwD9Aw/KUvb9/JyZcrme0To3R8/F2U0JoR2I8UQV3OmK9V71wMGL1tSik7VgUWXZmoEUnKBk0JtEEMdYW/H9U5R7AcosboRHBBLS5rGe7cPB9bqmfyuu+6Q/mz1ynH7O94DaJikeC1RmFOf90P3GPbhwy75FpjehPhNJVpvGz8X4NVG/rObXn3NuJ5OEwHrmqK0ii1NgQ9p+ZZTgiP3lB/UX6Ca2/cS2VrmLT1SqI9R63c/Le1uRuYLnnsxRnELuix+3/P329l8AAAD//3p5sfn6BwAA"]'
         cookies: []
         headers:
           - name: date
@@ -3797,14 +3523,14 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
@@ -3816,8 +3542,6 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
         headersSize: 0
         httpVersion: HTTP/1.1
         redirectURL: ""
@@ -3912,8 +3636,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4025,8 +3747,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4138,8 +3858,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4251,8 +3969,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4285,7 +4001,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 034a673937c6196287e0d760ff5ab207
+    - _id: 57d426eb97aa088bf3053ed1973ab21f
       _order: 0
       cache: {}
       request:
@@ -4339,7 +4055,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4348,13 +4064,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 112
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          size: 122
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -4365,8 +4076,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4401,7 +4110,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 869d103f953a0c3190caf0857cab1466
+    - _id: 2b1f22fb4872a677facadef9efb4ea2d
       _order: 0
       cache: {}
       request:
@@ -4455,7 +4164,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4464,8 +4173,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 122
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -4476,8 +4185,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4512,7 +4219,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 88de2cce28b0ab84962bfbe9854f95ab
+    - _id: e9086fdc42c4266039d0386367319761
       _order: 0
       cache: {}
       request:
@@ -4566,7 +4273,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4575,8 +4282,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -4587,8 +4294,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4623,7 +4328,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: faf7a884bd11f3160cb539ee68fa2173
+    - _id: 2ed61a409845f1cd7a59306933bae507
       _order: 0
       cache: {}
       request:
@@ -4677,7 +4382,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4686,13 +4391,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 112
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          size: 122
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -4703,8 +4403,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4739,7 +4437,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: eed92b456f519c7972e07cb5478a1c63
+    - _id: cfd63f4827acb03e3e51f65d9fc0d0af
       _order: 0
       cache: {}
       request:
@@ -4793,7 +4491,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -4802,8 +4500,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -4814,8 +4512,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4850,7 +4546,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 49781905e735793580db84a00e44fbdf
+    - _id: 25e34a85c91cbb1ea2d79c5f7e344533
       _order: 0
       cache: {}
       request:
@@ -4904,7 +4600,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -5037,8 +4733,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -5126,12 +4820,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 120
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
-          textDecoded:
-            data:
-              repository:
-                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
+          size: 123
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q","BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -5142,8 +4832,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -5254,8 +4942,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -5342,12 +5028,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 136
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5sYmBvFGBkYmugaGuoYG8aZ6RroplmapickGxknGZklKtbW1AAAAAP//AwArauoHSQAAAA=="]'
-          textDecoded:
-            data:
-              site:
-                productVersion: 257340_2024-01-10_5.2-d96eac03b36b
+          size: 139
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp","pcklYalFxZn5eUpWSkam5qZGFvFGBkYmugaGuoaG8aZ6RroGlgZmxmmplpYpRqlKtbW1AAAAAP//AwDzjpyXSQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -5358,8 +5040,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin

--- a/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
+++ b/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
@@ -5,7 +5,7 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: b4a608bdb7b328f3aa319bb4d2aa720d
+    - _id: e165d1526a4b74e8eb512ee50e8f06e4
       _order: 0
       cache: {}
       request:
@@ -38,7 +38,7 @@ log:
                 text: sqrt(9)
               - speaker: assistant
             model: anthropic/claude-2.0
-            temperature: 0.2
+            temperature: 0
             topK: -1
             topP: -1
         queryString: []
@@ -71,13 +71,13 @@ log:
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
           - name: x-cloud-trace-context
-            value: 84a8b2f36bd6a381b80cbf525d971426
+            value: e3280902f3d7c7e5307db550c8425e2c
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
             value: DENY
           - name: x-is-cody-pro-user
-            value: "false"
+            value: "true"
           - name: x-ratelimit-limit
             value: "1"
           - name: x-ratelimit-remaining
@@ -158,18 +158,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 212
-          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA="]'
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  chatModel: anthropic/claude-2.0
-                  chatModelMaxTokens: 12000
-                  completionModel: anthropic/claude-instant-1
-                  completionModelMaxTokens: 9000
-                  fastChatModel: anthropic/claude-instant-1
-                  fastChatModelMaxTokens: 9000
+          size: 219
+          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//w==","AwCpmMLNBAEAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -270,13 +260,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 128
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  provider: sourcegraph
+          size: 131
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//","AwAfFAXARQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -382,18 +367,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 344
-          text: '["H4sIAAAAAAAAA2yO3U6DQBSE3+Vc8xNtbNpNmkis8a9iokLRu8PuEdYuLNldsIXwMD6LL2YIXno3M18mMwMIdAhsAN4aQ7VLLJnJSgEM0ixW/FMfn16T88dttAEPSrQpGfkhSVxXKBUwZ1ryQEjbKDzFWBEw2P58d1KAB60lU89ZR7YnpTvbH2QgcObYoUOTPO+AQelcY1kYqnIRFFoXiqY217Wj2gVcVyGG0VWx0nx393bfLw5f5ujUyq99yvZF/pKny9s4u3lXuooeLtb5XpyVG7te+hw8aIys0Jz+Pg9As/jn1WUxoWkPxnEcfwEAAP//AwCyKDmxIgEAAA=="]'
-          textDecoded:
-            data:
-              currentUser:
-                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocLIYJz3kwrxtl8-n-eXWgbSbV6HNXGZlomAK59bWd1h=s96-c
-                displayName: Dávid
-                hasVerifiedEmail: true
-                id: VXNlcjoxOTU2MDA=
-                primaryEmail:
-                  email: veszelovszki.david@gmail.com
-                username: veszelovszki.david
+          size: 347
+          text: '["H4sIAAAAAAAAA2yOzUrDQBSF3+Wu84PYljhQMGgXBYmoTdBVuZ25JlNnMunMZLAJeRifxReT0C7dnR8O5xtBoEdgI/DeWmp96cjOVgpgUL0Xih/N9/OuvCkGvoYIGnQVWfkpSWw0SgXM254iENJ1Cs8FagIGj78/QQqIoHdk20smMEiRBHIDKRPc8CUhAgzo0ZavT8Cg8b5zLE1Vc5vUxtSK5jU3rafWJ9zoFNP8oc4M3+aL2OxV1p3iPj7mzZvamuViZ18qn1Ur+jgM4aT7uNkf1u5uFXOIoLNSoz1fmUegi/iH6r6eq/kPpmma/gAAAP//","AwAWfOcnIgEAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -440,7 +415,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fb21b36f1f7c652617e0a9e8c3d194a3
+    - _id: c24c1c5c8d214fde2fe90194baba56ed
       _order: 0
       cache: {}
       request:
@@ -460,7 +435,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "101"
+            value: "115"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -478,26 +453,26 @@ log:
           textJSON:
             query: |-
               
-              query CurrentUser {
+              query CurrentUserCodyProEnabled {
                   currentUser {
                       codyProEnabled
                   }
               }
             variables: {}
         queryString:
-          - name: CurrentUser
+          - name: CurrentUserCodyProEnabled
             value: null
-        url: https://sourcegraph.com/.api/graphql?CurrentUser
+        url: https://sourcegraph.com/.api/graphql?CurrentUserCodyProEnabled
       response:
         content:
           encoding: base64
           mimeType: application/json
           size: 100
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJz81MqA4ryXfMSk3JSU5Ss0hJzilNra2sBAAAA//8DAFJUb/wxAAAA"]'
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJz81MqA4ryXfMSk3JSU5SsSopKU2trawEAAAD//wMAqqwCpjAAAAA="]'
           textDecoded:
             data:
               currentUser:
-                codyProEnabled: false
+                codyProEnabled: true
         cookies: []
         headers:
           - name: date
@@ -981,50 +956,40 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 524
-          text: '["H4sIAAAAAAAAA6ySUW7cMAxE76Lv8AJ7gFyi6ActjWU1suiS1K6Nxd49cJqkSYrsYoH+CRA5HD7OOSR2DodzwJFrZ0d6BHtXPFbOFg4/zqHxjHAIBtY4UcLQc3gIeznCYeRquDy8V0VJG8WJnWaJT+Qwv1HM3SXKvFQ4KG2N5xJp7tVLLQ30+lWk2T1CUZpjdRrGTHNZke5ygZF7dTJnjZKgNG2DlkQmXSOy8jL9D72/Gq79o8Qr65clmtPAhkSVW6YER9xp3DN/7+yc94ejxe3buY6KGa4bYV1E/ZbBhhM9YTuJXuXbXNn8zykLNyfbmvNKU8lTLXny0vJdPIvxUEGKuMVaWiYZaVEci3Qjxe8O81txWVToF3xQLh+j9WVR5Z1fmYsbYY1AQqJR9CXZn2x/aXyb8T3CkltfyLoesRHavlG6LvcJgivHq9zQEnWDkrRBWNM1t7Kg7cm8Ee2hykDLniQ7FY8TsYKNbBL12P9F/vNyeQYAAP//AwA/9+8XYgQAAA=="]'
+          size: 452
+          text: '["H4sIAAAAAAAAA6ySQW7jMAxF76J1eYEcoJcouqClb4mtLHlIKrER5O5FZwq0QZFkM2t+PvLz8xwSO4fDOeDIdbAjPYN9KJ4rZwuHl3NovCAcQuxpJx7eY1/WCgelvfEikZZRXao00FdJerPwFD6JCIeZq+HydA1atX8rXMdPgbKDqiziRtgikJBo7koOc2n5ZqOBNRZqONE79lPX9GCLWNhp6fH9L/qB+Mp77M2xOU1zpkU23Jk01T7RyhlkJ/FYiBVsZKWrx+F3LmWS21jJhh6xExpPFXctNVc2/xeDcHOyvTlvVCSXKrlcX++xy4SZR3UyZ409Qansk0q6mcBvhCvH/zSVrA+NyMpruc1zVCxw3Qnb2tXv77pqpzf4pCw/f/ahrST2mQYp4h6rtEx9plVxlD6MFH8G7He0r5fLBwAAAP//AwBVv5cKcgMAAA=="]'
           textDecoded:
             data:
               evaluatedFeatureFlags:
-                - name: search-debug
-                  value: false
-                - name: cody-chat-mock-test
-                  value: false
                 - name: cody-autocomplete-dynamic-multiline-completions
                   value: false
-                - name: cody-autocomplete-context-bfg-mixed
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid
-                  value: true
-                - name: search-content-based-lang-detection
-                  value: false
-                - name: cody-autocomplete-language-latency
-                  value: true
-                - name: telemetry-export
-                  value: true
-                - name: search-new-keyword
-                  value: false
-                - name: contrast-compliant-syntax-highlighting
-                  value: false
-                - name: cody-autocomplete-disable-recycling-of-previous-requests
-                  value: false
-                - name: cody-pro-jetbrains
+                - name: cody-pro
                   value: true
                 - name: rate-limits-exceeded-for-testing
                   value: true
-                - name: cody-pro
-                  value: true
+                - name: search-new-keyword
+                  value: false
+                - name: cody-chat-mock-test
+                  value: false
+                - name: cody-autocomplete-context-bfg-mixed
+                  value: false
+                - name: blob-page-switch-areas-shortcuts
+                  value: false
                 - name: signup-survey-enabled
+                  value: false
+                - name: contrast-compliant-syntax-highlighting
+                  value: false
+                - name: cody-autocomplete-default-starcoder-hybrid
                   value: true
                 - name: cody-autocomplete-tracing
                   value: false
-                - name: end-user-onboarding
-                  value: true
-                - name: opencodegraph
+                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
                   value: false
-                - name: blob-page-switch-areas-shortcuts
+                - name: telemetry-export
+                  value: true
+                - name: cody-pro-jetbrains
+                  value: true
+                - name: cody-autocomplete-disable-recycling-of-previous-requests
                   value: false
         cookies: []
         headers:
@@ -1185,7 +1150,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: eed92b456f519c7972e07cb5478a1c63
+    - _id: cfd63f4827acb03e3e51f65d9fc0d0af
       _order: 0
       cache: {}
       request:
@@ -1239,7 +1204,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -1301,7 +1266,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 869d103f953a0c3190caf0857cab1466
+    - _id: 2b1f22fb4872a677facadef9efb4ea2d
       _order: 0
       cache: {}
       request:
@@ -1355,7 +1320,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.1.0
+                    clientVersion: 1.1.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -1466,13 +1431,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 148
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
-          textDecoded:
-            data:
-              repository:
-                embeddingExists: true
-                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
+          size: 155
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8=","AwD/h5WCVAAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1572,8 +1532,12 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 123
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//","AwDHAhygPQAAAA=="]'
+          size: 120
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
+          textDecoded:
+            data:
+              repository:
+                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
         cookies: []
         headers:
           - name: date
@@ -1785,11 +1749,11 @@ log:
           encoding: base64
           mimeType: application/json
           size: 136
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5sYmBvFGBkYmugaGuoYG8aZ6RroplmapickGxknGZklKtbW1AAAAAP//AwArauoHSQAAAA=="]'
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5qZGFvFGBkYmugaGuoaG8aZ6RroGlgZmxmmplpYpRqlKtbW1AAAAAP//AwDzjpyXSQAAAA=="]'
           textDecoded:
             data:
               site:
-                productVersion: 257340_2024-01-10_5.2-d96eac03b36b
+                productVersion: 257528_2024-01-11_5.2-09063fe99d2e
         cookies: []
         headers:
           - name: date

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -175,6 +175,7 @@ export class TestClient extends MessageHandler {
             cwd: agentDir,
             env: {
                 CODY_SHIM_TESTING: 'true',
+                CODY_TEMPERATURE_ZERO: 'true',
                 CODY_LOCAL_EMBEDDINGS_DISABLED: 'true',
                 CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
                 CODY_RECORDING_DIRECTORY: recordingDirectory,
@@ -361,9 +362,9 @@ describe('Agent', () => {
             `
           {
             "contextFiles": [],
-            "displayText": " Hello there!",
+            "displayText": " Hello there! How can I help you with coding today?",
             "speaker": "assistant",
-            "text": " Hello there!",
+            "text": " Hello there! How can I help you with coding today?",
           }
         `,
             explainPollyError
@@ -375,7 +376,7 @@ describe('Agent', () => {
         const trimmedMessage = trimEndOfLine(lastMessage?.text ?? '')
         expect(trimmedMessage).toMatchInlineSnapshot(
             `
-          " Here is a simple Hello World program in Java:
+          " Here is a simple Hello World function in Java:
 
           \`\`\`java
           public class Main {
@@ -385,21 +386,13 @@ describe('Agent', () => {
           }
           \`\`\`
 
-          To break this down:
-
-          - The code is wrapped in a class called Main. In Java, code must be contained within classes.
-
-          - The main method is the entry point of the program. It is marked as static so it can be run without creating an instance of Main.
-
-          - The main method accepts a String array called args as a parameter. This contains any command line arguments passed to the program.
-
-          - System.out.println prints the text \\"Hello World!\\" to the console.
+          This defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \\"Hello World!\\" to the console using System.out.println.
 
           To run this:
 
           1. Save the code in a file called Main.java
-          2. Compile it with: javac Main.java
-          3. Run it with: java Main
+          2. Compile it with \`javac Main.java\`
+          3. Run it with \`java Main\`
 
           This will print \\"Hello World!\\" to the console when executed."
         `,

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -10,8 +10,16 @@ import { SourcegraphCompletionsClient } from './client'
 import { parseEvents } from './parse'
 import { type CompletionCallbacks, type CompletionParameters } from './types'
 
+const isTemperatureZero = process.env.CODY_TEMPERATURE_ZERO === 'true'
+
 export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClient {
     public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
+        if (isTemperatureZero) {
+            params = {
+                ...params,
+                temperature: 0,
+            }
+        }
         const log = this.logger?.startCompletion(params, this.completionsEndpoint)
 
         const requestFn = this.completionsEndpoint.startsWith('https://') ? https.request : http.request

--- a/vscode/src/testutils/CodyPersister.ts
+++ b/vscode/src/testutils/CodyPersister.ts
@@ -78,6 +78,8 @@ export class CodyPersister extends FSPersister {
                     case 'retry-after':
                         header.value = '0'
                         break
+                    case 'x-cloud-trace-context':
+                        header.value = 'e3280902f3d7c7e5307db550c8425e2c'
                 }
             }
 


### PR DESCRIPTION
Previously, running `pnpm update-agent-recordings` more or less always
made the agent tests fail because the LLM response had minor changes.
This PR sets the LLM temperature to zero when we run agent tsets, which
should help make the tests be a bit more stable when updating
recordings. The tests are still non-deterministic with this change based
on local testing.

## Test plan

Green CI
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
