### PR TITLE
remove now-unreachable chat history keyed on primary email

### DIFF
--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -92,7 +92,7 @@ export class LocalStorage {
 
         // For backwards compatibility, we upgrade the local storage key from the old layout that is
         // not scoped to individual user accounts to be scoped instead.
-        if (history && !isMigratedChatHistory(history)) {
+        if (history && !isMigratedChatHistory2261(history)) {
             // HACK: We spread both parts here as TS would otherwise have issues validating the type
             //       of AccountKeyedChatHistory. This is only three fields though.
             history = {
@@ -132,6 +132,9 @@ export class LocalStorage {
             }
 
             await this.storage.update(this.KEY_LOCAL_HISTORY, fullHistory)
+
+            // MIGRATION: Delete old/orphaned storage data from a previous migration.
+            this.migrateChatHistory2665(fullHistory as AccountKeyedChatHistory)
         } catch (error) {
             console.error(error)
         }
@@ -206,6 +209,20 @@ export class LocalStorage {
     public async delete(key: string): Promise<void> {
         await this.storage.update(key, undefined)
     }
+
+    /**
+     * In https://github.com/sourcegraph/cody/pull/2665 we migrated the chat history key to use the
+     * user's username instead of their email address. This means that the storage would retain the chat
+     * history under the old key indefinitely. Large storage data slows down extension host activation
+     * and each `Memento#update` call, so we don't want it to linger.
+     */
+    private migrateChatHistory2665(history: AccountKeyedChatHistory): void {
+        const needsMigration = Object.keys(history).some(key => key.includes('@'))
+        if (needsMigration) {
+            const cleanedHistory = Object.fromEntries(Object.entries(history).filter(([key]) => !key.includes('@')))
+            this.storage.update(this.KEY_LOCAL_HISTORY, cleanedHistory).then(() => {}, console.error)
+        }
+    }
 }
 
 /**
@@ -223,7 +240,7 @@ function getKeyForAuthStatus(authStatus: AuthStatus): ChatHistoryKey {
  * user account. This checks if the new format is used by checking if any key contains a hyphen (the
  * separator between endpoint and email in the new format).
  */
-function isMigratedChatHistory(
+function isMigratedChatHistory2261(
     history: AccountKeyedChatHistory | UserLocalHistory
 ): history is AccountKeyedChatHistory {
     return !!Object.keys(history).find(k => k.includes('-'))


### PR DESCRIPTION
In https://github.com/sourcegraph/cody/pull/2665 we migrated the chat history key to use the user's username instead of their email address. This means that the storage would retain the chat history under the old key indefinitely.

Large storage data slows down extension host activation and every `set` operation. My storage was 1.8MB, which was causing warnings from VS Code like this:

```
[mainThreadStorage] large extension state detected (extensionId: sourcegraph.cody-ai, global: true): 916.8603515625kb. Consider to use 'storageUri' or 'globalStorageUri' to store this data on disk instead.
```

Each `Memento#set` call was taking ~37ms (with 1.8MB of data). With ~1kb of data, each set call takes ~1-3ms.

Of course, the data will accumulate as the user uses Cody more, but at least we can manage the data now without some of it being "orphaned".

## Test plan:

Confirmed that this removes the old data:

1. Added a console.log to ensure that the code had the right before/after values.
2. Confirmed the storage DB on disk had the keys before and after the migration did not have them, with `sqlite3 ~/.config/Code/User/globalStorage/state.vscdb "select value from itemtable where key='sourcegraph.cody-ai';" | jq '."cody-local-chatHistory-v2" | keys'`.
3. Confirmed the length of the key's value went down (from 1.8MB to 672 bytes, as expected).