### PR TITLE
remove unused codebase-specific ignores

### DIFF
--- a/lib/shared/src/chat/context-filter.ts
+++ b/lib/shared/src/chat/context-filter.ts
@@ -12,13 +12,3 @@ export const ignores = new IgnoreHelper()
 export function isCodyIgnoredFile(uri: URI): boolean {
     return ignores.isIgnored(uri)
 }
-
-/**
- * Checks if the relative path of a file should be ignored by Cody based on the ignore rules.
- *
- * Use for matching search results returned from the embeddings client that do not contain absolute path/URI
- * In isIgnoredByCurrentWorkspace, we will construct a URI with the relative path and workspace root before checking
- */
-export function isCodyIgnoredFilePath(codebase: string, relativePath: string): boolean {
-    return ignores.isIgnoredByCodebase(codebase.trim(), relativePath)
-}

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -1,5 +1,5 @@
 import { type ContextFile, type ContextMessage, type PreciseContext } from '../../codebase-context/messages'
-import { isCodyIgnoredFile, isCodyIgnoredFilePath } from '../context-filter'
+import { isCodyIgnoredFile } from '../context-filter'
 
 import { type ChatMessage, type ChatMetadata, type InteractionMessage } from './messages'
 
@@ -41,17 +41,9 @@ export class Interaction {
             const message = contextMessages[i]
             // Skips the assistant message if the human message is ignored
             if (message.speaker === 'human' && message.file) {
-                const { uri, repoName, fileName, source } = message.file
-                if (uri && isCodyIgnoredFile(uri)) {
+                if (message.file.uri && isCodyIgnoredFile(message.file.uri)) {
                     i++
                     continue
-                }
-                // Filter embedding results from the current workspace
-                if (source === 'embeddings') {
-                    if (repoName && isCodyIgnoredFilePath(repoName, fileName)) {
-                        i++
-                        continue
-                    }
                 }
             }
             newMessages.push(message)
@@ -82,11 +74,6 @@ export class Interaction {
     public async getFullContext(): Promise<ContextMessage[]> {
         const msgs = await this.removeCodyIgnoredFiles()
         return msgs.map(msg => ({ ...msg }))
-    }
-
-    public async hasContext(): Promise<boolean> {
-        const contextMessages = await this.removeCodyIgnoredFiles()
-        return contextMessages.length > 0
     }
 
     public setUsedContext(usedContextFiles: ContextFile[], usedPreciseContext: PreciseContext[]): void {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -23,7 +23,6 @@ import { type LocalEmbeddingsController } from '../local-context/local-embedding
 import { logDebug } from '../log'
 import { getCodebaseFromWorkspaceUri, gitDirectoryUri } from '../repository/repositoryHelpers'
 import { type AuthProvider } from '../services/AuthProvider'
-import { updateCodyIgnoreCodespaceMap } from '../services/context-filter'
 import { getProcessInfo } from '../services/LocalAppDetector'
 import { logPrefix, telemetryService } from '../services/telemetry'
 import { telemetryRecorder } from '../services/telemetry-v2'
@@ -95,7 +94,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
                 await this.updateCodebaseContext()
             }),
             this.statusAggregator,
-            this.statusAggregator.onDidChangeStatus(_ => {
+            this.statusAggregator.onDidChangeStatus(() => {
                 this.contextStatusChangeEmitter.fire(this)
             }),
             this.contextStatusChangeEmitter
@@ -103,7 +102,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
 
         if (this.localEmbeddings) {
             this.disposables.push(
-                this.localEmbeddings.onChange(_ => {
+                this.localEmbeddings.onChange(() => {
                     void this.forceUpdateCodebaseContext()
                 })
             )
@@ -302,9 +301,6 @@ async function getCodebaseContext(
     if (!codebase) {
         return null
     }
-
-    // Map the ignore rules for the workspace with the codebase name
-    updateCodyIgnoreCodespaceMap(codebase, workspaceRoot.fsPath)
 
     // TODO: When we remove this class (ContextProvider), SimpleChatContextProvider
     // should be updated to invoke localEmbeddings.load when the codebase changes

--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -1,6 +1,5 @@
 import { isEqual } from 'lodash'
 import * as vscode from 'vscode'
-import { type URI } from 'vscode-uri'
 
 import {
     type ContextGroup,
@@ -16,7 +15,6 @@ import { getConfiguration } from '../../configuration'
 import { getEditor } from '../../editor/active-editor'
 import { type SymfRunner } from '../../local-context/symf'
 import { getCodebaseFromWorkspaceUri } from '../../repository/repositoryHelpers'
-import { updateCodyIgnoreCodespaceMap } from '../../services/context-filter'
 import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 
 export interface CodebaseIdentifiers {
@@ -186,7 +184,7 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
             // Get codebase from config or fallback to getting codebase name from current file URL
             // Always use the codebase from config as this is manually set by the user
             newCodebase.remote =
-                config.codebase || (currentFile ? detectCodebaseName(currentFile, workspaceRoot) : config.codebase)
+                config.codebase || (currentFile ? getCodebaseFromWorkspaceUri(currentFile) : config.codebase)
             if (newCodebase.remote) {
                 const repoId = await this.embeddingsClient.getRepoIdIfEmbeddingExists(newCodebase.remote)
                 if (!isError(repoId)) {
@@ -211,14 +209,4 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
         this.symfIndexStatus = newSymfStatus
         return didSymfStatusChange
     }
-}
-
-function detectCodebaseName(currentFileUri: URI, workspaceUri: URI): string | undefined {
-    const codebase = getCodebaseFromWorkspaceUri(currentFileUri)
-    if (codebase) {
-        // Map the ignore rules for the workspace with the codebase name
-        updateCodyIgnoreCodespaceMap(codebase, workspaceUri.fsPath)
-        return codebase
-    }
-    return undefined
 }

--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/src/utils'
 
 import { logDebug } from '../log'
-import { setUpCodyIgnore, updateCodyIgnoreCodespaceMap } from '../services/context-filter'
+import { setUpCodyIgnore } from '../services/context-filter'
 
 import { type API, type GitExtension, type Repository } from './builtinGitExtension'
 
@@ -61,7 +61,6 @@ export async function gitAPIinit(): Promise<vscode.Disposable | undefined> {
             setUpCodyIgnore()
             // This throws error if the git extension is disabled
             vscodeGitAPI = extension.exports?.getAPI(1)
-            getAllCodebasesInWorkspace().map(result => updateCodyIgnoreCodespaceMap(result.codebase, result.ws))
         }
     }
     // Initialize the git extension if it is available

--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -51,15 +51,6 @@ export function setUpCodyIgnore(): vscode.Disposable {
 }
 
 /**
- * Updates the mapping of codebase name to workspace file system path
- * in the ignores context filter.
- */
-export function updateCodyIgnoreCodespaceMap(codebaseName: string, workspaceFsPath: string): void {
-    ignores.updateCodebaseWorkspaceMap(codebaseName, workspaceFsPath)
-    logDebug('CodyIgnore:updateCodyIgnoreCodespaceMap:codebase', codebaseName)
-}
-
-/**
  * Rebuilds the ignore files for the workspace containing `uri`.
  */
 async function refresh(uri: vscode.Uri): Promise<void> {
@@ -104,10 +95,10 @@ async function refresh(uri: vscode.Uri): Promise<void> {
     logDebug('CodyIgnore:refresh:workspace', wf.uri.fsPath)
 
     // Main workspace root
-    ignores.setIgnoreFiles(wf.uri.fsPath, filesWithContent, codebaseName)
+    ignores.setIgnoreFiles(wf.uri.fsPath, filesWithContent)
     // Nested codebases
     for (const cb of codebases) {
-        ignores.setIgnoreFiles(cb[1], filesWithContent, cb[0])
+        ignores.setIgnoreFiles(cb[1], filesWithContent)
     }
 }
 


### PR DESCRIPTION
The `isCodyIgnoredFilePath` API for checking ignores is not actually used. Only `isCodyIgnoredFile` is used.

See discussion: https://sourcegraph.slack.com/archives/C05AGQYD528/p1705004134538609?thread_ts=1704886845.816059&cid=C05AGQYD528.



## Test plan

CI and manually ensured that the removed function was not actually being called for local embeddings, remote embeddings, and symf context (using a debugger).