### PR TITLE
remove custom cody.chat.open.file command, proxy standard vscode.open

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -6,8 +6,9 @@ import { registerHighlightContributions, renderMarkdown as renderMarkdownCommon 
  * - vscode: VS Code URL scheme (open in editor)
  * - command:cody. VS Code command scheme for cody (run command)
  *  - e.g. command:cody.welcome: VS Code command scheme exception we add to support directly linking to the welcome guide from within the chat.
+ * {@link CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID}
  */
-const ALLOWED_URI_REGEXP = /^((https?|vscode):\/\/[^\s#$./?].\S*|command:cody.*)$/i
+const ALLOWED_URI_REGEXP = /^((https?|vscode):\/\/[^\s#$./?].\S*|command:(_cody.vscode.open\?.*))$/i
 
 const DOMPURIFY_CONFIG = {
     ALLOWED_TAGS: [

--- a/vscode/src/commands/prompt/display-text.test.ts
+++ b/vscode/src/commands/prompt/display-text.test.ts
@@ -18,14 +18,16 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
     it('replaces file name with markdown link', () => {
         expect(replaceFileNameWithMarkdownLink('Hello @path/to/test.js', URI.file('/path/to/test.js'))).toEqual(
-            'Hello [_@path/to/test.js_](command:cody.chat.open.file?%22file%3A%2F%2F%2Fpath%2Fto%2Ftest.js%3Arange%3A0%22)'
+            'Hello [_@path/to/test.js_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Fpath%2Fto%2Ftest.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)'
         )
     })
 
     it('replaces file name with range with markdown link', () => {
         expect(
             replaceFileNameWithMarkdownLink('What is @foo.ts:2-2?', URI.file('/foo.ts'), new vscode.Range(2, 0, 2, 0))
-        ).toEqual('What is [_@foo.ts:2-2_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ffoo.ts%3Arange%3A2%22)?')
+        ).toEqual(
+            'What is [_@foo.ts:2-2_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ffoo.ts%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)?'
+        )
     })
 
     it('replaces file name with symbol with markdown link', () => {
@@ -37,13 +39,13 @@ describe('replaceFileNameWithMarkdownLink', () => {
                 'codySymbol'
             )
         ).toEqual(
-            'What is [_@e2e/cody.ts:2-2#codySymbol_](command:cody.chat.open.file?%22file%3A%2F%2F%2Fe2e%2Fcody.ts%3Arange%3A2%22)?'
+            'What is [_@e2e/cody.ts:2-2#codySymbol_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Fe2e%2Fcody.ts%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)?'
         )
     })
 
     it('respects spaces in file name', () => {
         expect(replaceFileNameWithMarkdownLink('Loaded @my file.js', URI.file('/my file.js'))).toEqual(
-            'Loaded [_@my file.js_](command:cody.chat.open.file?%22file%3A%2F%2F%2Fmy%2520file.js%3Arange%3A0%22)'
+            'Loaded [_@my file.js_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Fmy%20file.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)'
         )
     })
 
@@ -64,7 +66,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
         it('uses OS-native path separator', () => {
             expect(replaceFileNameWithMarkdownLink('Loaded @a\\b.js', windowsFileURI('C:\\a\\b.js'))).toEqual(
-                'Loaded [_@a\\b.js_](command:cody.chat.open.file?%22file%3A%2F%2F%2Fc%253A%2Fa%2Fb.js%3Arange%3A0%22)'
+                'Loaded [_@a\\b.js_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2FC%3A%2Fa%2Fb.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)'
             )
         })
     })
@@ -80,26 +82,32 @@ describe('replaceFileNameWithMarkdownLink', () => {
                 URI.file('/path/with/@#special$chars.js')
             )
         ).toEqual(
-            'Loaded [_@path/with/@#special$chars.js_](command:cody.chat.open.file?%22file%3A%2F%2F%2Fpath%2Fwith%2F%2540%2523special%2524chars.js%3Arange%3A0%22)'
+            'Loaded [_@path/with/@#special$chars.js_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Fpath%2Fwith%2F%40%23special%24chars.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)'
         )
     })
 
     it('handles line numbers', () => {
         expect(
             replaceFileNameWithMarkdownLink('Error in @test.js:2-2', URI.file('/test.js'), new vscode.Range(2, 0, 2, 0))
-        ).toEqual('Error in [_@test.js:2-2_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ftest.js%3Arange%3A2%22)')
+        ).toEqual(
+            'Error in [_@test.js:2-2_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ftest.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)'
+        )
     })
 
     it('handles non alphanumeric characters follows the file name in input', () => {
         expect(
             replaceFileNameWithMarkdownLink('What is @test.js:2-2?', URI.file('/test.js'), new vscode.Range(2, 0, 2, 0))
-        ).toEqual('What is [_@test.js:2-2_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ftest.js%3Arange%3A2%22)?')
+        ).toEqual(
+            'What is [_@test.js:2-2_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ftest.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)?'
+        )
     })
 
     it('handles edge case where start line at 0 - exclude start line in markdown link', () => {
         expect(
             replaceFileNameWithMarkdownLink('Error in @test.js', URI.file('/test.js'), new vscode.Range(0, 0, 0, 0))
-        ).toEqual('Error in [_@test.js_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ftest.js%3Arange%3A0%22)')
+        ).toEqual(
+            'Error in [_@test.js_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ftest.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A0%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A0%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D)'
+        )
     })
 
     it('handles names that showed up more than once', () => {
@@ -110,7 +118,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
                 new vscode.Range(2, 0, 2, 0)
             )
         ).toEqual(
-            'Compare and explain [_@foo.js:2-2_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ffoo.js%3Arange%3A2%22) and @bar.js. What does [_@foo.js:2-2_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ffoo.js%3Arange%3A2%22) do?'
+            'Compare and explain [_@foo.js:2-2_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ffoo.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D) and @bar.js. What does [_@foo.js:2-2_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ffoo.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D) do?'
         )
     })
 
