### PR TITLE
disable eslint no-explicit-any

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,9 @@ const config = {
     'unicorn/prefer-top-level-await': 'off',
     'unicorn/prefer-dom-node-remove': 'off',
     'ban/ban': 'off',
+
+    '@typescript-eslint/no-explicit-any': 'off',
+
     '@typescript-eslint/consistent-type-exports': [
       'error',
       {
@@ -52,6 +55,13 @@ const config = {
       files: ['*.d.ts'],
       rules: {
         'no-restricted-imports': 'off',
+      },
+    },
+    {
+      files: '*.test.ts?(x)',
+      rules: {
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
       },
     },
     {

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type * as vscode from 'vscode'
 
 import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'

--- a/cli/src/commands/commit/command.test.ts
+++ b/cli/src/commands/commit/command.test.ts
@@ -22,7 +22,7 @@ describe('commit', () => {
                         {
                             cwd: gitDir,
                             gitHelpers: createGitHelpers(),
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+
                             client: {} as any,
                         },
                         { debug: false }

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -17,7 +17,6 @@ const escapeHTML = (html: string): string => {
  * Attempts to syntax-highlight the given code.
  * If the language is not given, it is auto-detected.
  * If an error occurs, the code is returned as plain text with escaped HTML entities
- *
  * @param code The code to highlight
  * @param language The language of the code, if known
  * @returns Safe HTML
@@ -43,7 +42,6 @@ export const highlightCodeSafe = (code: string, language?: string): string => {
 /**
  * Renders the given markdown to HTML, highlighting code and sanitizing dangerous HTML.
  * Can throw an exception on parse errors.
- *
  * @param markdown The markdown to render
  */
 export const renderMarkdown = (

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -82,14 +82,12 @@ export interface ConfigurationWithAccessToken extends Configuration {
 export interface OllamaOptions {
     /**
      * URL to the Ollama server.
-     *
      * @example http://localhost:11434
      */
     url: string
 
     /**
      * The Ollama model to use. Currently only codellama and derived models are supported.
-     *
      * @example codellama:7b-code
      */
     model: string

--- a/lib/shared/src/editor/hydrateAfterPostMessage.ts
+++ b/lib/shared/src/editor/hydrateAfterPostMessage.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -295,7 +295,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
 
         this.disposables.push(
             panel.webview.onDidReceiveMessage(message =>
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 this.onDidReceiveMessage(hydrateAfterPostMessage(message, uri => vscode.Uri.from(uri as any)))
             )
         )

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/bestJaccardMatch.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/bestJaccardMatch.ts
@@ -9,7 +9,6 @@ export interface JaccardMatch {
  * Finds the window from matchText with the lowest Jaccard distance from targetText.
  * The Jaccard distance is the ratio of intersection over union, using a bag-of-words-with-count as
  * the representation for text snippet.
- *
  * @param targetText is the text that serves as the target we are trying to find a match for
  * @param matchText is the text we are sliding our window through to find the best match
  * @param windowSize is the size of the match window in number of lines

--- a/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
@@ -24,7 +24,7 @@ async function getInlineCompletionAfterAccepting(
             triggerKind,
             lastAcceptedCompletionItem: {
                 requestParams: initialRequestParams,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
                 analyticsItem: item!.items[0]!,
             },
         })

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -143,7 +143,6 @@ export async function getInlineCompletions(params: InlineCompletionsParams): Pro
         params.tracer?.({ result })
         return result
     } catch (unknownError: unknown) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const error = unknownError instanceof Error ? unknownError : new Error(unknownError as any)
 
         params.tracer?.({ error: error.toString() })

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -64,10 +64,9 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
             // Most of these are just passed directly to `getInlineCompletions`, which we've mocked, so
             // we can just make them `null`.
             //
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+
             statusBar: null as any,
             providerConfig: createProviderConfig({
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
                 client: null as any,
             }),
             triggerNotice: null,

--- a/vscode/src/editor/utils/document-sections.ts
+++ b/vscode/src/editor/utils/document-sections.ts
@@ -50,7 +50,6 @@ export async function getSelectionAroundLine(
  * Finds the folding range containing the given target position.
  *
  * NOTE: exported for testing purposes only
- *
  * @param ranges - The array of folding ranges to search.
  * @param targetLine - The position to find the containing range for.
  * @returns The folding range containing the target position, or undefined if not found.
@@ -142,7 +141,6 @@ async function removeOutermostFoldingRanges(
  * additional nested folding ranges (e.g. for inner code blocks).
  *
  * By removing the nested ranges, you are left with only the top-level outermost folding ranges.
- *
  * @param ranges - Array of folding ranges
  * @returns Array containing only folding ranges that do not contain any nested child ranges
  */
@@ -159,7 +157,6 @@ function removeNestedFoldingRanges(ranges: vscode.FoldingRange[], isTextBased = 
  *
  * This will iterate through the input ranges, and combine any ranges that are adjacent (end line of previous connects to start line of next)
  * into a single combined range.
- *
  * @param ranges - Array of folding ranges to combine
  * @returns Array of combined folding ranges
  */

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -17,7 +17,6 @@ import type { getRgPath } from './rg'
 import { type OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { captureException, type SentryService } from './services/sentry/sentry'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T extends new (...args: any) => any> = T extends new (...args: infer A) => infer R
     ? (...args: A) => R
     : never

--- a/vscode/src/fetch.ts
+++ b/vscode/src/fetch.ts
@@ -24,7 +24,6 @@ import {
  */
 export const agent: { current: ((url: URL) => Agent) | undefined } = { current: undefined }
 
-// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<BrowserOrNodeResponse> {
     if (customUserAgent) {
         init = init ?? {}

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import assert from 'assert'
 import { type ChildProcessWithoutNullStreams } from 'child_process'
 import { appendFileSync, existsSync, mkdirSync, rmSync } from 'fs'

--- a/vscode/src/non-stop/FixupScheduler.ts
+++ b/vscode/src/non-stop/FixupScheduler.ts
@@ -20,7 +20,6 @@ export class FixupScheduler implements FixupIdleTaskRunner {
 
     /**
      * Schedules a callback which will run when the event loop is idle.
-     *
      * @param callback the callback to run.
      */
     public scheduleIdle<T>(worker: () => T): Promise<T> {

--- a/vscode/src/repository/builtinGitExtension.d.ts
+++ b/vscode/src/repository/builtinGitExtension.d.ts
@@ -345,7 +345,6 @@ export interface GitExtension {
      * Throws error if git extension is disabled. You can listen to the
      * [GitExtension.onDidChangeEnablement](#GitExtension.onDidChangeEnablement) event
      * to know when the extension becomes enabled/disabled.
-     *
      * @param version Version number.
      * @returns API instance
      */

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -213,7 +213,6 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
         // Register to receive messages from webview
         this.disposables.push(
             webviewView.webview.onDidReceiveMessage(message =>
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 this.onDidReceiveMessage(hydrateAfterPostMessage(message, uri => vscode.Uri.from(uri as any)))
             )
         )

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 /* eslint-disable import/no-duplicates */
 /* eslint-disable @typescript-eslint/no-empty-function */

--- a/vscode/src/utils.ts
+++ b/vscode/src/utils.ts
@@ -42,7 +42,7 @@ export function getEditorTabSize(uri: vscode.Uri): number {
 
     const { languageId } = editor.document
     const languageConfig = vscode.workspace.getConfiguration(`[${languageId}]`, uri)
-    const languageSetting = languageConfig.get('editor.tabSize') as number | undefined
+    const languageSetting = languageConfig.get<number>('editor.tabSize')
     // Prefer language specific setting.
     const tabSize = languageSetting || editor.options.tabSize
 

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -34,7 +34,7 @@ export async function afterIntegrationTest(): Promise<void> {
 }
 
 // executeCommand specifies ...any[] https://code.visualstudio.com/api/references/vscode-api#commands
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export async function ensureExecuteCommand<T>(command: string, ...args: any[]): Promise<T> {
     await waitUntil(async () => (await vscode.commands.getCommands(true)).includes(command))
     const result = await vscode.commands.executeCommand<T>(command, ...args)

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -263,7 +263,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     }
 
     // Can't point at and use VSCodeCheckBox type with 'ref'
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const autofocusTarget = React.useRef<any>(null)
     React.useEffect(() => {
         if (isOpen) {
@@ -272,7 +272,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     }, [isOpen])
 
     // Can't point at and use VSCodeButton type with 'ref'
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const restoreFocusTarget = React.useRef<any>(null)
     const handleDismiss = React.useCallback(() => {
         setOpen(false)

--- a/vscode/webviews/utils/VSCodeApi.ts
+++ b/vscode/webviews/utils/VSCodeApi.ts
@@ -28,7 +28,6 @@ export function getVSCodeAPI(): VSCodeWrapper {
             postMessage: message => vsCodeApi.postMessage(message),
             onMessage: callback => {
                 const listener = (event: MessageEvent<ExtensionMessage>): void => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     callback(hydrateAfterPostMessage(event.data, uri => URI.from(uri as any)))
                 }
                 window.addEventListener('message', listener)


### PR DESCRIPTION
It will still warn on implicit use of any. This is causing a lot of our eslint warnings, and 95%+ of them are intentional, which just makes us ignore eslint warnings.

Before this, there were 153 no-explicit-any warnings. That represented more than 1/3 of our total eslint warning count.



## Test plan

CI