### PR TITLE
run `tsc --watch` for project-wide TypeScript diagnostics

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,21 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": ["$tsc-watch"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "option": "watch",
+      "runOptions": { "runOn": "folderOpen", "instanceLimit": 1 },
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      }
+    },
+    {
       "label": "Build VS Code Extension (Desktop)",
       "type": "npm",
       "path": "vscode",


### PR DESCRIPTION
This means that VS Code will show you project-wide diagnostics counts in the status bar.

## Test plan

n/a; dev only