@@ -122,7 +130,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
                 new vscode.Range(2, 0, 2, 0)
             )
         ).toEqual(
-            'Compare and explain [_@foo.js:2-2_](command:cody.chat.open.file?%22file%3A%2F%2F%2Ffoo.js%3Arange%3A2%22) and @bar.js. What does @foo.js:2-2#FooBar() do?'
+            'Compare and explain [_@foo.js:2-2_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Ffoo.js%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A2%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D) and @bar.js. What does @foo.js:2-2#FooBar() do?'
         )
     })
 
@@ -137,7 +145,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
         )
 
         expect(result).toEqual(
-            '[_@vscode/src/logged-rerank.ts:7-23#getRerankWithLog()_](command:cody.chat.open.file?%22file%3A%2F%2F%2Fvscode%2Fsrc%2Flogged-rerank.ts%3Arange%3A7%22) what does this do'
+            '[_@vscode/src/logged-rerank.ts:7-23#getRerankWithLog()_](command:_cody.vscode.open?%5B%7B%22%24mid%22%3A1%2C%22path%22%3A%22%2Fvscode%2Fsrc%2Flogged-rerank.ts%22%2C%22scheme%22%3A%22file%22%7D%2C%7B%22selection%22%3A%7B%22start%22%3A%7B%22line%22%3A7%2C%22character%22%3A0%7D%2C%22end%22%3A%7B%22line%22%3A23%2C%22character%22%3A0%7D%7D%2C%22preserveFocus%22%3Atrue%2C%22background%22%3Atrue%2C%22preview%22%3Atrue%2C%22viewColumn%22%3A-2%7D%5D) what does this do'
         )
     })
 })

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -775,6 +775,7 @@ export const vsCodeMocks = {
     FoldingRangeKind,
     CodeActionKind,
     DiagnosticSeverity,
+    ViewColumn,
 } as const
 
 export function emptyEvent<T>(): vscode_types.Event<T> {


### PR DESCRIPTION
This removes a custom command in favor of using the built-in `vscode.open` (although we need to proxy it for reasons described in https://github.com/microsoft/vscode/issues/178868#issuecomment-1494826381).

## Test plan

Open Cody chat. Mention both files and symbols. Ensure that Cody chat properly opens those links in the editor to the side, with the right selection.